### PR TITLE
[fix] calling calcBeams twice, remove default parameters

### DIFF
--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -551,7 +551,7 @@ protected:
 	* TIGHT LOOP; Physics & sound; 
 	* @param doUpdate Only passed to Beam::calcShocks2()
 	*/
-	void calcBeams(int doUpdate, Ogre::Real dt, int step, int maxsteps, int chunk_index = 0, int chunk_number = 1);
+	void calcBeams(int doUpdate, Ogre::Real dt, int step, int maxsteps, int chunk_index, int chunk_number);;
 
 	/**
 	* TIGHT LOOP; Physics; 

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -551,7 +551,7 @@ protected:
 	* TIGHT LOOP; Physics & sound; 
 	* @param doUpdate Only passed to Beam::calcShocks2()
 	*/
-	void calcBeams(int doUpdate, Ogre::Real dt, int step, int maxsteps, int chunk_index, int chunk_number);;
+	void calcBeams(int doUpdate, Ogre::Real dt, int step, int maxsteps, int chunk_index, int chunk_number);
 
 	/**
 	* TIGHT LOOP; Physics; 


### PR DESCRIPTION
fixes issue #101

I must have not added the change for removing the default values on calcBeams/6 this caused the wrong calcBeams to be called  and resulted in it being called twice in a loop.