### PR TITLE
[Fix] Build without Angelscript

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -18,6 +18,7 @@ core requirements:
 optional but recommended:
 * angelscript: 2.22.1 
   * required for scripting (AI, racing, server mods...)
+  * when building without AS this has to be removed in resources/particles/water.particle: "affector FireExtinguisher {	effectiveness 	1 }"
 * caelum: >= 0.6.2, compatible with the OGRE version you chose 
   * sky plugin: provides dynamic sky with time of day, weather and clouds
 * mysocketw: latest from git

--- a/source/main/main_sim/MainThread.cpp
+++ b/source/main/main_sim/MainThread.cpp
@@ -60,7 +60,6 @@
 #include "RigEditor_Config.h"
 #include "RigEditor_Main.h"
 #include "RoRFrameListener.h"
-#include "ScriptEngine.h"
 #include "Scripting.h"
 #include "Settings.h"
 #include "Skin.h"
@@ -73,6 +72,10 @@
 
 #include <OgreRoot.h>
 #include <OgreString.h>
+
+#ifdef USE_ANGELSCRIPT
+#    include "ScriptEngine.h"
+#endif
 
 // Global instance of GlobalEnvironment used throughout the game.
 GlobalEnvironment *gEnv; 
@@ -237,7 +240,10 @@ void MainThread::Go()
 	// Create legacy RoRFrameListener
 
 	gEnv->frameListener = new RoRFrameListener();
+
+#ifdef USE_ANGELSCRIPT
 	ScriptEngine::getSingleton().SetFrameListener(gEnv->frameListener);
+#endif
 
 	gEnv->frameListener->enablePosStor = BSETTING("Position Storage", false);
 

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -25,7 +25,6 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "CacheSystem.h"
 #include "Collisions.h"
 #include "ErrorUtils.h"
-#include "ExtinguishableFireAffector.h"
 #include "Language.h"
 #include "LoadingWindow.h"
 #include "MeshObject.h"
@@ -43,6 +42,10 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <OgreRTShaderSystem.h>
 #include <OgreFontManager.h>
+
+#ifdef USE_ANGELSCRIPT
+#    include "ExtinguishableFireAffector.h"
+#endif // USE_ANGELSCRIPT
 
 using namespace Ogre;
 


### PR DESCRIPTION
* Fixes compiler errors when building without Angelscript (#534)
* Additionally, to avoid crashing when loading terrains, in resources/particles/water.particle this needs to be removed:
```
	affector FireExtinguisher
	{
		effectiveness 	1
	}
```