### PR TITLE
[Cleanup] Reworked the way 'showSkeleton' and 'hideSkeleton' are called

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -3830,10 +3830,6 @@ void Beam::preMapLabelRenderUpdate(bool mode, float charheight)
 
 void Beam::showSkeleton(bool meshes, bool linked)
 {
-	if (lockSkeletonchange)
-		return;
-
-	lockSkeletonchange = true;
 	m_skeletonview_is_active = true;
 
 	if (meshes)
@@ -3904,17 +3900,11 @@ void Beam::showSkeleton(bool meshes, bool linked)
 		}
 	}
 
-	lockSkeletonchange = false;
-
 	TRIGGER_EVENT(SE_TRUCK_SKELETON_TOGGLE, trucknum);
 }
 
 void Beam::hideSkeleton(bool linked)
 {
-	if (lockSkeletonchange)
-		return;
-
-	lockSkeletonchange=true;
 	m_skeletonview_is_active = false;
 
 	if (cabFadeMode >= 0)
@@ -3982,8 +3972,6 @@ void Beam::hideSkeleton(bool linked)
 			(*it)->hideSkeleton(false);
 		}
 	}
-
-	lockSkeletonchange = false;
 }
 
 void Beam::fadeMesh(SceneNode *node, float amount)
@@ -5756,7 +5744,6 @@ Beam::Beam(
 	, lastposition(pos)
 	, leftMirrorAngle(0.52)
 	, lights(1)
-	, lockSkeletonchange(false)
 	, locked(0)
 	, lockedold(0)
 	, m_request_skeletonview_change(0)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -671,7 +671,6 @@ protected:
 	float cabFadeTime;
 	int cabFadeMode; //<! Cab fading effect; values { -1, 0, 1, 2 }
 	// cab fading stuff - end
-	bool lockSkeletonchange;
 	bool floating_origin_enable;
 
 	Ogre::ManualObject *simpleSkeletonManualObject;

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -343,6 +343,7 @@ public:
 	Ogre::Vector3 getGForces();
 
 	int stabcommand; //!< Stabilization; values: { -1, 0, 1 }
+	int m_request_skeletonview_change; //!< Request activation(1) / deactivation(-1) of skeletonview
 	bool m_skeletonview_is_active; //!< Visibility of "skeleton" (visual rig) { false = not visible, true = visible }
 	float stabratio;
 	//direction


### PR DESCRIPTION
Those functions are now only called from the main thread (at most once per frame).

Also removed the obsolete ```lockSkeletonchange``` safeguard.