### PR TITLE
[Bugfix] Disable pressure buttons on trucks without wheels2

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -748,27 +748,32 @@ bool RoRFrameListener::updateEvents(float dt)
 				//camera mode
 				if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_PRESSURE_LESS) && curr_truck)
 				{
-					if (RoR::Application::GetOverlayWrapper()) RoR::Application::GetOverlayWrapper()->showPressureOverlay(true);
+					if (pressure_pressed = curr_truck->addPressure(dt * -10.0))
+					{
+						if (RoR::Application::GetOverlayWrapper())
+							RoR::Application::GetOverlayWrapper()->showPressureOverlay(true);
 #ifdef USE_OPENAL
-					SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_AIR);
+						SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_AIR);
 #endif // OPENAL
-					curr_truck->addPressure(-dt*10.0);
-					pressure_pressed=true;
+					}
 				} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_PRESSURE_MORE))
 				{
-					if (RoR::Application::GetOverlayWrapper()) RoR::Application::GetOverlayWrapper()->showPressureOverlay(true);
+					if (pressure_pressed = curr_truck->addPressure(dt * 10.0))
+					{
+						if (RoR::Application::GetOverlayWrapper())
+							RoR::Application::GetOverlayWrapper()->showPressureOverlay(true);
 #ifdef USE_OPENAL
-					SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_AIR);
+						SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_AIR);
 #endif // OPENAL
-					curr_truck->addPressure(dt*10.0);
-					pressure_pressed=true;
+					}
 				} else if (pressure_pressed)
 				{
 #ifdef USE_OPENAL
 					SoundScriptManager::getSingleton().trigStop(curr_truck, SS_TRIG_AIR);
 #endif // OPENAL
-					pressure_pressed=false;
-					if (RoR::Application::GetOverlayWrapper()) RoR::Application::GetOverlayWrapper()->showPressureOverlay(false);
+					pressure_pressed = false;
+					if (RoR::Application::GetOverlayWrapper())
+						RoR::Application::GetOverlayWrapper()->showPressureOverlay(false);
 				}
 
 				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESCUE_TRUCK, 0.5f) && !gEnv->network && curr_truck->driveable != AIRPLANE)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -763,15 +763,22 @@ void Beam::calcNetwork()
 	BES_GFX_STOP(BES_GFX_calcNetwork);
 }
 
-void Beam::addPressure(float v)
+bool Beam::addPressure(float v)
 {
-	refpressure+=v;
-	if (refpressure<0) refpressure=0;
-	if (refpressure>100) refpressure=100;
+	if (!free_pressure_beam)
+		return false;
+
+	float newpressure = std::max(0.0f, std::min(refpressure + v, 100.0f));
+
+	if (newpressure == refpressure)
+		return false;
+
+	refpressure = newpressure;
 	for (int i=0; i<free_pressure_beam; i++)
 	{
-		beams[pressure_beams[i]].k=10000+refpressure*10000;
+		beams[pressure_beams[i]].k = 10000 + refpressure * 10000;
 	}
+	return true;
 }
 
 float Beam::getPressure()

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -94,7 +94,7 @@ public:
 	
 	void activate();
 	void desactivate();
-	void addPressure(float v);
+	bool addPressure(float v);
 	float getPressure();
 	Ogre::Vector3 getPosition();
 	void resetAngle(float rot);


### PR DESCRIPTION
> Despite a truck not having wheels2, pressing [ or ] will still bring up the gauge, and will repeatedly loop the "air" trigger sound. https://github.com/RigsOfRods/rigs-of-rods/issues/446#issue-114336116

* Don't display the pressure gauge if the truck has no wheels2
* Don't play the 'air trigger' sound if the truck has no wheels2

Tested with this truck: http://www.rigsofrods.com/repository/view/4383
Related to: #446