### PR TITLE
revert links to documentation to old infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ bin/RelWithDebInfo/
 ror-dependencies-*.zip
 dependencies-*.zip
 _build
+0_build
 libangelscript_addons*.a

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,5 @@
 # Building instructions
-Please refer to https://rigsofrods.github.io/en/docs/index.html
+Please refer to http://www.rigsofrods.com/wiki/pages/Compiling_Sources
 
 ## CMake options
 ##### Rigs of Rods core:  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ e.g. screenshot of graphical glitch
 
 ### Setup
 * Fork, then clone the repository
-* Set up your development environment, help may be found [here][docindex]
+* Set up your development environment, help may be found [here][compile]
 * Make sure Rigs of Rods runs properly before doing any changes
 
 ### Applying changes
@@ -60,12 +60,11 @@ e.g. screenshot of graphical glitch
 * At this point you're waiting on us. We may suggest changes, improvements or alternatives
 
 #### Additional links:
-* [Documentation index][docindex]
 * [Developer Wiki Portal][devwiki]
 * [Doxygen documentation][doxy]
 
-[docindex]: https://rigsofrods.github.io/en/docs
-[style]: https://rigsofrods.github.io/en/docs/coding-style
-[commit]: https://rigsofrods.github.io/en/docs/commit-style
+[compile]: http://www.rigsofrods.com/wiki/pages/Compiling_Sources
+[style]: http://www.rigsofrods.com/wiki/pages/Coding_style
+[commit]: http://www.rigsofrods.com/wiki/pages/Commit_style
 [devwiki]: http://www.rigsofrods.com/wiki/pages/Developer_Wiki_Portal
 [doxy]: http://ror.ezzg.be/docs/

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Build Status](https://travis-ci.org/RigsOfRods/rigs-of-rods.png?branch=master)](https://travis-ci.org/RigsOfRods/rigs-of-rods)
 [![Join the chat at https://gitter.im/RigsOfRods/rigs-of-rods](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/RigsOfRods/rigs-of-rods?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Rigs of Rods is a free/libre soft-body physics simulator mainly targeted at simulating vehicle physics. The soft-body physics system is based on mass-spring-damper theory.
-For a simple overview of the features Rigs of Rods provides please refer to [doc/Things you can do in Rigs of Rods.pdf](doc/Things you can do in Rigs of Rods.pdf)
+Rigs of Rods is a free/libre soft-body physics simulator mainly targeted at simulating vehicle physics. The soft-body physics system is based on mass-spring-damper theory.  
+For a simple overview of the features Rigs of Rods provides please refer to [doc/Things you can do in Rigs of Rods.pdf](doc/Things you can do in Rigs of Rods.pdf)  
 
 #### Trailer:
 
@@ -17,41 +17,41 @@ For a simple overview of the features Rigs of Rods provides please refer to [doc
 
 
 ## Further documentation
-* Website: https://rigsofrods.github.io/
-* Wiki: https://rigsofrods.github.io/en/docs
+* Website: http://www.rigsofrods.com/
+* Wiki: http://www.rigsofrods.com/wiki/
+* Developer Wiki: http://www.rigsofrods.com/wiki/pages/Developer_Wiki_Portal
 * Forum: http://www.rigsofrods.com/forum/
 * Mod Repository: http://www.rigsofrods.com/repository/
 * Github: https://github.com/RigsOfRods/rigs-of-rods
-* Dev Chat: https://gitter.im/RigsOfRods/rigs-of-rods
 * IRC: #rigsofrods and #rigsofrods-dev on irc.freenode.net
 * [doc/](doc/)
 
 
 ## Paths
-$bin  - compiled binaries
-$res  - resources/assets for the game
-$user - user-created mods, configuration files, logs, screenshots
+$bin  - compiled binaries  
+$res  - resources/assets for the game  
+$user - user-created mods, configuration files, logs, screenshots  
 
-Windows:
-$bin   = source\bin
-$res   = source\bin\resources
-$user  = MyDocuments\Rigs of Rods
+Windows:  
+$bin   = source\bin  
+$res   = source\bin\resources  
+$user  = MyDocuments\Rigs of Rods  
 
-Linux:
-$bin    = source/bin
-$res    = source/bin/resources
-$user   = ~/.rigsofrods
+Linux:  
+$bin    = source/bin  
+$res    = source/bin/resources  
+$user   = ~/.rigsofrods  
 
-OS X:
-$bin    = source/bin
-$res    = source/bin/resources
-$user   = ~/.rigsofrods
+OS X:  
+$bin    = source/bin  
+$res    = source/bin/resources  
+$user   = ~/.rigsofrods  
 
 
 ## Controls
-Available commands depend on the vehicle you are in. For a graphical overview refer to [doc/keysheet.pdf](doc/keysheet.pdf)
-For an indepth view refer to ```$user/.rigsofrods/config/input.map```
-Please note that certain vehicles come with their own specific commands not represented in the above sources. In this case see the vehicle's documentation or go to Menu -> Simulation -> Show vehicle description.
+Available commands depend on the vehicle you are in. For a graphical overview refer to [doc/keysheet.pdf](doc/keysheet.pdf)  
+For an indepth view refer to ``` $user/.rigsofrods/config/input.map ```  
+Please note that certain vehicles come with their own specific commands not represented in the above sources. In this case see the vehicle's documentation or go to Menu -> Simulation -> Show vehicle description.  
 Rigs is Rods can also be played with Gamepads, Joysticks, Wheels and other controllers, including support for Force Feedback.
 
 ##### Basic controls:  
@@ -75,13 +75,13 @@ Rigs is Rods can also be played with Gamepads, Joysticks, Wheels and other contr
  
  
 ## Content/Mods
-Rigs of Rods only comes with a very small selection of vehicles and terrains. For the best experience download some mods from the [Rigs of Rods Mod Repository](http://www.rigsofrods.com/repository/). The [Showroom Subforum](http://www.rigsofrods.com/forums/103-Showrooms-and-WIP) may contain additional content not found in the Mod Repository.
+Rigs of Rods only comes with a very small selection of vehicles and terrains. For the best experience download some mods from the [Rigs of Rods Mod Repository](http://www.rigsofrods.com/repository/). The [Showroom Subforum](http://www.rigsofrods.com/forums/103-Showrooms-and-WIP) may contain additional content not found in the Mod Repository.  
 If you want to get going quickly have a look at modpacks which can be found in the Mod Repository as well.
 
 
 ## Configuration files
-- Default location:
-    ```$user/config/*```
+- Default location:  
+    ``` $user/config/* ```
 - They are created by RoRConfig on first use
 
 
@@ -89,16 +89,16 @@ If you want to get going quickly have a look at modpacks which can be found in t
 
 * -map \<mapname\>
     * loads map \<mapname\> on startup. Example:
-        * ```RoR.exe -map aspen```
+        * ``` RoR.exe -map aspen ```
     * note: do not add .terrn file format extension
 * -truck \<truckfile\>
     * loads a truck on startup. Example: 
-        * ```RoR.exe -map oahu -truck semi.truck```
-        * ```RoR.exe -map oahu -truck an-12.airplane```
+        * ``` RoR.exe -map oahu -truck semi.truck ```
+        * ``` RoR.exe -map oahu -truck an-12.airplane ```
 * -enter
     * enter selected truck by -truck option on startup
 * -setup 
-    * displays OGRE settings dialog instead of loading settings from ogre.cfg 
+    * displays OGRE3D settings dialog instead of loading settings from ogre.cfg 
 * -help
     * displays help for command line arguments
 
@@ -109,8 +109,8 @@ For instructions refer to [BUILDING.md](BUILDING.md)
 
 ## License of Rigs of Rods
 
-Copyright (c) 2005-2013 Pierre-Michel Ricordel
-Copyright (c) 2007-2013 Thomas Fischer
+Copyright (c) 2005-2013 Pierre-Michel Ricordel  
+Copyright (c) 2007-2013 Thomas Fischer  
 Copyright (c) 2009-2015 Rigs of Rods Contributors
 
 Rigs of Rods went open source under GPLv2 or later on the 8th of February, 2009.

--- a/bin/resources/scripts/races.as
+++ b/bin/resources/scripts/races.as
@@ -1,32 +1,36 @@
-// Hi,
-// 
-// You've found your way to the race system of Rigs of Rods.
-// 
-// If you are looking for more information on how to use this
-// class or what arguments should be given to certain functions,
-// please visit https://rigsofrods.github.io/en/docs/
-// 
-// If you are looking for examples on how to use this class,
-// please look at the scripting files of other terrains or
-// search the forum.
-// 
-// If you have questions that cannot be answerred using the
-// methods mentioned above, then please ask your question in
-// the scripting section of the Rigs of Rods forum:
-// http://www.rigsofrods.com/forums/167-Scripting
-// 
-// This class was designed to be as simple as possible for
-// normal users, while being as flexible as possible for
-// advanced users.
-// If you're here because this class doesn't provide the
-// functionality that you need for your terrain, then try
-// to improve the class and submit your additions using
-// the issue tracker of Rigs of Rods.
-// http://github.com/RigsOfRods/rigs-of-rods/issues
-// 
-// Don't forget to increase the version numbers after every
-// edit! (racesManager::raceManagerVersion and
-// raceBuilder::raceBuilderVersion)
+/*
+Hi,
+
+You've found your way to the race system of Rigs of Rods.
+
+If you are looking for more information on how to use this
+class or what arguments should be given to certain functions,
+please visit http://docs.rigsofrods.com/
+
+If you are looking for examples on how to use this class,
+please look at the scripting files of other terrains or
+search the forum.
+
+If you have questions that cannot be answerred using the
+methods mentioned above, then please ask your question in
+the scripting section of the Rigs of Rods forum:
+http://www.rigsofrods.com/forums/167-Scripting
+
+This class was designed to be as simple as possible for
+normal users, while being as flexible as possible for
+advanced users.
+If you're here because this class doesn't provide the
+functionality that you need for your terrain, then try
+to improve the class and submit your additions using
+the issue tracker of Rigs of Rods.
+http://redmine.rigsofrods.com
+
+Don't forget to increase the version numbers after every
+edit! (racesManager::raceManagerVersion and
+raceBuilder::raceBuilderVersion)
+
+-- neorej16
+*/
 
 // Define a function signature for the callback pointers
 funcdef void RACE_EVENT_CALLBACK(dictionary@);

--- a/source/main/gfx/OgreSubsystem.cpp
+++ b/source/main/gfx/OgreSubsystem.cpp
@@ -154,7 +154,7 @@ bool OgreSubsystem::StartOgre(Ogre::String const & name, Ogre::String const & hw
 	} 
 	catch(Ogre::Exception& e)
 	{
-		Ogre::String url = "https://rigsofrods.github.io/en/docs/errors/index.html#" + TOSTRING(e.getNumber());
+		Ogre::String url = "http://wiki.rigsofrods.com/index.php?title=Error_" + TOSTRING(e.getNumber())+"#"+e.getSource();
 		ErrorUtils::ShowOgreWebError(_L("A fatal exception has occured!"), ANSI_TO_UTF(e.getFullDescription()), ANSI_TO_UTF(url));
 		ErrorUtils::ShowStoredOgreWebErrors();
 		exit(1);

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -145,7 +145,7 @@ int OverlayWrapper::init()
 		directionArrowText = (TextAreaOverlayElement*)loadOverlayElement("tracks/DirectionArrow/Text");
 	} catch(...)
 	{
-		String url = "https://rigsofrods.github.io/en/docs/errors/index.html#Error_Resources_Not_Found";
+		String url = "http://wiki.rigsofrods.com/index.php?title=Error_Resources_Not_Found";
 		ErrorUtils::ShowOgreWebError("Resources not found!", "please ensure that your installation is complete and the resources are installed properly. If this error persists please re-install RoR.", url);
 	}
 	directionArrowDistance = (TextAreaOverlayElement*)loadOverlayElement("tracks/DirectionArrow/Distance");

--- a/source/main/main_sim/main.cpp
+++ b/source/main/main_sim/main.cpp
@@ -331,7 +331,7 @@ int main(int argc, char *argv[])
 	} 
 	catch (Ogre::Exception& e)
 	{
-		String url = "https://rigsofrods.github.io/en/docs/errors/index.html#" + TOSTRING(e.getNumber());
+		String url = "http://wiki.rigsofrods.com/index.php?title=Error_" + TOSTRING(e.getNumber())+"#"+e.getSource();
 		ErrorUtils::ShowOgreWebError(_L("An exception has occured!"), e.getFullDescription(), url);
 	}
 	catch (std::runtime_error& e)

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -231,7 +231,7 @@ int Collisions::loadGroundModelsConfigFile(Ogre::String filename)
 	if (this->collision_version != LATEST_GROUND_MODEL_VERSION)
 	{
 		// message box
-		String url = "https://rigsofrods.github.io/en/docs/errors/index.html#Error_Old_ground_model";
+		String url = "http://wiki.rigsofrods.com/index.php?title=Error_Old_ground_model#"+TOSTRING(this->collision_version)+"to"+TOSTRING(LATEST_GROUND_MODEL_VERSION);
 		ErrorUtils::ShowOgreWebError(_L("Configuration error"), _L("Your ground configuration is too old, please copy skeleton/config/ground_models.cfg to My Documents/Rigs of Rods/config"), url);
 		ErrorUtils::ShowStoredOgreWebErrors();
 		exit(124);


### PR DESCRIPTION
revert links to documentation to old infrastructure as the "new" docs section is now obsolete