### PR TITLE
[Fix] Crash in Multiplayer due to out of bounds access

### DIFF
--- a/source/main/datatypes/rig_t.h
+++ b/source/main/datatypes/rig_t.h
@@ -207,7 +207,7 @@ struct rig_t
 	std::vector<Ogre::Entity*> deletion_Entities; //!< For unloading vehicle; filled at spawn.
 	std::vector<Ogre::MovableObject *> deletion_Objects; //!< For unloading vehicle; filled at spawn.
 	std::vector<Ogre::SceneNode*> deletion_sceneNodes; //!< For unloading vehicle; filled at spawn.
-	int netCustomLightArray[4];
+	unsigned int netCustomLightArray[4];
 	unsigned char netCustomLightArray_counter;
 	MaterialFunctionMapper *materialFunctionMapper;
 	bool ispolice;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -6618,28 +6618,31 @@ bool Beam::getBrakeLightVisible()
 
 bool Beam::getCustomLightVisible(int number)
 {
-	return netCustomLightArray[number] != -1
-			&& flares[netCustomLightArray[number]].controltoggle_status;
+	if (number < 0 || number > 4)
+	{
+		LOG("AngelScript: Invalid Light ID (" + TOSTRING(number) + "), allowed range is (0 - 4)");
+		return false;
+	}
+
+	unsigned int flareID = netCustomLightArray[number];
+
+	return flareID < flares.size() && flares[flareID].controltoggle_status;
 }
 
 void Beam::setCustomLightVisible(int number, bool visible)
 {
-	if (number >= 5)
+	if (number < 0 || number > 4)
 	{
-		LOG("AngelScript: Light ID (" + TOSTRING(number) + ") overflow, max: 4...");
+		LOG("AngelScript: Invalid Light ID (" + TOSTRING(number) + "), allowed range is (0 - 4)");
 		return;
 	}
 
-	try
+	unsigned int flareID = netCustomLightArray[number];
+
+	if (flareID < flares.size() && flares[flareID].snode)
 	{
-		if (flares[netCustomLightArray[number]].snode)
-			flares[netCustomLightArray[number]].controltoggle_status = visible;
+		flares[flareID].controltoggle_status = visible;
 	}
-	catch (Exception ex)
-	{
-	}
-	/*else
-		LOG("AngelScript: Light ID (" + TOSTRING(number) + ") doesn't exist, ignored...");*/
 }
 
 bool Beam::getBeaconMode() // Angelscript export

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -289,10 +289,10 @@ void RigSpawner::InitializeRig()
 	m_rig->cablightNode = nullptr;
 	m_rig->deletion_sceneNodes.clear();
 	m_rig->deletion_Objects.clear();
-	m_rig->netCustomLightArray[0] = -1;
-	m_rig->netCustomLightArray[1] = -1;
-	m_rig->netCustomLightArray[2] = -1;
-	m_rig->netCustomLightArray[3] = -1;
+	m_rig->netCustomLightArray[0] = UINT_MAX;
+	m_rig->netCustomLightArray[1] = UINT_MAX;
+	m_rig->netCustomLightArray[2] = UINT_MAX;
+	m_rig->netCustomLightArray[3] = UINT_MAX;
 	m_rig->netCustomLightArray_counter = 0;
 	m_rig->materialFunctionMapper = nullptr;
 


### PR DESCRIPTION
Fix flares out of bounds access detection.
Fixed in Beam::setCustomLightVisible and Beam::getCustomLightVisible.
This fix bug #459 