### PR TITLE
[Fix] AS: Pass by value for Ogre types

### DIFF
--- a/source/main/scripting/OgreAngelscript.cpp
+++ b/source/main/scripting/OgreAngelscript.cpp
@@ -162,16 +162,16 @@ void registerOgreObjects(AngelScript::asIScriptEngine *engine)
 	// We start by registering some data types, so angelscript knows that they exist
 
 	// Ogre::Degree
-	r = engine->RegisterObjectType("degree", sizeof(Degree), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CA); MYASSERT( r >= 0 );
+	r = engine->RegisterObjectType("degree", sizeof(Degree), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CA | asOBJ_APP_CLASS_ALLFLOATS); MYASSERT( r >= 0 );
 
 	// Ogre::Radian
-	r = engine->RegisterObjectType("radian", sizeof(Radian), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CA); MYASSERT( r >= 0 );
+	r = engine->RegisterObjectType("radian", sizeof(Radian), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CA | asOBJ_APP_CLASS_ALLFLOATS); MYASSERT( r >= 0 );
 
 	// Ogre::Vector3
-	r = engine->RegisterObjectType("vector3", sizeof(Ogre::Vector3), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CA); MYASSERT( r >= 0 );
+	r = engine->RegisterObjectType("vector3", sizeof(Ogre::Vector3), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CA | asOBJ_APP_CLASS_ALLFLOATS); MYASSERT( r >= 0 );
 
 	// Ogre::Quaternion
-	r = engine->RegisterObjectType("quaternion", sizeof(Quaternion), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CA); MYASSERT( r >= 0 );
+	r = engine->RegisterObjectType("quaternion", sizeof(Quaternion), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CA | asOBJ_APP_CLASS_ALLFLOATS); MYASSERT( r >= 0 );
 	
 	registerOgreRadian(engine);
 	registerOgreDegree(engine);


### PR DESCRIPTION
> On Linux/amd64 with GNUC a class is treated very differently if the copy constructor is declared or not. A class with a copy constructor is always passed through a reference even when the function is declared to pass the type by value. When the copy constructor is not declared, the compiler will pass the type in the CPU registers instead, if the class is small enough. The real complicated part is that when the type is passed in the CPU registers, it is split up by the type of each member, so integer members are passed in the general purpose registers, and float members are passed in the floating point registers. This is why AngelScript doesn't allow these types to be passed by value, the implementation to support that in the native calling convention is just too difficult.

> I've added an additional flag asOBJ_APP_ALLFLOATS that when used with the registration of the Ogre::Vector3 should allow you to use this type in native functions without wrappers. It tells AngelScript that the class consists only of floats, and will thus allow AngelScript to know that the type is returned in the XMM registers instead of the general purpose registers  

\- A. Jonsson, AngelScript developer


* fixes #462 #174

Resources:
* https://plus.google.com/+OgitorOrg/posts/hVYL7BDDtf6
* http://www.ogre3d.org/forums/viewtopic.php?f=22&t=65876&sid=f6290f574ed0152ccfa06a2d3f1e60fb&start=25#p487284

thanks to @tritonas00 who made me aware of this issue.