### PR TITLE
Remove stencil shadows

### DIFF
--- a/bin/resources/mygui/settings.layout
+++ b/bin/resources/mygui/settings.layout
@@ -120,7 +120,6 @@
                 <Widget type="ComboBox" skin="ComboBox" position="160 70 445 30" name="shadow_type">
                     <Property key="AddItem" value="No shadows (fastest)"/>
                     <Property key="AddItem" value="Texture shadows"/>
-                    <Property key="AddItem" value="Stencil shadows (best looking)"/>
                     <Property key="ReadOnly" value="true"/>
                     <Property key="Static" value="true"/>
                 </Widget>

--- a/source/configurator/Configurator.cpp
+++ b/source/configurator/Configurator.cpp
@@ -1298,13 +1298,10 @@ MyDialog::MyDialog(const wxString& title, MyApp *_app) : wxDialog(NULL, wxID_ANY
 	shadow=new wxValueChoice(graphicsPanel, choice_shadow, wxPoint(x_row1, y), wxSize(200, -1), 0);
 	shadow->AppendValueItem(wxT("No shadows (fastest)"), _("No shadows (fastest)"));
 	shadow->AppendValueItem(wxT("Texture shadows"), _("Texture shadows"));
-	shadow->AppendValueItem(wxT("Stencil shadows (best looking)"), _("Stencil shadows (best looking)"));
-	// XXX: SHADOWS broken :(
-	//shadow->Disable();
 #if OGRE_VERSION>0x010602
 	shadow->AppendValueItem(wxT("Parallel-split Shadow Maps"), _("Parallel-split Shadow Maps"));
 #endif //OGRE_VERSION
-	shadow->SetToolTip(_("Texture shadows are fast but limited: jagged edges, no object self-shadowing, limited shadow distance.\nStencil shadows are slow but gives perfect shadows."));
+	shadow->SetToolTip(_("Shadow technique to be used ingame."));
 	sky->SetSelection(1); //Texture shadows
 	y+=25;
 

--- a/source/main/gameplay/Road2.cpp
+++ b/source/main/gameplay/Road2.cpp
@@ -641,11 +641,5 @@ void Road2::createMesh()
 	//msh->_setBoundingSphereRadius((aab->getMaximum()-aab->getMinimum()).length()/2.0);
 
 	/// Notify Mesh object that it has been loaded
-	if (gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		msh->buildEdgeList();
-		msh->prepareForShadowVolume();
-	}
-
 	msh->load();
 };

--- a/source/main/gfx/ShadowManager.cpp
+++ b/source/main/gfx/ShadowManager.cpp
@@ -40,9 +40,7 @@ ShadowManager::~ShadowManager()
 void ShadowManager::loadConfiguration()
 {
 	Ogre::String s = SSETTING("Shadow technique", "Parallel-split Shadow Maps");
-	if (s == "Stencil shadows (best looking)")
-		changeShadowTechnique(Ogre::SHADOWTYPE_STENCIL_MODULATIVE);
-	else if (s == "Texture shadows")
+	if (s == "Texture shadows")
 		changeShadowTechnique(Ogre::SHADOWTYPE_TEXTURE_MODULATIVE);
 	else if (s == "Parallel-split Shadow Maps")
 		changeShadowTechnique(Ogre::SHADOWTYPE_TEXTURE_MODULATIVE_INTEGRATED);
@@ -60,19 +58,7 @@ int ShadowManager::changeShadowTechnique(Ogre::ShadowTechnique tech)
 	gEnv->sceneManager->setShadowFarDistance(shadowFarDistance);
 	gEnv->sceneManager->setShowDebugShadows(false);
 
-	if (tech == Ogre::SHADOWTYPE_STENCIL_MODULATIVE)
-	{
-		//		gEnv->ogreSceneManager->setShadowIndexBufferSize(2000000);
-		gEnv->sceneManager->setShadowDirectionalLightExtrusionDistance(100);
-
-		//important optimization
-		gEnv->sceneManager->getRenderQueue()->getQueueGroup(Ogre::RENDER_QUEUE_WORLD_GEOMETRY_1)->setShadowsEnabled(false);
-		gEnv->sceneManager->getRenderQueue()->getQueueGroup(Ogre::RENDER_QUEUE_OVERLAY)->setShadowsEnabled(false);
- 
-		//		gEnv->ogreSceneManager->setUseCullCamera(false);
-		//		gEnv->ogreSceneManager->setShowBoxes(true);
-		//		gEnv->ogreSceneManager->showBoundingBoxes(true);
-	} else if (tech == Ogre::SHADOWTYPE_TEXTURE_MODULATIVE)
+	if (tech == Ogre::SHADOWTYPE_TEXTURE_MODULATIVE)
 	{
 		gEnv->sceneManager->setShadowTextureSettings(2048,2);
 	} else if (tech == Ogre::SHADOWTYPE_TEXTURE_MODULATIVE_INTEGRATED)

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -373,10 +373,8 @@ void CLASS::UpdateControls()
 	Ogre::String shadowtype = GameSettingsMap["Shadow technique"];
 	if (shadowtype == "Texture shadows")
 		m_shadow_type->setIndexSelected(1);
-	else if (shadowtype == "Stencil shadows (best looking)")
-		m_shadow_type->setIndexSelected(2);
 	else if (shadowtype == "Parallel-split Shadow Maps" && BSETTING("DevMode", false))
-		m_shadow_type->setIndexSelected(3);
+		m_shadow_type->setIndexSelected(2);
 	else
 		m_shadow_type->setIndexSelected(0);
 

--- a/source/main/physics/air/AirBrake.cpp
+++ b/source/main/physics/air/AirBrake.cpp
@@ -134,11 +134,6 @@ Airbrake::Airbrake(char* basename, int num, node_t *ndref, node_t *ndx, node_t *
     //msh->_setBoundingSphereRadius(Math::Sqrt(1*1+1*1));
 
     /// Notify Mesh object that it has been loaded
-	if (gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		msh->buildEdgeList();
-	}
-
 	msh->load();
 
 	// create the entity and scene node

--- a/source/main/physics/flex/FlexAirfoil.cpp
+++ b/source/main/physics/flex/FlexAirfoil.cpp
@@ -406,10 +406,6 @@ FlexAirfoil::FlexAirfoil(Ogre::String const & name, node_t *nds, int pnfld, int 
 
     /// Notify Mesh object that it has been loaded
 	//MeshManager::getSingleton().setPrepareAllMeshesForShadowVolumes(false);
-	if (gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		msh->buildEdgeList();
-	}
 	//msh->prepareForShadowVolume();
 	msh->load();
 	//MeshManager::getSingleton().setPrepareAllMeshesForShadowVolumes()
@@ -706,33 +702,13 @@ void FlexAirfoil::setControlDeflection(float val)
 Vector3 FlexAirfoil::flexit()
 {
 	Vector3 center;
-	if (gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		center=updateShadowVertices();
-		//find the binding
-		unsigned posbinding=msh->sharedVertexData->vertexDeclaration->findElementBySemantic(VES_POSITION)->getSource();
-		HardwareVertexBufferSharedPtr pbuf=msh->sharedVertexData->vertexBufferBinding->getBuffer(posbinding);
-		//pbuf->lock(HardwareBuffer::HBL_NORMAL);
-		pbuf->writeData(0, pbuf->getSizeInBytes(), shadowposvertices, true);
-		//pbuf->unlock();
-		//find the binding
-		unsigned norbinding=msh->sharedVertexData->vertexDeclaration->findElementBySemantic(VES_NORMAL)->getSource();
-		HardwareVertexBufferSharedPtr nbuf=msh->sharedVertexData->vertexBufferBinding->getBuffer(norbinding);
-		//nbuf->lock(HardwareBuffer::HBL_NORMAL);
-		nbuf->writeData(0, nbuf->getSizeInBytes(), shadownorvertices, true);
-		//nbuf->unlock();
 
-		EdgeData * 	ed=msh->getEdgeList();
-		ed->updateFaceNormals(0, pbuf);
-	}
-		else
-	{
-		center=updateVertices();
-		//vbuf->lock(HardwareBuffer::HBL_NORMAL);
-		vbuf->writeData(0, vbuf->getSizeInBytes(), vertices, true);
-		//vbuf->unlock();
-		//msh->sharedVertexData->vertexBufferBinding->getBuffer(0)->writeData(0, vbuf->getSizeInBytes(), vertices, true);
-	}
+	center=updateVertices();
+	//vbuf->lock(HardwareBuffer::HBL_NORMAL);
+	vbuf->writeData(0, vbuf->getSizeInBytes(), vertices, true);
+	//vbuf->unlock();
+	//msh->sharedVertexData->vertexBufferBinding->getBuffer(0)->writeData(0, vbuf->getSizeInBytes(), vertices, true);
+
 	return center;
 }
 

--- a/source/main/physics/flex/FlexBody.cpp
+++ b/source/main/physics/flex/FlexBody.cpp
@@ -143,13 +143,6 @@ FlexBody::FlexBody(
 	//LOG("FLEXBODY unique mesh created: "+String(meshname)+" -> "+String(uname_mesh));
 
 	msh=ent->getMesh();
-	//shadow
-	if (gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		LOG("FLEXBODY preparing for shadow volume");
-		msh->buildEdgeList();
-		msh->prepareForShadowVolume(); // we do this always so we have only one data structure format to manage
-	}
 
 	//determine if we have texture coordinates everywhere
 	hastexture=true;

--- a/source/main/physics/flex/FlexMesh.cpp
+++ b/source/main/physics/flex/FlexMesh.cpp
@@ -214,11 +214,6 @@ FlexMesh::FlexMesh(
 	//msh->_setBoundingSphereRadius(Math::Sqrt(1*1+1*1));
 
 		/// Notify Mesh object that it has been loaded
-	if (gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		msh->buildEdgeList();
-		msh->prepareForShadowVolume();
-	}
 	//msh->buildTangentVectors();
 	/*unsigned short src, dest;
 	if (!msh->suggestTangentVectorBuildParams(src, dest))
@@ -408,41 +403,15 @@ void FlexMesh::setVisible(bool visible)
 
 void FlexMesh::flexitCompute()
 {
-	if (gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		flexit_center = updateShadowVertices();
-	} else
-	{
-		flexit_center = updateVertices();
-	}
+	flexit_center = updateVertices();
 }
 
 Vector3 FlexMesh::flexitFinal()
 {
-	if (gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		//find the binding
-		unsigned posbinding = msh->sharedVertexData->vertexDeclaration->findElementBySemantic(VES_POSITION)->getSource();
-		HardwareVertexBufferSharedPtr pbuf=msh->sharedVertexData->vertexBufferBinding->getBuffer(posbinding);
-		//pbuf->lock(HardwareBuffer::HBL_NORMAL);
-		pbuf->writeData(0, pbuf->getSizeInBytes(), shadowposvertices, true);
-		//pbuf->unlock();
-		//find the binding
-		unsigned norbinding = msh->sharedVertexData->vertexDeclaration->findElementBySemantic(VES_NORMAL)->getSource();
-		HardwareVertexBufferSharedPtr nbuf=msh->sharedVertexData->vertexBufferBinding->getBuffer(norbinding);
-		//nbuf->lock(HardwareBuffer::HBL_NORMAL);
-		nbuf->writeData(0, nbuf->getSizeInBytes(), shadownorvertices, true);
-		//nbuf->unlock();
-
-		EdgeData* ed = msh->getEdgeList();
-		ed->updateFaceNormals(0, pbuf);
-	} else
-	{
-		//vbuf->lock(HardwareBuffer::HBL_NORMAL);
-		vbuf->writeData(0, vbuf->getSizeInBytes(), vertices, true);
-		//vbuf->unlock();
-		//msh->sharedVertexData->vertexBufferBinding->getBuffer(0)->writeData(0, vbuf->getSizeInBytes(), vertices, true);
-	}
+	//vbuf->lock(HardwareBuffer::HBL_NORMAL);
+	vbuf->writeData(0, vbuf->getSizeInBytes(), vertices, true);
+	//vbuf->unlock();
+	//msh->sharedVertexData->vertexBufferBinding->getBuffer(0)->writeData(0, vbuf->getSizeInBytes(), vertices, true);
 
 	return flexit_center;
 }

--- a/source/main/physics/flex/FlexMeshWheel.cpp
+++ b/source/main/physics/flex/FlexMeshWheel.cpp
@@ -187,11 +187,6 @@ FlexMeshWheel::FlexMeshWheel(
 	//msh->_setBoundingSphereRadius(Math::Sqrt(1*1+1*1));
 
 	/// Notify Mesh object that it has been loaded
-	if (gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		msh->buildEdgeList();
-		msh->prepareForShadowVolume();
-	}
 	//msh->buildTangentVectors();
 	/*unsigned short src, dest;
 	if (!msh->suggestTangentVectorBuildParams(src, dest))
@@ -329,41 +324,16 @@ bool FlexMeshWheel::flexitPrepare(Beam* b)
 
 void FlexMeshWheel::flexitCompute()
 {
-	if (gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		flexit_center = updateShadowVertices();
-	} else
-	{
-		flexit_center = updateVertices();
-	}
+	flexit_center = updateVertices();
 }
 
 Vector3 FlexMeshWheel::flexitFinal()
 {
-	if (gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		//find the binding
-		unsigned posbinding = msh->sharedVertexData->vertexDeclaration->findElementBySemantic(VES_POSITION)->getSource();
-		HardwareVertexBufferSharedPtr pbuf=msh->sharedVertexData->vertexBufferBinding->getBuffer(posbinding);
-		//pbuf->lock(HardwareBuffer::HBL_NORMAL);
-		pbuf->writeData(0, pbuf->getSizeInBytes(), shadowposvertices, true);
-		//pbuf->unlock();
-		//find the binding
-		unsigned norbinding = msh->sharedVertexData->vertexDeclaration->findElementBySemantic(VES_NORMAL)->getSource();
-		HardwareVertexBufferSharedPtr nbuf=msh->sharedVertexData->vertexBufferBinding->getBuffer(norbinding);
-		//nbuf->lock(HardwareBuffer::HBL_NORMAL);
-		nbuf->writeData(0, nbuf->getSizeInBytes(), shadownorvertices, true);
-		//nbuf->unlock();
 
-		EdgeData* ed = msh->getEdgeList();
-		ed->updateFaceNormals(0, pbuf);
-	} else
-	{
-		//vbuf->lock(HardwareBuffer::HBL_NORMAL);
-		vbuf->writeData(0, vbuf->getSizeInBytes(), vertices, true);
-		//vbuf->unlock();
-		//msh->sharedVertexData->vertexBufferBinding->getBuffer(0)->writeData(0, vbuf->getSizeInBytes(), vertices, true);
-	}
+	//vbuf->lock(HardwareBuffer::HBL_NORMAL);
+	vbuf->writeData(0, vbuf->getSizeInBytes(), vertices, true);
+	//vbuf->unlock();
+	//msh->sharedVertexData->vertexBufferBinding->getBuffer(0)->writeData(0, vbuf->getSizeInBytes(), vertices, true);
 
 	return flexit_center;
 }

--- a/source/main/physics/flex/FlexObj.cpp
+++ b/source/main/physics/flex/FlexObj.cpp
@@ -211,12 +211,6 @@ FlexObj::FlexObj(node_t *nds, int numtexcoords, Vector3* texcoords, int numtrian
 
 
     /// Notify Mesh object that it has been loaded
-	if (gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique() == SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		msh->buildEdgeList();
-		msh->prepareForShadowVolume();
-	}
-
     msh->load();
 }
 
@@ -353,30 +347,13 @@ Vector3 FlexObj::updateShadowVertices()
 Vector3 FlexObj::flexit()
 {
 	Vector3 center(Vector3::ZERO);
-	if (gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_MODULATIVE || gEnv->sceneManager->getShadowTechnique()==SHADOWTYPE_STENCIL_ADDITIVE)
-	{
-		center=updateShadowVertices();
-		//find the binding
-		unsigned posbinding=msh->sharedVertexData->vertexDeclaration->findElementBySemantic(VES_POSITION)->getSource();
-		HardwareVertexBufferSharedPtr pbuf=msh->sharedVertexData->vertexBufferBinding->getBuffer(posbinding);
-		//pbuf->lock(HardwareBuffer::HBL_NORMAL);
-		pbuf->writeData(0, pbuf->getSizeInBytes(), shadowposvertices, true);
-		//pbuf->unlock();
-		//find the binding
-		unsigned norbinding=msh->sharedVertexData->vertexDeclaration->findElementBySemantic(VES_NORMAL)->getSource();
-		HardwareVertexBufferSharedPtr nbuf=msh->sharedVertexData->vertexBufferBinding->getBuffer(norbinding);
-		//nbuf->lock(HardwareBuffer::HBL_NORMAL);
-		nbuf->writeData(0, nbuf->getSizeInBytes(), shadownorvertices, true);
-		//nbuf->unlock();
-		msh->getEdgeList()->updateFaceNormals(0, pbuf);
-	} else
-	{
-		center=updateVertices();
-		//vbuf->lock(HardwareBuffer::HBL_NORMAL);
-		vbuf->writeData(0, vbuf->getSizeInBytes(), vertices, true);
-		//vbuf->unlock();
-		//msh->sharedVertexData->vertexBufferBinding->getBuffer(0)->writeData(0, vbuf->getSizeInBytes(), vertices, true);
-	}
+
+	center=updateVertices();
+	//vbuf->lock(HardwareBuffer::HBL_NORMAL);
+	vbuf->writeData(0, vbuf->getSizeInBytes(), vertices, true);
+	//vbuf->unlock();
+	//msh->sharedVertexData->vertexBufferBinding->getBuffer(0)->writeData(0, vbuf->getSizeInBytes(), vertices, true);
+
 	return center;
 }
 


### PR DESCRIPTION
Stencil shadows were scrapped in Ogre 2.0 and are not maintained in RoR. It is time for us to say goodbye, cut them and move on.