### PR TITLE
[Bugfix] Workaround to prevent crash during terrain loading

### DIFF
--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -189,7 +189,12 @@ void TerrainGeometryManager::initTerrain()
 		if (!disableCaching)
 		{
 			LoadingWindow::getSingleton().setProgress(23, _L("saving all terrain pages ..."));
-			mTerrainGroup->saveAllTerrains(false);
+			try
+			{
+				mTerrainGroup->saveAllTerrains(false);
+			} catch(...)
+			{
+			}
 		}
 	} else
 	{


### PR DESCRIPTION
> How to reproduce this crash?

```mTerrainGroup->saveAllTerrains(false);``` tries to save the  ```mapbin``` file next to the RoR binary.

It will fail if the user that runs RoR does not have write access on that folder.