### PR TITLE
[Codechange] Reverts the latest changes to the battery light

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -5231,7 +5231,7 @@ void Beam::updateDashBoards(float &dt)
 		dash->setBool(DD_ENGINE_IGNITION, ign);
 
 		// battery
-		bool batt = engine->contact;
+		bool batt = (engine->contact && !engine->running);
 		dash->setBool(DD_ENGINE_BATTERY, batt);
 
 		// clutch warning


### PR DESCRIPTION
The battery light should go off, once the engine is running (and the alternator kicks in).