### PR TITLE
[Feature] New RoR.cfg option for high resolution (wheel-)node collisions

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -5693,6 +5693,7 @@ Beam::Beam(
 	, flap(0)
 	, floating_origin_enable(true)
 	, fusedrag(Ogre::Vector3::ZERO)
+	, high_res_wheelnode_collisions(false)
 	, hydroaileroncommand(0)
 	, hydroaileronstate(0)
 	, hydrodircommand(0)
@@ -5763,6 +5764,7 @@ Beam::Beam(
 	, watercontact(false)
 	, watercontactold(false)
 {
+	high_res_wheelnode_collisions = BSETTING("HighResWheelNodeCollisions", false);
 	useSkidmarks = BSETTING("Skidmarks", false);
 	LOG(" ===== LOADING VEHICLE: " + Ogre::String(fname));
 

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -609,6 +609,8 @@ protected:
 
 	ground_model_t *lastFuzzyGroundModel;
 
+	bool high_res_wheelnode_collisions;
+
 	// this is for managing the blinkers on the truck:
 	blinktype blinkingtype;
 

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1779,7 +1779,7 @@ void Beam::calcNodes(int doUpdate, Ogre::Real dt, int step, int maxsteps)
 		if (!nodes[i].contactless)
 		{
 			nodes[i].collTestTimer += dt;
-			if (nodes[i].contacted || nodes[i].collTestTimer>0.005 || (nodes[i].iswheel && nodes[i].collTestTimer>0.0025) || increased_accuracy)
+			if (nodes[i].contacted || nodes[i].collTestTimer>0.005 || (nodes[i].iswheel && (high_res_wheelnode_collisions || nodes[i].collTestTimer>0.0025)) || increased_accuracy)
 			{
 				float ns = 0;
 				ground_model_t *gm = 0; // this is used as result storage, so we can use it later on


### PR DESCRIPTION
Greatly improves the overall behavior of the wheel <-> ground surface interaction.
* This only affects wheel nodes
* You can enable this by appending ```HighResWheelNodeCollisions=Yes``` to your ```RoR.cfg```.

This could become a new parameter for truck files.