### PR TITLE
[Codechange] Reverts height offset for free positioned trucks

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -6130,7 +6130,7 @@ bool Beam::LoadTruck(
 		vehicle_position.z -= (boundingBox.getMaximum().z + boundingBox.getMinimum().z) / 2.0 - vehicle_position.z;
 		
 		if (freePositioned)
-			resetPosition(vehicle_position.x, vehicle_position.z, true, vehicle_position.y + 0.1f);
+			resetPosition(vehicle_position.x, vehicle_position.z, true, vehicle_position.y);
 		else
 			resetPosition(vehicle_position.x, vehicle_position.z, true, 0.0f);
 


### PR DESCRIPTION
Not needed and has the potential of breaking pre-spawned trucks.