### PR TITLE
Fix linking problem with configurator.

### DIFF
--- a/source/configurator/CMakeLists.txt
+++ b/source/configurator/CMakeLists.txt
@@ -96,6 +96,7 @@ IF(WIN32)
 	add_executable(RoRConfig WIN32 ${sources} ${headers} ${OS_SOURCE} ../main/utils/Settings.cpp ../main/utils/SHA1.cpp ../main/utils/ErrorUtils.cpp ../main/utils/Utils.cpp)
 	TARGET_LINK_LIBRARIES(RoRConfig Version.lib)
 ELSE(WIN32)
+        add_definitions ("-fPIC")
 	add_executable(RoRConfig ${sources} ${headers} ${OS_SOURCE} ../main/utils/Settings.cpp ../main/utils/SHA1.cpp ../main/utils/ErrorUtils.cpp ../main/utils/Utils.cpp)
 ENDIF(WIN32)
 


### PR DESCRIPTION
	Attempting to build the configurator complains that the object files
	created for the configurator contain relocations that are not suitable
	for a shared object.  This is solved by adding `-fPIC` to the compile
	flags for the configurator.

### Steps to reproduce
1. Build RoR from source for Fedora 23, following the instructions at http://www.rigsofrods.com/wiki/pages/Compiling_Sources_under_Linux.

### Expected behaviour
RoR is successfully built.

### Actual behaviour
After running `make`, the final stage of linking the configurator fails:
```
[ 98%] Linking CXX executable ../../bin/RoRConfig
/usr/bin/ld: CMakeFiles/RoRConfig.dir/Configurator.cpp.o: relocation R_X86_64_32 against `_ZTV10HtmlWindow' can not be used when making a shared object; recompile with -fPIC
CMakeFiles/RoRConfig.dir/Configurator.cpp.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
source/configurator/CMakeFiles/RoRConfig.dir/build.make:227: recipe for target 'bin/RoRConfig' failed
make[2]: *** [bin/RoRConfig] Error 1
CMakeFiles/Makefile2:237: recipe for target 'source/configurator/CMakeFiles/RoRConfig.dir/all' failed
make[1]: *** [source/configurator/CMakeFiles/RoRConfig.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```

### System configuration
Fedora 23 64bit with Radeon R9 R390 and default open source device driver. Output of uname -a:

    Linux wotan.home.gateway 4.2.8-300.fc23.x86_64 #1 SMP Tue Dec 15 16:49:06 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux

### Additional information, logs and screenshots (optional)

I don't really understand why the configurator object files are not being compiled correctly. Adding `-fPic` certainly fixes the problem. I'm a _cmake_ novice, so this is probably not the best way to fix the problem, but it allowed me to demonstrate the solution.

ChangeLog entry:

	* source/configurator/CMakeLists.txt: Add -fPIC as a compile flag
	for the configurator.