### PR TITLE
[Cleanup] Point collision detector cleanup, fixes #160

### DIFF
--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -26,21 +26,20 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 using namespace Ogre;
 
 PointColDetector::PointColDetector(std::vector < Vector3 > &o_list) : object_list(&o_list) {
-	ref_list = new refelem_t[1];
-	pointid_list = new pointid_t[1];
+	std::vector< refelem_t > ref_list(1);
+	std::vector< pointid_t > pointid_list(1);
 
 	update();
 }
 
 PointColDetector::PointColDetector() {
-	ref_list = new refelem_t[1];
-	pointid_list = new pointid_t[1];
+	std::vector< refelem_t > ref_list(1);
+	std::vector< pointid_t > pointid_list(1);
+
 	object_list_size = -1;
 }
 
 PointColDetector::~PointColDetector() {
-	delete [] ref_list;
-	delete [] pointid_list;
 }
 
 void PointColDetector::reset() {
@@ -49,7 +48,7 @@ void PointColDetector::reset() {
 
 void PointColDetector::update() {
 	if (object_list->size() != (unsigned int) object_list_size) {
-		object_list_size = (int)object_list->size();
+		object_list_size = (int) object_list->size();
 		update_structures();
 	}
 
@@ -80,8 +79,7 @@ void PointColDetector::update(Beam** trucks, const int numtrucks) {
 	int t, contacters_size=0;
 
 	//Count the contacters of all trucks
-	for (t = 0; t < numtrucks; t++)
-	{
+	for (t = 0; t < numtrucks; t++) {
 		if (!trucks[t] || trucks[t]->state >= SLEEPING) {
 			continue;
 		}
@@ -119,16 +117,17 @@ void PointColDetector::update_structures() {
 	hit_list.resize(object_list_size, NULL);
 	int exp_factor = ceil(log2(object_list_size)) + 1;
 
-	delete [] ref_list;
-	delete [] pointid_list;
-	ref_list = new refelem_t[object_list_size];
-	pointid_list = new pointid_t[object_list_size];
+	ref_list.clear();
+	pointid_list.clear();
+
+	ref_list.resize(object_list_size);
+	pointid_list.resize(object_list_size);
 
 	if (exp_factor < 0) {
 		exp_factor = 0;
 	}
 
-	kdtree.resize(pow(2, exp_factor), kdelem);
+	kdtree.resize(pow((float) 2, exp_factor), kdelem);
 }
 
 void PointColDetector::update_structures_for_contacters(Beam* truck) {
@@ -136,10 +135,11 @@ void PointColDetector::update_structures_for_contacters(Beam* truck) {
 	hit_list.resize(object_list_size, NULL);
 	int exp_factor = ceil(log2(object_list_size)) + 1;
 
-	delete [] ref_list;
-	delete [] pointid_list;
-	ref_list = new refelem_t[object_list_size];
-	pointid_list = new pointid_t[object_list_size];
+	ref_list.clear();
+	pointid_list.clear();
+
+	ref_list.resize(object_list_size);
+	pointid_list.resize(object_list_size);
 
 	int refi = 0;
 
@@ -158,7 +158,7 @@ void PointColDetector::update_structures_for_contacters(Beam* truck) {
 		exp_factor = 0;
 	}
 
-	kdtree.resize(pow(2, exp_factor), kdelem);
+	kdtree.resize(pow((float) 2, exp_factor), kdelem);
 }
 
 void PointColDetector::update_structures_for_contacters(Beam** trucks, const int numtrucks) {
@@ -166,12 +166,13 @@ void PointColDetector::update_structures_for_contacters(Beam** trucks, const int
 	hit_list.resize(object_list_size, NULL);
 	int exp_factor = ceil(log2(object_list_size)) + 1;
 
-	delete [] ref_list;
-	delete [] pointid_list;
-	ref_list=new refelem_t[object_list_size];
-	pointid_list=new pointid_t[object_list_size];
+	ref_list.clear();
+	pointid_list.clear();
 
-	int t, refi=0;
+	ref_list.resize(object_list_size);
+	pointid_list.resize(object_list_size);
+
+	int t, refi = 0;
 
 	//Insert all contacters, into the list of points to consider when building the kdtree
 	for (t = 0; t < numtrucks; t++) {
@@ -180,10 +181,10 @@ void PointColDetector::update_structures_for_contacters(Beam** trucks, const int
 		}
 
 		for (int i = 0; i < trucks[t]->free_contacter; ++i) {
-			ref_list[refi].pidref=&pointid_list[refi];
-			pointid_list[refi].truckid=t;
-			pointid_list[refi].nodeid=trucks[t]->contacters[i].nodeid;
-			ref_list[refi].point=&(trucks[t]->nodes[pointid_list[refi].nodeid].AbsPosition.x);
+			ref_list[refi].pidref = &pointid_list[refi];
+			pointid_list[refi].truckid = t;
+			pointid_list[refi].nodeid = trucks[t]->contacters[i].nodeid;
+			ref_list[refi].point = &(trucks[t]->nodes[pointid_list[refi].nodeid].AbsPosition.x);
 			refi++;
 		}
 	}
@@ -192,7 +193,7 @@ void PointColDetector::update_structures_for_contacters(Beam** trucks, const int
 		exp_factor = 0;
 	}
 
-	kdtree.resize(pow(2, exp_factor), kdelem);
+	kdtree.resize(pow((float) 2, exp_factor), kdelem);
 }
 
 void PointColDetector::querybb(const Vector3 &bmin, const Vector3 &bmax) {
@@ -217,7 +218,7 @@ void PointColDetector::query(const Vector3 &vec1, const Vector3 &vec2, const flo
 	queryrec(0, 0);
 }
 
-inline void PointColDetector::calc_bounding_box(Vector3 &bmin, Vector3 &bmax, const Vector3 &vec1, const Vector3 &vec2, const Vector3 &vec3, const float enlargeBB) {
+void PointColDetector::calc_bounding_box(Vector3 &bmin, Vector3 &bmax, const Vector3 &vec1, const Vector3 &vec2, const Vector3 &vec3, const float enlargeBB) {
 	if (vec1.y < vec2.y) {
 		bmin.y = vec1.y;
 		bmax.y = vec2.y;
@@ -268,7 +269,7 @@ inline void PointColDetector::calc_bounding_box(Vector3 &bmin, Vector3 &bmax, co
 	if (vec3.z < bmin.z) {
 		bmin.z= vec3.z;
 	}
-	else if (vec3.z > bmax.z){
+	else if (vec3.z > bmax.z) {
 		bmax.z= vec3.z;
 	}
 
@@ -276,7 +277,7 @@ inline void PointColDetector::calc_bounding_box(Vector3 &bmin, Vector3 &bmax, co
 	bmax.z+= enlargeBB;
 }
 
-inline void PointColDetector::calc_bounding_box(Vector3 &bmin, Vector3 &bmax, const Vector3 &vec1, const Vector3 &vec2, const float enlargeBB) {
+void PointColDetector::calc_bounding_box(Vector3 &bmin, Vector3 &bmax, const Vector3 &vec1, const Vector3 &vec2, const float enlargeBB) {
 	if (vec1.x < vec2.x) {
 		bmin.x= vec1.x; bmax.x=vec2.x;
 	}
@@ -308,7 +309,7 @@ inline void PointColDetector::calc_bounding_box(Vector3 &bmin, Vector3 &bmax, co
 	bmax.z+= enlargeBB;
 }
 
-inline void PointColDetector::queryrec(int kdindex, int axis) {
+void PointColDetector::queryrec(int kdindex, int axis) {
 	for (;;) {
 		if (kdtree[kdindex].end < 0) {
 			build_kdtree_incr(axis, kdindex);
@@ -316,9 +317,7 @@ inline void PointColDetector::queryrec(int kdindex, int axis) {
 
 		if (kdtree[kdindex].ref != NULL) {
 			float *point = kdtree[kdindex].ref->point;
-			if (point[0] >= bbmin.x && point[0] <= bbmax.x
-			  && point[1] >= bbmin.y && point[1] <= bbmax.y
-			  && point[2] >= bbmin.z && point[2] <= bbmax.z ) {
+			if (point[0] >= bbmin.x && point[0] <= bbmax.x && point[1] >= bbmin.y && point[1] <= bbmax.y && point[2] >= bbmin.z && point[2] <= bbmax.z ) {
 				hit_list[hit_count] = kdtree[kdindex].ref->pidref;
 				hit_count++;
 			}
@@ -334,7 +333,7 @@ inline void PointColDetector::queryrec(int kdindex, int axis) {
 			}
 
 			newaxis = axis + 1;
-			
+
 			if (newaxis >= 3) {
 				newaxis = 0;
 			}
@@ -365,15 +364,13 @@ inline void PointColDetector::queryrec(int kdindex, int axis) {
 
 void PointColDetector::build_kdtree(int begin, int end, int axis, int index) {
 	int median;
-	for (;;)
-	{
-		int slice_size = end-begin;
+	for (;;) {
+		int slice_size = end - begin;
 		if (slice_size != 1) {
 			if (slice_size == 2) {
 				median = begin + 1;
 
-				if (ref_list[begin].point[axis] > ref_list[median].point[axis])
-				{
+				if (ref_list[begin].point[axis] > ref_list[median].point[axis]) {
 					std::swap(ref_list[begin],ref_list[median]);
 				}
 
@@ -390,15 +387,15 @@ void PointColDetector::build_kdtree(int begin, int end, int axis, int index) {
 
 			axis++;
 
-			if (axis==3) {
-				axis=0;
+			if (axis == 3) {
+				axis = 0;
 			}
 
 			int newindex = index + index + 1;
 			build_kdtree(begin, median, axis, newindex);
 
 			//Tail cutting
-			index = newindex+1;
+			index = newindex + 1;
 			begin = median;
 		}
 		else {
@@ -427,28 +424,28 @@ void PointColDetector::build_kdtree_incr(int axis, int index)
 				std::swap(ref_list[begin], ref_list[median]);
 			}
 
-			kdtree[index].min=ref_list[begin].point[axis];
-			kdtree[index].max=ref_list[median].point[axis];
-			kdtree[index].middle=kdtree[index].max;
-			kdtree[index].ref=NULL;
+			kdtree[index].min = ref_list[begin].point[axis];
+			kdtree[index].max = ref_list[median].point[axis];
+			kdtree[index].middle = kdtree[index].max;
+			kdtree[index].ref = NULL;
 
 			axis++;
 			if (axis >= 3) {
 				axis = 0;
 			}
 
-			kdtree[newindex].ref=&ref_list[begin];
-			kdtree[newindex].middle=kdtree[newindex].ref->point[axis];
-			kdtree[newindex].min=kdtree[newindex].middle;
-			kdtree[newindex].max=kdtree[newindex].middle;
-			kdtree[newindex].end=median;
+			kdtree[newindex].ref = &ref_list[begin];
+			kdtree[newindex].middle = kdtree[newindex].ref->point[axis];
+			kdtree[newindex].min = kdtree[newindex].middle;
+			kdtree[newindex].max = kdtree[newindex].middle;
+			kdtree[newindex].end = median;
 			newindex++;
 
-			kdtree[newindex].ref=&ref_list[median];
-			kdtree[newindex].middle=kdtree[newindex].ref->point[axis];
-			kdtree[newindex].min=kdtree[newindex].middle;
-			kdtree[newindex].max=kdtree[newindex].middle;
-			kdtree[newindex].end=end;
+			kdtree[newindex].ref = &ref_list[median];
+			kdtree[newindex].middle = kdtree[newindex].ref->point[axis];
+			kdtree[newindex].min = kdtree[newindex].middle;
+			kdtree[newindex].max = kdtree[newindex].middle;
+			kdtree[newindex].end = end;
 			return;
 		}
 		else {
@@ -456,15 +453,15 @@ void PointColDetector::build_kdtree_incr(int axis, int index)
 			partintwo(begin, median, end, axis, kdtree[index].min, kdtree[index].max);
 		}
 
-		kdtree[index].middle=ref_list[median].point[axis];
-		kdtree[index].ref=NULL;
+		kdtree[index].middle = ref_list[median].point[axis];
+		kdtree[index].ref = NULL;
 
-		kdtree[newindex].begin=begin;
-		kdtree[newindex].end=-median;
+		kdtree[newindex].begin = begin;
+		kdtree[newindex].end = -median;
 
 		newindex++;
-		kdtree[newindex].begin=median;
-		kdtree[newindex].end=-end;
+		kdtree[newindex].begin = median;
+		kdtree[newindex].end = -end;
 
 	}
 	else {
@@ -478,7 +475,6 @@ void PointColDetector::build_kdtree_incr(int axis, int index)
 void PointColDetector::partintwo(const int start, const int median, const int end, const int axis, float &minex, float &maxex)
 {
 	int i, j, l, m;
-	refelem_t t;
 	int k = median;
 	l = start;
 	m = end - 1;
@@ -496,9 +492,6 @@ void PointColDetector::partintwo(const int start, const int median, const int en
 			}
 
 			std::swap(ref_list[i], ref_list[j]);
-			// t = ref_list[i];
-			// ref_list[i] = ref_list[j];
-			// ref_list[j] = t;
 			i++;
 			j--;
 		}
@@ -514,9 +507,13 @@ void PointColDetector::partintwo(const int start, const int median, const int en
 	minex = x;
 	maxex = x;
 	for (i = start; i < median; ++i) {
-		if (ref_list[i].point[axis] < minex) minex = ref_list[i].point[axis];
+		if (ref_list[i].point[axis] < minex) {
+			minex = ref_list[i].point[axis];
+		}
 	}
 	for (i = median+1; i < end; ++i) {
-		if (ref_list[i].point[axis] > maxex) maxex = ref_list[i].point[axis];
+		if (ref_list[i].point[axis] > maxex) {
+			maxex = ref_list[i].point[axis];
+		}
 	}
 }

--- a/source/main/physics/collision/PointColDetector.h
+++ b/source/main/physics/collision/PointColDetector.h
@@ -50,8 +50,8 @@ public:
 	void querybb(const Ogre::Vector3 &bmin, const Ogre::Vector3 &bmax);
 	void query(const Ogre::Vector3 &vec1, const Ogre::Vector3 &vec2, const Ogre::Vector3 &vec3, float enlargeBB=0.0f);
 	void query(const Ogre::Vector3 &vec1, const Ogre::Vector3 &vec2, const float enlargeBB=0.0f);
-	inline void calc_bounding_box(Ogre::Vector3 &bmin, Ogre::Vector3 &bmax, const Ogre::Vector3 &vec1, const Ogre::Vector3 &vec2, const Ogre::Vector3 &vec3, const float enlargeBB=0.0f);
-	inline void calc_bounding_box(Ogre::Vector3 &bmin, Ogre::Vector3 &bmax, const Ogre::Vector3 &vec1, const Ogre::Vector3 &vec2, const float enlargeBB=0.0f);
+	void calc_bounding_box(Ogre::Vector3 &bmin, Ogre::Vector3 &bmax, const Ogre::Vector3 &vec1, const Ogre::Vector3 &vec2, const Ogre::Vector3 &vec3, const float enlargeBB=0.0f);
+	void calc_bounding_box(Ogre::Vector3 &bmin, Ogre::Vector3 &bmax, const Ogre::Vector3 &vec1, const Ogre::Vector3 &vec2, const float enlargeBB=0.0f);
 
 private:
 
@@ -70,12 +70,12 @@ private:
 	} kdnode_t;
 
 	int object_list_size;
-	refelem_t *ref_list;
-	pointid_t *pointid_list;
+	std::vector< refelem_t > ref_list;
+	std::vector< pointid_t > pointid_list;
 	std::vector< kdnode_t > kdtree;
 	Ogre::Vector3 bbmin;
 	Ogre::Vector3 bbmax;
-	inline void queryrec(int kdindex, int axis);
+	void queryrec(int kdindex, int axis);
 	void build_kdtree(int begin, int end, int axis, int index);
 	void build_kdtree_incr(int axis, int index);
 	void partintwo(const int start, const int median, const int end, const int axis, float &minex, float &maxex);


### PR DESCRIPTION
This PR cleans up mechanism of ref list storage by replacing dynamic arrays with std::vector. Moreover, the lists are persistant now, which (eliminates race condition?) fixes #160.