### PR TITLE
[Discussion] main loop: mainthread vs. simthread updates.

### DIFF
--- a/source/main/datatypes/rig_t.h
+++ b/source/main/datatypes/rig_t.h
@@ -9,6 +9,7 @@
 
 #include "RoRPrerequisites.h"
 #include "BeamData.h"
+#include "Powertrain.h"
 #include <vector>
 
 #include <OgrePrerequisites.h>
@@ -195,7 +196,9 @@ struct rig_t
 	Buoyance *buoyance;
 
 	int driveable;
-	BeamEngine *engine;
+
+    RoR::Powertrain* powertrain; //!< Land vehicle powertrain
+
 	int hascommands;
 	int hashelp;
 	char helpmat[256];

--- a/source/main/datatypes/transmission.h
+++ b/source/main/datatypes/transmission.h
@@ -1,0 +1,31 @@
+
+#pragma once
+
+namespace RoR
+{
+
+struct Gearbox
+{
+    enum shiftmodes {
+        SHIFTMODE_AUTOMATIC,    //!< Automatic shift
+        SHIFTMODE_SEMIAUTO,     //!< Manual shift - Auto clutch
+        SHIFTMODE_MANUAL,       //!< Fully Manual: sequential shift
+        SHIFTMODE_MANUAL_STICK, //!< Fully manual: stick shift
+        SHIFTMODE_MANUAL_RANGES, //!< Fully Manual: stick shift with ranges
+
+        SHIFTMODE_DEFAULT = 0xFFFFFFFD,
+        SHIFTMODE_UNKNOWN = 0xFFFFFFFE,
+        SHIFTMODE_INVALID = 0xFFFFFFFF
+    };
+
+    enum autoswitch {
+        AUTOSWITCH_REAR,
+        AUTOSWITCH_NEUTRAL,
+        AUTOSWITCH_DRIVE,
+        AUTOSWITCH_TWO,
+        AUTOSWITCH_ONE,
+        AUTOSWITCH_MANUALMODE
+    };
+};
+
+} // namespace RoR

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -26,213 +26,231 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace Ogre;
 
-BeamEngine::BeamEngine(float minRPM, float maxRPM, float torque, std::vector<float> gears, float dratio, int trucknum) :
-	  apressure(0.0f)
-	, autocurAcc(0.0f)
-	, automode(AUTOMATIC)
-	, autoselect(DRIVE)
-	, brakingTorque(-torque / 5.0f)
-	, clutchForce(10000.0f)
-	, clutchTime(0.2f)
-	, contact(false)
-	, curAcc(0.0f)
-	, curClutch(0.0f)
-	, curClutchTorque(0.0f)
-	, curEngineRPM(0.0f)
-	, curGear(0)
-	, curGearRange(0)
-	, curWheelRevolutions(0.0f)
-	, diffRatio(dratio)
-	, engineTorque(torque - brakingTorque)
-	, gearsRatio(gears)
-	, hasair(true)
-	, hasturbo(false)
-	, hydropump(0.0f)
-	, idleRPM(std::min(minRPM, 800.0f))
-	, inertia(10.0f)
-	, maxIdleMixture(0.2f)
-	, maxRPM(std::abs(maxRPM))
-	, minIdleMixture(0.0f)
-	, minRPM(std::abs(minRPM))
-	, numGears((int)gears.size() - 2)
-	, post_shift_time(0.2f)
-	, postshiftclock(0.0f)
-	, postshifting(0)
-	, prime(0)
-	, running(false)
-	, shiftBehaviour(0.0f)
-	, shift_time(0.5f)
-	, shiftclock(0.0f)
-	, shifting(0)
-	, shiftval(0)
-	, stallRPM(300.0f)
-	, starter(0)
-	, torqueCurve(new TorqueCurve())
-	, trucknum(trucknum)
-	, type('t')
-	, upShiftDelayCounter(0)
-	, is_Electric(false)
-	, turboInertiaFactor(1)
-	, numTurbos(1)
-	, maxTurboRPM(200000.0f)
-	, turboEngineRpmOperation(0.0f)
-	, turboVer(1)
-	, minBOVPsi(11)
-	, minWGPsi(20)
-	, b_WasteGate(false)
-	, b_BOV(false)
-	, b_flutter(false)
-	, wastegate_threshold_p(0)
-	, wastegate_threshold_n(0)
-	, b_anti_lag(false)
-	, rnd_antilag_chance(0.9975)
-	, minRPM_antilag(3000)
-	, antilag_power_factor(170)
-{
-	fullRPMRange = (maxRPM - minRPM);
-	oneThirdRPMRange = fullRPMRange / 3.0f;
-	halfRPMRange = fullRPMRange / 2.0f;
+/*
+ENGINE UPDATE TRACE (static):
+bool RoRFrameListener::frame Started(const FrameEvent& evt)
+	void BeamFactory::calc Physics(float dt)
+		trucks[t]->engine->Update Beam Engine(dt, 1);
+        [Executed for idle vehicles with engine m_is_engine_running (rig_t::state > DESACTIVATED)]
 
-	gearsRatio[0] = -gearsRatio[0];
-	for (std::vector< float >::iterator it = gearsRatio.begin(); it != gearsRatio.end(); ++it)
+void Beam::run()
+bool Beam::frameStep(Real dt)
+
+void Beam::thread entry()
+	void Beam::calc Forces Euler Compute(int doUpdate_int, Real dt, int step, int maxsteps)
+		calc Truck Engine(doUpdate, dt);
+			Update Beam Engine(doUpdate)
+            [Executed for player-driven vehicle, for N steps (N dynamic based on frame-deltatime)]
+			[doUpdate is 1 in first iteration, then 0]
+*/
+
+BeamEngine::BeamEngine(float m_conf_engine_min_rpm, float m_conf_engine_max_rpm, float torque, std::vector<float> gears, float dratio, int m_vehicle_index) :
+	  m_air_pressure(0.0f)
+	, m_auto_curr_acc(0.0f)
+	, m_transmission_mode(AUTOMATIC)
+	, m_autoselect(DRIVE)
+	, m_conf_engine_braking_torque(-torque / 5.0f)
+	, m_conf_clutch_force(10000.0f)
+	, m_conf_clutch_time(0.2f)
+	, m_starter_has_contact(false)
+	, m_curr_acc(0.0f)
+	, m_curr_clutch(0.0f)
+	, m_curr_clutch_torque(0.0f)
+	, m_prime(0)
+	, m_curr_engine_rpm(0.0f)
+	, m_curr_gear(0)
+	, m_curr_gear_range(0)
+	, m_cur_wheel_revolutions(0.0f)
+	, m_conf_engine_diff_ratio(dratio)
+	, m_conf_engine_torque(torque - m_conf_engine_braking_torque)
+	, m_conf_gear_ratios(gears)
+	, m_conf_engine_has_air(true)
+	, m_conf_engine_has_turbo(false)
+	, m_engine_hydropump(0.0f)
+	, m_conf_engine_idle_rpm(std::min(m_conf_engine_min_rpm, 800.0f))
+	, m_conf_engine_inertia(10.0f)
+	, m_conf_engine_max_idle_mixture(0.2f)
+	, m_conf_engine_max_rpm(std::abs(m_conf_engine_max_rpm))
+	, m_conf_engine_min_idle_mixture(0.0f)
+	, m_conf_engine_min_rpm(std::abs(m_conf_engine_min_rpm))
+	, m_conf_num_gears((int)gears.size() - 2)
+	, m_conf_post_shift_time(0.2f)
+	, m_post_shift_clock(0.0f)
+	, m_is_post_shifting(false)
+	, m_is_engine_running(false)
+	, m_autotrans_curr_shift_behavior(0.0f)
+	, m_conf_shift_time(0.5f)
+	, m_shift_clock(0.0f)
+	, m_is_shifting(0)
+	, m_curr_gear_change_relative(0)
+	, m_conf_engine_stall_rpm(300.0f)
+	, m_starter_is_running(0)
+	, m_conf_engine_torque_curve(new TorqueCurve())
+	, m_vehicle_index(m_vehicle_index)
+	, m_conf_engine_type('t')
+	, m_autotrans_up_shift_delay_counter(0)
+	, m_conf_turbo_inertia_factor(1)
+	, m_conf_num_turbos(1)
+	, m_conf_turbo_max_rpm(200000.0f)
+	, m_conf_turbo_engine_rpm_operation(0.0f)
+	, m_conf_turbo_version(1)
+	, m_conf_turbo_min_bov_psi(11)
+	, m_conf_turbo_wg_min_psi(20)
+	, m_conf_turbo_has_wastegate(false)
+	, m_conf_turbo_has_bov(false)
+	, m_conf_turbo_has_flutter(false)
+	, m_conf_turbo_wg_threshold_p(0)
+	, m_conf_turbo_wg_threshold_n(0)
+	, m_conf_turbo_has_antilag(false)
+	, m_conf_turbo_antilag_chance_rand(0.9975)
+	, m_conf_turbo_antilag_min_rpm(3000)
+	, m_conf_turbo_antilag_power_factor(170)
+{
+	m_conf_autotrans_full_rpm_range = (m_conf_engine_max_rpm - m_conf_engine_min_rpm);
+
+	m_conf_gear_ratios[0] = -m_conf_gear_ratios[0];
+	for (std::vector< float >::iterator it = m_conf_gear_ratios.begin(); it != m_conf_gear_ratios.end(); ++it)
 	{
-		(*it) *= diffRatio;
+		(*it) *= m_conf_engine_diff_ratio;
 	}
 
-	for (int i = 0; i < MAXTURBO; i++)
+	for (int i = 0; i < MAX_NUM_TURBOS; i++)
 	{ 
-		EngineAddiTorque[i] = 0;
-		curTurboRPM[i] = 0;
+		m_conf_turbo_addi_torque[i] = 0;
+		m_turbo_curr_rpm[i] = 0;
 	}
 }
 
 BeamEngine::~BeamEngine()
 {
 	// delete NULL is safe
-	delete torqueCurve;
-	torqueCurve = NULL;
+    /* ============== DISABLED for snapshotting, temporary ~only_a_ptr ================== //
+	delete m_conf_engine_torque_curve;
+	m_conf_engine_torque_curve = NULL;
+    */
 }
 
 void BeamEngine::setTurboOptions(int type, float tinertiaFactor, int nturbos, float param1, float param2, float param3, float param4, float param5, float param6, float param7, float param8, float param9, float param10, float param11)
 {
-	if (!hasturbo)
-		hasturbo = true; //Should have a turbo
+	if (!m_conf_engine_has_turbo)
+		m_conf_engine_has_turbo = true; //Should have a turbo
 
-	if (nturbos > MAXTURBO)
+	if (nturbos > MAX_NUM_TURBOS)
 	{
-		numTurbos = 4;
+		m_conf_num_turbos = 4;
 		LOG("Turbo: No more than 4 turbos allowed"); //TODO: move this under RigParser
 	} else
-		numTurbos = nturbos;
+		m_conf_num_turbos = nturbos;
 
-	turboVer = type;
-	turboInertiaFactor = tinertiaFactor;
+	m_conf_turbo_version = type;
+	m_conf_turbo_inertia_factor = tinertiaFactor;
 
 	if (param2 != 9999)
-		turboEngineRpmOperation = param2;
+		m_conf_turbo_engine_rpm_operation = param2;
 	
 
-	if (turboVer == 1)
+	if (m_conf_turbo_version == 1)
 	{
-		for (int i = 0; i < numTurbos; i++)
-			EngineAddiTorque[i] = param1 / numTurbos; //Additional torque
+		for (int i = 0; i < m_conf_num_turbos; i++)
+			m_conf_turbo_addi_torque[i] = param1 / m_conf_num_turbos; //Additional torque
 	}
 	else
 	{
-		turboMaxPSI = param1; //maxPSI
-		maxTurboRPM = turboMaxPSI * 10000;
+		m_conf_turbo_max_psi = param1; //maxPSI
+		m_conf_turbo_max_rpm = m_conf_turbo_max_psi * 10000;
 
 		//Duh
 		if (param3 == 1)
-			b_BOV = true;
+			m_conf_turbo_has_bov = true;
 		else
-			b_BOV = false;
+			m_conf_turbo_has_bov = false;
 
 		if (param3 != 9999)
-			minBOVPsi = param4;
+			m_conf_turbo_min_bov_psi = param4;
 
 		if (param5 == 1)
-			b_WasteGate = true;
+			m_conf_turbo_has_wastegate = true;
 		else
-			b_WasteGate = false;
+			m_conf_turbo_has_wastegate = false;
 
 		if (param6 != 9999)
-			minWGPsi = param6 * 10000;
+			m_conf_turbo_wg_min_psi = param6 * 10000;
 
 		if (param7 != 9999)
 		{
-			wastegate_threshold_n = 1 - param7;
-			wastegate_threshold_p = 1 + param7;
+			m_conf_turbo_wg_threshold_n = 1 - param7;
+			m_conf_turbo_wg_threshold_p = 1 + param7;
 		}
 
 		if (param8 == 1)
-			b_anti_lag = true;
+			m_conf_turbo_has_antilag = true;
 		else
-			b_anti_lag = false;
+			m_conf_turbo_has_antilag = false;
 
 		if (param9 != 9999)
-			rnd_antilag_chance = param9;
+			m_conf_turbo_antilag_chance_rand = param9;
 
 		if (param10 != 9999)
-			minRPM_antilag = param10;
+			m_conf_turbo_antilag_min_rpm = param10;
 
 		if (param11 != 9999)
-			antilag_power_factor = param11;
+			m_conf_turbo_antilag_power_factor = param11;
 	}
 }
 
 void BeamEngine::setOptions(float einertia, char etype, float eclutch, float ctime, float stime, float pstime, float irpm, float srpm, float maximix, float minimix)
 {
-	inertia = einertia;
-	type = etype;
-	clutchForce = eclutch;
+	m_conf_engine_inertia = einertia;
+	m_conf_engine_type = etype;
+	m_conf_clutch_force = eclutch;
 
-	if (ctime > 0)  clutchTime = ctime;
-	if (pstime > 0) post_shift_time = pstime;
-	if (stime > 0)  shift_time = stime;
-	if (irpm > 0) idleRPM = irpm;
-	if (srpm > 0) idleRPM = srpm;
-	if (maximix > 0) maxIdleMixture = maximix;
-	if (minimix > 0) minIdleMixture = minimix;
+	if (ctime > 0)  m_conf_clutch_time = ctime;
+	if (pstime > 0) m_conf_post_shift_time = pstime;
+	if (stime > 0)  m_conf_shift_time = stime;
+	if (irpm > 0) m_conf_engine_idle_rpm = irpm;
+	if (srpm > 0) m_conf_engine_idle_rpm = srpm;
+	if (maximix > 0) m_conf_engine_max_idle_mixture = maximix;
+	if (minimix > 0) m_conf_engine_min_idle_mixture = minimix;
 
 	if (etype == 'c')
 	{
 		// it's a car!
-		hasair = false;
-		is_Electric = false;
+		m_conf_engine_has_air = false;
 		// set default clutch force
-		if (clutchForce < 0.0f)
+		if (m_conf_clutch_force < 0.0f)
 		{
-			clutchForce = 5000.0f;
+			m_conf_clutch_force = 5000.0f;
 		}
 	}
 	else if (etype == 'e') //electric
 	{
-		is_Electric = true;
-		hasair = false;
-		if (clutchForce < 0.0f)
+		m_conf_engine_has_air = false;
+		if (m_conf_clutch_force < 0.0f)
 		{
-			clutchForce = 5000.0f;
+			m_conf_clutch_force = 5000.0f;
 		}
 	}
 	else
 	{
-		is_Electric = false;
 		// it's a truck
-		if (clutchForce < 0.0f)
+		if (m_conf_clutch_force < 0.0f)
 		{
-			clutchForce = 10000.0f;
+			m_conf_clutch_force = 10000.0f;
 		}
 	}
 }
 
-void BeamEngine::update(float dt, int doUpdate)
+// TIGHT-LOOP: Called at least once per frame.
+void BeamEngine::UpdateBeamEngine(float dt, int doUpdate)
 {
-	Beam* truck = BeamFactory::getSingleton().getTruck(trucknum);
+	BeamEngine snapshot_before = *this;
+
+	Beam* truck = BeamFactory::getSingleton().getTruck(this->m_vehicle_index);
 
 	if (!truck) return;
 
-	float acc = curAcc;
+	float acc = this->m_curr_acc;
+	bool engine_is_electric = (m_conf_engine_type == 'e');
 
 	acc = std::max(getIdleMixture(), acc);
 	acc = std::max(getPrimeMixture(), acc);
@@ -240,137 +258,137 @@ void BeamEngine::update(float dt, int doUpdate)
 	if (doUpdate)
 	{
 #ifdef USE_OPENAL
-		SoundScriptManager::getSingleton().modulate(trucknum, SS_MOD_INJECTOR, acc);
+		SoundScriptManager::getSingleton().modulate(m_vehicle_index, SS_MOD_INJECTOR, acc);
 #endif // USE_OPENAL
 	}
 
-	if (hasair)
+	if (m_conf_engine_has_air)
 	{
 		// air pressure
-		apressure += dt * curEngineRPM;
-		if (apressure > 50000.0f)
+		m_air_pressure += dt * m_curr_engine_rpm;
+		if (m_air_pressure > 50000.0f)
 		{
 #ifdef USE_OPENAL
-			SoundScriptManager::getSingleton().trigOnce(trucknum, SS_TRIG_AIR_PURGE);
+			SoundScriptManager::getSingleton().trigOnce(m_vehicle_index, SS_TRIG_AIR_PURGE);
 #endif // USE_OPENAL
-			apressure = 0.0f;
+			m_air_pressure = 0.0f;
 		}
 	}
 
-	if (hasturbo)
+	if (m_conf_engine_has_turbo)
 	{
-		for (int i = 0; i < numTurbos; i++)
+		for (int i = 0; i < m_conf_num_turbos; i++)
 		{
 			// update turbo speed (lag)
 			// reset each of the values for each turbo
-			turbotorque = 0.0f;
-			turboBOVtorque = 0.0f;
+			m_turbo_torque = 0.0f;
+			m_turbo_bov_torque = 0.0f;
 
-			turboInertia = 0.000003f * turboInertiaFactor;
+			m_turbo_inertia = 0.000003f * m_conf_turbo_inertia_factor;
 
 			// braking (compression)
-			turbotorque -= curTurboRPM[i] / maxTurboRPM;
-			turboBOVtorque -= curBOVTurboRPM[i] / maxTurboRPM;
+			m_turbo_torque -= m_turbo_curr_rpm[i] / m_conf_turbo_max_rpm;
+			m_turbo_bov_torque -= m_turbo_cur_bov_rpm[i] / m_conf_turbo_max_rpm;
 
 			// powering (exhaust) with limiter
-			if (curEngineRPM >= turboEngineRpmOperation)
+			if (m_curr_engine_rpm >= m_conf_turbo_engine_rpm_operation)
 			{
-				if (curTurboRPM[i] <= maxTurboRPM && running && acc > 0.06f)
+				if (m_turbo_curr_rpm[i] <= m_conf_turbo_max_rpm && m_is_engine_running && acc > 0.06f)
 				{
-					if (b_WasteGate)
+					if (m_conf_turbo_has_wastegate)
 					{
-						if (curTurboRPM[i] < minWGPsi * wastegate_threshold_p && !b_flutter)
+						if (m_turbo_curr_rpm[i] < m_conf_turbo_wg_min_psi * m_conf_turbo_wg_threshold_p && !m_conf_turbo_has_flutter)
 						{
-							turbotorque += 1.5f * acc * (((curEngineRPM - turboEngineRpmOperation) / (maxRPM - turboEngineRpmOperation)));
+							m_turbo_torque += 1.5f * acc * (((m_curr_engine_rpm - m_conf_turbo_engine_rpm_operation) / (m_conf_engine_max_rpm - m_conf_turbo_engine_rpm_operation)));
 						}
 						else
 						{
-							b_flutter = true;
-							turbotorque -= (curTurboRPM[i] / maxTurboRPM) *1.5;
+							m_conf_turbo_has_flutter = true;
+							m_turbo_torque -= (m_turbo_curr_rpm[i] / m_conf_turbo_max_rpm) *1.5;
 						}	
 
-						if (b_flutter)
+						if (m_conf_turbo_has_flutter)
 						{
-							SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_TURBOWASTEGATE);
-							if (curTurboRPM[i] < minWGPsi * wastegate_threshold_n)
+							SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_TURBOWASTEGATE);
+							if (m_turbo_curr_rpm[i] < m_conf_turbo_wg_min_psi * m_conf_turbo_wg_threshold_n)
 							{
-								b_flutter = false;
-								SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_TURBOWASTEGATE);
+								m_conf_turbo_has_flutter = false;
+								SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_TURBOWASTEGATE);
 							}
 								
 						}
 					}
 					else
-						turbotorque += 1.5f * acc * (((curEngineRPM - turboEngineRpmOperation) / (maxRPM - turboEngineRpmOperation)));
+						m_turbo_torque += 1.5f * acc * (((m_curr_engine_rpm - m_conf_turbo_engine_rpm_operation) / (m_conf_engine_max_rpm - m_conf_turbo_engine_rpm_operation)));
 				}
 				else
 				{
-					turbotorque += 0.1f * (((curEngineRPM - turboEngineRpmOperation) / (maxRPM - turboEngineRpmOperation)));
+					m_turbo_torque += 0.1f * (((m_curr_engine_rpm - m_conf_turbo_engine_rpm_operation) / (m_conf_engine_max_rpm - m_conf_turbo_engine_rpm_operation)));
 				}
 
 				//Update waste gate, it's like a BOV on the exhaust part of the turbo, acts as a limiter
-				if (b_WasteGate)
+				if (m_conf_turbo_has_wastegate)
 				{
-					if (curTurboRPM[i] > minWGPsi * 0.95)
-						turboInertia = turboInertia *0.7; //Kill inertia so it flutters
+					if (m_turbo_curr_rpm[i] > m_conf_turbo_wg_min_psi * 0.95)
+						m_turbo_inertia = m_turbo_inertia *0.7; //Kill m_conf_engine_inertia so it flutters
 					else
-						turboInertia = turboInertia *1.3; //back to normal inertia
+						m_turbo_inertia = m_turbo_inertia *1.3; //back to normal m_conf_engine_inertia
 				}
 			}
 			
 			//simulate compressor surge
-			if (!b_BOV)
+			if (!m_conf_turbo_has_bov)
 			{
-				if (curTurboRPM[i] > 13 * 10000 && curAcc < 0.06f)
+				if (m_turbo_curr_rpm[i] > 13 * 10000 && m_curr_acc < 0.06f)
 				{
-					turbotorque += (turbotorque * 2.5);
+					m_turbo_torque += (m_turbo_torque * 2.5);
 				}
 			}
 
 			// anti lag
-			if (b_anti_lag && curAcc < 0.5)
+			if (m_conf_turbo_has_antilag && m_curr_acc < 0.5)
 			{
 				float f = frand();
-				if (curEngineRPM > minRPM_antilag && f > rnd_antilag_chance)
+				if (m_curr_engine_rpm > m_conf_turbo_antilag_min_rpm && f > m_conf_turbo_antilag_chance_rand)
 				{
-					if (curTurboRPM[i] > maxTurboRPM*0.35 && curTurboRPM[i] < maxTurboRPM)
+					if (m_turbo_curr_rpm[i] > m_conf_turbo_max_rpm*0.35 && m_turbo_curr_rpm[i] < m_conf_turbo_max_rpm)
 					{
-						turbotorque -= (turbotorque * (f * antilag_power_factor));
-						SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_TURBOBACKFIRE);
+						m_turbo_torque -= (m_turbo_torque * (f * m_conf_turbo_antilag_power_factor));
+						SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_TURBOBACKFIRE);
 					}
 				}
 				else
-					SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_TURBOBACKFIRE);
+					SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_TURBOBACKFIRE);
 			}
 
 			// update main turbo rpm
-			curTurboRPM[i] += dt * turbotorque / turboInertia;
+			m_turbo_curr_rpm[i] += dt * m_turbo_torque / m_turbo_inertia;
 
 			//Update BOV
 			//It's basicly an other turbo which is limmited to the main one's rpm, but it doesn't affect its rpm.  It only affects the power going into the engine.
 			//This one is used to simulate the pressure between the engine and the compressor.
 			//I should make the whole turbo code work this way. -Max98
-			if (b_BOV)
+			if (m_conf_turbo_has_bov)
 			{
 				
-				if (curBOVTurboRPM[i] < curTurboRPM[i])
-					turboBOVtorque += 1.5f * acc * (((curEngineRPM) / (maxRPM)));
+				if (m_turbo_cur_bov_rpm[i] < m_turbo_curr_rpm[i])
+					m_turbo_bov_torque += 1.5f * acc * (((m_curr_engine_rpm) / (m_conf_engine_max_rpm)));
 				else
-					turboBOVtorque += 0.07f * (((curEngineRPM) / (maxRPM)));
+					m_turbo_bov_torque += 0.07f * (((m_curr_engine_rpm) / (m_conf_engine_max_rpm)));
 
 
-				if (curAcc < 0.06 && curTurboRPM[i] > minBOVPsi * 10000) 
+				if (m_curr_acc < 0.06 && m_turbo_curr_rpm[i] > m_conf_turbo_min_bov_psi * 10000) 
 				{
-					SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_TURBOBOV);
-					curBOVTurboRPM[i] += dt * turboBOVtorque / (turboInertia * 0.1);
+					SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_TURBOBOV);
+					m_turbo_cur_bov_rpm[i] += dt * m_turbo_bov_torque / (m_turbo_inertia * 0.1);
 				}
 				else
 				{
-					SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_TURBOBOV);
-					if (curBOVTurboRPM[i] < curTurboRPM[i])
-						curBOVTurboRPM[i] += dt * turboBOVtorque / (turboInertia * 0.05);
+					SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_TURBOBOV);
+					if (m_turbo_cur_bov_rpm[i] < m_turbo_curr_rpm[i])
+						m_turbo_cur_bov_rpm[i] += dt * m_turbo_bov_torque / (m_turbo_inertia * 0.05);
 					else
-						curBOVTurboRPM[i] += dt * turboBOVtorque / turboInertia;
+						m_turbo_cur_bov_rpm[i] += dt * m_turbo_bov_torque / m_turbo_inertia;
 				}	
 			}
 		}
@@ -380,44 +398,44 @@ void BeamEngine::update(float dt, int doUpdate)
 	float totaltorque = 0.0f;
 
 	// engine braking
-	if (contact)
+	if (m_starter_has_contact)
 	{
-		totaltorque += brakingTorque * curEngineRPM / maxRPM;
+		totaltorque += m_conf_engine_braking_torque * m_curr_engine_rpm / m_conf_engine_max_rpm;
 	} else
 	{
-		totaltorque += 10.0f * brakingTorque * curEngineRPM / maxRPM;
+		totaltorque += 10.0f * m_conf_engine_braking_torque * m_curr_engine_rpm / m_conf_engine_max_rpm;
 	}
 
-	// braking by hydropump
-	if (curEngineRPM > 100.0f)
+	// braking by m_conf_engine_hydropump
+	if (m_curr_engine_rpm > 100.0f)
 	{
-		totaltorque -= 8.0f * hydropump / (curEngineRPM * 0.105f * dt);
+		totaltorque -= 8.0f * m_engine_hydropump / (m_curr_engine_rpm * 0.105f * dt);
 	}
 
-	if (running && contact && curEngineRPM < (maxRPM * 1.25f))
+	if (m_is_engine_running && m_starter_has_contact && m_curr_engine_rpm < (m_conf_engine_max_rpm * 1.25f))
 	{
-		totaltorque += getEnginePower(curEngineRPM) * acc;
+		totaltorque += getEnginePower(m_curr_engine_rpm) * acc;
 	}
 
-	if (!is_Electric)
+	if (!engine_is_electric)
 	{
-		if (running && curEngineRPM < stallRPM)
+		if (m_is_engine_running && m_curr_engine_rpm < m_conf_engine_stall_rpm)
 		{
 			stop(); //No, electric engine has no stop
 		}
-		// starter
+		// m_starter_is_running
 
-		if (contact && starter && curEngineRPM < stallRPM * 1.5f)
+		if (m_starter_has_contact && m_starter_is_running && m_curr_engine_rpm < m_conf_engine_stall_rpm * 1.5f)
 		{
-			totaltorque += -brakingTorque; //No starter in electric engines
+			totaltorque += -m_conf_engine_braking_torque; //No m_starter_is_running in electric engines
 		}
 		// restart
 
-		if (!running && curEngineRPM > stallRPM && contact)
+		if (!m_is_engine_running && m_curr_engine_rpm > m_conf_engine_stall_rpm && m_starter_has_contact)
 		{
-			running = true;
+			m_is_engine_running = true;
 #ifdef USE_OPENAL
-			SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_ENGINE);
+			SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_ENGINE);
 #endif // USE_OPENAL
 		}
 	}
@@ -425,165 +443,168 @@ void BeamEngine::update(float dt, int doUpdate)
 	// clutch
 	float retorque = 0.0f;
 
-	if (curGear)
+	if (m_curr_gear)
 	{
-		retorque = curClutchTorque / gearsRatio[curGear + 1];
+		retorque = m_curr_clutch_torque / m_conf_gear_ratios[m_curr_gear + 1];
 	}
 
 	totaltorque -= retorque;
 
 	// integration
-	curEngineRPM += dt * totaltorque / inertia;
+	m_curr_engine_rpm += dt * totaltorque / m_conf_engine_inertia;
 
 	// update clutch torque
-	if (curGear)
+	if (m_curr_gear)
 	{
-		float gearboxspinner = curEngineRPM / gearsRatio[curGear + 1];
-		curClutchTorque = (gearboxspinner - curWheelRevolutions) * curClutch * curClutch * clutchForce;
+		float gearboxspinner = m_curr_engine_rpm / m_conf_gear_ratios[m_curr_gear + 1];
+		m_curr_clutch_torque = (gearboxspinner - m_cur_wheel_revolutions) * m_curr_clutch * m_curr_clutch * m_conf_clutch_force;
 	} else
 	{
-		curClutchTorque = 0.0f;
+		m_curr_clutch_torque = 0.0f;
 	}
 
-	curEngineRPM = std::max(0.0f, curEngineRPM);
+	m_curr_engine_rpm = std::max(0.0f, m_curr_engine_rpm);
 
-	if (automode < MANUAL)
+	if (m_transmission_mode < MANUAL)
 	{
 		// auto-shift
-		if (shifting && !is_Electric) //No shifting in electric cars
+		if (m_is_shifting && !engine_is_electric) //No m_is_shifting in electric cars
 		{
-			shiftclock += dt;
+			m_shift_clock += dt;
 
 			// clutch
-			if (shiftclock < clutchTime)
+			if (m_shift_clock < m_conf_clutch_time)
 			{
-				curClutch = 1.0f - (shiftclock / clutchTime);
-			} else if (shiftclock > (shift_time - clutchTime))
+				m_curr_clutch = 1.0f - (m_shift_clock / m_conf_clutch_time);
+			} else if (m_shift_clock > (m_conf_shift_time - m_conf_clutch_time))
 			{
-				curClutch = 1.0f - (shift_time - shiftclock) / clutchTime;
+				m_curr_clutch = 1.0f - (m_conf_shift_time - m_shift_clock) / m_conf_clutch_time;
 			} else
 			{
-				curClutch = 0.0f;
+				m_curr_clutch = 0.0f;
 			}
 
 			// shift
-			if (shiftval && shiftclock > clutchTime / 2.0f)
+			if (m_curr_gear_change_relative && m_shift_clock > m_conf_clutch_time / 2.0f)
 			{
 #ifdef USE_OPENAL
-				SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_SHIFT);
+				SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_SHIFT);
 #endif // USE_OPENAL
-				curGear += shiftval;
-				curGear = std::max(-1, curGear);
-				curGear = std::min(curGear, numGears);
-				shiftval = 0;
+				m_curr_gear += m_curr_gear_change_relative;
+				m_curr_gear = std::max(-1, m_curr_gear);
+				m_curr_gear = std::min(m_curr_gear, m_conf_num_gears);
+				m_curr_gear_change_relative = 0;
 			}
 
-			// end of shifting
-			if (shiftclock > shift_time)
+			// end of m_is_shifting
+			if (m_shift_clock > m_conf_shift_time)
 			{
 #ifdef USE_OPENAL
-				SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_SHIFT);
+				SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_SHIFT);
 #endif // USE_OPENAL
-				setAcc(autocurAcc);
-				shifting = 0;
-				curClutch = 1.0f;
-				postshifting = 1;
-				postshiftclock = 0.0f;
+				setAcc(m_auto_curr_acc);
+				m_is_shifting = 0;
+				m_curr_clutch = 1.0f;
+				m_is_post_shifting = true;
+				m_post_shift_clock = 0.0f;
 			}
 		} else
-			setAcc(autocurAcc);
+			setAcc(m_auto_curr_acc);
 
 
 
 		// auto declutch
-		if (!is_Electric)
+		if (!engine_is_electric)
 		{
-			if (postshifting)
+			if (m_is_post_shifting)
 			{
-				postshiftclock += dt;
-				if (postshiftclock > post_shift_time)
+				m_post_shift_clock += dt;
+				if (m_post_shift_clock > m_conf_post_shift_time)
 				{
-					postshifting = 0;
+					m_is_post_shifting = false;
 				}
 			}
-			if (shifting)
+			if (m_is_shifting)
 			{
-				// we are shifting, just avoid stalling in worst case
-				if (curEngineRPM < stallRPM * 1.2f)
+				// we are m_is_shifting, just avoid stalling in worst case
+				if (m_curr_engine_rpm < m_conf_engine_stall_rpm * 1.2f)
 				{
-					curClutch = 0.0f;
+					m_curr_clutch = 0.0f;
 				}
 			}
-			else if (postshifting)
+			else if (m_is_post_shifting)
 			{
-				// we are postshifting, no gear change
-				if (curEngineRPM < stallRPM * 1.2f && acc < 0.5f)
+				// we are m_is_post_shifting, no gear change
+				if (m_curr_engine_rpm < m_conf_engine_stall_rpm * 1.2f && acc < 0.5f)
 				{
-					curClutch = 0.0f;
+					m_curr_clutch = 0.0f;
 				}
 				else
 				{
-					curClutch = 1.0f;
+					m_curr_clutch = 1.0f;
 				}
 			}
-			else if (curEngineRPM < stallRPM * 1.2f && acc < 0.5f)
+			else if (m_curr_engine_rpm < m_conf_engine_stall_rpm * 1.2f && acc < 0.5f)
 			{
-				curClutch = 0.0f;
+				m_curr_clutch = 0.0f;
 			}
-			else if (std::abs(curGear) == 1)
+			else if (std::abs(m_curr_gear) == 1)
 			{
 				// 1st gear : special
-				if (curEngineRPM > minRPM)
+				if (m_curr_engine_rpm > m_conf_engine_min_rpm)
 				{
-					curClutch = (curEngineRPM - minRPM) / (maxRPM - minRPM);
-					curClutch = std::min(curClutch, 1.0f);
+					m_curr_clutch = (m_curr_engine_rpm - m_conf_engine_min_rpm) / (m_conf_engine_max_rpm - m_conf_engine_min_rpm);
+					m_curr_clutch = std::min(m_curr_clutch, 1.0f);
 				}
 				else
 				{
-					curClutch = 0.0f;
+					m_curr_clutch = 0.0f;
 				}
 			}
 			else
 			{
-				curClutch = 1.0f;
+				m_curr_clutch = 1.0f;
 			}
 		} else
-			curClutch = 1.0f;
+			m_curr_clutch = 1.0f;
 	}
 
-	if (doUpdate && !shifting && !postshifting)
+	if (doUpdate && !m_is_shifting && !m_is_post_shifting)
 	{
+		float halfRPMRange     = m_conf_autotrans_full_rpm_range / 2.f;
+		float oneThirdRPMRange = m_conf_autotrans_full_rpm_range / 3.f;
+
 		// gear hack
-		absVelocity = truck->nodes[0].Velocity.length();
-		float velocity = absVelocity;
+		this->m_abs_velocity = truck->nodes[0].Velocity.length();
+		float velocity = m_abs_velocity;
 
 		if (truck->cameranodepos[0] >= 0 && truck->cameranodedir[0] >=0)
 		{
 			Vector3 hdir = (truck->nodes[truck->cameranodepos[0]].RelPosition - truck->nodes[truck->cameranodedir[0]].RelPosition).normalisedCopy();
 			velocity = hdir.dotProduct(truck->nodes[0].Velocity);
 		}
-		relVelocity = std::abs(velocity);
+		m_rel_velocity = std::abs(velocity);
 
 		if (truck->wheels[0].radius != 0)
 		{
-			refWheelRevolutions = velocity / truck->wheels[0].radius * RAD_PER_SEC_TO_RPM;
+			m_ref_wheel_revolutions = velocity / truck->wheels[0].radius * RAD_PER_SEC_TO_RPM;
 		}
 
-		if (automode == AUTOMATIC && (autoselect == DRIVE || autoselect == TWO) && curGear > 0)
+		if (m_transmission_mode == AUTOMATIC && (m_autoselect == DRIVE || m_autoselect == TWO) && m_curr_gear > 0)
 		{
-			if ((curEngineRPM > maxRPM - 100.0f && curGear > 1) || curWheelRevolutions * gearsRatio[curGear + 1] > maxRPM - 100.0f)
+			if ((m_curr_engine_rpm > m_conf_engine_max_rpm - 100.0f && m_curr_gear > 1) || m_cur_wheel_revolutions * m_conf_gear_ratios[m_curr_gear + 1] > m_conf_engine_max_rpm - 100.0f)
 			{
-				if ((autoselect == DRIVE && curGear < numGears) || (autoselect == TWO && curGear < std::min(2, numGears)) && !is_Electric)
+				if ((m_autoselect == DRIVE && m_curr_gear < m_conf_num_gears) || (m_autoselect == TWO && m_curr_gear < std::min(2, m_conf_num_gears)) && !engine_is_electric)
 				{
-					shift(1);
+					this->BeamEngineShift(1);
 				}
-			} else if (curGear > 1 && refWheelRevolutions * gearsRatio[curGear] < maxRPM && (curEngineRPM < minRPM || (curEngineRPM < minRPM + shiftBehaviour * halfRPMRange / 2.0f &&
-				getEnginePower(curWheelRevolutions * gearsRatio[curGear]) > getEnginePower(curWheelRevolutions * gearsRatio[curGear + 1]))) && !is_Electric)
+			} else if (m_curr_gear > 1 && m_ref_wheel_revolutions * m_conf_gear_ratios[m_curr_gear] < m_conf_engine_max_rpm && (m_curr_engine_rpm < m_conf_engine_min_rpm || (m_curr_engine_rpm < m_conf_engine_min_rpm + m_autotrans_curr_shift_behavior * halfRPMRange / 2.0f &&
+				getEnginePower(m_cur_wheel_revolutions * m_conf_gear_ratios[m_curr_gear]) > getEnginePower(m_cur_wheel_revolutions * m_conf_gear_ratios[m_curr_gear + 1]))) && !engine_is_electric)
 			{
-				shift(-1);
+				this->BeamEngineShift(-1);
 			}
 
-			int newGear = curGear;
+			int newGear = m_curr_gear;
 			
 			float brake = 0.0f;
 
@@ -592,9 +613,9 @@ void BeamEngine::update(float dt, int doUpdate)
 				brake = truck->brake / truck->brakeforce;
 			}
 
-			rpms.push_front(curEngineRPM);
-			accs.push_front(acc);
-			brakes.push_front(brake);
+			m_autotrans_rpm_buffer.push_front(m_curr_engine_rpm);
+			m_autotrans_acc_buffer.push_front(acc);
+			m_autotrans_brake_buffer.push_front(brake);
 
 			float avgRPM50 = 0.0f;
 			float avgRPM200 = 0.0f;
@@ -603,185 +624,290 @@ void BeamEngine::update(float dt, int doUpdate)
 			float avgBrake50 = 0.0f;
 			float avgBrake200 = 0.0f;
 
-			for (unsigned int i=0; i < accs.size(); i++)
+			for (unsigned int i=0; i < m_autotrans_acc_buffer.size(); i++)
 			{
 				if (i < 50)
 				{
-					avgRPM50 += rpms[i];
-					avgAcc50 += accs[i];
-					avgBrake50 += brakes[i];
+					avgRPM50 += m_autotrans_rpm_buffer[i];
+					avgAcc50 += m_autotrans_acc_buffer[i];
+					avgBrake50 += m_autotrans_brake_buffer[i];
 				}
 
-				avgRPM200 += rpms[i];
-				avgAcc200 += accs[i];
-				avgBrake200 += brakes[i];
+				avgRPM200 += m_autotrans_rpm_buffer[i];
+				avgAcc200 += m_autotrans_acc_buffer[i];
+				avgBrake200 += m_autotrans_brake_buffer[i];
 			}
 
-			avgRPM50 /= std::min(rpms.size(), (std::deque<float>::size_type)50);
-			avgAcc50 /= std::min(accs.size(), (std::deque<float>::size_type)50);
-			avgBrake50 /= std::min(brakes.size(), (std::deque<float>::size_type)50);
+			avgRPM50 /= std::min(m_autotrans_rpm_buffer.size(), (std::deque<float>::size_type)50);
+			avgAcc50 /= std::min(m_autotrans_acc_buffer.size(), (std::deque<float>::size_type)50);
+			avgBrake50 /= std::min(m_autotrans_brake_buffer.size(), (std::deque<float>::size_type)50);
 
-			avgRPM200 /= rpms.size();
-			avgAcc200 /= accs.size();
-			avgBrake200 /= brakes.size();
+			avgRPM200 /= m_autotrans_rpm_buffer.size();
+			avgAcc200 /= m_autotrans_acc_buffer.size();
+			avgBrake200 /= m_autotrans_brake_buffer.size();
 
-			if (!is_Electric)
+			if (!engine_is_electric)
 			{
 
 				if (avgAcc50 > 0.8f || avgAcc200 > 0.8f || avgBrake50 > 0.8f || avgBrake200 > 0.8f)
 				{
-					shiftBehaviour = std::min(shiftBehaviour + 0.01f, 1.0f);
+					m_autotrans_curr_shift_behavior = std::min(m_autotrans_curr_shift_behavior + 0.01f, 1.0f);
 				}
 				else if (acc < 0.5f && avgAcc50 < 0.5f && avgAcc200 < 0.5f && brake < 0.5f && avgBrake50 < 0.5f && avgBrake200 < 0.5 )
 				{
-					shiftBehaviour /= 1.01;
+					m_autotrans_curr_shift_behavior /= 1.01;
 				}
 			
 
-				if (avgAcc50 > 0.8f && curEngineRPM < maxRPM - oneThirdRPMRange)
+				if (avgAcc50 > 0.8f && m_curr_engine_rpm < m_conf_engine_max_rpm - oneThirdRPMRange)
 				{
-					while (newGear > 1 && curWheelRevolutions * gearsRatio[newGear] < maxRPM - oneThirdRPMRange &&
-						getEnginePower(curWheelRevolutions * gearsRatio[newGear])   * gearsRatio[newGear] >
-						getEnginePower(curWheelRevolutions * gearsRatio[newGear+1]) * gearsRatio[newGear+1])
+					while (newGear > 1 && m_cur_wheel_revolutions * m_conf_gear_ratios[newGear] < m_conf_engine_max_rpm - oneThirdRPMRange &&
+						getEnginePower(m_cur_wheel_revolutions * m_conf_gear_ratios[newGear])   * m_conf_gear_ratios[newGear] >
+						getEnginePower(m_cur_wheel_revolutions * m_conf_gear_ratios[newGear+1]) * m_conf_gear_ratios[newGear+1])
 					{
 						newGear--;
 					}
-				} else if (avgAcc50 > 0.6f && acc < 0.8f && acc > avgAcc50 + 0.1f && curEngineRPM < minRPM + halfRPMRange)
+				} else if (avgAcc50 > 0.6f && acc < 0.8f && acc > avgAcc50 + 0.1f && m_curr_engine_rpm < m_conf_engine_min_rpm + halfRPMRange)
 				{
-					if (newGear > 1 && curWheelRevolutions * gearsRatio[newGear] < minRPM + halfRPMRange &&
-						getEnginePower(curWheelRevolutions * gearsRatio[newGear])   * gearsRatio[newGear] >
-						getEnginePower(curWheelRevolutions * gearsRatio[newGear+1]) * gearsRatio[newGear+1])
+					if (newGear > 1 && m_cur_wheel_revolutions * m_conf_gear_ratios[newGear] < m_conf_engine_min_rpm + halfRPMRange &&
+						getEnginePower(m_cur_wheel_revolutions * m_conf_gear_ratios[newGear])   * m_conf_gear_ratios[newGear] >
+						getEnginePower(m_cur_wheel_revolutions * m_conf_gear_ratios[newGear+1]) * m_conf_gear_ratios[newGear+1])
 					{
 						newGear--;
 					}
-				} else if (avgAcc50 > 0.4f && acc < 0.8f && acc > avgAcc50 + 0.1f && curEngineRPM < minRPM + halfRPMRange)
+				} else if (avgAcc50 > 0.4f && acc < 0.8f && acc > avgAcc50 + 0.1f && m_curr_engine_rpm < m_conf_engine_min_rpm + halfRPMRange)
 				{
-					if (newGear > 1 && curWheelRevolutions * gearsRatio[newGear] < minRPM + oneThirdRPMRange &&
-						getEnginePower(curWheelRevolutions * gearsRatio[newGear])   * gearsRatio[newGear] >
-						getEnginePower(curWheelRevolutions * gearsRatio[newGear+1]) * gearsRatio[newGear+1])
+					if (newGear > 1 && m_cur_wheel_revolutions * m_conf_gear_ratios[newGear] < m_conf_engine_min_rpm + oneThirdRPMRange &&
+						getEnginePower(m_cur_wheel_revolutions * m_conf_gear_ratios[newGear])   * m_conf_gear_ratios[newGear] >
+						getEnginePower(m_cur_wheel_revolutions * m_conf_gear_ratios[newGear+1]) * m_conf_gear_ratios[newGear+1])
 					{
 						newGear--;
 					}
 				}
-				else if (curGear < (autoselect == TWO ? std::min(2, numGears) : numGears) &&
-					avgBrake200 < 0.2f && acc < std::min(avgAcc200 + 0.1f, 1.0f) && curEngineRPM > avgRPM200 - fullRPMRange / 20.0f)
+				else if (m_curr_gear < (m_autoselect == TWO ? std::min(2, m_conf_num_gears) : m_conf_num_gears) &&
+					avgBrake200 < 0.2f && acc < std::min(avgAcc200 + 0.1f, 1.0f) && m_curr_engine_rpm > avgRPM200 - m_conf_autotrans_full_rpm_range / 20.0f)
 				{
-					if (avgAcc200 < 0.6f && avgAcc200 > 0.4f && curEngineRPM > minRPM + oneThirdRPMRange && curEngineRPM < maxRPM - oneThirdRPMRange)
+					if (avgAcc200 < 0.6f && avgAcc200 > 0.4f && m_curr_engine_rpm > m_conf_engine_min_rpm + oneThirdRPMRange && m_curr_engine_rpm < m_conf_engine_max_rpm - oneThirdRPMRange)
 					{
-						if (curWheelRevolutions * gearsRatio[newGear + 2] > minRPM + oneThirdRPMRange)
+						if (m_cur_wheel_revolutions * m_conf_gear_ratios[newGear + 2] > m_conf_engine_min_rpm + oneThirdRPMRange)
 						{
 							newGear++;
 						}
 					}
-					else if (avgAcc200 < 0.4f && avgAcc200 > 0.2f && curEngineRPM > minRPM + oneThirdRPMRange)
+					else if (avgAcc200 < 0.4f && avgAcc200 > 0.2f && m_curr_engine_rpm > m_conf_engine_min_rpm + oneThirdRPMRange)
 					{
-						if (curWheelRevolutions * gearsRatio[newGear + 2] > minRPM + oneThirdRPMRange / 2.0f)
+						if (m_cur_wheel_revolutions * m_conf_gear_ratios[newGear + 2] > m_conf_engine_min_rpm + oneThirdRPMRange / 2.0f)
 						{
 							newGear++;
 						}
 					}
-					else if (avgAcc200 < 0.2f && curEngineRPM > minRPM + oneThirdRPMRange / 2.0f && curEngineRPM < minRPM + halfRPMRange)
+					else if (avgAcc200 < 0.2f && m_curr_engine_rpm > m_conf_engine_min_rpm + oneThirdRPMRange / 2.0f && m_curr_engine_rpm < m_conf_engine_min_rpm + halfRPMRange)
 					{
-						if (curWheelRevolutions * gearsRatio[newGear + 2] > minRPM + oneThirdRPMRange / 2.0f)
+						if (m_cur_wheel_revolutions * m_conf_gear_ratios[newGear + 2] > m_conf_engine_min_rpm + oneThirdRPMRange / 2.0f)
 						{
 							newGear++;
 						}
 					}
 
-					if (newGear > curGear)
+					if (newGear > m_curr_gear)
 					{
-						upShiftDelayCounter++;
-						if (upShiftDelayCounter <= 100 * shiftBehaviour)
+						m_autotrans_up_shift_delay_counter++;
+						if (m_autotrans_up_shift_delay_counter <= 100 * m_autotrans_curr_shift_behavior)
 						{
-							newGear = curGear;
+							newGear = m_curr_gear;
 						}
 					}
 					else
 					{
-						upShiftDelayCounter = 0;
+						m_autotrans_up_shift_delay_counter = 0;
 					}
 				}
-				if (newGear < curGear && std::abs(curWheelRevolutions * (gearsRatio[newGear + 1] - gearsRatio[curGear + 1])) > oneThirdRPMRange / 6.0f ||
-					newGear > curGear && std::abs(curWheelRevolutions * (gearsRatio[newGear + 1] - gearsRatio[curGear + 1])) > oneThirdRPMRange / 3.0f && !is_Electric)
+				if (newGear < m_curr_gear && std::abs(m_cur_wheel_revolutions * (m_conf_gear_ratios[newGear + 1] - m_conf_gear_ratios[m_curr_gear + 1])) > oneThirdRPMRange / 6.0f ||
+					newGear > m_curr_gear && std::abs(m_cur_wheel_revolutions * (m_conf_gear_ratios[newGear + 1] - m_conf_gear_ratios[m_curr_gear + 1])) > oneThirdRPMRange / 3.0f && !engine_is_electric)
 				{
-					if (absVelocity - relVelocity < 0.5f)
-						shiftTo(newGear);
+					if (m_abs_velocity - m_rel_velocity < 0.5f)
+						this->BeamEngineShiftTo(newGear);
 				}
 			}
 
 
-			if (accs.size() > 200)
+			if (m_autotrans_acc_buffer.size() > 200)
 			{
-				rpms.pop_back();
-				accs.pop_back();
-				brakes.pop_back();
+				m_autotrans_rpm_buffer.pop_back();
+				m_autotrans_acc_buffer.pop_back();
+				m_autotrans_brake_buffer.pop_back();
 			}
 			// avoid over-revving
-			if (automode <= SEMIAUTO && curGear != 0)
+			if (m_transmission_mode <= SEMIAUTO && m_curr_gear != 0)
 			{
-				if (std::abs(curWheelRevolutions * gearsRatio[curGear + 1]) > maxRPM * 1.25f)
+				if (std::abs(m_cur_wheel_revolutions * m_conf_gear_ratios[m_curr_gear + 1]) > m_conf_engine_max_rpm * 1.25f)
 				{
-					float clutch = 0.0f + 1.0f / (1.0f + std::abs(curWheelRevolutions * gearsRatio[curGear + 1] - maxRPM * 1.25f) / 2.0f);
-					curClutch = std::min(clutch, curClutch);
+					float clutch = 0.0f + 1.0f / (1.0f + std::abs(m_cur_wheel_revolutions * m_conf_gear_ratios[m_curr_gear + 1] - m_conf_engine_max_rpm * 1.25f) / 2.0f);
+					m_curr_clutch = std::min(clutch, m_curr_clutch);
 				}
-				if (curGear * curWheelRevolutions < -10.0f)
+				if (m_curr_gear * m_cur_wheel_revolutions < -10.0f)
 				{
-					float clutch = 0.0f + 1.0f / (1.0f + std::abs(-10.0f - curGear * curWheelRevolutions) / 2.0f);
-					curClutch = std::min(clutch, curClutch);
+					float clutch = 0.0f + 1.0f / (1.0f + std::abs(-10.0f - m_curr_gear * m_cur_wheel_revolutions) / 2.0f);
+					m_curr_clutch = std::min(clutch, m_curr_clutch);
 				}
 			}
 		}
 	}
 
 	// audio stuff
-	updateAudio(doUpdate);
+	UpdateBeamEngineAudio(doUpdate);
+
+	// ============ DEBUG =================
+	// Print all contents
+    //this->DEBUG_LogClassState(snapshot_before, dt, doUpdate);
 }
 
-void BeamEngine::updateAudio(int doUpdate)
+#define LOG_DEQUE_FLOAT(sstream, var) { \
+    auto itor = var.begin();\
+    auto iend = var.end();\
+    sstream << "[size: "<<var.size()<<"]";\
+    for (; itor != iend; ++itor) { sstream << std::setw(10) << *itor << ""; } \
+    } 
+
+void BeamEngine::DEBUG_LogClassState(BeamEngine snapshot_before, float dt, int doUpdate)
+{
+    using namespace std;
+    int width = 20;
+	std::stringstream msg;
+	msg.str().reserve(5000);
+    pthread_t thread = pthread_self();
+	
+	msg << " ====== Engine updated (thread: " << thread.p 
+        << ", truck: " << m_vehicle_index << ", deltatime: " << dt  
+        << ", doUpdate: " << doUpdate << ") =========";
+        /*
+	<<"\nrefWheelRevolutions       "<< setw(width) << snapshot_before.m_ref_wheel_revolutions                      << ", " << setw(width) << m_ref_wheel_revolutions
+	<<"\ncurWheelRevolutions       "<< setw(width) << snapshot_before.m_cur_wheel_revolutions                      << ", " << setw(width) << m_cur_wheel_revolutions 
+	<<"\ncurGear                   "<< setw(width) << snapshot_before.m_curr_gear                                  << ", " << setw(width) << m_curr_gear
+	<<"\ncurGearRange              "<< setw(width) << snapshot_before.m_curr_gear_range                             << ", " << setw(width) << m_curr_gear_range 
+	<<"\nnumGears                  "<< setw(width) << snapshot_before.m_conf_num_gears                                 << ", " << setw(width) << m_conf_num_gears 
+	<<"\nabsVelocity               "<< setw(width) << snapshot_before.m_abs_velocity                              << ", " << setw(width) << m_abs_velocity 
+	<<"\nrelVelocity               "<< setw(width) << snapshot_before.m_rel_velocity                              << ", " << setw(width) << m_rel_velocity 
+	<<"\nclutchForce               "<< setw(width) << snapshot_before.m_conf_clutch_force                              << ", " << setw(width) << m_conf_clutch_force
+	<<"\nclutchTime                "<< setw(width) << snapshot_before.m_conf_clutch_time                               << ", " << setw(width) << m_conf_clutch_time
+	<<"\ncurClutch                 "<< setw(width) << snapshot_before.m_curr_clutch                                << ", " << setw(width) << m_curr_clutch
+	<<"\ncurClutchTorque           "<< setw(width) << snapshot_before.m_curr_clutch_torque                          << ", " << setw(width) << m_curr_clutch_torque
+	<<"\ncontact                   "<< setw(width) << snapshot_before.m_starter_has_contact                                  << ", " << setw(width) << m_starter_has_contact 
+	<<"\nhasair                    "<< setw(width) << snapshot_before.m_conf_engine_has_air                                   << ", " << setw(width) << m_conf_engine_has_air 
+	<<"\nhasturbo                  "<< setw(width) << snapshot_before.m_conf_engine_has_turbo                                 << ", " << setw(width) << m_conf_engine_has_turbo 
+	<<"\nrunning                   "<< setw(width) << snapshot_before.m_is_engine_running                                  << ", " << setw(width) << m_is_engine_running 
+	<<"\ntype                      "<< setw(width) << snapshot_before.type                                     << ", " << setw(width) << type 
+	<<"\nbrakingTorque             "<< setw(width) << snapshot_before.m_conf_engine_braking_torque                            << ", " << setw(width) << m_conf_engine_braking_torque 
+	<<"\ncurAcc                    "<< setw(width) << snapshot_before.m_curr_acc                                   << ", " << setw(width) << m_curr_acc 
+	<<"\ncurEngineRPM              "<< setw(width) << snapshot_before.m_curr_engine_rpm                             << ", " << setw(width) << m_curr_engine_rpm 
+	<<"\ndiffRatio                 "<< setw(width) << snapshot_before.m_conf_engine_diff_ratio                                << ", " << setw(width) << m_conf_engine_diff_ratio 
+	<<"\nengineTorque              "<< setw(width) << snapshot_before.m_conf_engine_torque                             << ", " << setw(width) << m_conf_engine_torque 
+	<<"\nhydropump                 "<< setw(width) << snapshot_before.m_conf_engine_hydropump                                << ", " << setw(width) << m_conf_engine_hydropump 
+	<<"\nidleRPM                   "<< setw(width) << snapshot_before.m_conf_engine_idle_rpm                                  << ", " << setw(width) << m_conf_engine_idle_rpm 
+	<<"\nminIdleMixture            "<< setw(width) << snapshot_before.m_conf_engine_min_idle_mixture                           << ", " << setw(width) << m_conf_engine_min_idle_mixture 
+	<<"\nmaxIdleMixture            "<< setw(width) << snapshot_before.m_conf_engine_max_idle_mixture                           << ", " << setw(width) << m_conf_engine_max_idle_mixture 
+	<<"\ninertia                   "<< setw(width) << snapshot_before.m_conf_engine_inertia                                  << ", " << setw(width) << m_conf_engine_inertia 
+	<<"\nmaxRPM                    "<< setw(width) << snapshot_before.m_conf_engine_max_rpm                                   << ", " << setw(width) << m_conf_engine_max_rpm 
+	<<"\nminRPM                    "<< setw(width) << snapshot_before.m_conf_engine_min_rpm                                   << ", " << setw(width) << m_conf_engine_min_rpm 
+	<<"\nstallRPM                  "<< setw(width) << snapshot_before.m_conf_engine_stall_rpm                                 << ", " << setw(width) << m_conf_engine_stall_rpm 
+	<<"\nprime                     "<< setw(width) << snapshot_before.prime                                    << ", " << setw(width) << prime 
+	<<"\npost_shift_time           "<< setw(width) << snapshot_before.m_conf_post_shift_time                          << ", " << setw(width) << m_conf_post_shift_time 
+	<<"\npostshiftclock            "<< setw(width) << snapshot_before.m_post_shift_clock                           << ", " << setw(width) << m_post_shift_clock
+	<<"\nshift_time                "<< setw(width) << snapshot_before.m_conf_shift_time                               << ", " << setw(width) << m_conf_shift_time 
+	<<"\nshiftclock                "<< setw(width) << snapshot_before.m_shift_clock                               << ", " << setw(width) << m_shift_clock
+	<<"\npostshifting              "<< setw(width) << snapshot_before.m_is_post_shifting                             << ", " << setw(width) << m_is_post_shifting
+	<<"\nshifting                  "<< setw(width) << snapshot_before.m_is_shifting                                 << ", " << setw(width) << m_is_shifting
+	<<"\nshiftval                  "<< setw(width) << snapshot_before.m_curr_gear_change_relative                                 << ", " << setw(width) << m_curr_gear_change_relative
+	<<"\nautoselect                "<< setw(width) << snapshot_before.m_autoselect                               << ", " << setw(width) << m_autoselect
+	<<"\nautocurAcc                "<< setw(width) << snapshot_before.m_auto_curr_acc                               << ", " << setw(width) << m_auto_curr_acc
+	<<"\nstarter                   "<< setw(width) << snapshot_before.m_starter_is_running                                  << ", " << setw(width) << m_starter_is_running
+	<<"\nfullRPMRange              "<< setw(width) << snapshot_before.m_conf_autotrans_full_rpm_range                             << ", " << setw(width) << m_conf_autotrans_full_rpm_range
+	<<"\noneThirdRPMRange          "<< setw(width) << snapshot_before.oneThirdRPMRange                         << ", " << setw(width) << oneThirdRPMRange
+	<<"\nhalfRPMRange              "<< setw(width) << snapshot_before.halfRPMRange                             << ", " << setw(width) << halfRPMRange
+	<<"\nshiftBehaviour            "<< setw(width) << snapshot_before.m_autotrans_curr_shift_behavior                           << ", " << setw(width) << m_autotrans_curr_shift_behavior
+	<<"\nupShiftDelayCounter       "<< setw(width) << snapshot_before.m_autotrans_up_shift_delay_counter                      << ", " << setw(width) << m_autotrans_up_shift_delay_counter
+	<<"\nturboVer                  "<< setw(width) << snapshot_before.m_conf_turbo_version                                 << ", " << setw(width) << m_conf_turbo_version
+	<<"\ncurTurboRPM[MAX_NUM_TURBOS]     "<< setw(width) << snapshot_before.m_turbo_curr_rpm[MAX_NUM_TURBOS]                    << ", " << setw(width) << m_turbo_curr_rpm[MAX_NUM_TURBOS]
+	<<"\nturboInertiaFactor        "<< setw(width) << snapshot_before.m_conf_turbo_inertia_factor                       << ", " << setw(width) << m_conf_turbo_inertia_factor
+	<<"\nnumTurbos                 "<< setw(width) << snapshot_before.m_conf_num_turbos                                << ", " << setw(width) << m_conf_num_turbos
+	<<"\nmaxTurboRPM               "<< setw(width) << snapshot_before.m_conf_turbo_max_rpm                              << ", " << setw(width) << m_conf_turbo_max_rpm
+	<<"\nturbotorque               "<< setw(width) << snapshot_before.m_turbo_torque                              << ", " << setw(width) << m_turbo_torque
+	<<"\nturboInertia              "<< setw(width) << snapshot_before.m_turbo_inertia                             << ", " << setw(width) << m_turbo_inertia
+	<<"\nEngineAddiTorque[MAX_NUM_TURBOS]"<< setw(width) << snapshot_before.m_conf_turbo_addi_torque[MAX_NUM_TURBOS]               << ", " << setw(width) << m_conf_turbo_addi_torque[MAX_NUM_TURBOS]
+	<<"\nturboEngineRpmOperation   "<< setw(width) << snapshot_before.m_conf_turbo_engine_rpm_operation                  << ", " << setw(width) << m_conf_turbo_engine_rpm_operation
+	<<"\nturboMaxPSI               "<< setw(width) << snapshot_before.m_conf_turbo_max_psi                              << ", " << setw(width) << m_conf_turbo_max_psi
+	<<"\nturboPSI                  "<< setw(width) << snapshot_before.m_turbo_psi                                 << ", " << setw(width) << m_turbo_psi
+	<<"\nb_BOV                     "<< setw(width) << snapshot_before.m_conf_turbo_has_bov                                    << ", " << setw(width) << m_conf_turbo_has_bov
+	<<"\ncurBOVTurboRPM[MAX_NUM_TURBOS]  "<< setw(width) << snapshot_before.m_turbo_cur_bov_rpm[MAX_NUM_TURBOS]                 << ", " << setw(width) << m_turbo_cur_bov_rpm[MAX_NUM_TURBOS]
+	<<"\nturboBOVtorque            "<< setw(width) << snapshot_before.m_turbo_bov_torque                           << ", " << setw(width) << m_turbo_bov_torque
+	<<"\nminBOVPsi                 "<< setw(width) << snapshot_before.m_conf_turbo_min_bov_psi                                << ", " << setw(width) << m_conf_turbo_min_bov_psi
+	<<"\nb_WasteGate               "<< setw(width) << snapshot_before.m_conf_turbo_has_wastegate                              << ", " << setw(width) << m_conf_turbo_has_wastegate
+	<<"\nminWGPsi                  "<< setw(width) << snapshot_before.m_conf_turbo_wg_min_psi                                 << ", " << setw(width) << m_conf_turbo_wg_min_psi
+	<<"\nb_flutter                 "<< setw(width) << snapshot_before.m_conf_turbo_has_flutter                                << ", " << setw(width) << m_conf_turbo_has_flutter
+	<<"\nwastegate_threshold_p     "<< setw(width) << snapshot_before.m_conf_turbo_wg_threshold_p                    << ", " << setw(width) << m_conf_turbo_wg_threshold_p
+    <<"\nwastegate_threshold_n     "<< setw(width) << snapshot_before.m_conf_turbo_wg_threshold_n                    << ", " << setw(width) << m_conf_turbo_wg_threshold_n
+	<<"\nb_anti_lag                "<< setw(width) << snapshot_before.m_conf_turbo_has_antilag                               << ", " << setw(width) << m_conf_turbo_has_antilag
+	<<"\nminRPM_antilag            "<< setw(width) << snapshot_before.m_conf_turbo_antilag_min_rpm                           << ", " << setw(width) << m_conf_turbo_antilag_min_rpm
+	<<"\nrnd_antilag_chance        "<< setw(width) << snapshot_before.m_conf_turbo_antilag_chance_rand                       << ", " << setw(width) << m_conf_turbo_antilag_chance_rand
+	<<"\nantilag_power_factor      "<< setw(width) << snapshot_before.m_conf_turbo_antilag_power_factor                     << ", " << setw(width) << m_conf_turbo_antilag_power_factor
+	<<"\nm_air_pressure            "<< setw(width) << snapshot_before.m_air_pressure                           << ", " << setw(width) << m_air_pressure
+	<<"\nautomode                  "<< setw(width) << snapshot_before.m_transmission_mode                                 << ", " << setw(width) << m_transmission_mode
+    ;*/
+    //msg << "\nDEQUE m_autotrans_rpm_buffer BEFORE"; LOG_DEQUE_FLOAT(msg, snapshot_before.m_autotrans_rpm_buffer); 
+    //msg << "\nDEQUE m_autotrans_rpm_buffer   AFTER"; LOG_DEQUE_FLOAT(msg, m_autotrans_rpm_buffer);
+    //msg << "\nDEQUE m_autotrans_acc_buffer BEFORE"; LOG_DEQUE_FLOAT(msg, snapshot_before.m_autotrans_acc_buffer); 
+    //msg << "\nDEQUE m_autotrans_acc_buffer   AFTER"; LOG_DEQUE_FLOAT(msg, m_autotrans_acc_buffer);
+    //msg << "\nDEQUE m_autotrans_brake_buffer BEFORE"; LOG_DEQUE_FLOAT(msg, snapshot_before.m_autotrans_brake_buffer); 
+    //msg << "\nDEQUE m_autotrans_brake_buffer AFTER"; LOG_DEQUE_FLOAT(msg, m_autotrans_brake_buffer);
+
+    LOG(msg.str());
+}
+
+void BeamEngine::UpdateBeamEngineAudio(int doUpdate)
 {
 #ifdef USE_OPENAL
-	if (hasturbo)
+	if (m_conf_engine_has_turbo)
 	{
-		for (int i = 0; i < numTurbos; i++)
-			 SoundScriptManager::getSingleton().modulate(trucknum, SS_MOD_TURBO, curTurboRPM[i]);
+		for (int i = 0; i < m_conf_num_turbos; i++)
+			 SoundScriptManager::getSingleton().modulate(m_vehicle_index, SS_MOD_TURBO, m_turbo_curr_rpm[i]);
 	}
 
 	if (doUpdate)
 	{
-		SoundScriptManager::getSingleton().modulate(trucknum, SS_MOD_ENGINE, curEngineRPM);
-		SoundScriptManager::getSingleton().modulate(trucknum, SS_MOD_TORQUE, curClutchTorque);
-		SoundScriptManager::getSingleton().modulate(trucknum, SS_MOD_GEARBOX, curWheelRevolutions);
+		SoundScriptManager::getSingleton().modulate(m_vehicle_index, SS_MOD_ENGINE, m_curr_engine_rpm);
+		SoundScriptManager::getSingleton().modulate(m_vehicle_index, SS_MOD_TORQUE, m_curr_clutch_torque);
+		SoundScriptManager::getSingleton().modulate(m_vehicle_index, SS_MOD_GEARBOX, m_cur_wheel_revolutions);
 	}
 	// reverse gear beep
-	if (curGear == -1 && running)
+	if (m_curr_gear == -1 && m_is_engine_running)
 	{
-		SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_REVERSE_GEAR);
+		SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_REVERSE_GEAR);
 	} else
 	{
-		SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_REVERSE_GEAR);
+		SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_REVERSE_GEAR);
 	}
 #endif // USE_OPENAL
 }
 
 float BeamEngine::getRPM()
 {
-	return curEngineRPM;
+	return m_curr_engine_rpm;
 }
 
 void BeamEngine::toggleAutoMode()
 {
-	automode = (automode + 1) % (MANUAL_RANGES + 1);
+	m_transmission_mode = (m_transmission_mode + 1) % (MANUAL_RANGES + 1);
 
 	// this switches off all automatic symbols when in manual mode
-	if (automode != AUTOMATIC)
+	if (m_transmission_mode != AUTOMATIC)
 	{
-		autoselect = MANUALMODE;
+		m_autoselect = MANUALMODE;
 	} else
 	{
-		autoselect = NEUTRAL;
+		m_autoselect = NEUTRAL;
 	}
 
-	if (automode == MANUAL_RANGES)
+	if (m_transmission_mode == MANUAL_RANGES)
 	{
 		this->setGearRange(0);
 		this->setGear(0);
@@ -790,62 +916,62 @@ void BeamEngine::toggleAutoMode()
 
 int BeamEngine::getAutoMode()
 {
-	return automode;
+	return m_transmission_mode;
 }
 
 void BeamEngine::setAutoMode(int mode)
 {
-	automode = mode;
+	m_transmission_mode = mode;
 }
 
 void BeamEngine::setAcc(float val)
 {
-	curAcc = val;
+	m_curr_acc = val;
 }
 
 float BeamEngine::getTurboPSI()
 {
-	turboPSI = 0;
+	m_turbo_psi = 0;
 
-	if (b_BOV)
+	if (m_conf_turbo_has_bov)
 	{
-		for (int i = 0; i < numTurbos; i++)
-			turboPSI += curBOVTurboRPM[i] / 10000.0f;
+		for (int i = 0; i < m_conf_num_turbos; i++)
+			m_turbo_psi += m_turbo_cur_bov_rpm[i] / 10000.0f;
 	}
 	else
 	{
-		for (int i = 0; i < numTurbos; i++)
-			turboPSI += curTurboRPM[i] / 10000.0f;
+		for (int i = 0; i < m_conf_num_turbos; i++)
+			m_turbo_psi += m_turbo_curr_rpm[i] / 10000.0f;
 	}
 
-	return turboPSI;
+	return m_turbo_psi;
 }
 
 float BeamEngine::getAcc()
 {
-	return curAcc;
+	return m_curr_acc;
 }
 
 // this is mainly for smoke...
 void BeamEngine::netForceSettings(float rpm, float force, float clutch, int gear, bool _running, bool _contact, char _automode)
 {
-	curEngineRPM = rpm;
-	curAcc       = force;
-	curClutch    = clutch;
-	curGear      = gear;
-	running      = _running; //(fabs(rpm)>10.0);
-	contact      = _contact;
+	m_curr_engine_rpm = rpm;
+	m_curr_acc       = force;
+	m_curr_clutch    = clutch;
+	m_curr_gear      = gear;
+	m_is_engine_running      = _running; //(fabs(rpm)>10.0);
+	m_starter_has_contact      = _contact;
 	if (_automode != -1)
 	{
-		automode = _automode;
+		m_transmission_mode = _automode;
 	}
 }
 
 float BeamEngine::getSmoke()
 {
-	if (running)
+	if (m_is_engine_running)
 	{
-		return curAcc * (1.0f - curTurboRPM[0] /* doesn't matter */ / maxTurboRPM);// * engineTorque / 5000.0f;
+		return m_curr_acc * (1.0f - m_turbo_curr_rpm[0] /* doesn't matter */ / m_conf_turbo_max_rpm);// * m_conf_engine_torque / 5000.0f;
 	}
 
 	return -1;
@@ -853,29 +979,29 @@ float BeamEngine::getSmoke()
 
 float BeamEngine::getTorque()
 {
-	if (curClutchTorque >  1000000.0) return  1000000.0;
-	if (curClutchTorque < -1000000.0) return -1000000.0;
-	return curClutchTorque;
+	if (m_curr_clutch_torque >  1000000.0) return  1000000.0;
+	if (m_curr_clutch_torque < -1000000.0) return -1000000.0;
+	return m_curr_clutch_torque;
 }
 
 void BeamEngine::setRPM(float rpm)
 {
-	curEngineRPM = rpm;
+	m_curr_engine_rpm = rpm;
 }
 
 void BeamEngine::setSpin(float rpm)
 {
-	curWheelRevolutions = rpm;
+	m_cur_wheel_revolutions = rpm;
 }
 
 // for hydros acceleration
 float BeamEngine::getCrankFactor()
 {
-	float minWorkingRPM = idleRPM * 1.1f; // minWorkingRPM > idleRPM avoids commands deadlocking the engine
+	float minWorkingRPM = m_conf_engine_idle_rpm * 1.1f; // minWorkingRPM > m_conf_engine_idle_rpm avoids commands deadlocking the engine
 
-	float rpmRatio = (curEngineRPM - minWorkingRPM) / (maxRPM - minWorkingRPM);
-	rpmRatio = std::max(0.0f, rpmRatio); // Avoids a negative rpmRatio when curEngineRPM < minWorkingRPM
-	rpmRatio = std::min(rpmRatio, 1.0f); // Avoids a rpmRatio > 1.0f when curEngineRPM > maxRPM
+	float rpmRatio = (m_curr_engine_rpm - minWorkingRPM) / (m_conf_engine_max_rpm - minWorkingRPM);
+	rpmRatio = std::max(0.0f, rpmRatio); // Avoids a negative rpmRatio when m_curr_engine_rpm < minWorkingRPM
+	rpmRatio = std::min(rpmRatio, 1.0f); // Avoids a rpmRatio > 1.0f when m_curr_engine_rpm > m_conf_engine_max_rpm
 
 	float crankfactor = 5.0f * rpmRatio;
 
@@ -884,29 +1010,29 @@ float BeamEngine::getCrankFactor()
 
 void BeamEngine::setClutch(float clutch)
 {
-	curClutch = clutch;
+	m_curr_clutch = clutch;
 }
 
 float BeamEngine::getClutch()
 {
-	return curClutch;
+	return m_curr_clutch;
 }
 
 float BeamEngine::getClutchForce()
 {
-	return clutchForce;
+	return m_conf_clutch_force;
 }
 
 void BeamEngine::toggleContact()
 {
-	contact = !contact;
+	m_starter_has_contact = !m_starter_has_contact;
 #ifdef USE_OPENAL
-	if (contact)
+	if (m_starter_has_contact)
 	{
-		SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_IGNITION);
+		SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_IGNITION);
 	} else
 	{
-		SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_IGNITION);
+		SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_IGNITION);
 	}
 #endif // USE_OPENAL
 }
@@ -914,63 +1040,63 @@ void BeamEngine::toggleContact()
 // quick start
 void BeamEngine::start()
 {
-	if (automode == AUTOMATIC)
+	if (m_transmission_mode == AUTOMATIC)
 	{
-		curGear = 1;
-		autoselect = DRIVE;
+		m_curr_gear = 1;
+		m_autoselect = DRIVE;
 	} else
 	{
-		if (automode == SEMIAUTO)
+		if (m_transmission_mode == SEMIAUTO)
 		{
-			curGear = 1;
+			m_curr_gear = 1;
 		} else
 		{
-			curGear = 0;
+			m_curr_gear = 0;
 		}
-		autoselect = MANUALMODE;
+		m_autoselect = MANUALMODE;
 	}
-	curClutch = 0.0f;
-	curEngineRPM = 750.0f;
-	curClutchTorque = 0.0f;
+	m_curr_clutch = 0.0f;
+	m_curr_engine_rpm = 750.0f;
+	m_curr_clutch_torque = 0.0f;
 
-	for (int i = 0; i < numTurbos; i++)
+	for (int i = 0; i < m_conf_num_turbos; i++)
 	{
-		curTurboRPM[i] = 0.0f;
-		curBOVTurboRPM[i] = 0.0f;
+		m_turbo_curr_rpm[i] = 0.0f;
+		m_turbo_cur_bov_rpm[i] = 0.0f;
 	}
 
-	apressure = 0.0f;
-	running = true;
-	contact = true;
+	m_air_pressure = 0.0f;
+	m_is_engine_running = true;
+	m_starter_has_contact = true;
 #ifdef USE_OPENAL
-	SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_IGNITION);
+	SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_IGNITION);
 	setAcc(0.0f);
-	SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_ENGINE);
+	SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_ENGINE);
 #endif // USE_OPENAL
 }
 
 void BeamEngine::offstart()
 {
-	curGear = 0;
-	curClutch = 0.0f;
-	if (!is_Electric)
-		autoselect = NEUTRAL; //no Neutral in electric engines
+	m_curr_gear = 0;
+	m_curr_clutch = 0.0f;
+	if (m_conf_engine_type != 'e') // e = Electric engine
+		m_autoselect = NEUTRAL; //no Neutral in electric engines
 	else
-		autoselect = ONE;
+		m_autoselect = ONE;
 
-	curEngineRPM = 0.0f;
-	running = false;
-	contact = false;
+	m_curr_engine_rpm = 0.0f;
+	m_is_engine_running = false;
+	m_starter_has_contact = false;
 #ifdef USE_OPENAL
-	SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_IGNITION);
-	SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_ENGINE);
+	SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_IGNITION);
+	SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_ENGINE);
 #endif // USE_OPENAL
 }
 
 void BeamEngine::setstarter(int v)
 {
-	starter = v;
-	if (v && curEngineRPM < 750.0f)
+	m_starter_is_running = (v == 1);
+	if (v && m_curr_engine_rpm < 750.0f)
 	{
 		setAcc(1.0f);
 	}
@@ -978,153 +1104,154 @@ void BeamEngine::setstarter(int v)
 
 int BeamEngine::getGear()
 {
-	return curGear;
+	return m_curr_gear;
 }
 
 // low level gear changing
 void BeamEngine::setGear(int v)
 {
-	curGear = v;
+	m_curr_gear = v;
 }
 
 int BeamEngine::getGearRange()
 {
-	return curGearRange;
+	return m_curr_gear_range;
 }
 
 void BeamEngine::setGearRange(int v)
 {
-	curGearRange = v;
+	m_curr_gear_range = v;
 }
 
 void BeamEngine::stop()
 {
-	if (!running) return;
+	if (!m_is_engine_running) return;
 
-	running = false;
+	m_is_engine_running = false;
 	// Script Event - engine death
-	TRIGGER_EVENT(SE_TRUCK_ENGINE_DIED, trucknum);
+	TRIGGER_EVENT(SE_TRUCK_ENGINE_DIED, m_vehicle_index);
 #ifdef USE_OPENAL
-	SoundScriptManager::getSingleton().trigStop(trucknum, SS_TRIG_ENGINE);
+	SoundScriptManager::getSingleton().trigStop(m_vehicle_index, SS_TRIG_ENGINE);
 #endif // USE_OPENAL
 }
 
 // high level controls
 void BeamEngine::autoSetAcc(float val)
 {
-	autocurAcc = val;
-	if (!shifting)
+	m_auto_curr_acc = val;
+	if (!m_is_shifting)
 	{
 		setAcc(val);
 	}
 }
 
-void BeamEngine::shift(int val)
+void BeamEngine::BeamEngineShift(int val)
 {
-	if (!val || curGear + val < -1 || curGear + val > getNumGears()) return;
-	if (automode < MANUAL)
+	if (!val || m_curr_gear + val < -1 || m_curr_gear + val > getNumGears()) return;
+	if (m_transmission_mode < MANUAL)
 	{
 #ifdef USE_OPENAL
-		SoundScriptManager::getSingleton().trigStart(trucknum, SS_TRIG_SHIFT);
+		SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_SHIFT);
 #endif // USE_OPENAL
-		shiftval = val;
-		shifting = 1;
-		shiftclock = 0.0f;
+		m_curr_gear_change_relative = val;
+		m_is_shifting = 1;
+		m_shift_clock = 0.0f;
 		setAcc(0.0f);
 	} else
 	{
-		if (curClutch > 0.25f)
+		if (m_curr_clutch > 0.25f)
 		{
 #ifdef USE_OPENAL
-			SoundScriptManager::getSingleton().trigOnce(trucknum, SS_TRIG_GEARSLIDE);
+			SoundScriptManager::getSingleton().trigOnce(m_vehicle_index, SS_TRIG_GEARSLIDE);
 #endif // USE_OPENAL
 		} else
 		{
 #ifdef USE_OPENAL
-			SoundScriptManager::getSingleton().trigOnce(trucknum, SS_TRIG_SHIFT);
+			SoundScriptManager::getSingleton().trigOnce(m_vehicle_index, SS_TRIG_SHIFT);
 #endif // USE_OPENAL
-			curGear += val;
+			m_curr_gear += val;
 		}
 	}
 }
 
-void BeamEngine::shiftTo(int newGear)
+void BeamEngine::BeamEngineShiftTo(int newGear)
 {
-	shift(newGear - curGear);
+	this->BeamEngineShift(newGear - m_curr_gear);
 }
 
-void BeamEngine::updateShifts()
+void BeamEngine::UpdateBeamEngineShifts()
 {
-	if (autoselect == MANUALMODE) return;
+	if (m_autoselect == MANUALMODE) return;
 
 #ifdef USE_OPENAL
-	SoundScriptManager::getSingleton().trigOnce(trucknum, SS_TRIG_SHIFT);
+	SoundScriptManager::getSingleton().trigOnce(m_vehicle_index, SS_TRIG_SHIFT);
 #endif // USE_OPENAL
+	bool engine_is_electric = (m_conf_engine_type == 'e');
 
-	if (autoselect == REAR)
+	if (m_autoselect == REAR)
 	{
-		curGear = -1;
-	} else if (autoselect == NEUTRAL && !is_Electric)
+		m_curr_gear = -1;
+	} else if (m_autoselect == NEUTRAL && !engine_is_electric)
 	{
-		curGear =  0;
-	} else if (autoselect == ONE)
+		m_curr_gear =  0;
+	} else if (m_autoselect == ONE)
 	{
-		curGear =  1;
+		m_curr_gear =  1;
 	}
-	else if (!is_Electric) //no other gears for electric cars
+	else if (!engine_is_electric) //no other gears for electric cars
 	{
 		// search for an appropriate gear
 		int newGear = 1;
 
-		while (newGear < numGears && curWheelRevolutions > 0.0f && curWheelRevolutions * gearsRatio[newGear + 1] > maxRPM - 100.0f)
+		while (newGear < m_conf_num_gears && m_cur_wheel_revolutions > 0.0f && m_cur_wheel_revolutions * m_conf_gear_ratios[newGear + 1] > m_conf_engine_max_rpm - 100.0f)
 		{
 			newGear++;
 		}
 
-		curGear = newGear;
+		m_curr_gear = newGear;
 		
-		if (autoselect == TWO)
+		if (m_autoselect == TWO)
 		{
-			curGear = std::min(curGear, 2);
+			m_curr_gear = std::min(m_curr_gear, 2);
 		}
 	}
 }
 
 void BeamEngine::autoShiftSet(int mode)
 {
-	autoselect = (autoswitch)mode;
-	updateShifts();
+	m_autoselect = (autoswitch)mode;
+	this->UpdateBeamEngineShifts();
 }
 
 void BeamEngine::autoShiftUp()
 {
-	if (autoselect != REAR)
+	if (m_autoselect != REAR)
 	{
-		autoselect = (autoswitch)(autoselect-1);
-		updateShifts();
+		m_autoselect = (autoswitch)(m_autoselect-1);
+		this->UpdateBeamEngineShifts();
 	}
 }
 
 void BeamEngine::autoShiftDown()
 {
-	if (autoselect != ONE)
+	if (m_autoselect != ONE)
 	{
-		autoselect = (autoswitch)(autoselect+1);
-		updateShifts();
+		m_autoselect = (autoswitch)(m_autoselect+1);
+		this->UpdateBeamEngineShifts();
 	}
 }
 
 int BeamEngine::getAutoShift()
 {
-	return (int)autoselect;
+	return (int)m_autoselect;
 }
 
 void BeamEngine::setManualClutch(float val)
 {
-	if (automode >= MANUAL)
+	if (m_transmission_mode >= MANUAL)
 	{
 		val = std::max(0.0f, val);
-		curClutch = 1.0 - val;
+		m_curr_clutch = 1.0 - val;
 	}
 }
 
@@ -1135,53 +1262,53 @@ float BeamEngine::getEnginePower(float rpm)
 
 	float atValue = 0.0f; //Additional torque (turbo integreation)
 
-	float rpmRatio = rpm / (maxRPM * 1.25f);
+	float rpmRatio = rpm / (m_conf_engine_max_rpm * 1.25f);
 
 	rpmRatio = std::min(rpmRatio, 1.0f);
 
-	if (torqueCurve)
+	if (m_conf_engine_torque_curve)
 	{
-		tqValue = torqueCurve->getEngineTorque(rpmRatio);
+		tqValue = m_conf_engine_torque_curve->getEngineTorque(rpmRatio);
 	}
 
-	if (hasturbo)
+	if (m_conf_engine_has_turbo)
 	{
-		if (turboVer == 1)
+		if (m_conf_turbo_version == 1)
 		{
-			for (int i = 0; i < numTurbos; i++)
-				atValue = EngineAddiTorque[i] * (curTurboRPM[i] / maxTurboRPM);
+			for (int i = 0; i < m_conf_num_turbos; i++)
+				atValue = m_conf_turbo_addi_torque[i] * (m_turbo_curr_rpm[i] / m_conf_turbo_max_rpm);
 		}
 		else
 		{
-			atValue = (((getTurboPSI() * 6.8) * engineTorque) / 100); //1psi = 6% more power
+			atValue = (((getTurboPSI() * 6.8) * m_conf_engine_torque) / 100); //1psi = 6% more power
 		}
 	}
 
-	return (engineTorque * tqValue) + atValue;
+	return (m_conf_engine_torque * tqValue) + atValue;
 }
 
 float BeamEngine::getAccToHoldRPM(float rpm)
 {
-	float rpmRatio = rpm / (maxRPM * 1.25f);
+	float rpmRatio = rpm / (m_conf_engine_max_rpm * 1.25f);
 
 	rpmRatio = std::min(rpmRatio, 1.0f);
 
-	return (-brakingTorque * rpmRatio) / getEnginePower(curEngineRPM);
+	return (-m_conf_engine_braking_torque * rpmRatio) / getEnginePower(m_curr_engine_rpm);
 }
 
 float BeamEngine::getIdleMixture()
 {
-	if (curEngineRPM < idleRPM)
+	if (m_curr_engine_rpm < m_conf_engine_idle_rpm)
 	{
 		// determine the fuel injection needed to counter the engine braking force
-		float idleMix = getAccToHoldRPM(curEngineRPM);
+		float idleMix = getAccToHoldRPM(m_curr_engine_rpm);
 
 		idleMix = std::max(0.06f, idleMix);
 
-		idleMix = idleMix * (1.0f + (idleRPM - curEngineRPM) / 100.0f);
+		idleMix = idleMix * (1.0f + (m_conf_engine_idle_rpm - m_curr_engine_rpm) / 100.0f);
 
-		idleMix = std::max(minIdleMixture, idleMix);
-		idleMix = std::min(idleMix, maxIdleMixture);
+		idleMix = std::max(m_conf_engine_min_idle_mixture, idleMix);
+		idleMix = std::min(idleMix, m_conf_engine_max_idle_mixture);
 
 		return idleMix;
 	}
@@ -1191,7 +1318,7 @@ float BeamEngine::getIdleMixture()
 
 float BeamEngine::getPrimeMixture()
 {
-	if (prime)
+	if (m_prime)
 	{
 		float crankfactor = getCrankFactor();
 

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -1053,13 +1053,15 @@ float BeamEngine::getRPM()
 void BeamEngine::toggleAutoMode()
 {
     SCOPED_LOCK("toggleAutoMode()") // only external calls
-	m_transmission_mode = (m_transmission_mode + 1) % (Gearbox::SHIFTMODE_MANUAL_RANGES + 1);
+    int new_mode = (m_transmission_mode + 1) % (Gearbox::SHIFTMODE_MANUAL_RANGES + 1);
+	m_transmission_mode = static_cast<RoR::Gearbox::shiftmodes>(new_mode);
 
 	// this switches off all automatic symbols when in manual mode
 	if (m_transmission_mode != Gearbox::SHIFTMODE_AUTOMATIC)
 	{
 		m_autoselect = Gearbox::AUTOSWITCH_MANUALMODE;
-	} else
+	} 
+    else
 	{
 		m_autoselect = Gearbox::AUTOSWITCH_NEUTRAL;
 	}
@@ -1071,13 +1073,13 @@ void BeamEngine::toggleAutoMode()
 	}
 }
 
-int BeamEngine::getAutoMode()
+RoR::Gearbox::shiftmodes BeamEngine::getAutoMode()
 {
     SCOPED_LOCK("getAutoMode()") // only external calls
 	return m_transmission_mode;
 }
 
-void BeamEngine::setAutoMode(int mode)
+void BeamEngine::setAutoMode(RoR::Gearbox::shiftmodes mode)
 {
     SCOPED_LOCK("setAutoMode()") // OK
 	m_transmission_mode = mode;
@@ -1127,7 +1129,7 @@ void BeamEngine::netForceSettings(float rpm, float force, float clutch, int gear
 	m_starter_has_contact      = _contact;
 	if (_automode != -1)
 	{
-		m_transmission_mode = _automode;
+		m_transmission_mode = static_cast<RoR::Gearbox::shiftmodes>(_automode);
 	}
 }
 

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -1,22 +1,24 @@
 /*
-This source file is part of Rigs of Rods
-Copyright 2005-2012 Pierre-Michel Ricordel
-Copyright 2007-2012 Thomas Fischer
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2016 Petr Ohlidal
 
-For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.com/
 
-Rigs of Rods is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 3, as
-published by the Free Software Foundation.
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
 
-Rigs of Rods is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "BeamEngine.h"
 
 #include "BeamFactory.h"
@@ -25,6 +27,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "TorqueCurve.h"
 
 using namespace Ogre;
+using namespace RoR;
 
 #ifdef PTW32_VERSION // Win32 pthreads
 #   define PTHREAD_ID() reinterpret_cast<int32_t>(pthread_self().p)
@@ -64,29 +67,11 @@ private:
 
 #define SCOPED_LOCK_OPT(func_name, do_lock) BeamEngineScopedLock beamengine_lock(&m_mutex, func_name, do_lock);
 
-/*
-ENGINE UPDATE TRACE (static):
-bool RoRFrameListener::frame Started(const FrameEvent& evt)
-	void BeamFactory::calc Physics(float dt)
-		trucks[t]->engine->Update Beam Engine(dt, 1);
-        [Executed for idle vehicles with engine m_is_engine_running (rig_t::state > DESACTIVATED)]
-
-void Beam::run()
-bool Beam::frameStep(Real dt)
-
-void Beam::thread entry()
-	void Beam::calc Forces Euler Compute(int doUpdate_int, Real dt, int step, int maxsteps)
-		calc Truck Engine(doUpdate, dt);
-			Update Beam Engine(doUpdate)
-            [Executed for player-driven vehicle, for N steps (N dynamic based on frame-deltatime)]
-			[doUpdate is 1 in first iteration, then 0]
-*/
-
 BeamEngine::BeamEngine(float m_conf_engine_min_rpm, float m_conf_engine_max_rpm, float torque, std::vector<float> gears, float dratio, int m_vehicle_index) :
 	  m_air_pressure(0.0f)
 	, m_auto_curr_acc(0.0f)
-	, m_transmission_mode(AUTOMATIC)
-	, m_autoselect(DRIVE)
+	, m_transmission_mode(Gearbox::SHIFTMODE_AUTOMATIC)
+	, m_autoselect(Gearbox::AUTOSWITCH_DRIVE)
 	, m_conf_engine_braking_torque(-torque / 5.0f)
 	, m_conf_clutch_force(10000.0f)
 	, m_conf_clutch_time(0.2f)
@@ -665,7 +650,8 @@ void BeamEngine::UpdateBeamEngine(float dt, int doUpdate)
 	{
 		if (m_is_engine_running && m_curr_engine_rpm < m_conf_engine_stall_rpm)
 		{
-			stop(); //No, electric engine has no stop
+            bool const must_lock = false;
+			this->BeamEngineStop(must_lock); //No, electric engine has no stop
 		}
 		// m_starter_is_running
 
@@ -726,7 +712,7 @@ void BeamEngine::UpdateBeamEngine(float dt, int doUpdate)
 
 	m_curr_engine_rpm = std::max(0.0f, m_curr_engine_rpm);
 
-	if (m_transmission_mode < MANUAL)
+	if (m_transmission_mode < Gearbox::SHIFTMODE_MANUAL)
 	{
 		// auto-shift
 		if (m_is_shifting && !engine_is_electric) //No shifting in electric cars
@@ -851,11 +837,11 @@ void BeamEngine::UpdateBeamEngine(float dt, int doUpdate)
 			m_ref_wheel_revolutions = velocity / truck->wheels[0].radius * RAD_PER_SEC_TO_RPM;
 		}
 
-		if (m_transmission_mode == AUTOMATIC && (m_autoselect == DRIVE || m_autoselect == TWO) && m_curr_gear > 0)
+		if (m_transmission_mode == Gearbox::SHIFTMODE_AUTOMATIC && (m_autoselect == Gearbox::AUTOSWITCH_DRIVE || m_autoselect == Gearbox::AUTOSWITCH_TWO) && m_curr_gear > 0)
 		{
 			if ((m_curr_engine_rpm > m_conf_engine_max_rpm - 100.0f && m_curr_gear > 1) || m_cur_wheel_revolutions * m_conf_gear_ratios[m_curr_gear + 1] > m_conf_engine_max_rpm - 100.0f)
 			{
-				if ((m_autoselect == DRIVE && m_curr_gear < m_conf_num_gears) || (m_autoselect == TWO && m_curr_gear < std::min(2, m_conf_num_gears)) && !engine_is_electric)
+				if ((m_autoselect == Gearbox::AUTOSWITCH_DRIVE && m_curr_gear < m_conf_num_gears) || (m_autoselect == Gearbox::AUTOSWITCH_TWO && m_curr_gear < std::min(2, m_conf_num_gears)) && !engine_is_electric)
 				{
 					this->BeamEngineShift(1, false);
 				}
@@ -945,7 +931,7 @@ void BeamEngine::UpdateBeamEngine(float dt, int doUpdate)
 						newGear--;
 					}
 				}
-				else if (m_curr_gear < (m_autoselect == TWO ? std::min(2, m_conf_num_gears) : m_conf_num_gears) &&
+				else if (m_curr_gear < (m_autoselect == Gearbox::AUTOSWITCH_TWO ? std::min(2, m_conf_num_gears) : m_conf_num_gears) &&
 					avgBrake200 < 0.2f && acc < std::min(avgAcc200 + 0.1f, 1.0f) && m_curr_engine_rpm > avgRPM200 - m_conf_autotrans_full_rpm_range / 20.0f)
 				{
 					if (avgAcc200 < 0.6f && avgAcc200 > 0.4f && m_curr_engine_rpm > m_conf_engine_min_rpm + oneThirdRPMRange && m_curr_engine_rpm < m_conf_engine_max_rpm - oneThirdRPMRange)
@@ -999,7 +985,7 @@ void BeamEngine::UpdateBeamEngine(float dt, int doUpdate)
 				m_autotrans_brake_buffer.pop_back();
 			}
 			// avoid over-revving
-			if (m_transmission_mode <= SEMIAUTO && m_curr_gear != 0)
+			if (m_transmission_mode <= Gearbox::SHIFTMODE_SEMIAUTO && m_curr_gear != 0)
 			{
 				if (std::abs(m_cur_wheel_revolutions * m_conf_gear_ratios[m_curr_gear + 1]) > m_conf_engine_max_rpm * 1.25f)
 				{
@@ -1067,18 +1053,18 @@ float BeamEngine::getRPM()
 void BeamEngine::toggleAutoMode()
 {
     SCOPED_LOCK("toggleAutoMode()") // only external calls
-	m_transmission_mode = (m_transmission_mode + 1) % (MANUAL_RANGES + 1);
+	m_transmission_mode = (m_transmission_mode + 1) % (Gearbox::SHIFTMODE_MANUAL_RANGES + 1);
 
 	// this switches off all automatic symbols when in manual mode
-	if (m_transmission_mode != AUTOMATIC)
+	if (m_transmission_mode != Gearbox::SHIFTMODE_AUTOMATIC)
 	{
-		m_autoselect = MANUALMODE;
+		m_autoselect = Gearbox::AUTOSWITCH_MANUALMODE;
 	} else
 	{
-		m_autoselect = NEUTRAL;
+		m_autoselect = Gearbox::AUTOSWITCH_NEUTRAL;
 	}
 
-	if (m_transmission_mode == MANUAL_RANGES)
+	if (m_transmission_mode == Gearbox::SHIFTMODE_MANUAL_RANGES)
 	{
 		m_curr_gear_range = 0.f; //INLINED this->setGearRange(0);
 		m_curr_gear = 0.f; //INLINED this->setGear(0);
@@ -1225,23 +1211,23 @@ void BeamEngine::toggleContact()
 }
 
 // quick start
-void BeamEngine::start()
+void BeamEngine::BeamEngineStart()
 {
-    SCOPED_LOCK("start()") // not verified
-	if (m_transmission_mode == AUTOMATIC)
+    SCOPED_LOCK("start()") // OK, only external calls
+	if (m_transmission_mode == Gearbox::SHIFTMODE_AUTOMATIC)
 	{
 		m_curr_gear = 1;
-		m_autoselect = DRIVE;
+		m_autoselect = Gearbox::AUTOSWITCH_DRIVE;
 	} else
 	{
-		if (m_transmission_mode == SEMIAUTO)
+		if (m_transmission_mode == Gearbox::SHIFTMODE_SEMIAUTO)
 		{
 			m_curr_gear = 1;
 		} else
 		{
 			m_curr_gear = 0;
 		}
-		m_autoselect = MANUALMODE;
+		m_autoselect = Gearbox::AUTOSWITCH_MANUALMODE;
 	}
 	m_curr_clutch = 0.0f;
 	m_curr_engine_rpm = 750.0f;
@@ -1269,9 +1255,9 @@ void BeamEngine::offstart()
 	m_curr_gear = 0;
 	m_curr_clutch = 0.0f;
 	if (m_conf_engine_type != 'e') // e = Electric engine
-		m_autoselect = NEUTRAL; //no Neutral in electric engines
+		m_autoselect = Gearbox::AUTOSWITCH_NEUTRAL; //no Neutral in electric engines
 	else
-		m_autoselect = ONE;
+		m_autoselect = Gearbox::AUTOSWITCH_ONE;
 
 	m_curr_engine_rpm = 0.0f;
 	m_is_engine_running = false;
@@ -1317,9 +1303,9 @@ void BeamEngine::setGearRange(int v)
 	m_curr_gear_range = v;
 }
 
-void BeamEngine::stop()
+void BeamEngine::BeamEngineStop(bool must_lock)
 {
-    SCOPED_LOCK("stop()") // not verified
+    SCOPED_LOCK_OPT("stop()", must_lock)
 	if (!m_is_engine_running) return;
 
 	m_is_engine_running = false;
@@ -1345,7 +1331,7 @@ void BeamEngine::BeamEngineShift(int val, bool must_lock /*=true*/)
 {
     SCOPED_LOCK_OPT("BeamEngineShift()", must_lock)
 	if (!val || m_curr_gear + val < -1 || m_curr_gear + val > getNumGears()) return;
-	if (m_transmission_mode < MANUAL)
+	if (m_transmission_mode < Gearbox::SHIFTMODE_MANUAL)
 	{
 #ifdef USE_OPENAL
 		SoundScriptManager::getSingleton().trigStart(m_vehicle_index, SS_TRIG_SHIFT);
@@ -1384,20 +1370,20 @@ void BeamEngine::UpdateBeamEngineShifts()
     // NO LOCK - only called internally
 
 
-	if (m_autoselect == MANUALMODE) return;
+	if (m_autoselect == Gearbox::AUTOSWITCH_MANUALMODE) return;
 
 #ifdef USE_OPENAL
 	SoundScriptManager::getSingleton().trigOnce(m_vehicle_index, SS_TRIG_SHIFT);
 #endif // USE_OPENAL
 	bool engine_is_electric = (m_conf_engine_type == 'e');
 
-	if (m_autoselect == REAR)
+	if (m_autoselect == Gearbox::AUTOSWITCH_REAR)
 	{
 		m_curr_gear = -1;
-	} else if (m_autoselect == NEUTRAL && !engine_is_electric)
+	} else if (m_autoselect == Gearbox::AUTOSWITCH_NEUTRAL && !engine_is_electric)
 	{
 		m_curr_gear =  0;
-	} else if (m_autoselect == ONE)
+	} else if (m_autoselect == Gearbox::AUTOSWITCH_ONE)
 	{
 		m_curr_gear =  1;
 	}
@@ -1413,7 +1399,7 @@ void BeamEngine::UpdateBeamEngineShifts()
 
 		m_curr_gear = newGear;
 		
-		if (m_autoselect == TWO)
+		if (m_autoselect == Gearbox::AUTOSWITCH_TWO)
 		{
 			m_curr_gear = std::min(m_curr_gear, 2);
 		}
@@ -1423,16 +1409,16 @@ void BeamEngine::UpdateBeamEngineShifts()
 void BeamEngine::autoShiftSet(int mode)
 {
     SCOPED_LOCK("autoShiftSet()") // OK
-	m_autoselect = (autoswitch)mode;
+	m_autoselect = (Gearbox::autoswitch)mode;
 	this->UpdateBeamEngineShifts();
 }
 
 void BeamEngine::autoShiftUp()
 {
     SCOPED_LOCK("autoShiftUp()") // OK
-	if (m_autoselect != REAR)
+	if (m_autoselect != Gearbox::AUTOSWITCH_REAR)
 	{
-		m_autoselect = (autoswitch)(m_autoselect-1);
+		m_autoselect = (Gearbox::autoswitch)(m_autoselect-1);
 		this->UpdateBeamEngineShifts();
 	}
 }
@@ -1440,23 +1426,23 @@ void BeamEngine::autoShiftUp()
 void BeamEngine::autoShiftDown()
 {
     SCOPED_LOCK("autoShiftDown()") // OK
-	if (m_autoselect != ONE)
+	if (m_autoselect != Gearbox::AUTOSWITCH_ONE)
 	{
-		m_autoselect = (autoswitch)(m_autoselect+1);
+		m_autoselect = (Gearbox::autoswitch)(m_autoselect+1);
 		this->UpdateBeamEngineShifts();
 	}
 }
 
-int BeamEngine::getAutoShift()
+Gearbox::autoswitch BeamEngine::getAutoShift()
 {
     SCOPED_LOCK("getAutoShift()") // OK
-	return (int)m_autoselect;
+	return m_autoselect;
 }
 
 void BeamEngine::setManualClutch(float val)
 {
     SCOPED_LOCK("setManualClutch()") // OK
-	if (m_transmission_mode >= MANUAL)
+	if (m_transmission_mode >= Gearbox::SHIFTMODE_MANUAL)
 	{
 		val = std::max(0.0f, val);
 		m_curr_clutch = 1.0 - val;
@@ -1565,3 +1551,4 @@ float BeamEngine::CalcPrimeMixture()
 
 	return 0.0f;
 }
+

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -1,27 +1,28 @@
 /*
-This source file is part of Rigs of Rods
-Copyright 2005-2012 Pierre-Michel Ricordel
-Copyright 2007-2012 Thomas Fischer
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2016 Petr Ohlidal
 
-For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.com/
 
-Rigs of Rods is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 3, as
-published by the Free Software Foundation.
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
 
-Rigs of Rods is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
 */
+
 #pragma once
-#ifndef __BeamEngine_H_
-#define __BeamEngine_H_
 
 #include "RoRPrerequisites.h"
+#include "Powertrain.h"
 #include <pthread.h>
 
 /**
@@ -48,7 +49,7 @@ public:
 	float getSmoke();
 	float getTorque();
 	float getTurboPSI(bool must_lock = true);
-	int getAutoMode();
+	int getAutoMode(); // m_transmission_mode
 
 	/**
 	* Sets current engine state; Needed mainly for smoke.
@@ -116,7 +117,7 @@ public:
 	/**
 	* Quick engine start. Plays sounds.
 	*/
-	void start();
+	void BeamEngineStart();
 
 	// low level gear changing
 	int getGear();
@@ -125,7 +126,7 @@ public:
 	void setGearRange(int v);
 	
 	// stall engine
-	void stop();
+	void BeamEngineStop(bool must_lock = true);
 
 	// high level controls
 	bool hasContact() { return m_starter_has_contact; };
@@ -140,7 +141,7 @@ public:
 	float getMaxRPM() { return m_conf_engine_max_rpm; };
 	float getMinRPM() { return m_conf_engine_min_rpm; };
 	float CalcPrimeMixture();
-	int getAutoShift();
+	RoR::Gearbox::autoswitch getAutoShift(); // m_autoselect
 	int getNumGears() { return m_conf_gear_ratios.size() - 2; };
 	int getNumGearsRanges() { return getNumGears() / 6 + 1; };
 	TorqueCurve *getTorqueCurve() { return m_conf_engine_torque_curve; };
@@ -171,9 +172,6 @@ public:
 
 	void UpdateBeamEngine(float dt, int doUpdate);
 
-	enum shiftmodes {AUTOMATIC, SEMIAUTO, MANUAL, MANUAL_STICK, MANUAL_RANGES};
-	enum autoswitch {REAR, NEUTRAL, DRIVE, TWO, ONE, MANUALMODE};
-
 protected:
 
 	/**
@@ -185,8 +183,6 @@ protected:
 	* Changes gears. Plays sounds.
 	*/
 	void UpdateBeamEngineShifts();
-
-	void DEBUG_LogClassState(BeamEngine snapshot_before, float dt, int doUpdate);
 
 	// ================================================================
 	// VARIABLES
@@ -242,7 +238,7 @@ protected:
 	bool       m_starter_has_contact; //!< Engine
 	float      m_curr_acc; //!< Engine
 	float      m_curr_engine_rpm; //!< Engine
-	autoswitch m_autoselect;
+	RoR::Gearbox::autoswitch m_autoselect;
 	float      m_auto_curr_acc;
 	bool       m_starter_is_running;
 	int        m_prime;
@@ -293,4 +289,3 @@ protected:
     pthread_mutex_t m_mutex;
 };
 
-#endif // __BeamEngine_H_

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -129,13 +129,13 @@ public:
 	bool isRunning() { return m_is_engine_running; };
 	char getType() { return m_conf_engine_type; };
 	float getAccToHoldRPM(float rpm);
-	float getEnginePower(float rpm);
+	float CalcEnginePower(float rpm);
 	float getEngineTorque() { return m_conf_engine_torque; };
-	float getIdleMixture();
+	float CalcIdleMixture();
 	float getIdleRPM() { return m_conf_engine_idle_rpm; };
 	float getMaxRPM() { return m_conf_engine_max_rpm; };
 	float getMinRPM() { return m_conf_engine_min_rpm; };
-	float getPrimeMixture();
+	float CalcPrimeMixture();
 	int getAutoShift();
 	int getNumGears() { return m_conf_gear_ratios.size() - 2; };
 	int getNumGearsRanges() { return getNumGears() / 6 + 1; };

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -49,7 +49,7 @@ public:
 	float getSmoke();
 	float getTorque();
 	float getTurboPSI(bool must_lock = true);
-	int getAutoMode(); // m_transmission_mode
+	RoR::Gearbox::shiftmodes getAutoMode(); // m_transmission_mode
 
 	/**
 	* Sets current engine state; Needed mainly for smoke.
@@ -64,7 +64,7 @@ public:
 	void netForceSettings(float rpm, float force, float clutch, int gear, bool m_is_engine_running, bool m_starter_has_contact, char m_transmission_mode);
 
 	void setAcc(float val);
-	void setAutoMode(int mode);
+	void setAutoMode(RoR::Gearbox::shiftmodes mode);
 	void setClutch(float clutch);
 
 	/**
@@ -282,7 +282,7 @@ protected:
 	// air pressure
 	
 	float m_air_pressure; //!< Sound effect only
-	int   m_transmission_mode; //!< Transmission mode (@see enum BeamEngine::shiftmodes)
+	RoR::Gearbox::shiftmodes   m_transmission_mode;
 
 	int m_vehicle_index;
 

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -22,6 +22,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #define __BeamEngine_H_
 
 #include "RoRPrerequisites.h"
+#include <pthread.h>
 
 /**
 * Represents a virtual engine of a vehicle (not "engine" as in "physics engine").
@@ -42,11 +43,11 @@ public:
 	float getAcc();
 	float getClutch();
 	float getClutchForce();
-	float getCrankFactor();
+	float getCrankFactor(bool must_lock = true);
 	float getRPM();
 	float getSmoke();
 	float getTorque();
-	float getTurboPSI();
+	float getTurboPSI(bool must_lock = true);
 	int getAutoMode();
 
 	/**
@@ -160,13 +161,13 @@ public:
 	* Changes gear by a relative offset. Plays sounds.
 	* @param shift_change_relative 1 = shift up by 1, -1 = shift down by 1
 	*/
-	void BeamEngineShift(int shift_change_relative);
+	void BeamEngineShift(int shift_change_relative, bool must_lock = true);
 	
 	/**
 	* Changes gear to given value. Plays sounds.
 	* @see BeamEngine::shift
 	*/
-	void BeamEngineShiftTo(int val);
+	void BeamEngineShiftTo(int val, bool must_lock = true);
 
 	void UpdateBeamEngine(float dt, int doUpdate);
 
@@ -288,6 +289,8 @@ protected:
 	int   m_transmission_mode; //!< Transmission mode (@see enum BeamEngine::shiftmodes)
 
 	int m_vehicle_index;
+
+    pthread_mutex_t m_mutex;
 };
 
 #endif // __BeamEngine_H_

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -36,6 +36,9 @@ public:
 	BeamEngine(float m_conf_engine_min_rpm, float m_conf_engine_max_rpm, float torque, std::vector<float> gears, float dratio, int m_vehicle_index);
 	~BeamEngine();
 
+    // Full state logging for debugging LuaPowertrain
+    void LogFullState();
+
 	float getAcc();
 	float getClutch();
 	float getClutchForce();

--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -325,7 +325,7 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 			{
 				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_UP))
 				{
-						curr_truck->engine->shift(1);
+						curr_truck->engine->BeamEngineShift(1);
 						gear_changed_rel = true;
 				} 
 				else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_DOWN))
@@ -335,13 +335,13 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 						shiftmode == BeamEngine::SEMIAUTO  && curr_truck->engine->getGear() > 0 ||
 						shiftmode == BeamEngine::AUTOMATIC)
 					{
-						curr_truck->engine->shift(-1);
+						curr_truck->engine->BeamEngineShift(-1);
 						gear_changed_rel = true;
 					}
 				} 
 				else if (shiftmode != BeamEngine::AUTOMATIC && RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL))
 				{
-					curr_truck->engine->shiftTo(0);
+					curr_truck->engine->BeamEngineShiftTo(0);
 				}
 			} 
 			else //if (shiftmode > BeamEngine::MANUAL) // h-shift or h-shift with ranges shifting
@@ -401,12 +401,12 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 				{
 					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE))
 					{
-						curr_truck->engine->shiftTo(-1);
+						curr_truck->engine->BeamEngineShiftTo(-1);
 						found = true;
 					} 
 					else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_NEUTRAL))
 					{
-						curr_truck->engine->shiftTo(0);
+						curr_truck->engine->BeamEngineShiftTo(0);
 						found = true;
 					} 
 					else
@@ -417,7 +417,7 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 							{
 								if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
 								{
-									curr_truck->engine->shiftTo(i);
+									curr_truck->engine->BeamEngineShiftTo(i);
 									found = true;
 								}
 							}
@@ -428,7 +428,7 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 							{
 								if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
 								{
-									curr_truck->engine->shiftTo(i + curgearrange * 6);
+									curr_truck->engine->BeamEngineShiftTo(i + curgearrange * 6);
 									found = true;
 								}
 							}
@@ -436,7 +436,7 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 					}
 					if (!found)
 					{
-						curr_truck->engine->shiftTo(0);
+						curr_truck->engine->BeamEngineShiftTo(0);
 					}
 				} // end of if (gear_changed)
 			} // end of shitmode > BeamEngine::MANUAL

--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -2,7 +2,7 @@
 	This source file is part of Rigs of Rods
 	Copyright 2005-2012 Pierre-Michel Ricordel
 	Copyright 2007-2012 Thomas Fischer
-	Copyright 2013-2014 Petr Ohlidal
+	Copyright 2013-2016 Petr Ohlidal
 
 	For more information, see http://www.rigsofrods.com/
 
@@ -31,111 +31,6 @@
 #include "GUIManager.h"
 
 using namespace RoR;
-
-void LandVehicleSimulation::UpdateCruiseControl(Beam* curr_truck, float dt)
-{
-    PowertrainState powertrain = curr_truck->powertrain->GetStateOnMainThread();
-    PowertrainCommandQueue& cmd_queue = curr_truck->powertrain->GetQueueOnMainThread();
-
-	if (RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE) > 0.05f ||
-		RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_MANUAL_CLUTCH) > 0.05f ||
-		(curr_truck->cc_target_speed < curr_truck->cc_target_speed_lower_limit) ||
-		(curr_truck->parkingbrake && powertrain.transmission_current_gear > 0) ||
-		!powertrain.engine_is_running ||
-		!powertrain.engine_starter_has_contact)
-	{
-		curr_truck->cruisecontrolToggle();
-		return;
-	}
-
-    int curr_gear = powertrain.transmission_current_gear;
-	if (curr_gear > 0)
-	{
-		// Try to maintain the target speed
-		if (curr_truck->cc_target_speed > curr_truck->WheelSpeed)
-		{
-			float accl = (curr_truck->cc_target_speed - curr_truck->WheelSpeed) * 2.0f;
-			accl = std::max(powertrain.current_acceleration, accl);
-			accl = std::min(accl, 1.0f);
-			cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_ACC, accl);
-		}
-	} 
-    else if (curr_gear == 0) // out of gear
-	{
-		// Try to maintain the target rpm
-		if (curr_truck->cc_target_rpm > powertrain.engine_current_rpm)
-		{
-			float accl = (curr_truck->cc_target_rpm - powertrain.engine_current_rpm) * 0.01f;
-			accl = std::max(powertrain.current_acceleration, accl);
-			accl = std::min(accl, 1.0f);
-			cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_ACC, accl);
-		}
-	}
-
-	if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_ACCL))
-	{
-		if (curr_gear > 0)
-		{
-			curr_truck->cc_target_speed += 2.5f * dt;
-			curr_truck->cc_target_speed  = std::max(curr_truck->cc_target_speed_lower_limit, curr_truck->cc_target_speed);
-			if (curr_truck->sl_enabled)
-			{
-				curr_truck->cc_target_speed  = std::min(curr_truck->cc_target_speed, curr_truck->sl_speed_limit);
-			}
-		}
-        else if (curr_gear == 0) // out of gear
-		{
-			curr_truck->cc_target_rpm += 1000.0f * dt;
-			curr_truck->cc_target_rpm  = std::min(curr_truck->cc_target_rpm, powertrain.conf_engine_max_rpm);
-		}
-	}
-	if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_DECL))
-	{
-		if (curr_gear > 0)
-		{
-			curr_truck->cc_target_speed -= 2.5f * dt;
-			curr_truck->cc_target_speed  = std::max(curr_truck->cc_target_speed_lower_limit, curr_truck->cc_target_speed);
-		}
-        else if (curr_gear == 0) // out of gear
-		{
-			curr_truck->cc_target_rpm -= 1000.0f * dt;
-			curr_truck->cc_target_rpm  = std::max(powertrain.conf_engine_min_rpm, curr_truck->cc_target_rpm);
-		}
-	}
-	if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_READJUST))
-	{
-		curr_truck->cc_target_speed = std::max(curr_truck->WheelSpeed, curr_truck->cc_target_speed);
-		if (curr_truck->sl_enabled)
-		{
-			curr_truck->cc_target_speed = std::min(curr_truck->cc_target_speed, curr_truck->sl_speed_limit);
-		}
-		curr_truck->cc_target_rpm   = powertrain.engine_current_rpm;
-	}
-
-	if (curr_truck->cc_can_brake)
-	{
-		if (curr_truck->WheelSpeed > curr_truck->cc_target_speed + 0.5f && !RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE))
-		{
-			float brake = (curr_truck->WheelSpeed - curr_truck->cc_target_speed) * 0.5f;
-			brake = std::min(brake, 1.0f);
-			curr_truck->brake = curr_truck->brakeforce * brake;
-		}
-	}
-}
-
-void LandVehicleSimulation::CheckSpeedLimit(Beam* curr_truck, float dt)
-{
-    PowertrainState powertrain = curr_truck->powertrain->GetStateOnMainThread();
-	if (curr_truck->sl_enabled && powertrain.transmission_current_gear != 0)
-	{
-		float accl = (curr_truck->sl_speed_limit - std::abs(curr_truck->WheelSpeed)) * 2.0f;
-		accl = std::max(0.0f, accl);
-		accl = std::min(accl, powertrain.current_acceleration);
-
-        PowertrainCommandQueue& cmd_queue = curr_truck->powertrain->GetQueueOnMainThread();
-        cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_ACC, accl);
-	}
-}
 
 void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_last_frame)
 {
@@ -181,358 +76,129 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 			curr_truck->hydroSpeedCoupling = true;
 		}
 
-		if (curr_truck->powertrain != nullptr)
-		{
-            PowertrainState pw_state = curr_truck->powertrain->GetStateOnMainThread();
-            PowertrainCommandQueue& cmd_queue = curr_truck->powertrain->GetQueueOnMainThread();
+        PowertrainState pw_state = curr_truck->powertrain->GetStateOnMainThread();
+        PowertrainCommandQueue& cmd_queue = curr_truck->powertrain->GetQueueOnMainThread();
+        auto* input_engine = RoR::Application::GetInputEngine();
 
-			bool arcadeControls = BSETTING("ArcadeControls", false);
-
-			float accl  = RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE);
-			float brake = RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE);
-
-			// arcade controls are only working with auto-clutch!
-			if (!arcadeControls || pw_state.transmission_auto_shift_mode > Gearbox::SHIFTMODE_SEMIAUTO)
-			{
-				// classic mode, realistic
-                cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SET_ACC, accl);
-				curr_truck->brake = brake * curr_truck->brakeforce;
-			} 
-			else
-			{
-				// start engine
-				if (pw_state.engine_starter_has_contact && !pw_state.engine_is_running && (accl > 0 || brake > 0))
-				{
-					cmd_queue.AddCommand(PowertrainCommand::COMMAND_START);
-				}
-
-				// arcade controls: hey - people wanted it x| ... <- and it's convenient
-				if (pw_state.transmission_current_gear >= 0)
-				{
-					// neutral or drive forward, everything is as its used to be: brake is brake and accel. is accel.
-					cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SET_ACC, accl);
-					curr_truck->brake = brake * curr_truck->brakeforce;
-				} 
-				else
-				{
-					// reverse gear, reverse controls: brake is accel. and accel. is brake.
-					cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SET_ACC, accl);
-					curr_truck->brake = accl * curr_truck->brakeforce;
-				}
-
-				// only when the truck really is not moving anymore
-				if (fabs(curr_truck->WheelSpeed) <= 1.0f)
-				{
-					float velocity = 0.0f;
-
-					if (curr_truck->cameranodepos[0] >= 0 && curr_truck->cameranodedir[0] >= 0)
-					{
-						Vector3 hdir = (curr_truck->nodes[curr_truck->cameranodepos[0]].RelPosition - curr_truck->nodes[curr_truck->cameranodedir[0]].RelPosition).normalisedCopy();
-						velocity = hdir.dotProduct(curr_truck->nodes[0].Velocity);
-					}
-
-					// switching point, does the user want to drive forward from backward or the other way round? change gears?
-					if (velocity < 1.0f && brake > 0.5f && accl < 0.5f && pw_state.transmission_current_gear > 0)
-					{
-						// we are on the brake, jump to reverse gear
-						if (pw_state.transmission_auto_shift_mode == Gearbox::SHIFTMODE_AUTOMATIC)
-						{
-                            cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SHIFT_SET, static_cast<float>(Gearbox::AUTOSWITCH_REAR));
-						} 
-						else
-						{
-                            cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR, -1.f);
-						}
-					} 
-                    else if (velocity > -1.0f && brake < 0.5f && accl > 0.5f && pw_state.transmission_current_gear < 0)
-					{
-						// we are on the gas pedal, jump to first gear when we were in rear gear
-                        if (pw_state.transmission_auto_shift_mode == Gearbox::SHIFTMODE_AUTOMATIC)
-						{									
-							cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SHIFT_SET, static_cast<float>(Gearbox::AUTOSWITCH_DRIVE));
-						} 
-						else
-						{
-							cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR, 1.f);
-						}
-					}
-				}
-			}
-
-			// ============ Gearbox simulation - to be ported into LuaPowertrain ==================
-
-			if (pw_state.transmission_auto_shift_mode == Gearbox::SHIFTMODE_AUTOMATIC)
-			{
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_UP))
-				{
-                    cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SHIFT_UP);
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_DOWN))
-				{
-					cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SHIFT_DOWN);
-				}
-			}
-
-			if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_CONTACT))
-			{
-				cmd_queue.AddCommand(PowertrainCommand::COMMAND_TOGGLE_CONTACT);
-			}
-
-			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_STARTER) && pw_state.engine_starter_has_contact)
-			{
-				// starter
-                cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_STARTER, 1.f);
-#ifdef USE_OPENAL
-				SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_STARTER);
-#endif // OPENAL
-			} 
-			else
-			{
-				cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_STARTER, 0.f);
-#ifdef USE_OPENAL
-				SoundScriptManager::getSingleton().trigStop(curr_truck, SS_TRIG_STARTER);
-#endif // OPENAL
-			}
-
-			if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SWITCH_SHIFT_MODES))
-			{
-				// toggle Auto shift
-				cmd_queue.AddCommand(PowertrainCommand::COMMAND_TOGGLE_AUTO_MODE);
-
-				// force gui update
-				curr_truck->triggerGUIFeaturesChanged();
+        if (curr_truck->powertrain != nullptr)
+        {
 #ifdef USE_MYGUI
-				switch(pw_state.transmission_auto_shift_mode)
-				{
-					case Gearbox::SHIFTMODE_AUTOMATIC:
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Automatic shift"), "cog.png", 3000);
-						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Automatic shift");
-						break;
-					case Gearbox::SHIFTMODE_SEMIAUTO:
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Manual shift - Auto clutch"), "cog.png", 3000);
-						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Manual shift - Auto clutch");
-						break;
-					case Gearbox::SHIFTMODE_MANUAL:
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully Manual: sequential shift"), "cog.png", 3000);
-						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully Manual: sequential shift");
-						break;
-					case Gearbox::SHIFTMODE_MANUAL_STICK:
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully manual: stick shift"), "cog.png", 3000);
-						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully manual: stick shift");
-						break;
-					case Gearbox::SHIFTMODE_MANUAL_RANGES:
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully Manual: stick shift with ranges"), "cog.png", 3000);
-						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully Manual: stick shift with ranges");
-						break;
-				}
+            if (pw_state.transmission_shiftmodes_toggled)
+            {
+                // force gui update
+                curr_truck->triggerGUIFeaturesChanged();
+                switch(pw_state.transmission_auto_shift_mode)
+                {
+                case Gearbox::SHIFTMODE_AUTOMATIC:
+                    RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Automatic shift"), "cog.png", 3000);
+                    RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Automatic shift");
+                    break;
+                case Gearbox::SHIFTMODE_SEMIAUTO:
+                    RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Manual shift - Auto clutch"), "cog.png", 3000);
+                    RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Manual shift - Auto clutch");
+                    break;
+                case Gearbox::SHIFTMODE_MANUAL:
+                    RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully Manual: sequential shift"), "cog.png", 3000);
+                    RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully Manual: sequential shift");
+                    break;
+                case Gearbox::SHIFTMODE_MANUAL_STICK:
+                    RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully manual: stick shift"), "cog.png", 3000);
+                    RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully manual: stick shift");
+                    break;
+                case Gearbox::SHIFTMODE_MANUAL_RANGES:
+                    RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully Manual: stick shift with ranges"), "cog.png", 3000);
+                    RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully Manual: stick shift with ranges");
+                    break;
+                }
+            }
+
+            // Ranges
+            if (pw_state.transmission_gear_range_selected == 1)
+            {
+                RoR::Application::GetConsole()->putMessage(
+                    Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png", 3000);
+            } 
+            else if (pw_state.transmission_gear_range_selected == 2)
+            {
+                RoR::Application::GetConsole()->putMessage(
+                    Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png", 3000);
+            } 
+            else if (pw_state.transmission_gear_range_selected == 3)
+            {
+                RoR::Application::GetConsole()->putMessage(
+                    Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png", 3000);
+            }
+
+            // Axle
+            if (pw_state.transmission_axlelock_toggled == -1)
+            {
+                RoR::Application::GetConsole()->putMessage(
+                    Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, 
+                    _L("No differential installed on current vehicle!"), "warning.png", 3000);
+                RoR::Application::GetGuiManager()->PushNotification("Differential:", "No differential installed on current vehicle!");
+            }
+            else if (pw_state.transmission_axlelock_toggled == 1)
+            {
+                RoR::Application::GetConsole()->putMessage(
+                    Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, 
+                    _L("Differentials switched to: ") + curr_truck->getAxleLockName(), "cog.png", 3000);
+                RoR::Application::GetGuiManager()->PushNotification("Differential:", "Differentials switched to: " + curr_truck->getAxleLockName());
+            }
 #endif //USE_MYGUI
-			}
 
-			// joy clutch
-			float cval = RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_MANUAL_CLUTCH);
-            cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_MANUAL_CLUTCH, cval);
+            PowertrainInputStates inputs;
+            inputs.Reset();
 
-			bool gear_changed_rel = false;
-			int shiftmode = pw_state.transmission_auto_shift_mode;
+            inputs.acceleration            = input_engine->getEventValue(EV_TRUCK_ACCELERATE);
+            inputs.brake                   = input_engine->getEventValue(EV_TRUCK_BRAKE);
+            inputs.manual_clutch           = input_engine->getEventValue(EV_TRUCK_MANUAL_CLUTCH);
 
-			if (shiftmode <= Gearbox::SHIFTMODE_MANUAL) // auto, semi auto and sequential shifting
-			{
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_UP))
-				{
-					cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT, 1.f); // shift up
-					gear_changed_rel = true;
-				} 
-				else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_DOWN))
-				{
-					if (shiftmode  > Gearbox::SHIFTMODE_SEMIAUTO ||
-						shiftmode == Gearbox::SHIFTMODE_SEMIAUTO  && !arcadeControls ||
-						shiftmode == Gearbox::SHIFTMODE_SEMIAUTO  && pw_state.transmission_current_gear > 0 ||
-						shiftmode == Gearbox::SHIFTMODE_AUTOMATIC)
-					{
-						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT, -1.f); // shift down
-						gear_changed_rel = true;
-					}
-				} 
-				else if (shiftmode != Gearbox::SHIFTMODE_AUTOMATIC && RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL))
-				{
-					cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, 0.f);
-				}
-			} 
-			else //if (shiftmode > BeamEngine::MANUAL) // h-shift or h-shift with ranges shifting
-			{
-				bool gear_changed = false;
-				bool found        = false;
-				int curgear       = pw_state.transmission_current_gear;
-				int curgearrange    = pw_state.transmission_current_gear_range;
-				int gearoffset      = std::max(0, curgear - curgearrange * 6);
+            inputs.autoshift_up            = input_engine->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_UP);
+            inputs.autoshift_down          = input_engine->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_DOWN);
+            inputs.toggle_contact          = input_engine->getEventBoolValueBounce(EV_TRUCK_TOGGLE_CONTACT);
+            inputs.switch_shift_modes      = input_engine->getEventBoolValueBounce(EV_TRUCK_SWITCH_SHIFT_MODES);
+            inputs.shift_up                = input_engine->getEventBoolValueBounce(EV_TRUCK_SHIFT_UP);
+            inputs.shift_down              = input_engine->getEventBoolValueBounce(EV_TRUCK_SHIFT_DOWN);
+            inputs.shift_neutral           = input_engine->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL);
+            inputs.shift_lowrange          = input_engine->getEventBoolValueBounce(EV_TRUCK_SHIFT_LOWRANGE);
+            inputs.shift_midrange          = input_engine->getEventBoolValueBounce(EV_TRUCK_SHIFT_MIDRANGE);
+            inputs.shift_highrange         = input_engine->getEventBoolValueBounce(EV_TRUCK_SHIFT_HIGHRANGE);
+            inputs.parking_brake_toggle    = input_engine->getEventBoolValueBounce(EV_TRUCK_PARKING_BRAKE);
+            inputs.antilock_brake_toggle   = input_engine->getEventBoolValueBounce(EV_TRUCK_ANTILOCK_BRAKE);
+            inputs.traction_control_toggle = input_engine->getEventBoolValueBounce(EV_TRUCK_TRACTION_CONTROL);
+            inputs.cruise_control_toggle   = input_engine->getEventBoolValueBounce(EV_TRUCK_CRUISE_CONTROL);
 
-				// one can select range only if in neutral
-				if (shiftmode==Gearbox::SHIFTMODE_MANUAL_RANGES && curgear == 0)
-				{
-					//  maybe this should not be here, but should experiment
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_LOWRANGE) && curgearrange != 0)
-					{
-                        cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR_RANGE, 0.f);
-						gear_changed = true;
-#ifdef USE_MYGUI
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png", 3000);
-#endif //USE_MYGUI
-					} 
-					else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_MIDRANGE)  && curgearrange != 1 && pw_state.conf_transmission_num_gears_ranges>1)
-					{
-						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR_RANGE, 1.f);
-						gear_changed = true;
-#ifdef USE_MYGUI
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png", 3000);
-#endif //USE_MYGUI
-					} 
-					else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_HIGHRANGE) && curgearrange != 2 && pw_state.conf_transmission_num_gears_ranges>2)
-					{
-						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR_RANGE, 2.f);
-						gear_changed = true;
-#ifdef USE_MYGUI
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png", 3000);
-#endif // USE_MYGUI
-					}
-				}
-//zaxxon
-				if (curgear == -1)
-				{
-					gear_changed = !RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE);
-				} 
-				else if (curgear > 0 && curgear < 19)
-				{
-					if (shiftmode==Gearbox::SHIFTMODE_MANUAL)
-					{
-						gear_changed = !RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + curgear -1);
-					} 
-                    else
-					{
-						gear_changed = !RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + gearoffset-1); // range mode
-					}
-				}
+            inputs.starter                 = input_engine->getEventBoolValue(EV_TRUCK_STARTER);
+            inputs.shift_gear_reverse      = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE);
+            inputs.shift_neutral           = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_NEUTRAL);
+            inputs.cruise_control_accel    = input_engine->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_ACCL);
+            inputs.cruise_control_decel    = input_engine->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_DECL);
+            inputs.cruise_control_readjust = input_engine->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_READJUST);
 
-				if (gear_changed || curgear == 0)
-				{
-					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE))
-					{
-						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, -1.f);
-						found = true;
-					} 
-					else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_NEUTRAL))
-					{
-						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, 0.f);
-						found = true;
-					} 
-					else
-					{
-						if (shiftmode == Gearbox::SHIFTMODE_MANUAL_STICK)
-						{
-							for (int i=1; i < 19 && !found; i++)
-							{
-								if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
-								{
-									cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, i);
-									found = true;
-								}
-							}
-						} 
-						else // BeamEngine::MANUALMANUAL_RANGES
-						{
-							for (int i=1; i < 7 && !found; i++)
-							{
-								if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
-								{
-                                    int val = i + curgearrange * 6;
-									cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, val);
-									found = true;
-								}
-							}
-						}
-					}
-					if (!found)
-					{
-						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, 0.f);
-					}
-				} // end of if (gear_changed)
-			} // end of shitmode > BeamEngine::MANUAL
+            inputs.direct_shift[ 0]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01);
+            inputs.direct_shift[ 1]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR02);
+            inputs.direct_shift[ 2]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR03);
+            inputs.direct_shift[ 3]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR04);
+            inputs.direct_shift[ 4]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR05);
+            inputs.direct_shift[ 5]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR06);
+            inputs.direct_shift[ 6]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR07);
+            inputs.direct_shift[ 7]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR08);
+            inputs.direct_shift[ 8]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR09);
+            inputs.direct_shift[ 9]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR10);
+            inputs.direct_shift[10]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR11);
+            inputs.direct_shift[11]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR12);
+            inputs.direct_shift[12]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR13);
+            inputs.direct_shift[13]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR14);
+            inputs.direct_shift[14]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR15);
+            inputs.direct_shift[15]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR16);
+            inputs.direct_shift[16]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR17);
+            inputs.direct_shift[17]        = input_engine->getEventBoolValue(EV_TRUCK_SHIFT_GEAR18);
 
-			// anti roll back in BeamEngine::AUTOMATIC (DRIVE, TWO, ONE) mode
-			if  (pw_state.transmission_mode  == Gearbox::SHIFTMODE_AUTOMATIC &&
-			   (pw_state.transmission_auto_shift_mode == Gearbox::AUTOSWITCH_DRIVE ||
-				pw_state.transmission_auto_shift_mode  == Gearbox::AUTOSWITCH_TWO ||
-				pw_state.transmission_auto_shift_mode  == Gearbox::AUTOSWITCH_ONE) &&
-				curr_truck->WheelSpeed < +0.1f)
-			{
-				Vector3 dirDiff = (curr_truck->nodes[curr_truck->cameranodepos[0]].RelPosition - curr_truck->nodes[curr_truck->cameranodedir[0]].RelPosition).normalisedCopy();
-				Degree pitchAngle = Radian(asin(dirDiff.dotProduct(Vector3::UNIT_Y)));
+            cmd_queue.input_states = inputs;
+        } // end of (powertrain != nullptr)
 
-				if (pitchAngle.valueDegrees() > +1.0f)
-				{
-					if (sin(pitchAngle.valueRadians()) * curr_truck->getTotalMass() > pw_state.engine_current_torque / 2.0f)
-					{
-						curr_truck->brake = curr_truck->brakeforce;
-					} 
-					else
-					{
-						curr_truck->brake = curr_truck->brakeforce * (1.0f - accl);
-					}
-				}
-			}
-
-			// anti roll forth in BeamEngine::AUTOMATIC (REAR) mode
-			if (pw_state.transmission_mode  == Gearbox::SHIFTMODE_AUTOMATIC &&
-				pw_state.transmission_auto_shift_mode  == Gearbox::AUTOSWITCH_REAR &&
-				curr_truck->WheelSpeed > -0.1f)
-			{
-				Vector3 dirDiff = (curr_truck->nodes[curr_truck->cameranodepos[0]].RelPosition - curr_truck->nodes[curr_truck->cameranodedir[0]].RelPosition).normalisedCopy();
-				Degree pitchAngle = Radian(asin(dirDiff.dotProduct(Vector3::UNIT_Y)));
-				float accl = RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE);
-
-				if (pitchAngle.valueDegrees() < -1.0f)
-				{
-					if (sin(pitchAngle.valueRadians()) * curr_truck->getTotalMass() < pw_state.engine_current_torque / 2.0f)
-					{
-						curr_truck->brake = curr_truck->brakeforce;
-					} 
-					else
-					{
-						curr_truck->brake = curr_truck->brakeforce * (1.0f - accl);
-					}
-				}
-			}
-		} // end of ->engine
-#ifdef USE_OPENAL
-		if (curr_truck->brake > curr_truck->brakeforce / 6.0f)
-		{
-			SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_BRAKE);
-		} 
-		else
-		{
-			SoundScriptManager::getSingleton().trigStop(curr_truck, SS_TRIG_BRAKE);
-		}
-#endif // USE_OPENAL
-	} // end of ->replaymode
-
-	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_AXLE_LOCK))
-	{
-		// toggle auto shift
-		if (!curr_truck->getAxleLockCount())
-		{
-#ifdef USE_MYGUI
-			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("No differential installed on current vehicle!"), "warning.png", 3000);
-			RoR::Application::GetGuiManager()->PushNotification("Differential:", "No differential installed on current vehicle!");
-#endif // USE_MYGUI
-		} 
-		else
-		{
-			curr_truck->toggleAxleLock();
-#ifdef USE_MYGUI
-			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Differentials switched to: ") + curr_truck->getAxleLockName(), "cog.png", 3000);
-			RoR::Application::GetGuiManager()->PushNotification("Differential:", "Differentials switched to: " + curr_truck->getAxleLockName());
-#endif // USE_MYGUI
-		}
-	}
+        cmd_queue.input_states.toggle_axle_lock = input_engine->getEventBoolValueBounce(EV_TRUCK_TOGGLE_AXLE_LOCK);
+    } // end of ->replaymode
 
 #ifdef USE_OPENAL
 	if (curr_truck->ispolice)
@@ -553,32 +219,4 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 		}
 	}
 #endif // OPENAL
-
-	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_PARKING_BRAKE))
-	{
-		curr_truck->parkingbrakeToggle();
-	}
-
-	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_ANTILOCK_BRAKE))
-	{
-		if (curr_truck->alb_present && !curr_truck->alb_notoggle)
-		{
-			curr_truck->antilockbrakeToggle();
-		}
-	}
-
-	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TRACTION_CONTROL))
-	{
-		if (curr_truck->tc_present && !curr_truck->tc_notoggle) curr_truck->tractioncontrolToggle();
-	}
-
-	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_CRUISE_CONTROL))
-	{
-		curr_truck->cruisecontrolToggle();
-	}
-	if (curr_truck->cc_mode)
-	{
-		LandVehicleSimulation::UpdateCruiseControl(curr_truck, seconds_since_last_frame);
-	}
-	LandVehicleSimulation::CheckSpeedLimit(curr_truck, seconds_since_last_frame);
 }

--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -34,42 +34,47 @@ using namespace RoR;
 
 void LandVehicleSimulation::UpdateCruiseControl(Beam* curr_truck, float dt)
 {
+    PowertrainState powertrain = curr_truck->powertrain->GetStateOnMainThread();
+    PowertrainCommandQueue& cmd_queue = curr_truck->powertrain->GetQueueOnMainThread();
+
 	if (RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE) > 0.05f ||
 		RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_MANUAL_CLUTCH) > 0.05f ||
 		(curr_truck->cc_target_speed < curr_truck->cc_target_speed_lower_limit) ||
-		(curr_truck->parkingbrake && curr_truck->engine->getGear() > 0) ||
-		!curr_truck->engine->isRunning() ||
-		!curr_truck->engine->hasContact())
+		(curr_truck->parkingbrake && powertrain.transmission_current_gear > 0) ||
+		!powertrain.engine_is_running ||
+		!powertrain.engine_starter_has_contact)
 	{
 		curr_truck->cruisecontrolToggle();
 		return;
 	}
 
-	if (curr_truck->engine->getGear() > 0)
+    int curr_gear = powertrain.transmission_current_gear;
+	if (curr_gear > 0)
 	{
 		// Try to maintain the target speed
 		if (curr_truck->cc_target_speed > curr_truck->WheelSpeed)
 		{
 			float accl = (curr_truck->cc_target_speed - curr_truck->WheelSpeed) * 2.0f;
-			accl = std::max(curr_truck->engine->getAcc(), accl);
+			accl = std::max(powertrain.current_acceleration, accl);
 			accl = std::min(accl, 1.0f);
-			curr_truck->engine->setAcc(accl);
+			cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_ACC, accl);
 		}
-	} else if (curr_truck->engine->getGear() == 0) // out of gear
+	} 
+    else if (curr_gear == 0) // out of gear
 	{
 		// Try to maintain the target rpm
-		if (curr_truck->cc_target_rpm > curr_truck->engine->getRPM())
+		if (curr_truck->cc_target_rpm > powertrain.engine_current_rpm)
 		{
-			float accl = (curr_truck->cc_target_rpm - curr_truck->engine->getRPM()) * 0.01f;
-			accl = std::max(curr_truck->engine->getAcc(), accl);
+			float accl = (curr_truck->cc_target_rpm - powertrain.engine_current_rpm) * 0.01f;
+			accl = std::max(powertrain.current_acceleration, accl);
 			accl = std::min(accl, 1.0f);
-			curr_truck->engine->setAcc(accl);
+			cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_ACC, accl);
 		}
 	}
 
 	if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_ACCL))
 	{
-		if (curr_truck->engine->getGear() > 0)
+		if (curr_gear > 0)
 		{
 			curr_truck->cc_target_speed += 2.5f * dt;
 			curr_truck->cc_target_speed  = std::max(curr_truck->cc_target_speed_lower_limit, curr_truck->cc_target_speed);
@@ -77,22 +82,24 @@ void LandVehicleSimulation::UpdateCruiseControl(Beam* curr_truck, float dt)
 			{
 				curr_truck->cc_target_speed  = std::min(curr_truck->cc_target_speed, curr_truck->sl_speed_limit);
 			}
-		} else if (curr_truck->engine->getGear() == 0) // out of gear
+		}
+        else if (curr_gear == 0) // out of gear
 		{
 			curr_truck->cc_target_rpm += 1000.0f * dt;
-			curr_truck->cc_target_rpm  = std::min(curr_truck->cc_target_rpm, curr_truck->engine->getMaxRPM());
+			curr_truck->cc_target_rpm  = std::min(curr_truck->cc_target_rpm, powertrain.conf_engine_max_rpm);
 		}
 	}
 	if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_DECL))
 	{
-		if (curr_truck->engine->getGear() > 0)
+		if (curr_gear > 0)
 		{
 			curr_truck->cc_target_speed -= 2.5f * dt;
 			curr_truck->cc_target_speed  = std::max(curr_truck->cc_target_speed_lower_limit, curr_truck->cc_target_speed);
-		} else if (curr_truck->engine->getGear() == 0) // out of gear
+		}
+        else if (curr_gear == 0) // out of gear
 		{
 			curr_truck->cc_target_rpm -= 1000.0f * dt;
-			curr_truck->cc_target_rpm  = std::max(curr_truck->engine->getMinRPM(), curr_truck->cc_target_rpm);
+			curr_truck->cc_target_rpm  = std::max(powertrain.conf_engine_min_rpm, curr_truck->cc_target_rpm);
 		}
 	}
 	if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_CRUISE_CONTROL_READJUST))
@@ -102,7 +109,7 @@ void LandVehicleSimulation::UpdateCruiseControl(Beam* curr_truck, float dt)
 		{
 			curr_truck->cc_target_speed = std::min(curr_truck->cc_target_speed, curr_truck->sl_speed_limit);
 		}
-		curr_truck->cc_target_rpm   = curr_truck->engine->getRPM();
+		curr_truck->cc_target_rpm   = powertrain.engine_current_rpm;
 	}
 
 	if (curr_truck->cc_can_brake)
@@ -118,12 +125,15 @@ void LandVehicleSimulation::UpdateCruiseControl(Beam* curr_truck, float dt)
 
 void LandVehicleSimulation::CheckSpeedLimit(Beam* curr_truck, float dt)
 {
-	if (curr_truck->sl_enabled && curr_truck->engine->getGear() != 0)
+    PowertrainState powertrain = curr_truck->powertrain->GetStateOnMainThread();
+	if (curr_truck->sl_enabled && powertrain.transmission_current_gear != 0)
 	{
 		float accl = (curr_truck->sl_speed_limit - std::abs(curr_truck->WheelSpeed)) * 2.0f;
 		accl = std::max(0.0f, accl);
-		accl = std::min(accl, curr_truck->engine->getAcc());
-		curr_truck->engine->setAcc(accl);
+		accl = std::min(accl, powertrain.current_acceleration);
+
+        PowertrainCommandQueue& cmd_queue = curr_truck->powertrain->GetQueueOnMainThread();
+        cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_ACC, accl);
 	}
 }
 
@@ -171,39 +181,42 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 			curr_truck->hydroSpeedCoupling = true;
 		}
 
-		if (curr_truck->engine)
+		if (curr_truck->powertrain != nullptr)
 		{
+            PowertrainState pw_state = curr_truck->powertrain->GetStateOnMainThread();
+            PowertrainCommandQueue& cmd_queue = curr_truck->powertrain->GetQueueOnMainThread();
+
 			bool arcadeControls = BSETTING("ArcadeControls", false);
 
 			float accl  = RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE);
 			float brake = RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE);
 
 			// arcade controls are only working with auto-clutch!
-			if (!arcadeControls || curr_truck->engine->getAutoMode() > BeamEngine::SEMIAUTO)
+			if (!arcadeControls || pw_state.transmission_auto_shift_mode > Gearbox::SHIFTMODE_SEMIAUTO)
 			{
 				// classic mode, realistic
-				curr_truck->engine->autoSetAcc(accl);
+                cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SET_ACC, accl);
 				curr_truck->brake = brake * curr_truck->brakeforce;
 			} 
 			else
 			{
 				// start engine
-				if (curr_truck->engine->hasContact() && !curr_truck->engine->isRunning() && (accl > 0 || brake > 0))
+				if (pw_state.engine_starter_has_contact && !pw_state.engine_is_running && (accl > 0 || brake > 0))
 				{
-					curr_truck->engine->start();
+					cmd_queue.AddCommand(PowertrainCommand::COMMAND_START);
 				}
 
 				// arcade controls: hey - people wanted it x| ... <- and it's convenient
-				if (curr_truck->engine->getGear() >= 0)
+				if (pw_state.transmission_current_gear >= 0)
 				{
 					// neutral or drive forward, everything is as its used to be: brake is brake and accel. is accel.
-					curr_truck->engine->autoSetAcc(accl);
+					cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SET_ACC, accl);
 					curr_truck->brake = brake * curr_truck->brakeforce;
 				} 
 				else
 				{
 					// reverse gear, reverse controls: brake is accel. and accel. is brake.
-					curr_truck->engine->autoSetAcc(brake);
+					cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SET_ACC, accl);
 					curr_truck->brake = accl * curr_truck->brakeforce;
 				}
 
@@ -219,62 +232,63 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 					}
 
 					// switching point, does the user want to drive forward from backward or the other way round? change gears?
-					if (velocity < 1.0f && brake > 0.5f && accl < 0.5f && curr_truck->engine->getGear() > 0)
+					if (velocity < 1.0f && brake > 0.5f && accl < 0.5f && pw_state.transmission_current_gear > 0)
 					{
 						// we are on the brake, jump to reverse gear
-						if (curr_truck->engine->getAutoMode() == BeamEngine::AUTOMATIC)
+						if (pw_state.transmission_auto_shift_mode == Gearbox::SHIFTMODE_AUTOMATIC)
 						{
-							curr_truck->engine->autoShiftSet(BeamEngine::REAR);
+                            cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SHIFT_SET, static_cast<float>(Gearbox::AUTOSWITCH_REAR));
 						} 
 						else
 						{
-							curr_truck->engine->setGear(-1);
+                            cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR, -1.f);
 						}
-					} else if (velocity > -1.0f && brake < 0.5f && accl > 0.5f && curr_truck->engine->getGear() < 0)
+					} 
+                    else if (velocity > -1.0f && brake < 0.5f && accl > 0.5f && pw_state.transmission_current_gear < 0)
 					{
 						// we are on the gas pedal, jump to first gear when we were in rear gear
-						if (curr_truck->engine->getAutoMode() == BeamEngine::AUTOMATIC)
+                        if (pw_state.transmission_auto_shift_mode == Gearbox::SHIFTMODE_AUTOMATIC)
 						{									
-							curr_truck->engine->autoShiftSet(BeamEngine::DRIVE);
+							cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SHIFT_SET, static_cast<float>(Gearbox::AUTOSWITCH_DRIVE));
 						} 
 						else
 						{
-							curr_truck->engine->setGear(1);
+							cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR, 1.f);
 						}
 					}
 				}
 			}
 
-			// IMI
-			// gear management -- it might, should be transferred to a standalone function of Beam or RoRFrameListener
-			if (curr_truck->engine->getAutoMode() == BeamEngine::AUTOMATIC)
+			// ============ Gearbox simulation - to be ported into LuaPowertrain ==================
+
+			if (pw_state.transmission_auto_shift_mode == Gearbox::SHIFTMODE_AUTOMATIC)
 			{
 				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_UP))
 				{
-					curr_truck->engine->autoShiftUp();
+                    cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SHIFT_UP);
 				}
 				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_DOWN))
 				{
-					curr_truck->engine->autoShiftDown();
+					cmd_queue.AddCommand(PowertrainCommand::COMMAND_AUTO_SHIFT_DOWN);
 				}
 			}
 
 			if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_CONTACT))
 			{
-				curr_truck->engine->toggleContact();
+				cmd_queue.AddCommand(PowertrainCommand::COMMAND_TOGGLE_CONTACT);
 			}
 
-			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_STARTER) && curr_truck->engine->hasContact())
+			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_STARTER) && pw_state.engine_starter_has_contact)
 			{
 				// starter
-				curr_truck->engine->setstarter(1);
+                cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_STARTER, 1.f);
 #ifdef USE_OPENAL
 				SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_STARTER);
 #endif // OPENAL
 			} 
 			else
 			{
-				curr_truck->engine->setstarter(0);
+				cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_STARTER, 0.f);
 #ifdef USE_OPENAL
 				SoundScriptManager::getSingleton().trigStop(curr_truck, SS_TRIG_STARTER);
 #endif // OPENAL
@@ -283,30 +297,30 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 			if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SWITCH_SHIFT_MODES))
 			{
 				// toggle Auto shift
-				curr_truck->engine->toggleAutoMode();
+				cmd_queue.AddCommand(PowertrainCommand::COMMAND_TOGGLE_AUTO_MODE);
 
 				// force gui update
 				curr_truck->triggerGUIFeaturesChanged();
 #ifdef USE_MYGUI
-				switch(curr_truck->engine->getAutoMode())
+				switch(pw_state.transmission_auto_shift_mode)
 				{
-					case BeamEngine::AUTOMATIC:
+					case Gearbox::SHIFTMODE_AUTOMATIC:
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Automatic shift"), "cog.png", 3000);
 						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Automatic shift");
 						break;
-					case BeamEngine::SEMIAUTO:
+					case Gearbox::SHIFTMODE_SEMIAUTO:
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Manual shift - Auto clutch"), "cog.png", 3000);
 						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Manual shift - Auto clutch");
 						break;
-					case BeamEngine::MANUAL:
+					case Gearbox::SHIFTMODE_MANUAL:
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully Manual: sequential shift"), "cog.png", 3000);
 						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully Manual: sequential shift");
 						break;
-					case BeamEngine::MANUAL_STICK:
+					case Gearbox::SHIFTMODE_MANUAL_STICK:
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully manual: stick shift"), "cog.png", 3000);
 						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully manual: stick shift");
 						break;
-					case BeamEngine::MANUAL_RANGES:
+					case Gearbox::SHIFTMODE_MANUAL_RANGES:
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Fully Manual: stick shift with ranges"), "cog.png", 3000);
 						RoR::Application::GetGuiManager()->PushNotification("Gearbox Mode:", "Fully Manual: stick shift with ranges");
 						break;
@@ -316,65 +330,65 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 
 			// joy clutch
 			float cval = RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_MANUAL_CLUTCH);
-			curr_truck->engine->setManualClutch(cval);
+            cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_MANUAL_CLUTCH, cval);
 
 			bool gear_changed_rel = false;
-			int shiftmode = curr_truck->engine->getAutoMode();
+			int shiftmode = pw_state.transmission_auto_shift_mode;
 
-			if (shiftmode <= BeamEngine::MANUAL) // auto, semi auto and sequential shifting
+			if (shiftmode <= Gearbox::SHIFTMODE_MANUAL) // auto, semi auto and sequential shifting
 			{
 				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_UP))
 				{
-						curr_truck->engine->BeamEngineShift(1);
-						gear_changed_rel = true;
+					cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT, 1.f); // shift up
+					gear_changed_rel = true;
 				} 
 				else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_DOWN))
 				{
-					if (shiftmode  > BeamEngine::SEMIAUTO ||
-						shiftmode == BeamEngine::SEMIAUTO  && !arcadeControls ||
-						shiftmode == BeamEngine::SEMIAUTO  && curr_truck->engine->getGear() > 0 ||
-						shiftmode == BeamEngine::AUTOMATIC)
+					if (shiftmode  > Gearbox::SHIFTMODE_SEMIAUTO ||
+						shiftmode == Gearbox::SHIFTMODE_SEMIAUTO  && !arcadeControls ||
+						shiftmode == Gearbox::SHIFTMODE_SEMIAUTO  && pw_state.transmission_current_gear > 0 ||
+						shiftmode == Gearbox::SHIFTMODE_AUTOMATIC)
 					{
-						curr_truck->engine->BeamEngineShift(-1);
+						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT, -1.f); // shift down
 						gear_changed_rel = true;
 					}
 				} 
-				else if (shiftmode != BeamEngine::AUTOMATIC && RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL))
+				else if (shiftmode != Gearbox::SHIFTMODE_AUTOMATIC && RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL))
 				{
-					curr_truck->engine->BeamEngineShiftTo(0);
+					cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, 0.f);
 				}
 			} 
 			else //if (shiftmode > BeamEngine::MANUAL) // h-shift or h-shift with ranges shifting
 			{
 				bool gear_changed = false;
 				bool found        = false;
-				int curgear       = curr_truck->engine->getGear();
-				int curgearrange    = curr_truck->engine->getGearRange();
+				int curgear       = pw_state.transmission_current_gear;
+				int curgearrange    = pw_state.transmission_current_gear_range;
 				int gearoffset      = std::max(0, curgear - curgearrange * 6);
 
 				// one can select range only if in neutral
-				if (shiftmode==BeamEngine::MANUAL_RANGES && curgear == 0)
+				if (shiftmode==Gearbox::SHIFTMODE_MANUAL_RANGES && curgear == 0)
 				{
 					//  maybe this should not be here, but should experiment
 					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_LOWRANGE) && curgearrange != 0)
 					{
-						curr_truck->engine->setGearRange(0);
+                        cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR_RANGE, 0.f);
 						gear_changed = true;
 #ifdef USE_MYGUI
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png", 3000);
 #endif //USE_MYGUI
 					} 
-					else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_MIDRANGE)  && curgearrange != 1 && curr_truck->engine->getNumGearsRanges()>1)
+					else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_MIDRANGE)  && curgearrange != 1 && pw_state.conf_transmission_num_gears_ranges>1)
 					{
-						curr_truck->engine->setGearRange(1);
+						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR_RANGE, 1.f);
 						gear_changed = true;
 #ifdef USE_MYGUI
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png", 3000);
 #endif //USE_MYGUI
 					} 
-					else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_HIGHRANGE) && curgearrange != 2 && curr_truck->engine->getNumGearsRanges()>2)
+					else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_HIGHRANGE) && curgearrange != 2 && pw_state.conf_transmission_num_gears_ranges>2)
 					{
-						curr_truck->engine->setGearRange(2);
+						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SET_GEAR_RANGE, 2.f);
 						gear_changed = true;
 #ifdef USE_MYGUI
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png", 3000);
@@ -388,10 +402,11 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 				} 
 				else if (curgear > 0 && curgear < 19)
 				{
-					if (shiftmode==BeamEngine::MANUAL)
+					if (shiftmode==Gearbox::SHIFTMODE_MANUAL)
 					{
 						gear_changed = !RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + curgear -1);
-					} else
+					} 
+                    else
 					{
 						gear_changed = !RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + gearoffset-1); // range mode
 					}
@@ -401,23 +416,23 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 				{
 					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE))
 					{
-						curr_truck->engine->BeamEngineShiftTo(-1);
+						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, -1.f);
 						found = true;
 					} 
 					else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_NEUTRAL))
 					{
-						curr_truck->engine->BeamEngineShiftTo(0);
+						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, 0.f);
 						found = true;
 					} 
 					else
 					{
-						if (shiftmode == BeamEngine::MANUAL_STICK)
+						if (shiftmode == Gearbox::SHIFTMODE_MANUAL_STICK)
 						{
 							for (int i=1; i < 19 && !found; i++)
 							{
 								if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
 								{
-									curr_truck->engine->BeamEngineShiftTo(i);
+									cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, i);
 									found = true;
 								}
 							}
@@ -428,7 +443,8 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 							{
 								if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
 								{
-									curr_truck->engine->BeamEngineShiftTo(i + curgearrange * 6);
+                                    int val = i + curgearrange * 6;
+									cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, val);
 									found = true;
 								}
 							}
@@ -436,16 +452,16 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 					}
 					if (!found)
 					{
-						curr_truck->engine->BeamEngineShiftTo(0);
+						cmd_queue.AddCommand(PowertrainCommand::COMMAND_SHIFT_TO, 0.f);
 					}
 				} // end of if (gear_changed)
 			} // end of shitmode > BeamEngine::MANUAL
 
 			// anti roll back in BeamEngine::AUTOMATIC (DRIVE, TWO, ONE) mode
-			if (curr_truck->engine->getAutoMode()  == BeamEngine::AUTOMATIC &&
-				(curr_truck->engine->getAutoShift() == BeamEngine::DRIVE ||
-				curr_truck->engine->getAutoShift() == BeamEngine::TWO ||
-				curr_truck->engine->getAutoShift() == BeamEngine::ONE) &&
+			if  (pw_state.transmission_mode  == Gearbox::SHIFTMODE_AUTOMATIC &&
+			   (pw_state.transmission_auto_shift_mode == Gearbox::AUTOSWITCH_DRIVE ||
+				pw_state.transmission_auto_shift_mode  == Gearbox::AUTOSWITCH_TWO ||
+				pw_state.transmission_auto_shift_mode  == Gearbox::AUTOSWITCH_ONE) &&
 				curr_truck->WheelSpeed < +0.1f)
 			{
 				Vector3 dirDiff = (curr_truck->nodes[curr_truck->cameranodepos[0]].RelPosition - curr_truck->nodes[curr_truck->cameranodedir[0]].RelPosition).normalisedCopy();
@@ -453,7 +469,7 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 
 				if (pitchAngle.valueDegrees() > +1.0f)
 				{
-					if (sin(pitchAngle.valueRadians()) * curr_truck->getTotalMass() > curr_truck->engine->getTorque() / 2.0f)
+					if (sin(pitchAngle.valueRadians()) * curr_truck->getTotalMass() > pw_state.engine_current_torque / 2.0f)
 					{
 						curr_truck->brake = curr_truck->brakeforce;
 					} 
@@ -465,8 +481,8 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 			}
 
 			// anti roll forth in BeamEngine::AUTOMATIC (REAR) mode
-			if (curr_truck->engine->getAutoMode()  == BeamEngine::AUTOMATIC &&
-				curr_truck->engine->getAutoShift() == BeamEngine::REAR &&
+			if (pw_state.transmission_mode  == Gearbox::SHIFTMODE_AUTOMATIC &&
+				pw_state.transmission_auto_shift_mode  == Gearbox::AUTOSWITCH_REAR &&
 				curr_truck->WheelSpeed > -0.1f)
 			{
 				Vector3 dirDiff = (curr_truck->nodes[curr_truck->cameranodepos[0]].RelPosition - curr_truck->nodes[curr_truck->cameranodedir[0]].RelPosition).normalisedCopy();
@@ -475,7 +491,7 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 
 				if (pitchAngle.valueDegrees() < -1.0f)
 				{
-					if (sin(pitchAngle.valueRadians()) * curr_truck->getTotalMass() < curr_truck->engine->getTorque() / 2.0f)
+					if (sin(pitchAngle.valueRadians()) * curr_truck->getTotalMass() < pw_state.engine_current_torque / 2.0f)
 					{
 						curr_truck->brake = curr_truck->brakeforce;
 					} 

--- a/source/main/gameplay/Powertrain.cpp
+++ b/source/main/gameplay/Powertrain.cpp
@@ -1,0 +1,173 @@
+
+/** 
+    @file
+    @date   01/2016
+    @author Petr Ohlidal
+*/
+
+#include "Powertrain.h"
+
+#include "BeamEngine.h"
+
+using namespace RoR;
+
+Powertrain::Powertrain():
+    m_engine(nullptr),
+    m_main_thread_index(0),
+    m_sim_thread_index(1)
+{
+    m_state[0].Reset();
+    m_state[1].Reset();
+
+    m_command_queue[0].queue.reserve(20);
+    m_command_queue[1].queue.reserve(20);
+}
+
+Powertrain::~Powertrain()
+{
+    delete m_engine;
+}
+
+void Powertrain::PowertrainExportState()
+{
+    PowertrainState state;
+    state.Reset();
+    
+    state.conf_engine_has_turbo              = m_engine->hasTurbo();
+    state.conf_engine_max_rpm                = m_engine->getMaxRPM();
+    state.conf_transmission_clutch_force     = m_engine->getClutchForce();
+    state.current_acceleration               = m_engine->getAcc();
+    state.engine_crank_factor                = m_engine->getCrankFactor();
+    state.engine_current_rpm                 = m_engine->getRPM();
+    state.engine_current_torque              = m_engine->getTorque();
+    state.engine_is_running                  = m_engine->isRunning();
+    state.engine_starter_has_contact         = m_engine->hasContact();
+    state.gfx_engine_exhaust_smoke           = m_engine->getSmoke();
+    state.transmission_auto_shift_mode       = m_engine->getAutoShift();
+    state.transmission_current_clutch        = m_engine->getClutch();
+    state.transmission_current_gear          = m_engine->getGear();
+    state.transmission_num_forward_gears     = m_engine->getNumGears();
+    state.turbo_current_psi                  = m_engine->getTurboPSI();
+    state.conf_engine_min_rpm                = m_engine->getMinRPM();
+    state.transmission_current_gear_range    = m_engine->getGearRange();
+    state.conf_transmission_num_gears_ranges = m_engine->getNumGearsRanges();
+
+    this->GetStateOnSimThread() = state;
+}
+
+void Powertrain::PowertrainUpdate(float dt_seconds, bool just_synced)
+{
+    m_engine->UpdateBeamEngine(dt_seconds, just_synced);
+}
+
+void Powertrain::PowertrainProcessInput()
+{
+    // Process command queue
+    auto& cmd_queue = this->GetQueueOnSimThread();
+    auto itor = cmd_queue.queue.begin();
+    auto endi = cmd_queue.queue.end();
+    for (; itor != endi; ++itor)
+    {
+        auto cmd = *itor;
+        switch (cmd.type)
+        {
+        case PowertrainCommand::COMMAND_AUTO_SET_ACC:
+            m_engine->autoSetAcc(cmd.value);
+            break;
+        case PowertrainCommand::COMMAND_OFFSTART:
+            m_engine->offstart();
+            break;
+        case PowertrainCommand::COMMAND_SET_ACC:
+            m_engine->setAcc(cmd.value);
+            break;
+        case PowertrainCommand::COMMAND_SET_CLUTCH:
+            m_engine->setClutch(cmd.value);
+            break;
+        case PowertrainCommand::COMMAND_SHIFT:
+            m_engine->BeamEngineShift(static_cast<int>(cmd.value));
+            break;
+        case PowertrainCommand::COMMAND_START:
+            m_engine->BeamEngineStart();
+            break;
+        case PowertrainCommand::COMMAND_AUTO_SHIFT_SET:
+            m_engine->autoShiftSet(static_cast<int>(cmd.value));
+            break;
+        case PowertrainCommand::COMMAND_SET_GEAR:
+            m_engine->setGear(static_cast<int>(cmd.value));
+            break;
+        case PowertrainCommand::COMMAND_AUTO_SHIFT_UP:
+            m_engine->autoShiftUp();
+            break;
+        case PowertrainCommand::COMMAND_AUTO_SHIFT_DOWN:
+            m_engine->autoShiftDown();
+            break;
+        case PowertrainCommand::COMMAND_TOGGLE_CONTACT:
+            m_engine->toggleContact();
+            break;
+        case PowertrainCommand::COMMAND_SET_STARTER:
+            m_engine->setstarter(static_cast<int>(cmd.value));
+            break;
+        case PowertrainCommand::COMMAND_TOGGLE_AUTO_MODE:
+            m_engine->toggleAutoMode();
+            break;
+        case PowertrainCommand::COMMAND_SET_MANUAL_CLUTCH:
+            m_engine->setManualClutch(cmd.value);
+            break;
+        case PowertrainCommand::COMMAND_SHIFT_TO:
+            m_engine->BeamEngineShiftTo(static_cast<int>(cmd.value));
+            break;
+        case PowertrainCommand::COMMAND_SET_GEAR_RANGE:
+            m_engine->setGearRange(static_cast<int>(cmd.value));
+            break;
+        }
+    }
+
+    // Process networked update
+    if (cmd_queue.was_network_updated)
+    {
+        m_engine->netForceSettings(
+            cmd_queue.net_rpm,
+            cmd_queue.net_force,
+            cmd_queue.net_clutch,
+            cmd_queue.net_gear,
+            cmd_queue.net_is_running,
+            cmd_queue.net_has_contact,
+            cmd_queue.net_auto_mode
+            );
+    }
+    cmd_queue.Reset();
+}
+
+void PowertrainCommandQueue::AddCommand(PowertrainCommand::CommandType type, float value /* = 0.f */)
+{
+    PowertrainCommand cmd;
+    cmd.type = type;
+    cmd.value = value;
+    queue.push_back(cmd);
+}
+
+void PowertrainCommandQueue::NetworkedUpdate(float rpm, float force, float clutch, int gear, bool _running, bool _contact, char _automode)
+{
+    net_rpm = rpm;
+    net_force = force;
+    net_clutch = clutch;
+    net_gear = gear;
+    net_is_running = _running;
+    net_has_contact = _contact;
+    net_auto_mode = _automode;
+
+    was_network_updated = true;
+}
+
+void PowertrainCommandQueue::Reset()
+{
+    queue.clear(); // Doesn't affect pre-allocated capacity
+    was_network_updated = false;
+    net_rpm = 0.f;
+    net_force = 0.f;
+    net_clutch = 0.f;
+    net_gear = 0;
+    net_is_running = false;
+    net_has_contact = false;
+    net_auto_mode = 0;
+}

--- a/source/main/gameplay/Powertrain.cpp
+++ b/source/main/gameplay/Powertrain.cpp
@@ -7,7 +7,10 @@
 
 #include "Powertrain.h"
 
+#include "Beam.h"
 #include "BeamEngine.h"
+#include "Settings.h"
+#include "SoundScriptManager.h"
 
 using namespace RoR;
 
@@ -51,17 +54,455 @@ void Powertrain::PowertrainExportState()
     state.conf_engine_min_rpm                = m_engine->getMinRPM();
     state.transmission_current_gear_range    = m_engine->getGearRange();
     state.conf_transmission_num_gears_ranges = m_engine->getNumGearsRanges();
+    state.transmission_mode                  = m_engine->getAutoMode();
 
     this->GetStateOnSimThread() = state;
 }
 
 void Powertrain::PowertrainUpdate(float dt_seconds, bool just_synced)
 {
+    if (just_synced)
+    {
+        if (m_vehicle->cc_mode)
+        {
+            this->UpdateCruiseControl(dt_seconds);
+        }
+        this->CheckSpeedLimit(dt_seconds);
+    }
     m_engine->UpdateBeamEngine(dt_seconds, just_synced);
+}
+
+void Powertrain::CheckSpeedLimit(float dt_seconds)
+{
+    if (m_vehicle->sl_enabled && m_engine->getGear() != 0)
+    {
+        float accl = (m_vehicle->sl_speed_limit - std::abs(m_vehicle->WheelSpeed)) * 2.0f;
+        accl = std::max(0.0f, accl);
+        accl = std::min(accl, m_engine->getAcc());
+
+        m_engine->setAcc(accl);
+    }
+}
+
+void Powertrain::PowertrainProcessInputStates()
+{
+    // TODO: Cache this!
+    bool use_arcade_controls = BSETTING("ArcadeControls", false);
+
+    BeamEngine* engine               = this->GetEngine();
+    PowertrainInputStates inputs     = this->GetQueueOnSimThread().input_states;
+
+    PowertrainState pw_out_state;
+    pw_out_state.Reset();
+
+    RoR::Gearbox::shiftmodes transmission_mode = m_engine->getAutoMode();
+
+    if (!use_arcade_controls && engine->getAutoShift() > Gearbox::SHIFTMODE_SEMIAUTO)
+    {
+        // Classic mode, realistic
+        engine->autoSetAcc(inputs.acceleration);
+        m_vehicle->brake = inputs.brake * m_vehicle->brakeforce;
+    }
+    else // arcade controls: hey - people wanted it x| ... <- and it's convenient
+    {
+        // start engine
+        if (engine->hasContact() && !engine->isRunning() && (inputs.acceleration > 0 || inputs.brake > 0))
+        {
+            engine->BeamEngineStart();
+        }
+
+        if (engine->getGear() >= 0)
+        {
+            // neutral or drive forward, everything is as its used to be: brake is brake and accel. is accel.
+            engine->autoSetAcc(inputs.acceleration);
+            m_vehicle->brake = inputs.brake * m_vehicle->brakeforce;
+        }
+        else
+        {
+            // reverse gear, reverse controls: brake is accel. and accel. is brake.
+            engine->autoSetAcc(inputs.brake);
+            m_vehicle->brake = inputs.acceleration * m_vehicle->brakeforce;
+        }
+
+        // only when the truck really is not moving anymore
+        if (fabs(m_vehicle->WheelSpeed) <= 1.f)
+        {
+            float velocity = 0;
+            if (m_vehicle->cameranodepos[0] >= 0 && m_vehicle->cameranodedir[0] >= 0)
+            {
+                Ogre::Vector3 hdir = (m_vehicle->nodes[m_vehicle->cameranodepos[0]].RelPosition - m_vehicle->nodes[m_vehicle->cameranodedir[0]].RelPosition).normalisedCopy();
+                velocity = hdir.dotProduct(m_vehicle->nodes[0].Velocity);
+            }
+            // switching point, does the user want to drive forward from backward or the other way round? change gears?
+            if (velocity < 1.0f && inputs.brake > 0.5f && inputs.acceleration < 0.5f && engine->getGear() > 0)
+            {
+                // we are on the brake, jump to reverse gear
+                if (engine->getAutoShift() == Gearbox::SHIFTMODE_AUTOMATIC)
+                {
+                    engine->autoShiftSet(Gearbox::AUTOSWITCH_REAR);
+                } 
+                else
+                {
+                    engine->setGear(-1.f);
+                }
+            } 
+            else if (velocity > -1.0f && inputs.brake < 0.5f && inputs.acceleration > 0.5f && engine->getGear() < 0)
+            {
+                // we are on the gas pedal, jump to first gear when we were in rear gear
+                if (engine->getAutoShift() == Gearbox::SHIFTMODE_AUTOMATIC)
+                {
+                    engine->autoShiftSet(Gearbox::AUTOSWITCH_DRIVE);
+                } 
+                else
+                {
+                    engine->setGear(1.f);
+                }
+            }
+        }
+    } // end of arcade controls
+
+    if (engine->getAutoShift() == Gearbox::SHIFTMODE_AUTOMATIC)
+    {
+        if (inputs.autoshift_up)
+        {
+            engine->autoShiftUp();
+        }
+        if (inputs.autoshift_down)
+        {
+            engine->autoShiftDown();
+        }
+    }
+
+    if (inputs.toggle_contact)
+    {
+        engine->toggleContact();
+    }
+
+    if (inputs.starter && engine->hasContact())
+    {
+        // starter
+        engine->setstarter(1);
+#ifdef USE_OPENAL
+        SoundScriptManager::getSingleton().trigStart(m_vehicle, SS_TRIG_STARTER);
+#endif // OPENAL
+    } 
+    else
+    {
+        engine->setstarter(0);
+#ifdef USE_OPENAL
+        SoundScriptManager::getSingleton().trigStop(m_vehicle, SS_TRIG_STARTER);
+#endif // OPENAL
+    }
+
+    if (inputs.switch_shift_modes)
+    {
+        // toggle Auto shift
+        engine->toggleAutoMode();
+    }
+
+    // joy clutch
+    engine->setClutch(inputs.manual_clutch);
+
+    bool gear_changed_rel = false;
+    int shiftmode = engine->getAutoShift();
+
+    if (shiftmode <= Gearbox::SHIFTMODE_MANUAL) // auto, semi auto and sequential shifting
+    {
+        if (inputs.shift_up)
+        {
+            engine->BeamEngineShift(1); // shift up
+            gear_changed_rel = true;
+        } 
+        else if (inputs.shift_down)
+        {
+            if (shiftmode  > Gearbox::SHIFTMODE_SEMIAUTO ||
+            shiftmode == Gearbox::SHIFTMODE_SEMIAUTO  && !use_arcade_controls ||
+            shiftmode == Gearbox::SHIFTMODE_SEMIAUTO  && engine->getGear() > 0 ||
+            shiftmode == Gearbox::SHIFTMODE_AUTOMATIC)
+            {
+                engine->BeamEngineShift(-1); // shift down
+                gear_changed_rel = true;
+            }
+        } 
+        else if (shiftmode != Gearbox::SHIFTMODE_AUTOMATIC && inputs.shift_neutral)
+        {
+            engine->BeamEngineShiftTo(0);
+        }
+    } 
+    else //if (shiftmode > BeamEngine::MANUAL) // h-shift or h-shift with ranges shifting
+    {
+        bool gear_changed = false;
+        bool found        = false;
+        int  curgear      = engine->getGear();
+        int  curgearrange = engine->getGearRange();
+        int  gearoffset   = std::max(0, curgear - curgearrange * 6);
+
+        // one can select range only if in neutral
+        if (shiftmode==Gearbox::SHIFTMODE_MANUAL_RANGES && curgear == 0)
+        {
+            if (inputs.shift_lowrange && curgearrange != 0)
+            {
+                engine->setGearRange(0);
+                pw_out_state.transmission_gear_range_selected = 1;
+            } 
+            else if (inputs.shift_midrange && curgearrange != 1 && engine->getNumGearsRanges()>1)
+            {
+                engine->setGearRange(1);
+                pw_out_state.transmission_gear_range_selected = 2;
+            } 
+            else if (inputs.shift_highrange && curgearrange != 2 && engine->getNumGearsRanges()>2)
+            {
+                engine->setGearRange(2);
+                pw_out_state.transmission_gear_range_selected = 3;
+            }
+        }
+        //zaxxon
+        if (curgear == -1)
+        {
+            gear_changed = !inputs.shift_gear_reverse;
+        } 
+        else if (curgear > 0 && curgear < 19)
+        {
+            if (shiftmode==Gearbox::SHIFTMODE_MANUAL)
+            {
+                gear_changed = !inputs.direct_shift[curgear - 1];
+            } 
+            else
+            {
+                gear_changed = !inputs.direct_shift[gearoffset - 1];
+            }
+        }
+
+        if (gear_changed || curgear == 0)
+        {
+            if (inputs.shift_gear_reverse)
+            {
+                engine->BeamEngineShiftTo(-1);
+                found = true;
+            } 
+            else if (inputs.shift_neutral)
+            {
+                engine->BeamEngineShiftTo(0);
+                found = true;
+            } 
+            else
+            {
+                if (shiftmode == Gearbox::SHIFTMODE_MANUAL_STICK)
+                {
+                    for (int i=0; i < 18 && !found; i++)
+                    {
+                        if (inputs.direct_shift[i])
+                        {
+                            engine->BeamEngineShiftTo(i + 1);
+                            found = true;
+                        }
+                    }
+                } 
+                else // BeamEngine::MANUALMANUAL_RANGES
+                {
+                    for (int i=1; i < 7 && !found; i++)
+                    {
+                        if (inputs.direct_shift[i - 1])
+                        {
+                            int val = i + curgearrange * 6;
+                            engine->BeamEngineShiftTo(val);
+                            found = true;
+                        }
+                    }
+                }
+            }
+            if (!found)
+            {
+                engine->BeamEngineShiftTo(0);
+            }
+        } // end of if (gear_changed)
+    } // end of shitmode > BeamEngine::MANUAL
+
+    // anti roll back in BeamEngine::AUTOMATIC (DRIVE, TWO, ONE) mode
+    int autoshift = engine->getAutoShift();
+    if  (transmission_mode  == Gearbox::SHIFTMODE_AUTOMATIC &&
+        (autoshift == Gearbox::AUTOSWITCH_DRIVE ||
+        autoshift  == Gearbox::AUTOSWITCH_TWO ||
+        autoshift  == Gearbox::AUTOSWITCH_ONE) &&
+        m_vehicle->WheelSpeed < +0.1f)
+    {
+        Ogre::Vector3 dirDiff = (m_vehicle->nodes[m_vehicle->cameranodepos[0]].RelPosition - m_vehicle->nodes[m_vehicle->cameranodedir[0]].RelPosition).normalisedCopy();
+        Ogre::Degree pitchAngle = Ogre::Radian(asin(dirDiff.dotProduct(Ogre::Vector3::UNIT_Y)));
+
+        if (pitchAngle.valueDegrees() > +1.0f)
+        {
+            if (sin(pitchAngle.valueRadians()) * m_vehicle->getTotalMass() > engine->getTorque() / 2.0f)
+            {
+                m_vehicle->brake = m_vehicle->brakeforce;
+            } 
+            else
+            {
+                m_vehicle->brake = m_vehicle->brakeforce * (1.0f - engine->getAcc());
+            }
+        }
+    }
+
+    // anti roll forth in BeamEngine::AUTOMATIC (REAR) mode
+    if (transmission_mode  == Gearbox::SHIFTMODE_AUTOMATIC &&
+        engine->getAutoShift()  == Gearbox::AUTOSWITCH_REAR &&
+        m_vehicle->WheelSpeed > -0.1f)
+    {
+        Ogre::Vector3 dirDiff = (m_vehicle->nodes[m_vehicle->cameranodepos[0]].RelPosition - m_vehicle->nodes[m_vehicle->cameranodedir[0]].RelPosition).normalisedCopy();
+        Ogre::Degree pitchAngle = Ogre::Radian(asin(dirDiff.dotProduct(Ogre::Vector3::UNIT_Y)));
+
+        if (pitchAngle.valueDegrees() < -1.0f)
+        {
+            if (sin(pitchAngle.valueRadians()) * m_vehicle->getTotalMass() < engine->getTorque() / 2.0f)
+            {
+                m_vehicle->brake = m_vehicle->brakeforce;
+            } 
+            else
+            {
+                m_vehicle->brake = m_vehicle->brakeforce * (1.0f - inputs.acceleration);
+            }
+        }
+    }
+
+#ifdef USE_OPENAL
+    if (m_vehicle->brake > m_vehicle->brakeforce / 6.0f)
+    {
+        SoundScriptManager::getSingleton().trigStart(m_vehicle, SS_TRIG_BRAKE);
+    } 
+    else
+    {
+        SoundScriptManager::getSingleton().trigStop(m_vehicle, SS_TRIG_BRAKE);
+    }
+#endif // USE_OPENAL
+
+    if (inputs.toggle_axle_lock)
+    {
+        // toggle auto shift
+        if (m_vehicle->getAxleLockCount())
+        {
+            m_vehicle->toggleAxleLock();
+            pw_out_state.transmission_axlelock_toggled = 1;
+        }
+        else
+        {
+            pw_out_state.transmission_axlelock_toggled = -1;
+        }
+    }
+
+    if (inputs.parking_brake_toggle)
+    {
+        m_vehicle->parkingbrakeToggle();
+    }
+
+    if (inputs.antilock_brake_toggle && m_vehicle->alb_present && !m_vehicle->alb_notoggle)
+    {
+        m_vehicle->antilockbrakeToggle();
+    }
+
+    if (inputs.traction_control_toggle && m_vehicle->tc_present && !m_vehicle->tc_notoggle)
+    {
+        m_vehicle->tractioncontrolToggle();
+    }
+
+    if (inputs.cruise_control_toggle)
+    {
+        m_vehicle->cruisecontrolToggle();
+    }
+}
+
+void Powertrain::UpdateCruiseControl(float dt)
+{
+    PowertrainInputStates inputs = this->GetQueueOnSimThread().input_states;
+
+    if (inputs.brake > 0.05f || inputs.manual_clutch > 0.05f ||
+        (m_vehicle->cc_target_speed < m_vehicle->cc_target_speed_lower_limit) ||
+        (m_vehicle->parkingbrake && m_engine->getGear() > 0) ||
+        !m_engine->isRunning() ||
+        !m_engine->hasContact())
+    {
+        m_vehicle->cruisecontrolToggle();
+        return;
+    }
+
+    if (m_engine->getGear() > 0)
+    {
+        // Try to maintain the target speed
+        if (m_vehicle->cc_target_speed > m_vehicle->WheelSpeed)
+        {
+            float accl = (m_vehicle->cc_target_speed - m_vehicle->WheelSpeed) * 2.0f;
+            accl = std::max(m_engine->getAcc(), accl);
+            accl = std::min(accl, 1.0f);
+            m_engine->setAcc(accl);
+        }
+    }
+    else if (m_engine->getGear() == 0)
+    {
+        // Try to maintain the target rpm
+        if (m_vehicle->cc_target_rpm > m_engine->getRPM())
+        {
+            float accl = (m_vehicle->cc_target_rpm - m_engine->getRPM()) * 0.01f;
+            accl = std::max(m_engine->getAcc(), accl);
+            accl = std::min(accl, 1.0f);
+            m_engine->setAcc(accl);
+        }
+    }
+
+    if (inputs.cruise_control_accel)
+    {
+        if (m_engine->getGear() > 0)
+        {
+            m_vehicle->cc_target_speed += 2.5f * dt;
+            m_vehicle->cc_target_speed  = std::max(m_vehicle->cc_target_speed_lower_limit, m_vehicle->cc_target_speed);
+            if (m_vehicle->sl_enabled)
+            {
+                m_vehicle->cc_target_speed  = std::min(m_vehicle->cc_target_speed, m_vehicle->sl_speed_limit);
+            }
+        }
+        else if (m_engine->getGear() == 0)
+        {
+            m_vehicle->cc_target_rpm += 1000.0f * dt;
+            m_vehicle->cc_target_rpm  = std::min(m_vehicle->cc_target_rpm, m_engine->getMaxRPM());
+        }
+    }
+
+    if (inputs.cruise_control_decel)
+    {
+        if (m_engine->getGear() > 0)
+        {
+            m_vehicle->cc_target_speed -= 2.5f * dt;
+            m_vehicle->cc_target_speed  = std::max(m_vehicle->cc_target_speed_lower_limit, m_vehicle->cc_target_speed);
+        }
+        else if (m_engine->getGear() == 0)
+        {
+            m_vehicle->cc_target_rpm -= 1000.0f * dt;
+            m_vehicle->cc_target_rpm  = std::max(m_engine->getMaxRPM(), m_vehicle->cc_target_rpm);
+        }
+    }
+
+	if (inputs.cruise_control_readjust)
+	{
+		m_vehicle->cc_target_speed = std::max(m_vehicle->WheelSpeed, m_vehicle->cc_target_speed);
+		if (m_vehicle->sl_enabled)
+		{
+			m_vehicle->cc_target_speed = std::min(m_vehicle->cc_target_speed, m_vehicle->sl_speed_limit);
+		}
+		m_vehicle->cc_target_rpm   = m_engine->getRPM();
+	}
+
+	if (m_vehicle->cc_can_brake)
+	{
+		if (m_vehicle->WheelSpeed > m_vehicle->cc_target_speed + 0.5f && !inputs.acceleration)
+		{
+			float brake = (m_vehicle->WheelSpeed - m_vehicle->cc_target_speed) * 0.5f;
+			brake = std::min(brake, 1.0f);
+			m_vehicle->brake = m_vehicle->brakeforce * brake;
+		}
+	}
 }
 
 void Powertrain::PowertrainProcessInput()
 {
+    this->PowertrainProcessInputStates();
+
     // Process command queue
     auto& cmd_queue = this->GetQueueOnSimThread();
     auto itor = cmd_queue.queue.begin();
@@ -162,6 +603,7 @@ void PowertrainCommandQueue::NetworkedUpdate(float rpm, float force, float clutc
 void PowertrainCommandQueue::Reset()
 {
     queue.clear(); // Doesn't affect pre-allocated capacity
+
     was_network_updated = false;
     net_rpm = 0.f;
     net_force = 0.f;
@@ -170,4 +612,6 @@ void PowertrainCommandQueue::Reset()
     net_is_running = false;
     net_has_contact = false;
     net_auto_mode = 0;
+
+    input_states.Reset();
 }

--- a/source/main/gameplay/Powertrain.h
+++ b/source/main/gameplay/Powertrain.h
@@ -1,0 +1,191 @@
+
+/** 
+    @file
+    @date   01/2016
+    @author Petr Ohlidal
+*/
+
+#pragma once
+
+#include "ForwardDeclarations.h"
+
+#include <vector>
+
+namespace RoR
+{
+
+struct Gearbox
+{
+    enum shiftmodes {
+        SHIFTMODE_AUTOMATIC,
+        SHIFTMODE_SEMIAUTO,
+        SHIFTMODE_MANUAL,
+        SHIFTMODE_MANUAL_STICK,
+        SHIFTMODE_MANUAL_RANGES
+    };
+
+    enum autoswitch {
+        AUTOSWITCH_REAR,
+        AUTOSWITCH_NEUTRAL,
+        AUTOSWITCH_DRIVE,
+        AUTOSWITCH_TWO,
+        AUTOSWITCH_ONE,
+        AUTOSWITCH_MANUALMODE
+    };
+};
+
+/// Powertrain state
+/// Each member replaces a member of legacy class BeamEngine (referenced in doc comments).
+struct PowertrainState
+{
+    void Reset()
+    {
+        std::memset(this, 0, sizeof(PowertrainState));
+    }
+
+    /// m_curr_gear
+    int transmission_current_gear; 
+
+    /// int getNumGears() { return m_conf_gear_ratios.size() - 2; };
+    int transmission_num_forward_gears;
+    
+    /// enum autoswitch m_autoselect
+    Gearbox::autoswitch transmission_auto_shift_mode;
+
+    /// float m_curr_clutch;
+    float transmission_current_clutch;
+
+    /// float m_curr_acc
+    float current_acceleration;
+
+    /// float m_conf_engine_max_rpm
+    float conf_engine_max_rpm;
+
+    /// float m_curr_engine_rpm
+    float engine_current_rpm;
+
+    /// Precomputed value of ```float BeamEngine::getTurboPSI()```
+    float turbo_current_psi;
+
+    /// bool m_starter_has_contact
+    bool engine_starter_has_contact;
+
+    /// Precomputed return of ```float BeamEngine::getTorque()```
+    float engine_current_torque;
+
+    /// bool isRunning() { return m_is_engine_running; };
+    bool engine_is_running;
+
+    /// float m_conf_clutch_force
+    float conf_transmission_clutch_force;
+
+    /// Precomputed ```float BeamEngine::getSmoke()```
+    float gfx_engine_exhaust_smoke;
+
+    /// bool hasTurbo() { return m_conf_engine_has_turbo; };
+    bool conf_engine_has_turbo;
+
+    /// Precalculated ```float BeamEngine::getCrankFactor()```
+    float engine_crank_factor;
+
+    /// m_conf_engine_min_rpm
+    float conf_engine_min_rpm;
+
+    /// int m_curr_gear_range
+    int transmission_current_gear_range;
+
+    /// int m_transmission_mode
+    Gearbox::shiftmodes transmission_mode;
+
+    /// Precomputed ```int getNumGearsRanges() { return getNumGears() / 6 + 1; };```
+    int conf_transmission_num_gears_ranges;
+};
+
+struct PowertrainCommand
+{
+    enum CommandType
+    {
+        COMMAND_NONE,
+        COMMAND_START,
+        COMMAND_AUTO_SET_ACC,
+        COMMAND_SET_CLUTCH,
+        COMMAND_SET_ACC,
+        COMMAND_SHIFT,
+        COMMAND_OFFSTART,
+        COMMAND_AUTO_SHIFT_SET,
+        COMMAND_SET_GEAR,
+        COMMAND_AUTO_SHIFT_UP,
+        COMMAND_AUTO_SHIFT_DOWN,
+        COMMAND_TOGGLE_CONTACT,
+        COMMAND_SET_STARTER,
+        COMMAND_TOGGLE_AUTO_MODE,
+        COMMAND_SET_MANUAL_CLUTCH,
+        COMMAND_SHIFT_TO,
+        COMMAND_SET_GEAR_RANGE
+    };
+
+    CommandType type;
+    float value;
+};
+
+struct PowertrainCommandQueue
+{
+    PowertrainCommandQueue()
+    {
+        this->Reset();
+    }
+
+    void AddCommand(PowertrainCommand::CommandType type, float value = 0.f);
+
+    void NetworkedUpdate(float rpm, float force, float clutch, int gear, bool _running, bool _contact, char _automode);
+
+    void Reset();
+
+    std::vector<PowertrainCommand> queue;
+
+    // Networked update
+    float net_rpm;
+    float net_force;
+    float net_clutch;
+    int   net_gear;
+    bool  net_is_running;
+    bool  net_has_contact;
+    char  net_auto_mode;
+    bool  was_network_updated;
+};
+
+/// Land vehicle powertrain
+class Powertrain
+{
+    friend class RigSpawner; // assigns BeamEngine* m_engine
+public:
+    Powertrain();
+
+    ~Powertrain();
+
+    void CriticalSection_SwapData()
+    {
+        m_main_thread_index = (m_main_thread_index + 1) % 2;
+        m_sim_thread_index  = (m_sim_thread_index + 1)  % 2;
+    }
+
+    void PowertrainProcessInput();
+    void PowertrainUpdate(float dt_seconds, bool just_synced);
+    void PowertrainExportState();
+
+    BeamEngine*             GetEngine()            { return m_engine; }
+    PowertrainState&        GetStateOnMainThread() { return m_state[m_main_thread_index]; }
+    PowertrainState&        GetStateOnSimThread()  { return m_state[m_sim_thread_index];  }
+    PowertrainCommandQueue& GetQueueOnMainThread() { return m_command_queue[m_main_thread_index]; }
+    PowertrainCommandQueue& GetQueueOnSimThread()  { return m_command_queue[m_sim_thread_index];  }
+
+private:
+    BeamEngine*              m_engine;
+    PowertrainState          m_state[2];
+    PowertrainCommandQueue   m_command_queue[2];
+    unsigned int             m_main_thread_index;
+    unsigned int             m_sim_thread_index;
+};
+
+} // namespace RoR
+

--- a/source/main/gameplay/Powertrain.h
+++ b/source/main/gameplay/Powertrain.h
@@ -89,33 +89,6 @@ struct PowertrainState
 
 };
 
-struct PowertrainCommand
-{
-    enum CommandType
-    {
-        COMMAND_NONE,
-        COMMAND_START,
-        COMMAND_AUTO_SET_ACC,
-        COMMAND_SET_CLUTCH,
-        COMMAND_SET_ACC,
-        COMMAND_SHIFT,
-        COMMAND_OFFSTART,
-        COMMAND_AUTO_SHIFT_SET,
-        COMMAND_SET_GEAR,
-        COMMAND_AUTO_SHIFT_UP,
-        COMMAND_AUTO_SHIFT_DOWN,
-        COMMAND_TOGGLE_CONTACT,
-        COMMAND_SET_STARTER,
-        COMMAND_TOGGLE_AUTO_MODE,
-        COMMAND_SET_MANUAL_CLUTCH,
-        COMMAND_SHIFT_TO,
-        COMMAND_SET_GEAR_RANGE
-    };
-
-    CommandType type;
-    float value;
-};
-
 struct PowertrainInputStates
 {
     void Reset()
@@ -159,13 +132,9 @@ struct PowertrainCommandQueue
         this->Reset();
     }
 
-    void  AddCommand(PowertrainCommand::CommandType type, float value = 0.f);
-
     void  NetworkedUpdate(float rpm, float force, float clutch, int gear, bool _running, bool _contact, char _automode);
 
     void  Reset();
-
-    std::vector<PowertrainCommand> queue;
 
     // Networked update
     float net_rpm;
@@ -176,6 +145,12 @@ struct PowertrainCommandQueue
     bool  net_has_contact;
     char  net_auto_mode;
     bool  was_network_updated;
+
+    // Local update
+    bool  command_auto_set_acc;
+    float command_auto_set_acc_value;
+    bool  command_offstart;
+    bool  command_start;
 
     PowertrainInputStates input_states;
 };

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -976,9 +976,9 @@ bool RoRFrameListener::updateEvents(float dt)
 				if (local_truck != nullptr && local_truck->driveable != NOT_DRIVEABLE)
 				{
 					/* We are supposed to be in this truck, if it is a truck */
-					if (local_truck->engine != nullptr)
+					if (local_truck->powertrain != nullptr)
 					{
-						local_truck->engine->start();
+						local_truck->powertrain->GetQueueOnMainThread().AddCommand(PowertrainCommand::COMMAND_START);
 					}
 					BeamFactory::getSingleton().setCurrentTruck(local_truck->trucknum);
 				} 
@@ -1184,9 +1184,9 @@ void RoRFrameListener::InitTrucks(
 		}
 #endif //USE_MYGUI
 
-		if (b && b->engine)
+		if (b != nullptr && b->powertrain != nullptr)
 		{
-			b->engine->start();
+			b->powertrain->GetEngine()->BeamEngineStart(); // Synchronous access is OK, this function is called before simulation starts.
 		}
 	}
 	
@@ -1458,7 +1458,7 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 					UpdateRacingGui(); //I really think that this should stay here.
 				}
 
-				if (vehicle->driveable == TRUCK && vehicle->engine != nullptr)
+				if (vehicle->driveable == TRUCK && vehicle->powertrain != nullptr)
 				{
 					RoR::Application::GetOverlayWrapper()->UpdateLandVehicleHUD(vehicle, flipflop);
 				}

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -978,7 +978,7 @@ bool RoRFrameListener::updateEvents(float dt)
 					/* We are supposed to be in this truck, if it is a truck */
 					if (local_truck->powertrain != nullptr)
 					{
-						local_truck->powertrain->GetQueueOnMainThread().AddCommand(PowertrainCommand::COMMAND_START);
+						local_truck->powertrain->GetQueueOnMainThread().command_start = true;
 					}
 					BeamFactory::getSingleton().setCurrentTruck(local_truck->trucknum);
 				} 

--- a/source/main/gameplay/TwoDReplay.cpp
+++ b/source/main/gameplay/TwoDReplay.cpp
@@ -77,12 +77,14 @@ void TwoDReplay::recordFrame()
 	frame.brake    = v->brake;
 	frame.steering = v->hydrodircommand;
 	frame.pbrake   = (v->parkingbrake > 0);
-	if (v->engine)
+	if (v->powertrain != nullptr)
 	{
-		frame.accel  = v->engine->getAcc();
-		frame.clutch = v->engine->getClutch();
-		frame.gear   = v->engine->getGear();
-		frame.gearMode = v->engine->getAutoMode();
+        RoR::PowertrainState pw_state = v->powertrain->GetStateOnMainThread();
+
+		frame.accel    = pw_state.current_acceleration;
+		frame.clutch   = pw_state.transmission_current_clutch;
+		frame.gear     = pw_state.transmission_current_gear;
+		frame.gearMode = pw_state.transmission_auto_shift_mode;
 	}
 	fwrite(&frame, 1, sizeof(frame), file);
 

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -999,12 +999,13 @@ void OverlayWrapper::UpdateLandVehicleHUD(Beam * vehicle, bool & flipflop)
 	turbotexture->setTextureRotate(Degree(angle));
 
 	// indicators
+    float vehicle_torque = vehicle->engine->getTorque();
 	igno->setMaterialName(String("tracks/ign-")         + ((vehicle->engine->hasContact())?"on":"off"));
 	batto->setMaterialName(String("tracks/batt-")       + ((vehicle->engine->hasContact() && !vehicle->engine->isRunning())?"on":"off"));
 	pbrakeo->setMaterialName(String("tracks/pbrake-")   + ((vehicle->parkingbrake)?"on":"off"));
 	lockedo->setMaterialName(String("tracks/locked-")   + ((vehicle->isLocked())?"on":"off"));
 	lopresso->setMaterialName(String("tracks/lopress-") + ((!vehicle->canwork)?"on":"off"));
-	clutcho->setMaterialName(String("tracks/clutch-")   + ((fabs(vehicle->engine->getTorque())>=vehicle->engine->getClutchForce()*10.0f)?"on":"off"));
+	clutcho->setMaterialName(String("tracks/clutch-")   + ((fabs(vehicle_torque)>=vehicle->engine->getClutchForce()*10.0f)?"on":"off"));
 	lightso->setMaterialName(String("tracks/lights-")   + ((vehicle->lights)?"on":"off"));
 
 	if (vehicle->tc_present)

--- a/source/main/gui/TruckHUD.cpp
+++ b/source/main/gui/TruckHUD.cpp
@@ -260,11 +260,10 @@ bool TruckHUD::update(float dt, Beam *truck, bool visible)
 	overlayElement = OverlayManager::getSingleton().getOverlayElement("tracks/TruckInfoBox/CurrentRPM");
 	overlayElement->setCaption("");
 	UTFString rpmsstr = _L("current RPM:");
-	if (truck->driveable == TRUCK && truck->engine)
-	{
-		overlayElement = OverlayManager::getSingleton().getOverlayElement("tracks/TruckInfoBox/CurrentRPM");
-		overlayElement->setCaption(rpmsstr + U(" ") + TOUTFSTRING(Round(truck->engine->getRPM())) + U(" / ") + TOUTFSTRING(Round(truck->engine->getMaxRPM())));
-	} else if (truck->driveable == AIRPLANE)
+
+    // Deleted engine update -> this HUD is obsolete anyway
+
+    if (truck->driveable == AIRPLANE)
 	{
 		for (int i=0; i < 8; i++)
 		{

--- a/source/main/gui/panels/GUI_SimUtils.cpp
+++ b/source/main/gui/panels/GUI_SimUtils.cpp
@@ -228,14 +228,15 @@ void CLASS::UpdateStats(float dt, Beam *truck)
 
 		truckstats = truckstats + "\n"; //Some space
 
-		if (truck->driveable == TRUCK && truck->engine)
+		if (truck->driveable == TRUCK && truck->powertrain != nullptr)
 		{
-			if (truck->engine->getRPM() > truck->engine->getMaxRPM())
-				truckstats = truckstats + MainThemeColor + "Engine RPM: " + RedColor + TOUTFSTRING(Round(truck->engine->getRPM())) + U(" / ") + TOUTFSTRING(Round(truck->engine->getMaxRPM())) + "\n";
+            PowertrainState powertrain = truck->powertrain->GetStateOnMainThread();
+			if (powertrain.engine_current_rpm > powertrain.conf_engine_max_rpm)
+				truckstats = truckstats + MainThemeColor + "Engine RPM: " + RedColor + TOUTFSTRING(Round(powertrain.engine_current_rpm)) + U(" / ") + TOUTFSTRING(Round(powertrain.conf_engine_max_rpm)) + "\n";
 			else
-				truckstats = truckstats + MainThemeColor + "Engine RPM: " + WhiteColor + TOUTFSTRING(Round(truck->engine->getRPM())) + U(" / ") + TOUTFSTRING(Round(truck->engine->getMaxRPM())) + "\n";
+				truckstats = truckstats + MainThemeColor + "Engine RPM: " + WhiteColor + TOUTFSTRING(Round(powertrain.engine_current_rpm)) + U(" / ") + TOUTFSTRING(Round(powertrain.conf_engine_max_rpm)) + "\n";
 
-			float currentKw = (((truck->engine->getRPM() * (truck->engine->getEngineTorque() + ((truck->engine->getTurboPSI() * 6.8) * truck->engine->getEngineTorque()) / 100) *(3.14159265358979323846 /* pi.. */ / 30)) / 1000));
+			float currentKw = (((powertrain.engine_current_rpm * (powertrain.engine_current_torque + ((powertrain.turbo_current_psi * 6.8) * powertrain.engine_current_torque) / 100) *(3.14159265358979323846 /* pi.. */ / 30)) / 1000));
 
 			truckstats = truckstats + MainThemeColor + "Current Power: " + WhiteColor + TOUTFSTRING(Round(currentKw *1.34102209)) + U(" hp / ") + TOUTFSTRING(Round(currentKw)) + U(" Kw") + "\n";
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -393,7 +393,7 @@ void Beam::scaleTruck(float value)
 	{
 		//engine->maxRPM *= value;
 		//engine->iddleRPM *= value;
-		engine->engineTorque *= value;
+		engine->ScaleEngineTorque(value);
 		//engine->stallRPM *= value;
 		//engine->brakingTorque *= value;
 	}
@@ -1499,7 +1499,7 @@ bool Beam::frameStep(Real dt)
 
 	if (dt==0) return true;
 	if (!loading_finished) return true;
-	if (state >= SLEEPING) return true;
+	if (this->state >= SLEEPING) return true;
 	if (mTimeUntilNextToggle > -1)
 		mTimeUntilNextToggle -= dt;
 	
@@ -1508,11 +1508,12 @@ bool Beam::frameStep(Real dt)
 	int steps = dt / PHYSICS_DT;
 
 	m_dt_remainder = dt - (steps * PHYSICS_DT);
+	// 2000 * [100ms] 0.1   = 200;
 
 	// TODO: move this to the correct spot
 	// update all dashboards
 #ifdef USE_MYGUI
-	updateDashBoards(dt);
+	this->updateDashBoards(dt);
 #endif // USE_MYGUI
 
 	// some scripting stuff:
@@ -1579,13 +1580,18 @@ bool Beam::frameStep(Real dt)
 			
 			for (int i=0; i<steps; i++)
 			{
-				int num_simulated_trucks = 0;
+				int num_simulated_trucks = 0; 
+					// WTF? This shadows member Beam::num_simulated_trucks
+					// A very similar code is in "Beam::threadentry()", except the "int" keyword is not there (!)  ~only_a_ptr
 
 				for (int t=0; t<numtrucks; t++)
 				{
 					if (trucks[t] && (trucks[t]->simulated = trucks[t]->calcForcesEulerPrepare(i==0, dtperstep, i, steps)))
 					{
-						num_simulated_trucks++;
+						num_simulated_trucks++; 
+							// Updates local variable, but there is member with the same name: Beam::num_simulated_trucks.
+							// Since the local variable isn't read anywyere, this effectively only blocks update of the member.
+							// Bug or feature? ~only_a_ptr
 						trucks[t]->calcForcesEulerCompute(i==0, dtperstep, i, steps);
 						trucks[t]->calcForcesEulerFinal(i==0, dtperstep, i, steps);
 						if (!disableTruckTruckSelfCollisions)
@@ -1735,8 +1741,8 @@ void Beam::sendStreamData()
 			send_oob->engine_clutch  = engine->getClutch();
 			send_oob->engine_gear    = engine->getGear();
 
-			if (engine->contact) send_oob->flagmask += NETMASK_ENGINE_CONT;
-			if (engine->running) send_oob->flagmask += NETMASK_ENGINE_RUN;
+			if (engine->hasContact()) send_oob->flagmask += NETMASK_ENGINE_CONT;
+			if (engine->isRunning()) send_oob->flagmask += NETMASK_ENGINE_RUN;
 
 			if      (engine->getAutoMode() == BeamEngine::AUTOMATIC)     send_oob->flagmask += NETMASK_ENGINE_MODE_AUTOMATIC;
 			else if (engine->getAutoMode() == BeamEngine::SEMIAUTO)      send_oob->flagmask += NETMASK_ENGINE_MODE_SEMIAUTO;
@@ -5134,7 +5140,7 @@ bool Beam::isLocked()
 bool Beam::navigateTo(Vector3 &in)
 {
 	// start engine if not running
-	if (engine && !engine->running)
+	if (engine && !engine->isRunning())
 		engine->start();
 
 	Vector3 TargetPosition = in;
@@ -5331,11 +5337,11 @@ void Beam::updateDashBoards(float &dt)
 		dash->setFloat(DD_ENGINE_TURBO, turbo);
 
 		// ignition
-		bool ign = engine->contact;
+		bool ign = engine->hasContact();
 		dash->setBool(DD_ENGINE_IGNITION, ign);
 
 		// battery
-		bool batt = (engine->contact && !engine->running);
+		bool batt = (engine->hasContact() && !engine->isRunning());
 		dash->setBool(DD_ENGINE_BATTERY, batt);
 
 		// clutch warning
@@ -5561,7 +5567,7 @@ void Beam::updateDashBoards(float &dt)
 
 		if (hasEngine)
 		{
-			hasturbo = engine->hasturbo;
+			hasturbo = engine->hasTurbo();
 			autogearVisible = (engine->getAutoShift() != BeamEngine::MANUALMODE);
 		}
 
@@ -5766,10 +5772,10 @@ void Beam::engineTriggerHelper(int engineNumber, int type, float triggerValue)
 		// TODO: Implement setTargetRPM in the BeamEngine.cpp
 		break;
 	case TRG_ENGINE_SHIFTUP:
-		if (e) e->shift(1);
+		if (e) e->BeamEngineShift(1);
 		break;
 	case TRG_ENGINE_SHIFTDOWN:
-		if (e) e->shift(-1);
+		if (e) e->BeamEngineShift(-1);
 		break;
 	default:
 		break;

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -218,7 +218,10 @@ public:
 	*/
 	void updateSkidmarks();
 
-	bool navigateTo(Ogre::Vector3 &in);
+    /**
+    * AngelScript: AI movement.
+    */
+    bool AS_NavigateTo(Ogre::Vector3 &in);
 
 
 	/**

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -922,7 +922,7 @@ void BeamFactory::calcPhysics(float dt)
 
 		default:
 			if (trucks[t]->state > DESACTIVATED && trucks[t]->engine)
-				trucks[t]->engine->update(dt, 1);
+				trucks[t]->engine->UpdateBeamEngine(dt, 1);
 			if (trucks[t]->networking)
 				trucks[t]->sendStreamData();
 			break;

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -921,8 +921,8 @@ void BeamFactory::calcPhysics(float dt)
 			break;
 
 		default:
-			if (trucks[t]->state > DESACTIVATED && trucks[t]->engine)
-				trucks[t]->engine->UpdateBeamEngine(dt, 1);
+			if (trucks[t]->state > DESACTIVATED && trucks[t]->powertrain != nullptr)
+				trucks[t]->powertrain->GetEngine()->UpdateBeamEngine(dt, 1);
 			if (trucks[t]->networking)
 				trucks[t]->sendStreamData();
 			break;

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -63,7 +63,7 @@ void Beam::calcForcesEulerCompute(int doUpdate, Real dt, int step, int maxsteps)
 	if (engine)
 	{
 		BES_START(BES_CORE_TruckEngine);
-		engine->update(dt, doUpdate);
+		engine->UpdateBeamEngine(dt, doUpdate);
 		BES_STOP(BES_CORE_TruckEngine);
 	}
 	//if (doUpdate) mWindow->setDebugText(engine->status);
@@ -1354,7 +1354,7 @@ void Beam::calcForcesEulerCompute(int doUpdate, Real dt, int step, int maxsteps)
 						if (bbeam_dir*beams[bbeam].autoMovingMode > 0)
 							v = 1;
 
-						if (beams[bbeam].commandNeedsEngine && ((engine && !engine->running) || !canwork)) continue;
+						if (beams[bbeam].commandNeedsEngine && ((engine && !engine->isRunning()) || !canwork)) continue;
 
 						if (v > 0.0f && beams[bbeam].commandEngineCoupling > 0.0f)
 							requestpower = true;
@@ -1407,7 +1407,7 @@ void Beam::calcForcesEulerCompute(int doUpdate, Real dt, int step, int maxsteps)
 				float v = 0.0f;
 				int rota = std::abs(commandkey[i].rotators[j]) - 1;
 
-				if (rotators[rota].rotatorNeedsEngine && ((engine && !engine->running) || !canwork)) continue;
+				if (rotators[rota].rotatorNeedsEngine && ((engine && !engine->isRunning()) || !canwork)) continue;
 
 				if (rotaInertia)
 				{
@@ -1433,8 +1433,8 @@ void Beam::calcForcesEulerCompute(int doUpdate, Real dt, int step, int maxsteps)
 
 		if (engine)
 		{
-			engine->hydropump = work;
-			engine->prime     = requested;
+			engine->SetHydroPump(work);
+			engine->SetPrime(requested);
 		}
 		if (doUpdate && state==ACTIVATED)
 		{

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -107,7 +107,7 @@ void PointColDetector::update_structures_for_contacters() {
 	int refi = 0;
 
 	//Insert all contacters, into the list of points to consider when building the kdtree
-	for (int t = 0; t < m_trucks.size(); t++) {
+	for (int t = 0; t < static_cast<int>(m_trucks.size()); t++) {
 		if (m_trucks[t]) {
 			for (int i = 0; i < m_trucks[t]->free_contacter; ++i) {
 				ref_list[refi].pidref = &pointid_list[refi];

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -5887,7 +5887,7 @@ void RigSpawner::ProcessEngine(RigDef::Engine & def)
 	}
 
     m_rig->powertrain = new Powertrain();
-
+    m_rig->powertrain->m_vehicle = m_rig;         // Friendly access
 	m_rig->powertrain->m_engine = new BeamEngine( // Friendly access
 		def.shift_down_rpm,
 		def.shift_up_rpm,

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -7234,7 +7234,7 @@ void RigSpawner::SetupDefaultSoundSources(Beam *vehicle)
 	//engine
 	if (vehicle->engine != nullptr) /* Land vehicle */
 	{
-		if (vehicle->engine->type=='t')
+		if (vehicle->engine->getType() =='t')
 		{
 			AddSoundSourceInstance(vehicle, "tracks/default_diesel", smokeId);
 			AddSoundSourceInstance(vehicle, "tracks/default_force", smokeId);
@@ -7242,13 +7242,13 @@ void RigSpawner::SetupDefaultSoundSources(Beam *vehicle)
 			AddSoundSourceInstance(vehicle, "tracks/default_parkbrakes", 0);
 			AddSoundSourceInstance(vehicle, "tracks/default_reverse_beep", 0);
 		}
-		if (vehicle->engine->type=='c')
+		if (vehicle->engine->getType() =='c')
 			AddSoundSourceInstance(vehicle, "tracks/default_car", smokeId);
-		if (vehicle->engine->hasturbo)
+		if (vehicle->engine->hasTurbo())
 		{
-			if (vehicle->engine->turboInertiaFactor >= 3)
+			if (vehicle->engine->GetTurboInertiaFactor() >= 3)
 				AddSoundSourceInstance(vehicle, "tracks/default_turbo_big", smokeId);
-			else if (vehicle->engine->turboInertiaFactor <= 0.5)
+			else if (vehicle->engine->GetTurboInertiaFactor() <= 0.5)
 				AddSoundSourceInstance(vehicle, "tracks/default_turbo_small", smokeId);
 			else
 				AddSoundSourceInstance(vehicle, "tracks/default_turbo_mid", smokeId);
@@ -7257,7 +7257,7 @@ void RigSpawner::SetupDefaultSoundSources(Beam *vehicle)
 			AddSoundSourceInstance(vehicle, "tracks/default_wastegate_flutter", smokeId);
 		}
 			
-		if (vehicle->engine->hasair)
+		if (vehicle->engine->HasAir())
 			AddSoundSourceInstance(vehicle, "tracks/default_air_purge", 0);
 		//starter
 		AddSoundSourceInstance(vehicle, "tracks/default_starter", 0);

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -839,13 +839,8 @@ int GameScript::useOnlineAPI(const String &apiquery, const AngelScript::CScriptD
 void GameScript::boostCurrentTruck(float factor)
 {
     // add C++ code here
-	Beam *b = BeamFactory::getSingleton().getCurrentTruck();
-	if (b && b->engine)
-	{
-		float rpm = b->engine->getRPM();
-		rpm += 2000.0f * factor;
-		b->engine->setRPM(rpm);
-	}
+
+    // DISABLED for LuaPowertrain project
 }
 
 int GameScript::addScriptFunction(const String &arg)

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -316,7 +316,7 @@ void ScriptEngine::init()
 	result = engine->RegisterObjectMethod("BeamClass", "vector3 getGForces()", AngelScript::asMETHOD(Beam,getGForces), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 
 	result = engine->RegisterObjectMethod("BeamClass", "vector3 getVehiclePosition()", AngelScript::asMETHOD(Beam,getVehiclePosition), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
-	result = engine->RegisterObjectMethod("BeamClass", "bool navigateTo(vector3 &in)", AngelScript::asMETHOD(Beam,navigateTo), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
+	result = engine->RegisterObjectMethod("BeamClass", "bool navigateTo(vector3 &in)", AngelScript::asMETHOD(Beam,AS_NavigateTo), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 
 	
 

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -71,7 +71,7 @@ bool FolderExists(Ogre::String const & path)
 
 Settings::Settings():
 	m_flares_mode(-1),
-	m_gearbox_mode(-1)
+	m_gearbox_mode(RoR::Gearbox::SHIFTMODE_UNKNOWN)
 {
 }
 
@@ -608,29 +608,29 @@ int Settings::GetFlaresMode(int default_value /*=2*/)
 	return m_flares_mode;
 }
 
-int Settings::GetGearBoxMode(int default_value /*=0*/)
+RoR::Gearbox::shiftmodes Settings::GetGearBoxMode(RoR::Gearbox::shiftmodes default_value /* = RoR::Gearbox::SHIFTMODE_AUTOMATIC */)
 {
-	if (m_gearbox_mode == -1) // -1: unknown, -2: default, 0+: mode ID
-	{
-		auto itor = settings.find("GearboxMode");
-		if (itor == settings.end())
-		{
-			m_gearbox_mode = -2;
-		}
-		else
-		{
-			if (itor->second == "Automatic shift")	{ m_gearbox_mode = 0; }
-			else if (itor->second == "Manual shift - Auto clutch")	{ m_gearbox_mode = 1; }
-			else if (itor->second == "Fully Manual: sequential shift")	{ m_gearbox_mode = 2; }
-			else if (itor->second == "Fully manual: stick shift")	{ m_gearbox_mode = 3; }
-			else if (itor->second == "Fully Manual: stick shift with ranges")	{ m_gearbox_mode = 4; }
+    if (m_gearbox_mode == RoR::Gearbox::SHIFTMODE_UNKNOWN)
+    {
+        auto itor = settings.find("GearboxMode");
+        if (itor == settings.end())
+        {
+            m_gearbox_mode = RoR::Gearbox::SHIFTMODE_DEFAULT;
+        }
+        else
+        {
+            if      (itor->second == "Automatic shift")                       { m_gearbox_mode = RoR::Gearbox::SHIFTMODE_AUTOMATIC;     }
+            else if (itor->second == "Manual shift - Auto clutch")            { m_gearbox_mode = RoR::Gearbox::SHIFTMODE_SEMIAUTO;      }
+            else if (itor->second == "Fully Manual: sequential shift")        { m_gearbox_mode = RoR::Gearbox::SHIFTMODE_MANUAL;        }
+            else if (itor->second == "Fully manual: stick shift")             { m_gearbox_mode = RoR::Gearbox::SHIFTMODE_MANUAL_STICK;  }
+            else if (itor->second == "Fully Manual: stick shift with ranges") { m_gearbox_mode = RoR::Gearbox::SHIFTMODE_MANUAL_RANGES; }
 
-			else { m_gearbox_mode = -2; }
-		}
-	}
-	if (m_gearbox_mode == -2)
-	{
-		return default_value;
-	}
-	return m_gearbox_mode;
+            else { m_gearbox_mode = RoR::Gearbox::SHIFTMODE_DEFAULT; }
+        }
+    }
+    if (m_gearbox_mode == RoR::Gearbox::SHIFTMODE_DEFAULT)
+    {
+        return default_value;
+    }
+    return m_gearbox_mode;
 }

--- a/source/main/utils/Settings.h
+++ b/source/main/utils/Settings.h
@@ -24,8 +24,8 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #define __Settings_H_
 
 #include "RoRPrerequisites.h"
-
 #include "Singleton.h"
+#include "transmission.h"
 
 // some shortcuts to improve code readability
 #define SETTINGS          Settings::getSingleton()
@@ -62,7 +62,7 @@ public:
 	void createGUID();
 
 	int GetFlaresMode(int default_value = 2);
-	int GetGearBoxMode(int default_value = 0);
+	RoR::Gearbox::shiftmodes GetGearBoxMode(RoR::Gearbox::shiftmodes default_value = RoR::Gearbox::SHIFTMODE_AUTOMATIC);
 
 #ifdef USE_ANGELSCRIPT
 	// we have to add this to be able to use the class as reference inside scripts
@@ -98,7 +98,7 @@ protected:
 	// Cached config data
 
 	int m_flares_mode; // -1: unknown, -2: default, 0+: mode ID
-	int m_gearbox_mode;
+	RoR::Gearbox::shiftmodes m_gearbox_mode;
 };
 
 #endif // __Settings_H_


### PR DESCRIPTION
*Discussion PR, do not merge yet!*

While working on [LuaPowertrain](http://www.rigsofrods.com/threads/120811-Dev-LuaPowertrain-project), I got blocked out by RoR's architecture - the engine/brakes/otherstuff are updated from both mainthread (gameplay/LandVehicleSimulation.cpp) and simthread (gameplay/BeamEngine.cpp) without proper synchronization. By coincidence, it always worked fine, but it can't stay that way. For one thing, it blows up when any scripting is added.

I refactored the code towards this architecture:
 * Mainthread reads and buffers all user inputs. Also updates GUI+visuals from vehicle state snapshot.
 * Simthread reads the input buffer and performs updates. At the end, it takes a snapshot of vehicle state.
 * [sync] Input buffer is passed to simthread, snapshot is passed to mainthread.

Now there's a question: what next?
 * Stabilize the code as it is and implement Lua scripting of the powertrain.
 * Continue the redesign and make simthread exclusively responsible for ALL vehicle updates. Powertrain took care of most, but there's also steering, commands, hooks...

@Speciesx I need you to build and test this. I think the vehicles behave differently.
@ulteq I need you to review this.

Branch: https://github.com/only-a-ptr/rigs-of-rods/tree/simulation-powertrain-MT-rev2