### PR TITLE
[Bugfix] Fixes broken rotator parsing

### DIFF
--- a/source/rig_file_input_output/RigDef_Parser.cpp
+++ b/source/rig_file_input_output/RigDef_Parser.cpp
@@ -4692,7 +4692,7 @@ void Parser::_ParseRotatorsCommon(Rotator & rotator, boost::smatch & results, un
 	rotator.rotating_plate_nodes[0] = _ParseNodeRef(results[13]);
 	rotator.rotating_plate_nodes[1] = _ParseNodeRef(results[15]);
 	rotator.rotating_plate_nodes[2] = _ParseNodeRef(results[17]);
-	rotator.rotating_plate_nodes[3] = _ParseNodeRef(results[21]);
+	rotator.rotating_plate_nodes[3] = _ParseNodeRef(results[19]);
 
 	rotator.rate = STR_PARSE_REAL(results[21]);
 


### PR DESCRIPTION
The fourth node of the rotating plate was parsed incorrectly due to a typo.

Fixes: #381