### PR TITLE
[Codechange] Some changes to the parser ('cab', 'rigidifiers', 'turboprops2')

### DIFF
--- a/source/rig_file_input_output/RigDef_Parser.cpp
+++ b/source/rig_file_input_output/RigDef_Parser.cpp
@@ -529,6 +529,7 @@ void Parser::ParseLine(Ogre::String const & line)
 
 			case (File::KEYWORD_RIGIDIFIERS):
 				AddMessage(line, Message::TYPE_WARNING, "Rigidifiers are not supported, ignoring...");
+				new_section = File::SECTION_NONE;
 				line_finished = true;
 				break;
 
@@ -720,6 +721,7 @@ void Parser::ParseLine(Ogre::String const & line)
 
 			case (File::KEYWORD_TURBOPROPS2):
 				AddMessage(line, Message::TYPE_WARNING, "Turboprops2 are not supported, ignoring...");
+				new_section = File::SECTION_NONE;
 				line_finished = true;
 				break;
 
@@ -2529,11 +2531,10 @@ void Parser::ParseSubmesh(Ogre::String const & line)
 
 		m_current_submesh->texcoords.push_back(texcoord);
 	}
-    // Experiment, left here for future use
-    //else if (this->_TryParseCab(line))
-    //{
-    //    AddMessage(line, Message::TYPE_WARNING, "Section submesh has no subsection defined, but subsequent line matches 'cab' entry. Parsed as 'cab'.");
-    //}
+	else if (this->_TryParseCab(line))
+	{
+		AddMessage(line, Message::TYPE_WARNING, "Section submesh has no subsection defined, but subsequent line matches 'cab' entry. Parsed as 'cab'.");
+	}
 	else
 	{
 		AddMessage(line, Message::TYPE_ERROR, "Section submesh has no subsection defined, line not parsed.");


### PR DESCRIPTION
Truly skip unsupported `rigidifiers` and `turboprops2` sections.
* Less warnings when parsing the [1949 Ford](http://www.rigsofrods.com/repository/view/2579).

Interpret `submesh` sections without subsections as `cab` subsection.
* Fixes `cab` parsing on the [Audio 80 Quattro](http://www.mediafire.com/?tc927day8vat1q7).