### PR TITLE
MyGUI API changes to use getValue in 3.2.1.

### DIFF
--- a/source/main/RoRPrerequisites.h
+++ b/source/main/RoRPrerequisites.h
@@ -60,7 +60,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <MyGUI_Prerequest.h> // Forward declarations
 
-#if MYGUI_VERSION >= 0x030202
+#if MYGUI_VERSION >= 0x030201
 #	define MYGUI_GET_SCANCODE(KEY) (KEY.getValue())
 #else
 #	define MYGUI_GET_SCANCODE(KEY) (KEY.toValue())


### PR DESCRIPTION
RoR master will not build out of the box on Fedora 23.

### Steps to reproduce
1. Install MyGUI from the official repositories on Fedora 23. This is MyGUI 3.2.1.
2. Follow the steps to  build for Fedora on http://www.rigsofrods.com/wiki/pages/Compiling_Sources_under_Linux, using Fedora 23

### Expected behaviour
RoR should build

### Actual behaviour
RoR fails, due to defining `MYGUI_GET_SCANCODE(KEY)` to be `KEY.toValue()`, rather than `KEY.getValue()`

### System configuration
Fedora 23 64bit with Radeon R9 R390 and default open source device driver. Output of uname -a:

    Linux wotan.home.gateway 4.2.8-300.fc23.x86_64 #1 SMP Tue Dec 15 16:49:06 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux

### Additional information, logs and screenshots (optional)

Patch provided here. ChangeLog record

	* source/main/RoRPrerequisites.h: Definition for MYGUI_GET_SCANCODE
	should change on version 3.2.1.

**Note.** A number of further changes are needed to complete the compilation under Fedora. Further patches to follow: