### PR TITLE
[Bugfix] Fixes broken cruise control feature

### DIFF
--- a/bin/resources/skeleton/config/input.map
+++ b/bin/resources/skeleton/config/input.map
@@ -172,14 +172,14 @@ COMMON_REPLAY_BACKWARD         Keyboard             EXPL+LEFT
 COMMON_REPLAY_FAST_BACKWARD    Keyboard             EXPL+SHIFT+LEFT 
 COMMON_REPLAY_FAST_FORWARD     Keyboard             EXPL+SHIFT+RIGHT 
 COMMON_REPLAY_FORWARD          Keyboard             EXPL+RIGHT 
-COMMON_RESCUE_TRUCK            Keyboard             R 
+COMMON_RESCUE_TRUCK            Keyboard             EXPL+R 
 COMMON_RESET_TRUCK             Keyboard             EXPL+I 
 COMMON_SCREENSHOT              Keyboard             SYSRQ 
 COMMON_SECURE_LOAD             Keyboard             O 
 COMMON_SHOW_SKELETON           Keyboard             K 
 COMMON_START_TRUCK_EDITOR      Keyboard             SHIFT+Y 
 COMMON_TOGGLE_CUSTOM_PARTICLES Keyboard             G 
-COMMON_TOGGLE_MAT_DEBUG        Keyboard             EXPL+CTRL+F 
+COMMON_TOGGLE_MAT_DEBUG        Keyboard             EXPL+CTRL+SHIFT+F 
 COMMON_TOGGLE_RENDER_MODE      Keyboard             E 
 COMMON_TOGGLE_REPLAY_MODE      Keyboard             J 
 COMMON_TOGGLE_STATS            Keyboard             EXPL+F 

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -490,10 +490,7 @@ void BeamEngine::update(float dt, int doUpdate)
 				postshifting = 1;
 				postshiftclock = 0.0f;
 			}
-		} else
-			setAcc(autocurAcc);
-
-
+		}
 
 		// auto declutch
 		if (!is_Electric)


### PR DESCRIPTION
Broken by this commit: https://github.com/RigsOfRods/rigs-of-rods/commit/a5724b12413de63ddaba3d51288ccdd29643bd5c#diff-d47d357a254e0b1523e9a63fa4af7382R309

* Does this affect the current engine code in any way?

**Edit:** I'm now pretty sure that this line is unnecessary.