### PR TITLE
[Codechange] Revamped the braking code

### DIFF
--- a/source/main/datatypes/rig_t.h
+++ b/source/main/datatypes/rig_t.h
@@ -146,7 +146,7 @@ struct rig_t
 	float alb_ratio;        //!< Anti-lock brake attribute: Regulating force
 	float alb_minspeed;     //!< Anti-lock brake attribute;
 	int alb_mode;           //!< Anti-lock brake status; Enabled? {1/0}
-	unsigned int alb_pulse; //!< Anti-lock brake attribute;
+	float alb_pulse_time;   //!< Anti-lock brake attribute;
 	bool alb_pulse_state;   //!< Anti-lock brake status;
 	bool alb_present;       //!< Anti-lock brake attribute: Display the dashboard indicator?
 	bool alb_notoggle;      //!< Anti-lock brake attribute: Disable in-game toggle?
@@ -154,11 +154,12 @@ struct rig_t
 	float tc_wheelslip;
 	float tc_fade;
 	int tc_mode;           //!< Traction control status; Enabled? {1/0}
-	unsigned int tc_pulse; //!< Traction control attribute;
+	float tc_pulse_time;   //!< Traction control attribute;
 	bool tc_pulse_state;
 	bool tc_present;       //!< Traction control attribute; Display the dashboard indicator?
 	bool tc_notoggle;      //!< Traction control attribute; Disable in-game toggle?
-	float tcalb_timer;
+	float tc_timer;
+	float alb_timer;
 	int antilockbrake;
 	int tractioncontrol;
 	float animTimer;

--- a/source/main/datatypes/wheel_t.h
+++ b/source/main/datatypes/wheel_t.h
@@ -34,6 +34,8 @@ struct wheel_t
 	int propulsed;
 	Ogre::Real radius;
 	Ogre::Real speed;
+	Ogre::Real lastSpeed;
+	Ogre::Real avgSpeed;
 	Ogre::Real delta_rotation; //!< Difference in wheel position
 	float rp;
 	float rp1; //<! Networking; triple buffer
@@ -44,7 +46,6 @@ struct wheel_t
 	// for skidmarks
 	Ogre::Vector3 lastContactInner;
 	Ogre::Vector3 lastContactOuter;
-	Ogre::Vector3 lastRotationVec;
 	bool firstLock;
 	float lastSlip;
 	int lastContactType;

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -343,11 +343,11 @@ void RigSpawner::InitializeRig()
 	m_rig->alb_minspeed = 0.0f;
 	m_rig->alb_mode = 0;
 	m_rig->alb_notoggle = false;
-	m_rig->alb_notoggle = false;
 	m_rig->alb_present = false;
-	m_rig->alb_pulse = 1;
+	m_rig->alb_pulse_time = 2000.0f;
 	m_rig->alb_pulse_state = false;
 	m_rig->alb_ratio = 0.0f;
+	m_rig->alb_timer = 0.0f;
 	m_rig->animTimer = 0.0f;
 	m_rig->antilockbrake = 0;
 
@@ -377,12 +377,13 @@ void RigSpawner::InitializeRig()
 
 	m_rig->tc_fade = 0.f;
 	m_rig->tc_mode = 0;
+	m_rig->tc_notoggle = false;
 	m_rig->tc_present = false;
-	m_rig->tc_pulse = 1;
+	m_rig->tc_pulse_time = 2000.0f;
 	m_rig->tc_pulse_state = false;
 	m_rig->tc_ratio = 0.f;
 	m_rig->tc_wheelslip = 0.f;
-	m_rig->tcalb_timer = 0.f;
+	m_rig->tc_timer = 0.f;
 
 	m_rig->tractioncontrol = 0;
 
@@ -5700,12 +5701,9 @@ void RigSpawner::ProcessTractionControl(RigDef::TractionControl & def)
 	float pulse = def.pulse_per_sec;
 	if (pulse <= 1.0f || pulse >= 2000.0f)
 	{
-		m_rig->tc_pulse = 1;
+		pulse = 2000.0f;
 	} 
-	else
-	{
-		m_rig->tc_pulse = static_cast <unsigned int> (2000.f / std::fabs(pulse));
-	}
+	m_rig->tc_pulse_time = 1 / pulse;
 
 	/* #5: mode */
 	if (BITMASK_IS_1(def.mode, RigDef::AntiLockBrakes::MODE_ON))
@@ -5754,12 +5752,9 @@ void RigSpawner::ProcessAntiLockBrakes(RigDef::AntiLockBrakes & def)
 	float pulse = def.pulse_per_sec;
 	if (pulse <= 1.0f || pulse >= 2000.0f)
 	{
-		m_rig->alb_pulse = 1;
+		pulse = 2000.0f;
 	} 
-	else
-	{
-		m_rig->alb_pulse = static_cast <unsigned int> (2000.f / std::fabs(pulse));
-	}
+	m_rig->alb_pulse_time = 1 / pulse;
 
 	/* #4: mode */
 	if (BITMASK_IS_1(def.mode, RigDef::AntiLockBrakes::MODE_ON))


### PR DESCRIPTION
Brakes in RoR apply torque against the direction of rotation of each wheel:
https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/physics/BeamForcesEuler.cpp#L729

However the rotary speed has no effect on the amount of torque which is applied. This is changed by this PR. It will fix the following issue:

* Greatly reduces brake induced skidding in parking positions.
Best example: [Bobcat Skid-Steer](http://www.rigsofrods.com/repository/view/1962)

* Prevents brakes from making wheels spin backwards.
Best example: [1974 Lotus 76/1](http://www.rigsofrods.com/threads/118984-Lotus-76-1-for-current-and-future-ror-versions-(Updated-for-test-build-4))

* Removes the (now unnecessary) [slopebrake](http://www.rigsofrods.com/wiki/pages/Truck_Description_File/#SlopeBrake).

* Fixes the anti-lock brake and traction control pulse modulation.