### PR TITLE
[Codechange] lockNodes should not be changed outside of the truck parser

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1326,7 +1326,6 @@ void Beam::SyncReset()
 		it->beam->mSceneNode->detachAllObjects();
 		it->beam->disabled = true;
 		it->locked        = UNLOCKED;
-		it->lockNodes     = true;
 		it->lockNode      = 0;
 		it->lockTruck     = 0;
 		it->beam->p2      = &nodes[0];


### PR DESCRIPTION
This might fix Bug #: 1013: http://www.rigsofrods.com/threads/111967-Bugtracker-users-we-need-your-help-to-collect-all-bugs!?p=1307247&viewfull=1#post1307247

**Edit:** Bug 1013 must be caused by sth. else.