### PR TITLE
[Codechange] Disables terrain caching on linux

### DIFF
--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -185,12 +185,14 @@ void TerrainGeometryManager::initTerrain()
 			}
 		}
 		
+#ifdef _WIN32
 		// always save the results when it was imported
 		if (!disableCaching)
 		{
 			LoadingWindow::getSingleton().setProgress(23, _L("saving all terrain pages ..."));
 			mTerrainGroup->saveAllTerrains(false);
 		}
+#endif // _WIN32
 	} else
 	{
 		LOG(" *** Terrain loaded from cache ***");


### PR DESCRIPTION
The mapbin file should be written into the ~/.rigsofrods/cache folder, but it's not

The ResourceGroupManager is not able to find the cache file