### PR TITLE
[Codechange] Added missing notifications messages in the camera manager

### DIFF
--- a/source/main/gfx/camera/CameraBehaviorIsometric.cpp
+++ b/source/main/gfx/camera/CameraBehaviorIsometric.cpp
@@ -21,21 +21,15 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Application.h"
 #include "Console.h"
-#include "Language.h"
 #include "GUIManager.h"
+#include "Language.h"
 
 using namespace Ogre;
 
 void CameraBehaviorIsometric::activate(const CameraManager::CameraContext &ctx, bool reset /* = true */)
 {
 #ifdef USE_MYGUI
-	RoR::Application::GetConsole()->putMessage(
-		RoR::Console::CONSOLE_MSGTYPE_INFO, 
-		RoR::Console::CONSOLE_SYSTEM_NOTICE, 
-		_L("fixed free camera"), 
-		"camera_link.png", 
-		3000
-	);
-	RoR::Application::GetGuiManager()->PushNotification("Notice:", _L("fixed free camera"));
+	RoR::Application::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("Fixed camera"), "camera_link.png", 3000);
+	RoR::Application::GetGuiManager()->PushNotification("Notice:", _L("Fixed camera"));
 #endif // USE_MYGUI
 }

--- a/source/main/gfx/camera/CameraBehaviorOrbit.cpp
+++ b/source/main/gfx/camera/CameraBehaviorOrbit.cpp
@@ -26,6 +26,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "BeamFactory.h"
 #include "Collisions.h"
 #include "Console.h"
+#include "GUIManager.h"
 #include "IHeightFinder.h"
 #include "InputEngine.h"
 #include "Language.h"
@@ -103,10 +104,12 @@ void CameraBehaviorOrbit::update(const CameraManager::CameraContext &ctx)
 #ifdef USE_MYGUI
 		if ( limitMinCamDist )
 		{
-			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("limited camera zoom enabled"), "camera_go.png", 3000);
+			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Limited camera zoom enabled"), "camera_go.png", 3000);
+			RoR::Application::GetGuiManager()->PushNotification("Notice:", _L("Limited camera zoom enabled"));
 		} else
 		{
-			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("limited camera zoom disabled"), "camera_go.png", 3000);
+			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Limited camera zoom disabled"), "camera_go.png", 3000);
+			RoR::Application::GetGuiManager()->PushNotification("Notice:", _L("Limited camera zoom disabled"));
 		}
 #endif // USE_MYGUI
 	}

--- a/source/main/gfx/camera/CameraBehaviorVehicleSpline.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicleSpline.cpp
@@ -24,6 +24,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "Application.h"
 #include "Beam.h"
 #include "Console.h"
+#include "GUIManager.h"
 #include "InputEngine.h"
 #include "Language.h"
 #include "Settings.h"
@@ -75,10 +76,12 @@ void CameraBehaviorVehicleSpline::update(const CameraManager::CameraContext &ctx
 #ifdef USE_MYGUI
 		if ( autoTracking )
 		{
-			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("auto tracking enabled"), "camera_go.png", 3000);
+			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Auto tracking enabled"), "camera_go.png", 3000);
+			RoR::Application::GetGuiManager()->PushNotification("Notice:", _L("Auto tracking enabled"));
 		} else
 		{
-			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("auto tracking disabled"), "camera_go.png", 3000);
+			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Auto tracking disabled"), "camera_go.png", 3000);
+			RoR::Application::GetGuiManager()->PushNotification("Notice:", _L("Auto tracking disabled"));
 		}
 #endif // USE_MYGUI
 	}


### PR DESCRIPTION
Added GUI notification messages:

* When the limited camera zoom range is enabled/disabled
* When the auto tracking (camera rail) is enabled/disabled