### PR TITLE
[Codechange] Trim vehicle name to fit into the 't' menus

### DIFF
--- a/source/main/gui/panels/GUI_SimUtils.cpp
+++ b/source/main/gui/panels/GUI_SimUtils.cpp
@@ -168,6 +168,7 @@ void CLASS::UpdateStats(float dt, Beam *truck)
 
 	if (b_truckinfo && truck != nullptr)
 	{
+		m_truck_name->setMaxTextLength(28);
 		m_truck_name->setCaptionWithReplacing(truck->getTruckName());
 		truckstats = "\n"; //always reset on each frame + space
 

--- a/source/main/gui/panels/GUI_VehicleDescription.cpp
+++ b/source/main/gui/panels/GUI_VehicleDescription.cpp
@@ -64,6 +64,7 @@ CLASS::~CLASS()
 
 void CLASS::LoadText()
 {
+	m_vehicle_title->setMaxTextLength(33);
 	m_vehicle_title->setCaptionWithReplacing(currTruck->getTruckName());
 
 	Ogre::String txt;


### PR DESCRIPTION
Show the beginning of the vehicle name instead of the end.

Fixes: #401

Bad solution, because it uses hard-coded values for [MyGUI::EditBox::setMaxTextLength(size_t 	_value)	
](http://mygui.info/docs/class_my_g_u_i_1_1_edit_box.html#a0931c6bc59eb4ca79b8c6d0e4f3bd466)