### PR TITLE
[Bugfix] Stops particle generation in pause menu (or after truck removal)

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1375,6 +1375,11 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 		gEnv->terrainManager->update(dt);
 	}
 
+	if (loading_state == ALL_LOADED)
+	{
+		DustManager::getSingleton().update();
+	}
+
 	//update visual - antishaking
 	if (loading_state == ALL_LOADED && !this->isSimPaused)
 	{

--- a/source/main/gfx/DustManager.cpp
+++ b/source/main/gfx/DustManager.cpp
@@ -98,13 +98,13 @@ void DustManager::addNewDustPool(ground_model_t *g)
 }
 */
 
-void DustManager::update(float wspeed)
+void DustManager::update()
 {
 	if (!mEnabled) return;
 	std::map < Ogre::String , DustPool * >::iterator it;
 	for (it=dustpools.begin(); it!=dustpools.end();it++)
 	{
-		it->second->update(wspeed);
+		it->second->update();
 	}
 }
 

--- a/source/main/gfx/DustManager.h
+++ b/source/main/gfx/DustManager.h
@@ -36,7 +36,7 @@ public:
 
 	DustPool *getGroundModelDustPool(ground_model_t *g);
 	
-	void update(float wspeed);
+	void update();
 
 	void setVisible(bool visible);
 

--- a/source/main/gfx/DustPool.cpp
+++ b/source/main/gfx/DustPool.cpp
@@ -198,9 +198,8 @@ void DustPool::allocRipple(Vector3 pos, Vector3 vel)
 	MUTEX_UNLOCK(&allocation_mutex);
 }
 
-void DustPool::update(float gspeed)
+void DustPool::update()
 {
-	gspeed=fabs(gspeed);
 	for (int i=0; i<allocated; i++)
 	{
 		ParticleEmitter *emit = pss[i]->getEmitter(0);
@@ -221,14 +220,13 @@ void DustPool::update(float gspeed)
 			sns[i]->setPosition(positions[i]);
 		}
 		
-
 		if (types[i]==DUST_NORMAL)
 		{
 			ndir.y=0;
 			ndir=ndir/2.0;
 
-			col.a=(vel+(gspeed/10.0))*0.05;
-			emit->setTimeToLive((vel+(gspeed/10.0))*0.05/0.1);
+			col.a=vel*0.05;
+			emit->setTimeToLive(vel*0.05/0.1);
 		}
 		else if (types[i]==DUST_CLUMP)
 		{

--- a/source/main/gfx/DustPool.h
+++ b/source/main/gfx/DustPool.h
@@ -51,7 +51,7 @@ public:
 
 	void allocRipple(Ogre::Vector3 pos, Ogre::Vector3 vel);
 
-	void update(float gspeed);
+	void update();
 
 protected:
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -46,7 +46,6 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "Console.h"
 #include "DashBoardManager.h"
 #include "Differentials.h"
-#include "DustManager.h"
 #include "ErrorUtils.h"
 #include "FlexAirfoil.h"
 #include "FlexBody.h"
@@ -3545,15 +3544,10 @@ void Beam::updateVisualPrepare(float dt)
 
 	Vector3 ref(Vector3::UNIT_Y);
 	autoBlinkReset();
-	//sounds too
 	updateSoundSources();
 
 	if (deleting) return;
 	if (debugVisuals) updateDebugOverlay();
-
-	//dust
-	// UH - design problem, it updates every truck dust D:
-	DustManager::getSingleton().update(WheelSpeed);
 
 #ifdef USE_OPENAL
 	//airplane radio chatter

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -25,7 +25,6 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "BeamFactory.h"
 #include "Collisions.h"
 #include "Dashboard.h"
-#include "DustManager.h"
 #include "EnvironmentMap.h"
 #include "ErrorUtils.h"
 #include "GUIFriction.h"


### PR DESCRIPTION
Moved the particle update routine out of the beam class.

-> Fixes #531
-> Fixes the particle part of this https://github.com/RigsOfRods/rigs-of-rods/issues/376