### PR TITLE
[Bugfix] 'Fixes' the mini picture generation on Ogre 1.9

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1573,7 +1573,6 @@ void CacheSystem::generateFileCache(CacheEntry &entry, Ogre::String directory)
 		if (files->empty())
 		{
 			deleteFileCache(const_cast<char*>(dst.c_str()));
-			return;
 		}
 
 		size_t fsize = 0;


### PR DESCRIPTION
Fixes: #468

Is there any reason not to fix it like that?