### PR TITLE
[Cleanup] Moved wettime back into node_t

### DIFF
--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -21,8 +21,9 @@ struct node_t
 	Ogre::Vector3 Forces;
 	
 	float collTestTimer;
-	int iswheel;  //!< 0=no, 1, 2=wheel1  3,4=wheel2, etc...
-	int locked;   //!< {UNLOCKED | PRELOCK | LOCKED}
+	float collRadius;
+	short iswheel; //!< 0=no, 1, 2=wheel1  3,4=wheel2, etc...
+	short locked;  //!< {UNLOCKED | PRELOCK | LOCKED}
 
 	bool contacted;
 	bool contactless;
@@ -31,28 +32,26 @@ struct node_t
 
 	// <-- 64 Bytes -->
 
+	Ogre::Vector3 smoothpos; //!< absolute, per-frame smooth, must be used for visual effects only
+
 	Ogre::Real mass;
-
-	int wheelid;  //!< Wheel index
-	int lockgroup;
-	int wetstate; //!< {DRY | DRIPPING | WET}
-	int collisionBoundingBoxID;
-
-	float collRadius;
-
 	Ogre::Real buoyancy;
 	Ogre::Real friction_coef;
 	Ogre::Real surface_coef;
 	Ogre::Real volume_coef;
 
+	float wettime; //!< Cumulative time this node has been wet. When wet, dripping particles are produced.
+	int wetstate;  //!< {DRY | DRIPPING | WET}
+	int wheelid;   //!< Wheel index
+	int lockgroup;
+	int pos;       //!< This node's index in rig_t::nodes array.
+	int id;        //!< Numeric identifier assigned in rig-definition file (if used), or -1 if the node was generated dynamically.
+	int collisionBoundingBoxID;
+
 	bool contacter;
 	bool overrideMass;
 	bool loadedMass;
-	bool isHot; //!< Makes this node emit vapour particles when in contact with water.
-
-	Ogre::Vector3 smoothpos; //!< absolute, per-frame smooth, must be used for visual effects only
-	int pos;      //!< This node's index in rig_t::nodes array.
-	int id;       //!< Numeric identifier assigned in rig-definition file (if used), or -1 if the node was generated dynamically.
+	bool isHot;    //!< Makes this node emit vapour particles when in contact with water.
 
 	// <-- 128 Bytes -->
 };

--- a/source/main/datatypes/rig_t.h
+++ b/source/main/datatypes/rig_t.h
@@ -22,7 +22,6 @@ struct rig_t
 	node_t nodes[MAX_NODES];
 	Ogre::Vector3 initial_node_pos[MAX_NODES];
 	bool node_mouse_grab_disabled[MAX_NODES];
-	float node_wet_time[MAX_NODES]; //!< Cumulative time these nodes have been wet. When wet, dripping particles are produced.
 	int free_node;
 
 	beam_t beams[MAX_BEAMS];

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1777,14 +1777,14 @@ void Beam::calcNodes(int doUpdate, Ogre::Real dt, int step, int maxsteps)
 		{
 			if (nodes[i].wetstate == DRIPPING && !nodes[i].contactless && !nodes[i].disable_particles)
 			{
-				node_wet_time[i] += dt * maxsteps;
-				if (node_wet_time[i] > 5.0)
+				nodes[i].wettime += dt * maxsteps;
+				if (nodes[i].wettime > 5.0)
 				{
 					nodes[i].wetstate = DRY;
 				} else
 				{
-					if (!nodes[i].iswheel && dripp) dripp->allocDrip(nodes[i].smoothpos, nodes[i].Velocity, node_wet_time[i]);
-					if (nodes[i].isHot && dustp) dustp->allocVapour(nodes[i].smoothpos, nodes[i].Velocity, node_wet_time[i]);
+					if (!nodes[i].iswheel && dripp) dripp->allocDrip(nodes[i].smoothpos, nodes[i].Velocity, nodes[i].wettime);
+					if (nodes[i].isHot && dustp) dustp->allocVapour(nodes[i].smoothpos, nodes[i].Velocity, nodes[i].wettime);
 				}
 			}
 		}
@@ -1934,7 +1934,7 @@ void Beam::calcNodes(int doUpdate, Ogre::Real dt, int step, int maxsteps)
 		} else if (nodes[i].wetstate == WET)
 		{
 			nodes[i].wetstate = DRIPPING;
-			node_wet_time[i] = 0.0f;
+			nodes[i].wettime = 0.0f;
 		}
 	}
 }

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1905,36 +1905,36 @@ void Beam::calcNodes(int doUpdate, Ogre::Real dt, int step, int maxsteps)
 			nodes[i].Forces += drag;
 		}
 
-		//if in water
-		if (water && water->isUnderWater(nodes[i].AbsPosition))
+		if (water)
 		{
-			//basic buoyance
-			watercontact = true;
-
-			if (free_buoycab == 0)
+			if (water->isUnderWater(nodes[i].AbsPosition))
 			{
-				// water drag (turbulent)
-				Real speed = approx_sqrt(nodes[i].Velocity.squaredLength()); //we will (not) reuse this
-				nodes[i].Forces -= (DEFAULT_WATERDRAG * speed) * nodes[i].Velocity;
-				nodes[i].Forces += nodes[i].buoyancy * Vector3::UNIT_Y;
-				// basic splashing
-				if (doUpdate && water->getHeight() - nodes[i].AbsPosition.y < 0.2 && nodes[i].Velocity.squaredLength() > 4.0 && !nodes[i].disable_particles)
+				watercontact = true;
+				if (free_buoycab == 0)
 				{
-					if (splashp) splashp->allocSplash(nodes[i].AbsPosition, nodes[i].Velocity);
-					if (ripplep) ripplep->allocRipple(nodes[i].AbsPosition, nodes[i].Velocity);
+					// water drag (turbulent)
+					Real speed = approx_sqrt(nodes[i].Velocity.squaredLength()); //we will (not) reuse this
+					nodes[i].Forces -= (DEFAULT_WATERDRAG * speed) * nodes[i].Velocity;
+					// basic buoyance
+					nodes[i].Forces += nodes[i].buoyancy * Vector3::UNIT_Y;
+					// basic splashing
+					if (doUpdate && water->getHeight() - nodes[i].AbsPosition.y < 0.2 && nodes[i].Velocity.squaredLength() > 4.0 && !nodes[i].disable_particles)
+					{
+						if (splashp) splashp->allocSplash(nodes[i].AbsPosition, nodes[i].Velocity);
+						if (ripplep) ripplep->allocRipple(nodes[i].AbsPosition, nodes[i].Velocity);
+					}
 				}
-			}
-			// engine stall
-			if (i == cinecameranodepos[0] && engine)
+				// engine stall
+				if (i == cinecameranodepos[0] && engine)
+				{
+					engine->stop();
+				}
+				nodes[i].wetstate = WET;
+			} else if (nodes[i].wetstate == WET)
 			{
-				engine->stop();
+				nodes[i].wetstate = DRIPPING;
+				nodes[i].wettime = 0.0f;
 			}
-			// wetness
-			nodes[i].wetstate = WET;
-		} else if (nodes[i].wetstate == WET)
-		{
-			nodes[i].wetstate = DRIPPING;
-			nodes[i].wettime = 0.0f;
 		}
 	}
 }


### PR DESCRIPTION
This does the following:
* Let ```int iswheel``` and ```int locked``` become shorts, to make room for another float.
* Move ```float collRadius``` into the first 64 bytes
* Fill the freed-up bytes with ```float wettime```

In addition ```wetstate``` and ```wettime``` are updated only if there is water on the terrain.