### PR TITLE
Update OutProtocol.h

### DIFF
--- a/source/main/gameplay/OutProtocol.h
+++ b/source/main/gameplay/OutProtocol.h
@@ -106,6 +106,14 @@ private:
 		char           Display2[16]; // Usually Settings
 		int			   ID;           // optional - only if OutGauge ID is specified
 	});
+		
+	// Zappadoc addition 2015-01, to extend outgauge API with backward compatibility
+	PACK (struct OutGaugePackV2 : public OutGaugePack // include v1
+	{
+		unsigned cha	MaxGears;	 // max forward gears
+		unsigned char	IgnitionStarter; // 0=0ff; 1=ignition; 2=ignition+starter (running)
+		float		MaxRPM;		// Max RPM engine
+	});
 };
 
 #endif // _OUTPROTCOL_H__


### PR DESCRIPTION
Rigs Of Rods is now supported by our game devices manager SLIMax Manager, here is an addition to extend the outgauge API with backward compatibility, some important data are missing in the current API like the max RPM of current engine, the distance traveled, the ignition/starter status, etc. so here is my 2 cents to extend it smoothly just by altered the OutProtocol header and cpp.
To activate the new OutGauge V2 structure you just have to change the OutGauge Mode to 3 (see OutProtocol.cpp).
This contribution includes a few additional data just to see if you agree with the change after that I or someone else will be able to add other telemetry data.
Cheers,
zappadoc