### PR TITLE
Update OutProtocol.cpp

### DIFF
--- a/source/main/gameplay/OutProtocol.cpp
+++ b/source/main/gameplay/OutProtocol.cpp
@@ -125,11 +125,7 @@ bool OutProtocol::update(float dt)
 	timer = 0;
 
 	// send a package
-	if( mode == 3) // OutGauge Packet V2
-		OutGaugePackV2 gd;
-	else
-		OutGaugePack gd;
-	
+	OutGaugePackV2 gd; // declare V2 as it is wider and backward compatible with v1
 	memset(&gd, 0, sizeof(gd));
 
 	// set some common things
@@ -208,7 +204,11 @@ bool OutProtocol::update(float dt)
 		}
 	}
 	// send the package
-	send(sockfd, (const char*)&gd, sizeof(gd), NULL);
+	// set the right size of the buffer depending the OutGauge mode
+	int sz = sizeof(OutGaugePack);
+	if(mode == 3)
+		sz = sizeof(OutGaugePackV2);
+	send(sockfd, (const char*)&gd, sz, NULL);
 
 	return true;
 #else

--- a/source/main/gameplay/OutProtocol.cpp
+++ b/source/main/gameplay/OutProtocol.cpp
@@ -125,7 +125,11 @@ bool OutProtocol::update(float dt)
 	timer = 0;
 
 	// send a package
-	OutGaugePack gd;
+	if( mode == 3) // OutGauge Packet V2
+		OutGaugePackV2 gd;
+	else
+		OutGaugePack gd;
+	
 	memset(&gd, 0, sizeof(gd));
 
 	// set some common things
@@ -187,6 +191,20 @@ bool OutProtocol::update(float dt)
 		if ( truck->realtruckname.length() > 15 )
 		{
 			strncpy(gd.Display2, truck->realtruckname.c_str() + 15, 15);
+		}
+		
+		if( mode == 3)
+		{
+			// OutGauge Packet V2
+			gd.MaxGears = truck->engine->getNumGears();
+			gd.MaxRPM = truck->engine->getMaxRPM();
+			
+			int ignition = 0;
+			if( truck->engine->hasContact() && truck->engine->isRunning())
+				ignition = 2;
+			if( truck->engine->hasContact() && !(truck->engine->isRunning()))
+				ignition = 1;	
+			gd.IgnitionStarter = ignition;
 		}
 	}
 	// send the package


### PR DESCRIPTION
Rigs Of Rods is now supported by our game devices manager SLIMax Manager, here is an addition to extend the outgauge API with backward compatibility, some important data are missing in the current API like the max RPM of current engine, the distance traveled, the ignition/starter status, etc. so here is my 2 cents to extend it smoothly just by altered the OutProtocol header and cpp.
To activate the new OutGauge V2 structure you just have to change the OutGauge Mode to 3 (see OutProtocol.cpp).
This contribution includes a few additional data just to see if you agree with the change after that I or someone else will be able to add other telemetry data.
Cheers,
zappadoc