### PR TITLE
[Bugfix] Removes race condition in calcBeams

### DIFF
--- a/source/main/datatypes/rig_t.h
+++ b/source/main/datatypes/rig_t.h
@@ -30,6 +30,8 @@ struct rig_t
 	Ogre::Real default_beam_plastic_coef[MAX_BEAMS];
 	int free_beam;
 
+	std::vector<beam_t*> interTruckBeams;
+
 	contacter_t contacters[MAX_CONTACTERS];
 	int free_contacter;
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1332,6 +1332,7 @@ void Beam::SyncReset()
 		it->beam->p2      = &nodes[0];
 		it->beam->p2truck = false;
 		it->beam->L       = (nodes[0].AbsPosition - it->hookNode->AbsPosition).length();
+		removeInterTruckBeam(it->beam);
 	}
 
 	for (std::vector <rope_t>::iterator it = ropes.begin(); it != ropes.end(); it++) it->lockedto=0;
@@ -4124,6 +4125,24 @@ void Beam::cabFade(float amount)
 	}
 }
 
+void Beam::addInterTruckBeam(beam_t* beam)
+{
+	auto pos = std::find(interTruckBeams.begin(), interTruckBeams.end(), beam);
+	if (pos == interTruckBeams.end())
+	{
+		interTruckBeams.push_back(beam);
+	}
+}
+
+void Beam::removeInterTruckBeam(beam_t* beam)
+{
+	auto pos = std::find(interTruckBeams.begin(), interTruckBeams.end(), beam);
+	if (pos != interTruckBeams.end())
+	{
+		interTruckBeams.erase(pos);
+	}
+}
+
 void Beam::tieToggle(int group)
 {
 	Beam **trucks = BeamFactory::getSingleton().getTrucks();
@@ -4161,6 +4180,7 @@ void Beam::tieToggle(int group)
 			it->beam->disabled = true;
 			it->beam->mSceneNode->detachAllObjects();
 			istied = true;
+			removeInterTruckBeam(it->beam);
 		}
 	}
 
@@ -4225,6 +4245,7 @@ void Beam::tieToggle(int group)
 					it->tying = true;
 					it->lockedto = locktedto;
 					it->lockedto->used++;
+					addInterTruckBeam(it->beam);
 				}
 			}
 		}
@@ -4365,6 +4386,7 @@ void Beam::hookToggle(int group, hook_states mode, int node_number)
 			it->beam->p2truck  = false;
 			it->beam->L        = (nodes[0].AbsPosition - it->hookNode->AbsPosition).length();
 			it->beam->disabled = true;
+			removeInterTruckBeam(it->beam);
 		}
 		// do this only for toggle or lock attempts, skip prelocked or locked nodes for performance
 		else if (mode != HOOK_UNLOCK && it->locked == UNLOCKED)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -300,7 +300,6 @@ public:
 	
 	//! @{ calc forces euler division
 	void calcTruckEngine(bool doUpdate, Ogre::Real dt);
-	void calcBeams(bool doUpdate, Ogre::Real dt, int step, int maxsteps);
 	void calcAnimatedProps(bool doUpdate, Ogre::Real dt);
 	void calcHooks(bool doUpdate);
 	void calcForceFeedBack(bool doUpdate);
@@ -554,8 +553,12 @@ protected:
 	void calcBeams(int doUpdate, Ogre::Real dt, int step, int maxsteps);
 
 	/**
+	* TIGHT LOOP; Physics & sound - only beams between multiple truck (noshock or ropes)
+	*/
+	void calcBeamsInterTruck(int doUpdate, Ogre::Real dt, int step, int maxsteps);
+
+	/**
 	* TIGHT LOOP; Physics; 
-	* @param doUpdate Unused (overwritten in function)
 	*/
 	void calcNodes(int doUpdate, Ogre::Real dt, int step, int maxsteps);
 
@@ -608,6 +611,9 @@ protected:
 	ground_model_t *lastFuzzyGroundModel;
 
 	bool high_res_wheelnode_collisions;
+
+	void addInterTruckBeam(beam_t* beam);
+	void removeInterTruckBeam(beam_t* beam);
 
 	// this is for managing the blinkers on the truck:
 	blinktype blinkingtype;


### PR DESCRIPTION
Prevents unsynchronized read/write access to `p2->Forces`, when `p2truck != 0`.

Should fix: #465
Related with: #189