### PR TITLE
[Feature] Sort GUI Selector search results by relevance

### DIFF
--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -78,7 +78,7 @@ private:
 	void OnCategorySelected(int categoryID);
 	void OnEntrySelected(int entryID);
 	void OnSelectionDone();
-	bool SearchCompare(Ogre::String searchString, CacheEntry *ce);
+	size_t SearchCompare(Ogre::String searchString, CacheEntry *ce);
 
 	void UpdateControls(CacheEntry *entry);
 	void SetPreviewImage(Ogre::String texture);


### PR DESCRIPTION
The search results are now arranged according to the position of the first search hit.

And additionally ranked by relevance in the following way:
* name
* filename
* description
* author name
* author email
* alphabetically

Example search: **Tra**

**Before:**
1. Muddy Russian Tracks
2. Train Valley

**After:**
1. Train Valley
2. Muddy Russian Tracks

