### PR TITLE
[Bugfix] Fixes cabs parsing on IHwood trailer

### DIFF
--- a/source/rig_file_input_output/RigDef_Parser.cpp
+++ b/source/rig_file_input_output/RigDef_Parser.cpp
@@ -210,14 +210,11 @@ void Parser::ParseLine(Ogre::String const & line)
 				break;
 
 			case (File::KEYWORD_CAB):
-				if (m_current_section == File::SECTION_SUBMESH)
+				new_subsection = File::SUBSECTION__SUBMESH__CAB;
+				if (m_current_section != File::SECTION_SUBMESH)
 				{
-					new_subsection = File::SUBSECTION__SUBMESH__CAB;
-				}
-				else
-				{
-					AddMessage(line, Message::TYPE_ERROR, "Misplaced sub-section 'cab' (belongs in section 'submesh'), ignoring...");
-					new_section = File::SECTION_NONE;
+					AddMessage(line, Message::TYPE_WARNING, "Misplaced sub-section 'cab' (belongs in section 'submesh'), falling back to classic unsafe parsing method.");
+					new_section = File::SECTION_SUBMESH;
 				}
 				line_finished = true;
 				break;
@@ -682,14 +679,11 @@ void Parser::ParseLine(Ogre::String const & line)
 				break;
 
 			case (File::KEYWORD_TEXCOORDS):
-				if (m_current_section == File::SECTION_SUBMESH)
+				new_subsection = File::SUBSECTION__SUBMESH__TEXCOORDS;
+				if (m_current_section != File::SECTION_SUBMESH)
 				{
-					new_subsection = File::SUBSECTION__SUBMESH__TEXCOORDS;
-				}
-				else
-				{
-					AddMessage(line, Message::TYPE_ERROR, "Misplaced sub-section 'texcoords' (belongs in section 'submesh'), ignoring...");
-					new_section = File::SECTION_NONE;
+					AddMessage(line, Message::TYPE_WARNING, "Misplaced sub-section 'texcoords' (belongs in section 'submesh'), falling back to classic unsafe parsing method.");
+					new_section = File::SECTION_SUBMESH;
 				}
 				line_finished = true;
 				break;
@@ -807,7 +801,7 @@ void Parser::ParseLine(Ogre::String const & line)
 
 		m_current_section = new_section;
 	}
-	else if (new_subsection != File::SUBSECTION_INVALID)
+	if (new_subsection != File::SUBSECTION_INVALID)
 	{
 		m_current_subsection = new_subsection;
 	}


### PR DESCRIPTION
Allows ```texcoords``` and ```cabs``` section parsing outside of ```submesh``` sections.