### PR TITLE
Bugfixes

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1537,11 +1537,11 @@ bool Beam::frameStep(Real dt)
 	if (mTimeUntilNextToggle > -1)
 		mTimeUntilNextToggle -= dt;
 	
-	dt += dt_rounding_loss;
+	dt += m_dt_remainder;
 
 	int steps = dt / PHYSICS_DT;
 
-	dt_rounding_loss = dt - (steps * PHYSICS_DT);
+	m_dt_remainder = dt - (steps * PHYSICS_DT);
 
 	// TODO: move this to the correct spot
 	// update all dashboards
@@ -6052,7 +6052,6 @@ Beam::Beam(
 	, disableDrag(false)
 	, disableTruckTruckCollisions(false)
 	, disableTruckTruckSelfCollisions(false)
-	, dt_rounding_loss(0.0)
 	, elevator(0)
 	, flap(0)
 	, floating_origin_enable(true)
@@ -6079,6 +6078,7 @@ Beam::Beam(
 	, lockSkeletonchange(false)
 	, locked(0)
 	, lockedold(0)
+	, m_dt_remainder(0.0)
 	, mTimeUntilNextToggle(0)
 	, meshesVisible(true)
 	, minCameraRadius(0)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2722,6 +2722,20 @@ void Beam::interTruckCollisionsCompute(Real dt, int chunk_index /*= 0*/, int chu
 				, na->AbsPosition
 				, nb->AbsPosition, trwidth*distance);
 
+			if (interPointCD[chunk_index]->hit_count > 0)
+			{
+				//calculate transform matrices
+				bx=na->RelPosition;
+				by=nb->RelPosition;
+				bx-=no->RelPosition;
+				by-=no->RelPosition;
+				bz=bx.crossProduct(by);
+				bz.normalise();
+				//coordinates change matrix
+				forward.FromAxes(bx,by,bz);
+				forward=forward.Inverse();
+			}
+
 			trucks[t]->inter_collcabrate[i].calcforward=true;
 			for (int h=0; h<interPointCD[chunk_index]->hit_count; h++)
 			{
@@ -2734,29 +2748,14 @@ void Beam::interTruckCollisionsCompute(Real dt, int chunk_index /*= 0*/, int chu
 
 				hittruck=trucks[hittruckid];
 
-				//calculate transform matrices
-				if (trucks[t]->inter_collcabrate[i].calcforward)
-				{
-					trucks[t]->inter_collcabrate[i].calcforward=false;
-					bx=na->RelPosition;
-					by=nb->RelPosition;
-					bx-=no->RelPosition;
-					by-=no->RelPosition;
-					bz=bx.crossProduct(by);
-					bz=fast_normalise(bz);
-					//coordinates change matrix
-					forward.SetColumn(0, bx);
-					forward.SetColumn(1, by);
-					forward.SetColumn(2, bz);
-					forward=forward.Inverse();
-				}
-
 				//change coordinates
 				point=forward*(hitnode->AbsPosition-no->AbsPosition);
 
 				//test
 				if (point.x>=0 && point.y>=0 && (point.x+point.y)<=1.0 && point.z<=trwidth && point.z>=-trwidth)
 				{
+					trucks[t]->inter_collcabrate[i].calcforward=false;
+
 					//collision
 					plnormal=bz;
 
@@ -2933,7 +2932,20 @@ void Beam::intraTruckCollisionsCompute(Real dt, int chunk_index /*= 0*/, int chu
 			, na->AbsPosition
 			, nb->AbsPosition, trwidth);
 
-		bool calcforward=true;
+		if (intraPointCD[chunk_index]->hit_count > 0)
+		{
+			//calculate transform matrices
+			bx=na->RelPosition;
+			by=nb->RelPosition;
+			bx-=no->RelPosition;
+			by-=no->RelPosition;
+			bz =bx.crossProduct(by);
+			bz.normalise();
+			//coordinates change matrix
+			forward.FromAxes(bx,by,bz);
+			forward=forward.Inverse();
+		}
+
 		intra_collcabrate[i].calcforward=true;
 		for (int h=0; h<intraPointCD[chunk_index]->hit_count;h++)
 		{
@@ -2944,23 +2956,6 @@ void Beam::intraTruckCollisionsCompute(Real dt, int chunk_index /*= 0*/, int chu
 			//if (hitnode->iswheel && !(trucks[t]->requires_wheel_contact)) continue;
 			if (hitnode->iswheel) continue;
 			if (no==hitnode || na==hitnode || nb==hitnode) continue;
-
-			//calculate transform matrices
-			if (calcforward)
-			{
-				calcforward=false;
-				bx=na->RelPosition;
-				by=nb->RelPosition;
-				bx-=no->RelPosition;
-				by-=no->RelPosition;
-				bz=bx.crossProduct(by);
-				bz=fast_normalise(bz);
-				//coordinates change matrix
-				forward.SetColumn(0, bx);
-				forward.SetColumn(1, by);
-				forward.SetColumn(2, bz);
-				forward=forward.Inverse();
-			}
 
 			//change coordinates
 			point = forward * (hitnode->AbsPosition - no->AbsPosition);

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2684,6 +2684,7 @@ void Beam::interTruckCollisionsCompute(Real dt, int chunk_index /*= 0*/, int chu
 
 	for (int t=0; t<numtrucks; t++)
 	{
+		if (t % chunk_number != chunk_index) continue;
 		//If you change any of the below "ifs" concerning trucks then you should
 		//also consider changing the parallel "ifs" inside PointColDetector
 		//see "pointCD" above.
@@ -2692,15 +2693,7 @@ void Beam::interTruckCollisionsCompute(Real dt, int chunk_index /*= 0*/, int chu
 
 		trwidth=trucks[t]->collrange;
 
-		int chunk_size = trucks[t]->free_collcab / chunk_number;
-		int end_index = (chunk_index+1)*chunk_size;
-
-		if (chunk_index+1 == chunk_number)
-		{
-			end_index = trucks[t]->free_collcab;
-		}
-
-		for (int i=chunk_index*chunk_size; i<end_index; i++)
+		for (int i=0; i<trucks[t]->free_collcab; i++)
 		{
 			trucks[t]->inter_collcabrate[i].update=true;
 			if (trucks[t]->inter_collcabrate[i].rate>0)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -587,8 +587,8 @@ protected:
 
 	void SetPropsCastShadows(bool do_cast_shadows);
 
-	// Simulation time lost, due to rounding errors
-	float dt_rounding_loss;
+	// Keeps track of the rounding error in the time step calculation
+	float m_dt_remainder;
 
 	float dtperstep;
 	int curtstep;

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -587,6 +587,9 @@ protected:
 
 	void SetPropsCastShadows(bool do_cast_shadows);
 
+	// Simulation time lost, due to rounding errors
+	float dt_rounding_loss;
+
 	float dtperstep;
 	int curtstep;
 	int tsteps;

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -122,9 +122,10 @@ BeamFactory::BeamFactory() :
 			} else if (num_cpu_cores > 2)
 			{
 				// Use default settings
-				gEnv->threadPool = new ThreadPool(num_cpu_cores);
-				beamThreadPool   = new ThreadPool(num_cpu_cores);
-				LOG("BEAMFACTORY: Creating: " + TOSTRING(num_cpu_cores) + " threads");
+				int num_threads = ceil(num_cpu_cores / 2);
+				gEnv->threadPool = new ThreadPool(num_threads);
+				beamThreadPool   = new ThreadPool(num_threads);
+				LOG("BEAMFACTORY: Creating: " + TOSTRING(num_threads) + " threads");
 			}
 		}
 

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -62,29 +62,64 @@ template<> BeamFactory *StreamableFactory < BeamFactory, Beam >::_instance = 0;
 int simulatedTruck;
 void* threadstart(void* vid);
 
-static unsigned hardware_concurrency()
+void cpuID(unsigned i, unsigned regs[4]) {
+#ifdef _WIN32
+	__cpuid((int *)regs, (int)i);
+#else
+	asm volatile
+		("cpuid" : "=a" (regs[0]), "=b" (regs[1]), "=c" (regs[2]), "=d" (regs[3])
+		 : "a" (i), "c" (0));
+#endif
+}
+
+unsigned int getNumberOfCPUCores()
 {
-	#if defined(PTW32_VERSION) || defined(__hpux)
-		return pthread_num_processors_np();
-	#elif defined(_GNU_SOURCE)
-		return get_nprocs();
-	#elif defined(__APPLE__) || defined(__FreeBSD__)
-		int count;
-		size_t size = sizeof(count);
-		return sysctlbyname("hw.ncpu", &count, &size, NULL, 0) ? 0 : count;
-	#elif defined(BOOST_HAS_UNISTD_H) && defined(_SC_NPROCESSORS_ONLN)
-		int const count = sysconf(_SC_NPROCESSORS_ONLN);
-		return (count > 0) ? count : 0;
-	#else
-		return 0;
-	#endif
-} 
+	unsigned regs[4];
+
+	// Get CPU vendor
+	char vendor[12];
+	cpuID(0, regs);
+	((unsigned *)vendor)[0] = regs[1]; // EBX
+	((unsigned *)vendor)[1] = regs[3]; // EDX
+	((unsigned *)vendor)[2] = regs[2]; // ECX
+	std::string cpuVendor = std::string(vendor, 12);
+
+	// Get CPU features
+	cpuID(1, regs);
+	unsigned cpuFeatures = regs[3]; // EDX
+
+	// Logical core count per CPU
+	cpuID(1, regs);
+	unsigned logical = (regs[1] >> 16) & 0xff; // EBX[23:16]
+	unsigned cores = logical;
+
+	if (cpuVendor == "GenuineIntel")
+	{
+		// Get DCP cache info
+		cpuID(4, regs);
+		cores = ((regs[0] >> 26) & 0x3f) + 1; // EAX[31:26] + 1
+	} else if (cpuVendor == "AuthenticAMD")
+	{
+		// Get NC: Number of CPU cores - 1
+		cpuID(0x80000008, regs);
+		cores = ((unsigned)(regs[2] & 0xff)) + 1; // ECX[7:0] + 1
+	}
+
+	// Detect hyper-threads  
+	bool hyperThreads = cpuFeatures & (1 << 28) && cores < logical;
+
+	LOG("BEAMFACTORY: " + TOSTRING(logical) + " Logical CPUs" + " found");
+	LOG("BEAMFACTORY: " + TOSTRING(cores) + " CPU Cores" + " found");
+	LOG("BEAMFACTORY: Hyper-Threading " + TOSTRING(hyperThreads));
+
+	return cores;
+}
 
 BeamFactory::BeamFactory() :
 	  current_truck(-1)
 	, forcedActive(false)
 	, free_truck(0)
-	, num_cpu_cores(hardware_concurrency())
+	, num_cpu_cores(getNumberOfCPUCores())
 	, physFrame(0)
 	, previous_truck(-1)
 	, tdr(0)
@@ -106,27 +141,24 @@ BeamFactory::BeamFactory() :
 
 	async_physics = BSETTING("AsynchronousPhysics", false);
 
-	LOG("BEAMFACTORY: " + TOSTRING(num_cpu_cores) + " CPU Core" + ((num_cpu_cores != 1) ? "s" : "") + " found");
-
 	// Create worker thread (used for physics calculations)
 	if (thread_mode == THREAD_MULTI)
 	{
-		if (!disableThreadPool)
+		if (num_cpu_cores < 2)
 		{
-			if (numThreadsInPool > 1 && num_cpu_cores > 1)
+			disableThreadPool = true;
+			LOG("BEAMFACTORY: ThreadPool disabled");
+		} else if (!disableThreadPool)
+		{
+			int threads = num_cpu_cores;
+			if (numThreadsInPool > 1)
 			{
 				// Use custom settings from RoR.cfg
-				gEnv->threadPool = new ThreadPool(numThreadsInPool);
-				beamThreadPool   = new ThreadPool(numThreadsInPool);
-				LOG("BEAMFACTORY: Creating: " + TOSTRING(numThreadsInPool) + " threads");
-			} else if (num_cpu_cores > 2)
-			{
-				// Use default settings
-				int num_threads = ceil(num_cpu_cores / 2);
-				gEnv->threadPool = new ThreadPool(num_threads);
-				beamThreadPool   = new ThreadPool(num_threads);
-				LOG("BEAMFACTORY: Creating: " + TOSTRING(num_threads) + " threads");
+				threads = numThreadsInPool;
 			}
+			gEnv->threadPool = new ThreadPool(threads);
+			beamThreadPool   = new ThreadPool(threads);
+			LOG("BEAMFACTORY: Creating " + TOSTRING(threads) + " threads");
 		}
 
 		pthread_cond_init(&thread_done_cv, NULL);


### PR DESCRIPTION
Fixes #1, #28 and improves #220:
- Replaces the variable physics time step with a fixed time step of 0.5 ms.
- Reduces the number of threads in the thread pool by half (only when Hyper-Threading is used).
- Corrects the "calcforward" logic in the inter truck collision code.
- Improves the efficiency of the multi-threaded inter truck collision code.
- Reverts this commit: https://github.com/RigsOfRods/rigs-of-rods/commit/d3ffea00e12c0f00aebf1e25ff20655cb6bef146