### PR TITLE
[Bugfix] Removes duplicate 'unknown' categories from the MainSelector

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -449,7 +449,15 @@ void CacheSystem::parseModAttribute(const String& line, CacheEntry& t)
 		// Set
 		t.categoryid = StringConverter::parseInt(params[1]);
 		category_usage[t.categoryid] = category_usage[t.categoryid] + 1;
-		t.categoryname=categories[t.categoryid].title;
+		if (categories.find(t.categoryid) != categories.end())
+		{
+			t.categoryname = categories[t.categoryid].title;
+		}
+		else
+		{
+			t.categoryid = -1;
+			t.categoryname = "Unsorted";
+		}
 	}
 	else if (attrib == "uniqueid")
 	{


### PR DESCRIPTION
Those 'unknown' cache entries will now show up in the 'Unsorted' category

Fixes: #631