### PR TITLE
[Codechange] CMake flag update (UNIX)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,8 @@ if(WIN32)
 
 ELSEIF(UNIX)
   set(CMAKE_CXX_FLAGS                       "-std=c++11 ${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS_DEBUG                 "${CMAKE_CXX_FLAGS_DEBUG}          -Og -g -Wall")
-  set(CMAKE_CXX_FLAGS_RELEASE               "${CMAKE_CXX_FLAGS_RELEASE}        -O2 -ffast-math -DNDEBUG")
+  set(CMAKE_CXX_FLAGS_DEBUG                 "${CMAKE_CXX_FLAGS_DEBUG}          -Og -g -Wall -Wno-deprecated-declarations")
+  set(CMAKE_CXX_FLAGS_RELEASE               "${CMAKE_CXX_FLAGS_RELEASE}        -O3 -ffast-math -DNDEBUG -Wno-deprecated-declarations")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO        "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -ffast-math -g")
   set(CMAKE_CXX_FLAGS_MINSIZEREL            "${CMAKE_CXX_FLAGS_MINSIZEREL}     -Os -ffast-math -DNDEBUG")
 


### PR DESCRIPTION
* Suppresses the excessive "Deprecated Ogre Function" warnings
* Enables -o3 for the release build