### PR TITLE
[Codechange] Some screenshot taking improvements

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -348,6 +348,8 @@ bool RoRFrameListener::updateEvents(float dt)
 		MyGUI::PointerManager::getInstance().setVisible(false);
 #endif // USE_MYGUI
 
+		BeamFactory::getSingleton().updateFlexbodiesFinal();   // Waits until all flexbody tasks are finished
+
 		if (String(screenshotformat) == "png")
 		{
 			// add some more data into the image
@@ -1451,6 +1453,11 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 		DustManager::getSingleton().update();
 	}
 
+	if (loading_state == ALL_LOADED && !this->isSimPaused)
+	{
+		BeamFactory::getSingleton().updateVisual(dt); // update visual - antishaking
+	}
+
 	if (!updateEvents(dt))
 	{
 		LOG("exiting...");
@@ -1482,9 +1489,8 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 		// we simulate one truck, it will take care of the others (except networked ones)
 		if (!isSimPaused)
 		{
-			BeamFactory::getSingleton().updateFlexbodiesFinal(); // Waits until all flexbody tasks are finished 
-			BeamFactory::getSingleton().updateVisual(dt);          // update visual - antishaking
 			BeamFactory::getSingleton().checkSleepingState();
+			BeamFactory::getSingleton().updateFlexbodiesFinal();   // Waits until all flexbody tasks are finished 
 			BeamFactory::getSingleton().calcPhysics(dt);           // we simulate one truck, it will take care of the others (except networked ones)
 		}
 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -98,6 +98,10 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "SurveyMapEntity.h"
 #endif //USE_MYGUI
 
+#include <sstream>
+#include <iomanip>
+#include <ctime>
+
 #ifdef USE_MPLATFORM
 #include "MPlatformFD.h"
 #endif //USE_MPLATFORM
@@ -314,22 +318,34 @@ bool RoRFrameListener::updateEvents(float dt)
 		gEnv->player->update(dt);
 	}
 
-	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_SCREENSHOT, 0.5f))
+	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_SCREENSHOT, 0.25f))
 	{
-		int mNumScreenShots=0;
-		String tmpfn = SSETTING("User Path", "") + String("screenshot_") + TOSTRING(++mNumScreenShots) + String(".") + String(screenshotformat);
-		while(RoR::PlatformUtils::FileExists(tmpfn.c_str()))
+		int mNumScreenShots = 0;
+
+		std::time_t t = std::time(nullptr);
+		std::stringstream date;
+		date << std::put_time(std::localtime(&t), "%Y-%m-%d_%H:%M:%S");
+
+		String fn_prefix = SSETTING("User Path", "") + String("screenshot_");
+		String fn_name = date.str() + String("_");
+		String fn_suffix = String(".") + String(screenshotformat);
+
+		String tmpfn = fn_prefix + fn_name + TOSTRING(++mNumScreenShots) + fn_suffix;
+
+		while (RoR::PlatformUtils::FileExists(tmpfn.c_str()))
 		{
-			tmpfn = SSETTING("User Path", "") + String("screenshot_") + TOSTRING(++mNumScreenShots) + String(".") + String(screenshotformat);
+			tmpfn = fn_prefix + fn_name + TOSTRING(++mNumScreenShots) + fn_suffix;
 		}
 
+		fn_name = fn_name + TOSTRING(mNumScreenShots) + fn_suffix;
+
 #ifdef USE_MYGUI
+		RoR::Application::GetGuiManager()->HideNotification();
 		MyGUI::PointerManager::getInstance().setVisible(false);
 #endif // USE_MYGUI
+
 		if (String(screenshotformat) == "png")
 		{
-
-
 			// add some more data into the image
 			AdvancedScreen *as = new AdvancedScreen(RoR::Application::GetOgreSubsystem()->GetRenderWindow(), tmpfn);
 			//as->addData("terrain_Name", loadedTerrain);
@@ -370,7 +386,7 @@ bool RoRFrameListener::updateEvents(float dt)
 #endif // USE_MYGUI
 
 		// show new flash message
-		String ssmsg = _L("Screenshot:") + TOSTRING(mNumScreenShots);
+		String ssmsg = _L("Screenshot:") + String(" ") + fn_name;
 		LOG(ssmsg);
 #ifdef USE_MYGUI
 		RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "camera.png", 10000, false);

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -324,7 +324,7 @@ bool RoRFrameListener::updateEvents(float dt)
 
 		std::time_t t = std::time(nullptr);
 		std::stringstream date;
-		date << std::put_time(std::localtime(&t), "%Y-%m-%d_%H:%M:%S");
+		date << std::put_time(std::localtime(&t), "%Y-%m-%d_%H-%M-%S");
 
 		String fn_prefix = SSETTING("User Path", "") + String("screenshot_");
 		String fn_name = date.str() + String("_");

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1484,8 +1484,6 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 	// one of the input modes is immediate, so update the movement vector
 	if (loading_state == ALL_LOADED)
 	{
-		BeamFactory::getSingleton().checkSleepingState();
-
 		// we simulate one truck, it will take care of the others (except networked ones)
 		if (!isSimPaused)
 		{

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -174,8 +174,10 @@ RoRFrameListener::RoRFrameListener() :
 	heathaze(0),
 	hidegui(false),
 	loading_state(NONE_LOADED),
-	mStatsOn(0),
+	mLastScreenShotID(1),
+	mLastScreenShotDate(""),
 	mLastSimulationSpeed(0.1f),
+	mStatsOn(0),
 	mTimeUntilNextToggle(0),
 	mTruckInfoOn(false),
 	netChat(0),
@@ -320,8 +322,6 @@ bool RoRFrameListener::updateEvents(float dt)
 
 	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_SCREENSHOT, 0.25f))
 	{
-		int mNumScreenShots = 0;
-
 		std::time_t t = std::time(nullptr);
 		std::stringstream date;
 		date << std::put_time(std::localtime(&t), "%Y-%m-%d_%H-%M-%S");
@@ -330,14 +330,18 @@ bool RoRFrameListener::updateEvents(float dt)
 		String fn_name = date.str() + String("_");
 		String fn_suffix = String(".") + String(screenshotformat);
 
-		String tmpfn = fn_prefix + fn_name + TOSTRING(++mNumScreenShots) + fn_suffix;
-
-		while (RoR::PlatformUtils::FileExists(tmpfn.c_str()))
+		if (mLastScreenShotDate == date.str())
 		{
-			tmpfn = fn_prefix + fn_name + TOSTRING(++mNumScreenShots) + fn_suffix;
+			mLastScreenShotID++;
+		} else
+		{
+			mLastScreenShotID = 1;
 		}
+		mLastScreenShotDate = date.str();
 
-		fn_name = fn_name + TOSTRING(mNumScreenShots) + fn_suffix;
+		fn_name = fn_name + TOSTRING(mLastScreenShotID);
+
+		String tmpfn = fn_prefix + fn_name + fn_suffix;
 
 #ifdef USE_MYGUI
 		RoR::Application::GetGuiManager()->HideNotification();
@@ -386,7 +390,7 @@ bool RoRFrameListener::updateEvents(float dt)
 #endif // USE_MYGUI
 
 		// show new flash message
-		String ssmsg = _L("Screenshot:") + String(" ") + fn_name;
+		String ssmsg = _L("Screenshot:") + String(" ") + fn_name + fn_suffix;
 		LOG(ssmsg);
 #ifdef USE_MYGUI
 		RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "camera.png", 10000, false);

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -76,6 +76,9 @@ protected:
 
 	float mLastSimulationSpeed; // previously used time ratio between real time (evt.timeSinceLastFrame) and physics time ('dt' used in calcPhysics)
 
+	int mLastScreenShotID;
+	Ogre::String mLastScreenShotDate;
+
 	unsigned long      m_race_start_time;
 	bool               m_race_in_progress;
 	float			   m_race_bestlap_time;

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -193,6 +193,13 @@ void GUIManager::PushNotification(String Title, UTFString text)
 	m_gui_SimUtils->PushNotification(Title, text);
 }
 
+void GUIManager::HideNotification()
+{
+	if (!m_gui_SimUtils) return;
+
+	m_gui_SimUtils->HideNotification();
+}
+
 void GUIManager::windowResized(Ogre::RenderWindow* rw)
 {
 	int width = (int)rw->getWidth();

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -86,6 +86,7 @@ public:
 	void framestep(float dt);
 
 	void PushNotification(Ogre::String Title, Ogre::UTFString text);
+	void HideNotification();
 
 	void ShowMessageBox(Ogre::String mTitle, Ogre::String mText, bool button1, Ogre::String mButton1, bool AllowClose, bool button2, Ogre::String mButton2);
 	void UpdateMessageBox(Ogre::String mTitle, Ogre::String mText, bool button1, Ogre::String mButton1, bool AllowClose, bool button2, Ogre::String mButton2, bool IsVisible);

--- a/source/main/gui/panels/GUI_SimUtils.cpp
+++ b/source/main/gui/panels/GUI_SimUtils.cpp
@@ -119,6 +119,11 @@ void CLASS::PushNotification(Ogre::String Title, Ogre::String text)
 	pushTime = Ogre::Root::getSingleton().getTimer()->getMilliseconds();
 }
 
+void CLASS::HideNotification()
+{
+	m_notification->setVisible(false);
+}
+
 void CLASS::framestep(float dt)
 {
 	if (!MAIN_WIDGET->getVisible()) return;

--- a/source/main/gui/panels/GUI_SimUtils.h
+++ b/source/main/gui/panels/GUI_SimUtils.h
@@ -62,6 +62,7 @@ public:
 	void framestep(float dt);
 
 	void PushNotification(Ogre::String Title, Ogre::String text);
+	void HideNotification();
 	
 private:
 	bool b_fpsbox;


### PR DESCRIPTION
* Reduces the screenshot key bounce time by half
* Adds time stamps to the screenshot file name
* Automatically hides screen notifications before another screenshot is taken
* Gets rid of the camera stuttering when taking a screenshot (introduced by: 1ff982a4b8bee32d6caf715503c8c31b52350c63)
* Prevents recording partially updated trucks when taking a screenshot (introduced by: 1ff982a4b8bee32d6caf715503c8c31b52350c63)

Fixes: #360
Fixes: #473