### PR TITLE
[Fix] CMake/UNIX: Build with Ogre 1.8

### DIFF
--- a/CMakeDependenciesConfig.txt
+++ b/CMakeDependenciesConfig.txt
@@ -178,7 +178,9 @@ ELSEIF(UNIX)
    # Ogre components
    PKG_CHECK_MODULES  (Ogre_Terrain  OGRE-Terrain         REQUIRED)
    PKG_CHECK_MODULES  (Ogre_Paging   OGRE-Paging          REQUIRED)
-   PKG_CHECK_MODULES  (Ogre_Overlay  OGRE-Overlay         REQUIRED)
+   if(NOT (Ogre_VERSION VERSION_LESS 1.9.0))
+	PKG_CHECK_MODULES  (Ogre_Overlay  OGRE-Overlay         REQUIRED)
+   endif()
    PKG_CHECK_MODULES  (Ogre_RTShader OGRE-RTShaderSystem  REQUIRED)
    
 


### PR DESCRIPTION
- allows to build RoR on older Linux distributions with only Ogre 1.8 in the repositories
- allows Intel GPU users to opt for Ogre 1.8 instead of Ogre 1.9, @tritonas00 told me Ogre 1.9 doesn't work as well with the Intel graphics driver