### PR TITLE
[Bugfix] Brings back the traction control toggle

### DIFF
--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -550,7 +550,7 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 
 	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TRACTION_CONTROL))
 	{
-		if (curr_truck->tc_present && !curr_truck->tc_notoggle) curr_truck->tractioncontrolToggle();
+		if (!curr_truck->tc_notoggle) curr_truck->tractioncontrolToggle();
 	}
 
 	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_CRUISE_CONTROL))


### PR DESCRIPTION
```tc_present``` represents the presence of the dash icon.

Reference: http://www.rigsofrods.com/wiki/pages/Truck_Description_File/#TractionControl