### PR TITLE
[Bugfix] Fixes the airplane spawner on some original maps

### DIFF
--- a/bin/resources/scripts/base.as
+++ b/bin/resources/scripts/base.as
@@ -29,7 +29,7 @@ void defaultEventCallback(int trigger_type, string inst, string box, int nodeid)
 	{
 		game.showChooser("load", inst, "spawnzone");
 		game.clearEventCache();
-	} else if (box == "shopplanes") // deprecated
+	} else if (box == "shopplane") // deprecated
 	{
 		game.showChooser("airplane", inst, "spawnzone");
 		game.clearEventCache();


### PR DESCRIPTION
I think that 'shopplanes' was just a typo, those spawners used to be called 'shopplane'.

Reference: http://www.rigsofrods.com/wiki/index.php?title=Object_Format