### PR TITLE
[Codechange] Clearing out and reordering of the node_t members

### DIFF
--- a/source/main/datatypes/beam_t.h
+++ b/source/main/datatypes/beam_t.h
@@ -14,18 +14,17 @@
 */
 struct beam_t
 {
-	Ogre::SceneNode *mSceneNode; //!< visual
-	Ogre::Entity *mEntity; //!< visual
-
 	node_t *p1;
 	node_t *p2;
 	Beam *p2truck; //!< in case p2 is on another truck
-	shock_t *shock;
-
+	bool disabled;
 	Ogre::Real k; //!< tensile spring
 	Ogre::Real d; //!< damping factor
 	Ogre::Real L; //!< length
 	Ogre::Real minmaxposnegstress;
+
+	//! Beam type (unnamed enum) { BEAM_NORMAL=0, BEAM_HYDRO=1, BEAM_VIRTUAL=2, BEAM_MARKED=3, BEAM_INVISIBLE=4, BEAM_INVISIBLE_HYDRO=5 }
+	int type;
 
 	Ogre::Real maxposstress;
 	Ogre::Real maxnegstress;
@@ -34,11 +33,17 @@ struct beam_t
 	Ogre::Real strength;
 	Ogre::Real stress;
 
+	//! Values (unnamed enum) { SHOCK1=1, SHOCK2=2, SUPPORTBEAM=3, ROPE=4 }
+	int bounded;
+
+	bool broken;
 	Ogre::Real plastic_coef;
 	Ogre::Real refL;       //!< reference length
 	Ogre::Real Lhydro;     //!< hydro reference len
 	Ogre::Real hydroRatio; //!< hydro rotation ratio
-
+	int hydroFlags;
+	int animFlags;
+	float animOption;
 	Ogre::Real commandRatioLong;
 	Ogre::Real commandRatioShort;
 	Ogre::Real commandShort; //<! Max. contraction; proportional to orig. length
@@ -46,30 +51,20 @@ struct beam_t
 	Ogre::Real commandEngineCoupling;
 	Ogre::Real maxtiestress;
 	Ogre::Real diameter;
+	bool commandNeedsEngine;
+	int detacher_group;	//!< Attribute: detacher group number (integer)
+	bool isCentering;
+	int isOnePressMode;
+	bool isForceRestricted;
+	float iStrength; //!< initial strength
 	Ogre::Real default_deform;
 	Ogre::Real default_plastic_coef;
-
-	float animOption;
-	float centerLength;
-	float iStrength; //!< initial strength
-	float scale;
-
-	//! Values (unnamed enum) { SHOCK1=1, SHOCK2=2, SUPPORTBEAM=3, ROPE=4 }
-	int bounded;
-	//! Beam type (unnamed enum) { BEAM_NORMAL=0, BEAM_HYDRO=1, BEAM_VIRTUAL=2, BEAM_MARKED=3, BEAM_INVISIBLE=4, BEAM_INVISIBLE_HYDRO=5 }
-	int type;
-	int hydroFlags;
-	int animFlags;
 	int autoMovingMode;
-	int detacher_group;	//!< Attribute: detacher group number (integer)
-	int isOnePressMode;
-
 	bool autoMoveLock;
-	bool commandNeedsEngine;
-	bool isCentering;
-	bool isForceRestricted;
 	bool pressedCenterMode;
-
-	bool disabled;
-	bool broken;
+	float centerLength;
+	float scale;
+	shock_t *shock;
+	Ogre::SceneNode *mSceneNode; //!< visual
+	Ogre::Entity *mEntity; //!< visual
 };

--- a/source/main/datatypes/beam_t.h
+++ b/source/main/datatypes/beam_t.h
@@ -9,24 +9,23 @@
 
 #include <OgrePrerequisites.h>
 
-#include "RoRPrerequisites.h"
-
 /**
 * SIM-CORE; Beam data.
 */
 struct beam_t
 {
+	Ogre::SceneNode *mSceneNode; //!< visual
+	Ogre::Entity *mEntity; //!< visual
+
 	node_t *p1;
 	node_t *p2;
 	Beam *p2truck; //!< in case p2 is on another truck
-	bool disabled;
+	shock_t *shock;
+
 	Ogre::Real k; //!< tensile spring
 	Ogre::Real d; //!< damping factor
 	Ogre::Real L; //!< length
 	Ogre::Real minmaxposnegstress;
-
-	//! Beam type (unnamed enum) { BEAM_NORMAL=0, BEAM_HYDRO=1, BEAM_VIRTUAL=2, BEAM_MARKED=3, BEAM_INVISIBLE=4, BEAM_INVISIBLE_HYDRO=5 }
-	int type;
 
 	Ogre::Real maxposstress;
 	Ogre::Real maxnegstress;
@@ -35,17 +34,11 @@ struct beam_t
 	Ogre::Real strength;
 	Ogre::Real stress;
 
-	//! Values (unnamed enum) { SHOCK1=1, SHOCK2=2, SUPPORTBEAM=3, ROPE=4 }
-	int bounded;
-
-	bool broken;
 	Ogre::Real plastic_coef;
 	Ogre::Real refL;       //!< reference length
 	Ogre::Real Lhydro;     //!< hydro reference len
 	Ogre::Real hydroRatio; //!< hydro rotation ratio
-	int hydroFlags;
-	int animFlags;
-	float animOption;
+
 	Ogre::Real commandRatioLong;
 	Ogre::Real commandRatioShort;
 	Ogre::Real commandShort; //<! Max. contraction; proportional to orig. length
@@ -53,20 +46,30 @@ struct beam_t
 	Ogre::Real commandEngineCoupling;
 	Ogre::Real maxtiestress;
 	Ogre::Real diameter;
-	bool commandNeedsEngine;
-	int detacher_group;	//!< Attribute: detacher group number (integer)
-	bool isCentering;
-	int isOnePressMode;
-	bool isForceRestricted;
-	float iStrength; //!< initial strength
 	Ogre::Real default_deform;
 	Ogre::Real default_plastic_coef;
-	int autoMovingMode;
-	bool autoMoveLock;
-	bool pressedCenterMode;
+
+	float animOption;
 	float centerLength;
+	float iStrength; //!< initial strength
 	float scale;
-	shock_t *shock;
-	Ogre::SceneNode *mSceneNode; //!< visual
-	Ogre::Entity *mEntity; //!< visual
+
+	//! Values (unnamed enum) { SHOCK1=1, SHOCK2=2, SUPPORTBEAM=3, ROPE=4 }
+	int bounded;
+	//! Beam type (unnamed enum) { BEAM_NORMAL=0, BEAM_HYDRO=1, BEAM_VIRTUAL=2, BEAM_MARKED=3, BEAM_INVISIBLE=4, BEAM_INVISIBLE_HYDRO=5 }
+	int type;
+	int hydroFlags;
+	int animFlags;
+	int autoMovingMode;
+	int detacher_group;	//!< Attribute: detacher group number (integer)
+	int isOnePressMode;
+
+	bool autoMoveLock;
+	bool commandNeedsEngine;
+	bool isCentering;
+	bool isForceRestricted;
+	bool pressedCenterMode;
+
+	bool disabled;
+	bool broken;
 };

--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -14,42 +14,51 @@
 */
 struct node_t
 {
+	Ogre::SceneNode *mSceneNode; //!< visual
+
 	Ogre::Vector3 RelPosition; //!< relative to the local physics origin (one origin per truck) (shaky)
 	Ogre::Vector3 AbsPosition; //!< absolute position in the world (shaky)
+	Ogre::Vector3 smoothpos; //!< absolute, per-frame smooth, must be used for visual effects only
+	Ogre::Vector3 iPosition; //!< initial position, absolute
+
 	Ogre::Vector3 Velocity;
+
 	Ogre::Vector3 Forces;
-	Ogre::Real mass;
-	int locked;
-	int iswheel; //!< 0=no, 1, 2=wheel1  3,4=wheel2, etc...
-	int wheelid; //!< Wheel index
-	int masstype; //!< Loaded (by vehicle cargo)? {0/1}
-	int wetstate; //!< {DRY | DRIPPING | WET}
-	int contactless; //!< Bool{0/1}
-	int lockgroup;
+	Ogre::Vector3 buoyanceForce;
+
+	Ogre::Vector3 lastdrag;
+	Ogre::Vector3 gravimass;
+
 	Ogre::Vector3 lockedPosition; //!< absolute
 	Ogre::Vector3 lockedForces;
 	Ogre::Vector3 lockedVelocity;
-	int contacted; //!< Boolean
-	Ogre::Real friction_coef;
+
+	Ogre::Real mass;
 	Ogre::Real buoyancy;
-	Ogre::Real volume_coef;
+	Ogre::Real friction_coef;
 	Ogre::Real surface_coef;
-	Ogre::Vector3 lastdrag;
-	Ogre::Vector3 gravimass;
+	Ogre::Real volume_coef;
+
 	float wettime; //!< Cumulative time this node has been in contact with water. When wet, produces dripping particles.
-	bool isHot; //!< Makes this node emit vapour particles when in contact with water.
-	bool overrideMass;
-	bool disable_particles;
-	bool disable_sparks;
-	Ogre::Vector3 buoyanceForce;
-	int id; //!< Numeric identifier assigned in rig-definition file (if used), or -1 if the node was generated dynamically.
-	int collisionBoundingBoxID;
 	float collRadius;
 	float collTestTimer;
-	Ogre::Vector3 iPosition; //!< initial position, absolute
-	Ogre::Vector3 smoothpos; //!< absolute, per-frame smooth, must be used for visual effects only
-	bool contacter;
+
+	int collisionBoundingBoxID;
+	int contacted; //!< Boolean
+	int contactless; //!< Bool{0/1}
+	int id; //!< Numeric identifier assigned in rig-definition file (if used), or -1 if the node was generated dynamically.
+	int iswheel; //!< 0=no, 1, 2=wheel1  3,4=wheel2, etc...
+	int locked;
+	int lockgroup;
+	int masstype; //!< Loaded (by vehicle cargo)? {0/1}
 	int mouseGrabMode;           //!< { 0=Mouse grab, 1=No mouse grab, 2=Mouse grab with force display}
 	int pos;                     //!< This node's index in rig_t::nodes array.
-	Ogre::SceneNode *mSceneNode; //!< visual
+	int wetstate; //!< {DRY | DRIPPING | WET}
+	int wheelid; //!< Wheel index
+
+	bool contacter;
+	bool disable_particles;
+	bool disable_sparks;
+	bool isHot; //!< Makes this node emit vapour particles when in contact with water.
+	bool overrideMass;
 };

--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -14,51 +14,45 @@
 */
 struct node_t
 {
-	Ogre::SceneNode *mSceneNode; //!< visual
-
 	Ogre::Vector3 RelPosition; //!< relative to the local physics origin (one origin per truck) (shaky)
 	Ogre::Vector3 AbsPosition; //!< absolute position in the world (shaky)
-	Ogre::Vector3 smoothpos; //!< absolute, per-frame smooth, must be used for visual effects only
-	Ogre::Vector3 iPosition; //!< initial position, absolute
 
 	Ogre::Vector3 Velocity;
-
 	Ogre::Vector3 Forces;
-	Ogre::Vector3 buoyanceForce;
+	
+	float collTestTimer;
+	int iswheel;  //!< 0=no, 1, 2=wheel1  3,4=wheel2, etc...
+	int locked;   //!< {UNLOCKED | PRELOCK | LOCKED}
 
-	Ogre::Vector3 lastdrag;
-	Ogre::Vector3 gravimass;
+	bool contacted;
+	bool contactless;
+	bool disable_particles;
+	bool disable_sparks;
 
-	Ogre::Vector3 lockedPosition; //!< absolute
-	Ogre::Vector3 lockedForces;
-	Ogre::Vector3 lockedVelocity;
+	// <-- 64 Bytes -->
 
 	Ogre::Real mass;
+
+	int wheelid;  //!< Wheel index
+	int lockgroup;
+	int wetstate; //!< {DRY | DRIPPING | WET}
+	int collisionBoundingBoxID;
+
+	float collRadius;
+
 	Ogre::Real buoyancy;
 	Ogre::Real friction_coef;
 	Ogre::Real surface_coef;
 	Ogre::Real volume_coef;
 
-	float wettime; //!< Cumulative time this node has been in contact with water. When wet, produces dripping particles.
-	float collRadius;
-	float collTestTimer;
-
-	int collisionBoundingBoxID;
-	int contacted; //!< Boolean
-	int contactless; //!< Bool{0/1}
-	int id; //!< Numeric identifier assigned in rig-definition file (if used), or -1 if the node was generated dynamically.
-	int iswheel; //!< 0=no, 1, 2=wheel1  3,4=wheel2, etc...
-	int locked;
-	int lockgroup;
-	int masstype; //!< Loaded (by vehicle cargo)? {0/1}
-	int mouseGrabMode;           //!< { 0=Mouse grab, 1=No mouse grab, 2=Mouse grab with force display}
-	int pos;                     //!< This node's index in rig_t::nodes array.
-	int wetstate; //!< {DRY | DRIPPING | WET}
-	int wheelid; //!< Wheel index
-
 	bool contacter;
-	bool disable_particles;
-	bool disable_sparks;
-	bool isHot; //!< Makes this node emit vapour particles when in contact with water.
 	bool overrideMass;
+	bool loadedMass;
+	bool isHot; //!< Makes this node emit vapour particles when in contact with water.
+
+	Ogre::Vector3 smoothpos; //!< absolute, per-frame smooth, must be used for visual effects only
+	int pos;      //!< This node's index in rig_t::nodes array.
+	int id;       //!< Numeric identifier assigned in rig-definition file (if used), or -1 if the node was generated dynamically.
+
+	// <-- 128 Bytes -->
 };

--- a/source/main/datatypes/rig_t.h
+++ b/source/main/datatypes/rig_t.h
@@ -20,6 +20,9 @@ struct rig_t
 {
 	// TODO: sort these a bit more ...
 	node_t nodes[MAX_NODES];
+	Ogre::Vector3 initial_node_pos[MAX_NODES];
+	bool node_mouse_grab_disabled[MAX_NODES];
+	float node_wet_time[MAX_NODES]; //!< Cumulative time these nodes have been wet. When wet, dripping particles are produced.
 	int free_node;
 
 	beam_t beams[MAX_BEAMS];

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1814,8 +1814,8 @@ void RoRFrameListener::reloadCurrentTruck()
 			newBeam->nodes[i].RelPosition = curr_truck->nodes[i].RelPosition;
 			newBeam->nodes[i].Velocity    = curr_truck->nodes[i].Velocity;
 			newBeam->nodes[i].Forces      = curr_truck->nodes[i].Forces;
-			newBeam->nodes[i].iPosition   = curr_truck->nodes[i].iPosition;
 			newBeam->nodes[i].smoothpos   = curr_truck->nodes[i].smoothpos;
+			newBeam->initial_node_pos[i]  = curr_truck->initial_node_pos[i];
 		}
 	}
 

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -143,7 +143,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
 				for (int j = 0; j < trucks[i]->free_node; j++)
 				{
 					// check if the mouse grab mode is ok
-					if (trucks[i]->nodes[j].mouseGrabMode == 1) continue;
+					if (trucks[i]->node_mouse_grab_disabled[j]) continue;
 
 					// check if our ray intersects with the node
 					std::pair<bool, Real> pair = mouseRay.intersects(Sphere(trucks[i]->nodes[j].smoothpos, 0.1f));

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -138,10 +138,6 @@ enum {
 	BEAM_INVISIBLE,
 	BEAM_INVISIBLE_HYDRO
 };
-enum {
-	NODE_NORMAL,
-	NODE_LOADED
-};
 
 enum {
 	ACTIVATED,      //!< leading truck

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -1047,7 +1047,7 @@ int Collisions::enableCollisionTri(int number, bool enable)
 	return 0;
 }
 
-bool Collisions::nodeCollision(node_t *node, int contacted, float dt, float* nso, ground_model_t** ogm)
+bool Collisions::nodeCollision(node_t *node, bool contacted, float dt, float* nso, ground_model_t** ogm)
 {
 	bool smoky = false;
 	// float corrf=1.0;
@@ -1099,7 +1099,7 @@ bool Collisions::nodeCollision(node_t *node, int contacted, float dt, float* nso
 							{
 								// collision, process as usual
 								// we have a collision
-								contacted++;
+								contacted=true;
 								// setup smoke
 								//float ns=node->Velocity.length();
 								smoky=true;
@@ -1142,7 +1142,7 @@ bool Collisions::nodeCollision(node_t *node, int contacted, float dt, float* nso
 						if (!cbox->virt)
 						{
 							// we have a collision
-							contacted++;
+							contacted=true;
 							// setup smoke
 							//float ns=node->Velocity.length();
 							smoky=true;
@@ -1193,7 +1193,7 @@ bool Collisions::nodeCollision(node_t *node, int contacted, float dt, float* nso
 	if (minctri)
 	{
 		// we have a contact
-		contacted++;
+		contacted=true;
 		// setup smoke
 		//float ns=node->Velocity.length();
 		smoky=true;

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -171,7 +171,7 @@ public:
 	bool groundCollision(node_t *node, float dt, ground_model_t** gm, float *nso=0);
 	bool isInside(Ogre::Vector3 pos, const Ogre::String &inst, const Ogre::String &box, float border=0);
 	bool isInside(Ogre::Vector3 pos, collision_box_t *cbox, float border=0);
-	bool nodeCollision(node_t *node, int contacted, float dt, float* nso, ground_model_t** ogm);
+	bool nodeCollision(node_t *node, bool contacted, float dt, float* nso, ground_model_t** ogm);
 
 	void clearEventCache();
 	void finishLoadingTerrain();

--- a/source/main/physics/water/Buoyance.h
+++ b/source/main/physics/water/Buoyance.h
@@ -31,6 +31,14 @@ public:
 	Buoyance();
 	~Buoyance();
 
+	void computeNodeForce(node_t *a, node_t *b, node_t *c, bool doUpdate, int type);
+
+	void setsink(int v);
+
+	enum { BUOY_NORMAL, BUOY_DRAGONLY, BUOY_DRAGLESS };
+
+private:
+
 	//compute tetrahedron volume
 	inline float computeVolume(Ogre::Vector3 o, Ogre::Vector3 a, Ogre::Vector3 b, Ogre::Vector3 c);
 
@@ -40,17 +48,9 @@ public:
 	//compute pressure and drag forces on a random triangle
 	Ogre::Vector3 computePressureForce(Ogre::Vector3 a, Ogre::Vector3 b, Ogre::Vector3 c, Ogre::Vector3 vel, int type);
 	
-	void computeNodeForce(node_t *a, node_t *b, node_t *c, int doupdate, int type);
-
-	void setsink(int v);
-
-	enum { BUOY_NORMAL, BUOY_DRAGONLY, BUOY_DRAGLESS };
-
-private:
-
 	DustPool *splashp, *ripplep;
 	int sink;
-	int update;
+	bool update;
 };
 
 #endif // __Buoyance_H_


### PR DESCRIPTION
Edit: I'll do separate pull requests for the ```beam_t``` and ```node_t``` structs.

**Before**: sizeof(node_t) = **240**
**After**: sizeof(node_t') = **128**

The ```node_t``` struct now fits into 2 cache lines.