### PR TITLE
[Codechange] Clearing out and reordering of the beam_t members 

### DIFF
--- a/source/main/datatypes/beam_t.h
+++ b/source/main/datatypes/beam_t.h
@@ -18,54 +18,55 @@ struct beam_t
 {
 	node_t *p1;
 	node_t *p2;
-	Beam *p2truck; //!< in case p2 is on another truck
-	bool disabled;
 	Ogre::Real k; //!< tensile spring
 	Ogre::Real d; //!< damping factor
 	Ogre::Real L; //!< length
 	Ogre::Real minmaxposnegstress;
-
-	//! Beam type (unnamed enum) { BEAM_NORMAL=0, BEAM_HYDRO=1, BEAM_VIRTUAL=2, BEAM_MARKED=3, BEAM_INVISIBLE=4, BEAM_INVISIBLE_HYDRO=5 }
-	int type;
-
 	Ogre::Real maxposstress;
 	Ogre::Real maxnegstress;
-	Ogre::Real shortbound;
-	Ogre::Real longbound;
 	Ogre::Real strength;
 	Ogre::Real stress;
-
-	//! Values (unnamed enum) { SHOCK1=1, SHOCK2=2, SUPPORTBEAM=3, ROPE=4 }
-	int bounded;
-
-	bool broken;
 	Ogre::Real plastic_coef;
+	int detacher_group;	//!< Attribute: detacher group number (integer)
+	short bounded;      //!< { SHOCK1=1, SHOCK2=2, SUPPORTBEAM=3, ROPE=4 }
+	short type;         //!< { BEAM_NORMAL=0, BEAM_HYDRO=1, BEAM_VIRTUAL=2, BEAM_MARKED=3, BEAM_INVISIBLE=4, BEAM_INVISIBLE_HYDRO=5 }
+	bool p2truck;       //!< in case p2 is on another truck
+	bool disabled;
+	bool broken;
+	bool autoMoveLock;
+
+	// < -- 64 Bytes -->
+
+	Ogre::Real shortbound;
+	Ogre::Real longbound;
 	Ogre::Real refL;       //!< reference length
 	Ogre::Real Lhydro;     //!< hydro reference len
 	Ogre::Real hydroRatio; //!< hydro rotation ratio
-	int hydroFlags;
-	int animFlags;
-	float animOption;
 	Ogre::Real commandRatioLong;
 	Ogre::Real commandRatioShort;
 	Ogre::Real commandShort; //<! Max. contraction; proportional to orig. length
 	Ogre::Real commandLong;  //<! Max. extension; proportional to orig. length
 	Ogre::Real commandEngineCoupling;
+	float centerLength;
+	float animOption;
+	int animFlags;
+	int hydroFlags;
+	short isOnePressMode;
+	short autoMovingMode;
+	bool pressedCenterMode;
+	bool isForceRestricted;
+	bool commandNeedsEngine;
+	bool isCentering;
+
+	// < -- 128 Bytes -->
+
 	Ogre::Real maxtiestress;
 	Ogre::Real diameter;
-	bool commandNeedsEngine;
-	int detacher_group;	//!< Attribute: detacher group number (integer)
-	bool isCentering;
-	int isOnePressMode;
-	bool isForceRestricted;
+	float scale;
 	float iStrength; //!< initial strength
 	Ogre::Real default_deform;
 	Ogre::Real default_plastic_coef;
-	int autoMovingMode;
-	bool autoMoveLock;
-	bool pressedCenterMode;
-	float centerLength;
-	float scale;
+
 	shock_t *shock;
 	Ogre::SceneNode *mSceneNode; //!< visual
 	Ogre::Entity *mEntity; //!< visual

--- a/source/main/datatypes/beam_t.h
+++ b/source/main/datatypes/beam_t.h
@@ -63,9 +63,6 @@ struct beam_t
 	Ogre::Real maxtiestress;
 	Ogre::Real diameter;
 	float scale;
-	float iStrength; //!< initial strength
-	Ogre::Real default_deform;
-	Ogre::Real default_plastic_coef;
 
 	shock_t *shock;
 	Ogre::SceneNode *mSceneNode; //!< visual

--- a/source/main/datatypes/rig_t.h
+++ b/source/main/datatypes/rig_t.h
@@ -23,6 +23,9 @@ struct rig_t
 	int free_node;
 
 	beam_t beams[MAX_BEAMS];
+	Ogre::Real initial_beam_strength[MAX_BEAMS];
+	Ogre::Real default_beam_deform[MAX_BEAMS];
+	Ogre::Real default_beam_plastic_coef[MAX_BEAMS];
 	int free_beam;
 
 	contacter_t contacters[MAX_CONTACTERS];

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1375,7 +1375,7 @@ void Beam::SyncReset()
 		it->lockNode      = 0;
 		it->lockTruck     = 0;
 		it->beam->p2      = &nodes[0];
-		it->beam->p2truck = 0;
+		it->beam->p2truck = false;
 		it->beam->L       = (nodes[0].AbsPosition - it->hookNode->AbsPosition).length();
 	}
 
@@ -4309,7 +4309,7 @@ void Beam::tieToggle(int group)
 			if (it->lockedto) it->lockedto->used--;
 			// disable the ties beam
 			it->beam->p2 = &nodes[0];
-			it->beam->p2truck = 0;
+			it->beam->p2truck = false;
 			it->beam->disabled = true;
 			it->beam->mSceneNode->detachAllObjects();
 			istied = true;
@@ -4371,7 +4371,7 @@ void Beam::tieToggle(int group)
 
 					// now trigger the tying action
 					it->beam->p2 = shorter;
-					it->beam->p2truck = shtruck;
+					it->beam->p2truck = true;
 					it->beam->stress = 0;
 					it->beam->L = it->beam->refL;
 					it->tied  = true;
@@ -4515,7 +4515,7 @@ void Beam::hookToggle(int group, hook_states mode, int node_number)
 			//disable hook-assistance beam
 			it->beam->mSceneNode->detachAllObjects();
 			it->beam->p2       = &nodes[0];
-			it->beam->p2truck  = 0;
+			it->beam->p2truck  = false;
 			it->beam->L        = (nodes[0].AbsPosition - it->hookNode->AbsPosition).length();
 			it->beam->disabled = true;
 		}

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4371,7 +4371,7 @@ void Beam::tieToggle(int group)
 
 					// now trigger the tying action
 					it->beam->p2 = shorter;
-					it->beam->p2truck = true;
+					it->beam->p2truck = shtruck != 0;
 					it->beam->stress = 0;
 					it->beam->L = it->beam->refL;
 					it->tied  = true;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1338,11 +1338,11 @@ void Beam::SyncReset()
 	for (int i=0; i<free_beam; i++)
 	{
 		beams[i].broken=0;
-		beams[i].maxposstress=beams[i].default_deform;
-		beams[i].maxnegstress=-beams[i].default_deform;
-		beams[i].minmaxposnegstress=beams[i].default_deform;
-		beams[i].strength=beams[i].iStrength;
-		beams[i].plastic_coef=beams[i].default_plastic_coef;
+		beams[i].maxposstress=default_beam_deform[i];
+		beams[i].maxnegstress=-default_beam_deform[i];
+		beams[i].minmaxposnegstress=default_beam_deform[i];
+		beams[i].strength=initial_beam_strength[i];
+		beams[i].plastic_coef=default_beam_plastic_coef[i];
 		beams[i].L=beams[i].refL;
 		beams[i].stress=0.0;
 		beams[i].disabled=false;
@@ -6538,6 +6538,13 @@ bool Beam::LoadTruck(
 	}
 #endif // USE_MYGUI
     LOAD_RIG_PROFILE_CHECKPOINT(ENTRY_BEAM_LOADTRUCK_LOAD_DASHBOARDS);
+
+	// Set beam defaults
+	for (int i=0; i<free_beam; i++) {
+		initial_beam_strength[i] = beams[i].strength;
+		default_beam_deform[i] = beams[i].minmaxposnegstress;
+		default_beam_plastic_coef[i] = beams[i].plastic_coef;
+	}
 
 	if (cameranodepos[0] != cameranodedir[0] && cameranodepos[0] >= 0 && cameranodepos[0] < MAX_NODES && cameranodedir[0] >= 0 && cameranodedir[0] < MAX_NODES)
 	{

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -2011,7 +2011,7 @@ void Beam::calcHooks()
 			{
 				//enable beam if not enabled yet between those 2 nodes
 				it->beam->p2       = it->lockNode;
-				it->beam->p2truck  = it->lockTruck;
+				it->beam->p2truck  = true;
 				it->beam->L = (it->hookNode->AbsPosition - it->lockNode->AbsPosition).length();
 				it->beam->disabled = false;
 				if (it->beam->mSceneNode->numAttachedObjects() == 0 && it->is_hook_visible)
@@ -2051,7 +2051,7 @@ void Beam::calcHooks()
 								it->lockNode       = 0;
 								it->lockTruck      = 0;
 								it->beam->p2       = &nodes[0];
-								it->beam->p2truck  = 0;
+								it->beam->p2truck  = false;
 								it->beam->L        = (nodes[0].AbsPosition - it->hookNode->AbsPosition).length();
 								it->beam->disabled = true;
 							}

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -2011,7 +2011,7 @@ void Beam::calcHooks()
 			{
 				//enable beam if not enabled yet between those 2 nodes
 				it->beam->p2       = it->lockNode;
-				it->beam->p2truck  = true;
+				it->beam->p2truck  = it->lockTruck != 0;
 				it->beam->L = (it->hookNode->AbsPosition - it->lockNode->AbsPosition).length();
 				it->beam->disabled = false;
 				if (it->beam->mSceneNode->numAttachedObjects() == 0 && it->is_hook_visible)

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -3910,14 +3910,12 @@ beam_t & RigSpawner::AddBeam(
 	/* Breaking threshold (strength) */
 	float strength = beam_defaults->breaking_threshold_constant;
 	beam.strength = strength;
-	beam.iStrength = strength;
 
 	/* Deformation */
 	SetBeamDeformationThreshold(beam, beam_defaults);
 
 	float plastic_coef = beam_defaults->plastic_deformation_coefficient;
 	beam.plastic_coef = plastic_coef;
-	beam.default_plastic_coef = plastic_coef;
 
 	return beam;
 }
@@ -3927,7 +3925,6 @@ void RigSpawner::SetBeamStrength(beam_t & beam, float strength)
 	SPAWNER_PROFILE_SCOPED();
 
     beam.strength = strength;
-	beam.iStrength = strength;
 }
 
 void RigSpawner::ProcessHydro(RigDef::Hydro & def)
@@ -4046,7 +4043,6 @@ void RigSpawner::ProcessHydro(RigDef::Hydro & def)
 	beam.hydroFlags           = hydro_flags;
 	beam.hydroRatio           = def.lenghtening_factor;
 	beam.plastic_coef         = def.beam_defaults->plastic_deformation_coefficient;
-	beam.default_plastic_coef = def.beam_defaults->plastic_deformation_coefficient;
 	beam.diameter             = DEFAULT_BEAM_DIAMETER;
 
 	CreateBeamVisuals(beam, beam_index, def.beam_defaults, (hydro_type == BEAM_INVISIBLE_HYDRO));
@@ -4123,7 +4119,6 @@ void RigSpawner::ProcessShock2(RigDef::Shock2 & def)
 	beam.shortbound           = short_bound;
 	beam.longbound            = long_bound;
 	beam.plastic_coef         = def.beam_defaults->plastic_deformation_coefficient;
-	beam.default_plastic_coef = def.beam_defaults->plastic_deformation_coefficient;
 	beam.diameter             = DEFAULT_BEAM_DIAMETER;
 
 	/* Length + pre-compression */
@@ -6080,7 +6075,6 @@ void RigSpawner::ProcessBeam(RigDef::Beam & def)
 	SetBeamDeformationThreshold(beam, def.defaults);
 			
 	beam.plastic_coef         = def.defaults->plastic_deformation_coefficient;
-	beam.default_plastic_coef = def.defaults->plastic_deformation_coefficient;
 
 	/* Calculate length */
 	// orig = precompression hardcoded to 1
@@ -6092,7 +6086,6 @@ void RigSpawner::ProcessBeam(RigDef::Beam & def)
 	/* Strength */
 	float beam_strength = def.defaults->GetScaledBreakingThreshold();
 	beam.strength  = beam_strength;
-	beam.iStrength = beam_strength;
 
 	/* Options */
 	if (BITMASK_IS_1(def.options, RigDef::Beam::OPTION_i_INVISIBLE))
@@ -6236,7 +6229,6 @@ void RigSpawner::SetBeamDeformationThreshold(beam_t & beam, boost::shared_ptr<Ri
 
 	float deformation_threshold = default_deform * beam_defaults->scale.deformation_threshold_constant;
 
-	beam.default_deform     = deformation_threshold;
 	beam.minmaxposnegstress = deformation_threshold;
 	beam.maxposstress       = deformation_threshold;
 	beam.maxnegstress       = -(deformation_threshold);


### PR DESCRIPTION
**Before**: sizeof(beam_t) = **208**
**After**: sizeof(beam_t) = **164**

All frequently accessed data is within the first 64 Bytes of the struct.