### PR TITLE
[Bugfix] Fixes engoption 'stallRPM' not being set

### DIFF
--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -191,7 +191,7 @@ void BeamEngine::setOptions(float einertia, char etype, float eclutch, float cti
 	if (pstime > 0) post_shift_time = pstime;
 	if (stime > 0)  shift_time = stime;
 	if (irpm > 0) idleRPM = irpm;
-	if (srpm > 0) idleRPM = srpm;
+	if (srpm > 0) stallRPM = srpm;
 	if (maximix > 0) maxIdleMixture = maximix;
 	if (minimix > 0) minIdleMixture = minimix;
 


### PR DESCRIPTION
This bug was introduced after the release of 0.38.67 and should therefore be fixed.

Reference: https://github.com/RigsOfRods/rigs-of-rods/commit/fa1916e24365be8920ec32f4f6cf4fa450bf6bd1#diff-d47d357a254e0b1523e9a63fa4af7382R93