### PR TITLE
[Bugfix] Fixes the gain of the turbo sounds (old turbomode)

### DIFF
--- a/bin/resources/sounds/defaults.soundscript
+++ b/bin/resources/sounds/defaults.soundscript
@@ -64,6 +64,8 @@ tracks/default_turbo_mid
 {
 	trigger_source engine
 	pitch_source	turbo_rpm
+	gain_source		turbo_rpm
+	gain_factors	0.0	0.0	1.852E-12
 	sound	80000.0	default_turbo.wav
 }
 
@@ -71,6 +73,8 @@ tracks/default_turbo_big
 {
 	trigger_source engine
 	pitch_source	turbo_rpm
+	gain_source		turbo_rpm
+	gain_factors	0.0	0.0	1.852E-12
 	sound	150000.0 default_turbo.wav
 }
 


### PR DESCRIPTION
Partly reverts this: https://github.com/RigsOfRods/rigs-of-rods/commit/64158020f70011583362cb25f6912161faa68d9d

* Doesn't seem to change the sound in vehicles which use the new turbo mode, but fixes the sound of all vehicles which use the old turbo mode.