### PR TITLE
[Feature] Overworked the reset in place feature

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -583,7 +583,10 @@ bool RoRFrameListener::updateEvents(float dt)
 
 					if (translation != Vector3::ZERO || rotation != 0.0f)
 					{
-						curr_truck->displace(translation, rotation);
+						float scale = RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LMENU)  ? 0.1f : 1.0f;
+						scale      *= RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) ? 3.0f : 1.0f;
+
+						curr_truck->displace(translation * scale, rotation * std::max(1.0f, scale));
 					}
 
 					curr_truck->reset(true);

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -541,6 +541,51 @@ bool RoRFrameListener::updateEvents(float dt)
 					curr_truck->reset();
 				} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
 				{
+					Vector3 translation = Vector3::ZERO;
+					float rotation = 0.0f;
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_ACCELERATE))
+					{
+						translation += 2.0f * Vector3::UNIT_Y * dt;
+					} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_BRAKE))
+					{
+						translation -= 2.0f * Vector3::UNIT_Y * dt;
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_STEER_LEFT))
+					{
+						rotation += 0.5f * dt;
+					} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_STEER_RIGHT))
+					{
+						rotation -= 0.5f * dt;
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_FORWARD))
+					{
+						float curRot = curr_truck->getRotation();
+						translation.x += 2.0f * cos(curRot - Ogre::Math::HALF_PI) * dt;
+						translation.z += 2.0f * sin(curRot - Ogre::Math::HALF_PI) * dt;
+					} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_BACKWARDS))
+					{
+						float curRot = curr_truck->getRotation();
+						translation.x -= 2.0f * cos(curRot - Ogre::Math::HALF_PI) * dt;
+						translation.z -= 2.0f * sin(curRot - Ogre::Math::HALF_PI) * dt;
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_SIDESTEP_RIGHT))
+					{
+						float curRot = curr_truck->getRotation();
+						translation.x += 2.0f * cos(curRot) * dt;
+						translation.z += 2.0f * sin(curRot) * dt;
+					} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_SIDESTEP_LEFT))
+					{
+						float curRot = curr_truck->getRotation();
+						translation.x -= 2.0f * cos(curRot) * dt;
+						translation.z -= 2.0f * sin(curRot) * dt;
+					}
+
+					if (translation != Vector3::ZERO || rotation != 0.0f)
+					{
+						curr_truck->displace(translation, rotation);
+					}
+
 					curr_truck->reset(true);
 				} else
 				{

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -535,334 +535,329 @@ bool RoRFrameListener::updateEvents(float dt)
 				}
 			} else // we are in a vehicle
 			{
-				// get commands
-				// -- here we should define a maximum numbers per trucks. Some trucks does not have that much commands
-				// -- available, so why should we iterate till MAX_COMMANDS?
-				for (int i=1; i<=MAX_COMMANDS+1; i++)
+				if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_RESET_TRUCK) && !curr_truck->replaymode)
 				{
-					int eventID = EV_COMMANDS_01 + (i - 1);
-
-					curr_truck->commandkey[i].playerInputValue = RoR::Application::GetInputEngine()->getEventValue(eventID);
-				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_FORWARDCOMMANDS))
+					StopRaceTimer();
+					curr_truck->reset();
+				} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
 				{
-					curr_truck->forwardcommands = !curr_truck->forwardcommands;
+					curr_truck->reset(true);
+				} else
+				{
+					// get commands
+					// -- here we should define a maximum numbers per trucks. Some trucks does not have that much commands
+					// -- available, so why should we iterate till MAX_COMMANDS?
+					for (int i=1; i<=MAX_COMMANDS+1; i++)
+					{
+						int eventID = EV_COMMANDS_01 + (i - 1);
+
+						curr_truck->commandkey[i].playerInputValue = RoR::Application::GetInputEngine()->getEventValue(eventID);
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_FORWARDCOMMANDS))
+					{
+						curr_truck->forwardcommands = !curr_truck->forwardcommands;
 #ifdef USE_MYGUI
-					if ( curr_truck->forwardcommands )
-					{
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("forwardcommands enabled"), "information.png", 3000);
-					} else
-					{
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("forwardcommands disabled"), "information.png", 3000);
-					}
-#endif // USE_MYGUI
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_IMPORTCOMMANDS))
-				{
-					curr_truck->importcommands = !curr_truck->importcommands;
-#ifdef USE_MYGUI
-					if ( curr_truck->importcommands )
-					{
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("importcommands enabled"), "information.png", 3000);
-					} else
-					{
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("importcommands disabled"), "information.png", 3000);
-					}
-#endif // USE_MYGUI
-				}
-
-				// replay mode
-				if (curr_truck->replaymode)
-				{
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FORWARD, 0.1f) && curr_truck->replaypos <= 0)
-					{
-						curr_truck->replaypos++;
-					}
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_BACKWARD, 0.1f) && curr_truck->replaypos > -curr_truck->replaylen)
-					{
-						curr_truck->replaypos--;
-					}
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FAST_FORWARD, 0.1f) && curr_truck->replaypos+10 <= 0)
-					{
-						curr_truck->replaypos+=10;
-					}
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FAST_BACKWARD, 0.1f) && curr_truck->replaypos-10 > -curr_truck->replaylen)
-					{
-						curr_truck->replaypos-=10;
-					}
-					if (RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LMENU) && RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_V))
-					{
-						
-					}
-
-					if (RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LMENU))
-					{
-						if (curr_truck->replaypos <= 0 && curr_truck->replaypos >= -curr_truck->replaylen)
+						if ( curr_truck->forwardcommands )
 						{
-							if (RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) || RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_RSHIFT))
+							RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("forwardcommands enabled"), "information.png", 3000);
+						} else
+						{
+							RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("forwardcommands disabled"), "information.png", 3000);
+						}
+#endif // USE_MYGUI
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_IMPORTCOMMANDS))
+					{
+						curr_truck->importcommands = !curr_truck->importcommands;
+#ifdef USE_MYGUI
+						if ( curr_truck->importcommands )
+						{
+							RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("importcommands enabled"), "information.png", 3000);
+						} else
+						{
+							RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("importcommands disabled"), "information.png", 3000);
+						}
+#endif // USE_MYGUI
+					}
+					// replay mode
+					if (curr_truck->replaymode)
+					{
+						if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FORWARD, 0.1f) && curr_truck->replaypos <= 0)
+						{
+							curr_truck->replaypos++;
+						}
+						if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_BACKWARD, 0.1f) && curr_truck->replaypos > -curr_truck->replaylen)
+						{
+							curr_truck->replaypos--;
+						}
+						if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FAST_FORWARD, 0.1f) && curr_truck->replaypos+10 <= 0)
+						{
+							curr_truck->replaypos+=10;
+						}
+						if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FAST_BACKWARD, 0.1f) && curr_truck->replaypos-10 > -curr_truck->replaylen)
+						{
+							curr_truck->replaypos-=10;
+						}
+						if (RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LMENU) && RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_V))
+						{
+							
+						}
+
+						if (RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LMENU))
+						{
+							if (curr_truck->replaypos <= 0 && curr_truck->replaypos >= -curr_truck->replaylen)
 							{
-								curr_truck->replaypos += RoR::Application::GetInputEngine()->getMouseState().X.rel * 1.5f;
-							} else
-							{
-								curr_truck->replaypos += RoR::Application::GetInputEngine()->getMouseState().X.rel * 0.05f;
-							}
-							if (curr_truck->replaypos > 0)
-							{
-								curr_truck->replaypos = 0;
-							}
-							if (curr_truck->replaypos < -curr_truck->replaylen)
-							{
-								curr_truck->replaypos = -curr_truck->replaylen;
+								if (RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) || RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_RSHIFT))
+								{
+									curr_truck->replaypos += RoR::Application::GetInputEngine()->getMouseState().X.rel * 1.5f;
+								} else
+								{
+									curr_truck->replaypos += RoR::Application::GetInputEngine()->getMouseState().X.rel * 0.05f;
+								}
+								if (curr_truck->replaypos > 0)
+								{
+									curr_truck->replaypos = 0;
+								}
+								if (curr_truck->replaypos < -curr_truck->replaylen)
+								{
+									curr_truck->replaypos = -curr_truck->replaylen;
+								}
 							}
 						}
 					}
-				}
 
-				if (curr_truck->driveable==TRUCK)
-				{
-					LandVehicleSimulation::UpdateVehicle(curr_truck, dt);
-				}
-				if (curr_truck->driveable==AIRPLANE)
-				{
-					AircraftSimulation::UpdateVehicle(curr_truck, dt);
-				}
-				if (curr_truck->driveable==BOAT)
-				{
-					//BOAT SPECIFICS
+					if (curr_truck->driveable==TRUCK)
+					{
+						LandVehicleSimulation::UpdateVehicle(curr_truck, dt);
+					}
+					if (curr_truck->driveable==AIRPLANE)
+					{
+						AircraftSimulation::UpdateVehicle(curr_truck, dt);
+					}
+					if (curr_truck->driveable==BOAT)
+					{
+						//BOAT SPECIFICS
 
-					//throttle
-					if (RoR::Application::GetInputEngine()->isEventDefined(EV_BOAT_THROTTLE_AXIS))
-					{
-						float f = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_THROTTLE_AXIS);
-						// use negative values also!
-						f = f * 2 - 1;
-						for (int i=0; i<curr_truck->free_screwprop; i++)
-							curr_truck->screwprops[i]->setThrottle(-f);
-					}
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_BOAT_THROTTLE_DOWN, 0.1f))
-					{
-						//throttle down
-						for (int i=0; i<curr_truck->free_screwprop; i++)
-							curr_truck->screwprops[i]->setThrottle(curr_truck->screwprops[i]->getThrottle()-0.05);
-					}
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_BOAT_THROTTLE_UP, 0.1f))
-					{
-						//throttle up
-						for (int i=0; i<curr_truck->free_screwprop; i++)
-							curr_truck->screwprops[i]->setThrottle(curr_truck->screwprops[i]->getThrottle()+0.05);
-					}
+						//throttle
+						if (RoR::Application::GetInputEngine()->isEventDefined(EV_BOAT_THROTTLE_AXIS))
+						{
+							float f = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_THROTTLE_AXIS);
+							// use negative values also!
+							f = f * 2 - 1;
+							for (int i=0; i<curr_truck->free_screwprop; i++)
+								curr_truck->screwprops[i]->setThrottle(-f);
+						}
+						if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_BOAT_THROTTLE_DOWN, 0.1f))
+						{
+							//throttle down
+							for (int i=0; i<curr_truck->free_screwprop; i++)
+								curr_truck->screwprops[i]->setThrottle(curr_truck->screwprops[i]->getThrottle()-0.05);
+						}
+						if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_BOAT_THROTTLE_UP, 0.1f))
+						{
+							//throttle up
+							for (int i=0; i<curr_truck->free_screwprop; i++)
+								curr_truck->screwprops[i]->setThrottle(curr_truck->screwprops[i]->getThrottle()+0.05);
+						}
 
 
-					// steer
-					float tmp_steer_left = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_STEER_LEFT);
-					float tmp_steer_right = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_STEER_RIGHT);
-					float stime = RoR::Application::GetInputEngine()->getEventBounceTime(EV_BOAT_STEER_LEFT) + RoR::Application::GetInputEngine()->getEventBounceTime(EV_BOAT_STEER_RIGHT);
-					float sum_steer = (tmp_steer_left - tmp_steer_right) * dt;
-					// do not center the rudder!
-					if (fabs(sum_steer)>0 && stime <= 0)
-					{
-						for (int i=0; i<curr_truck->free_screwprop; i++)
-							curr_truck->screwprops[i]->setRudder(curr_truck->screwprops[i]->getRudder() + sum_steer);
-					}
-					if (RoR::Application::GetInputEngine()->isEventDefined(EV_BOAT_STEER_LEFT_AXIS) && RoR::Application::GetInputEngine()->isEventDefined(EV_BOAT_STEER_RIGHT_AXIS))
-					{
-						tmp_steer_left = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_STEER_LEFT_AXIS);
-						tmp_steer_right = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_STEER_RIGHT_AXIS);
-						sum_steer = (tmp_steer_left - tmp_steer_right);
-						for (int i=0; i<curr_truck->free_screwprop; i++)
-							curr_truck->screwprops[i]->setRudder(sum_steer);
-					}
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_BOAT_CENTER_RUDDER, 0.1f))
-					{
-						for (int i=0; i<curr_truck->free_screwprop; i++)
-							curr_truck->screwprops[i]->setRudder(0);
-					}
+						// steer
+						float tmp_steer_left = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_STEER_LEFT);
+						float tmp_steer_right = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_STEER_RIGHT);
+						float stime = RoR::Application::GetInputEngine()->getEventBounceTime(EV_BOAT_STEER_LEFT) + RoR::Application::GetInputEngine()->getEventBounceTime(EV_BOAT_STEER_RIGHT);
+						float sum_steer = (tmp_steer_left - tmp_steer_right) * dt;
+						// do not center the rudder!
+						if (fabs(sum_steer)>0 && stime <= 0)
+						{
+							for (int i=0; i<curr_truck->free_screwprop; i++)
+								curr_truck->screwprops[i]->setRudder(curr_truck->screwprops[i]->getRudder() + sum_steer);
+						}
+						if (RoR::Application::GetInputEngine()->isEventDefined(EV_BOAT_STEER_LEFT_AXIS) && RoR::Application::GetInputEngine()->isEventDefined(EV_BOAT_STEER_RIGHT_AXIS))
+						{
+							tmp_steer_left = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_STEER_LEFT_AXIS);
+							tmp_steer_right = RoR::Application::GetInputEngine()->getEventValue(EV_BOAT_STEER_RIGHT_AXIS);
+							sum_steer = (tmp_steer_left - tmp_steer_right);
+							for (int i=0; i<curr_truck->free_screwprop; i++)
+								curr_truck->screwprops[i]->setRudder(sum_steer);
+						}
+						if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_BOAT_CENTER_RUDDER, 0.1f))
+						{
+							for (int i=0; i<curr_truck->free_screwprop; i++)
+								curr_truck->screwprops[i]->setRudder(0);
+						}
 
-					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_BOAT_REVERSE))
-					{
-						for (int i=0; i<curr_truck->free_screwprop; i++)
-							curr_truck->screwprops[i]->toggleReverse();
+						if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_BOAT_REVERSE))
+						{
+							for (int i=0; i<curr_truck->free_screwprop; i++)
+								curr_truck->screwprops[i]->toggleReverse();
+						}
 					}
-				}
-				//COMMON KEYS
+					//COMMON KEYS
 
-				if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_ACCELERATE_SIMULATION))
-				{
-					float simulation_speed = BeamFactory::getSingleton().getSimulationSpeed() * 1.003;
-					BeamFactory::getSingleton().setSimulationSpeed(simulation_speed);
+					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_ACCELERATE_SIMULATION))
+					{
+						float simulation_speed = BeamFactory::getSingleton().getSimulationSpeed() * 1.003;
+						BeamFactory::getSingleton().setSimulationSpeed(simulation_speed);
 #ifdef USE_MYGUI
-					String ssmsg = _L("New simulation speed: ") + TOSTRING(Round(simulation_speed * 100.0f, 1)) + "%";
-					RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
-					RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
-#endif //USE_MYGUI
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_DECELERATE_SIMULATION))
-				{
-					float simulation_speed = BeamFactory::getSingleton().getSimulationSpeed() * 0.997;
-					BeamFactory::getSingleton().setSimulationSpeed(simulation_speed);
-#ifdef USE_MYGUI
-					String ssmsg = _L("New simulation speed: ") + TOSTRING(Round(simulation_speed * 100.0f, 1)) + "%";
-					RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
-					RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
-#endif //USE_MYGUI
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESET_SIMULATION_PACE, 0.5f))
-				{
-					float simulation_speed = BeamFactory::getSingleton().getSimulationSpeed();
-					if (simulation_speed != 1.0f)
-					{
-						mLastSimulationSpeed = simulation_speed;
-						BeamFactory::getSingleton().setSimulationSpeed(1.0f);
-#ifdef USE_MYGUI
-						UTFString ssmsg = _L("Simulation speed reset.");
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
-						RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
-#endif //USE_MYGUI
-					} else if (mLastSimulationSpeed != 1.0f)
-					{
-						BeamFactory::getSingleton().setSimulationSpeed(mLastSimulationSpeed);
-#ifdef USE_MYGUI
-						String ssmsg = _L("New simulation speed: ") + TOSTRING(Round(mLastSimulationSpeed * 100.0f, 1)) + "%";
+						String ssmsg = _L("New simulation speed: ") + TOSTRING(Round(simulation_speed * 100.0f, 1)) + "%";
 						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
 						RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
 #endif //USE_MYGUI
 					}
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TRUCK_REMOVE))
-				{
-					BeamFactory::getSingleton().removeCurrentTruck();
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ROPELOCK))
-				{
-					curr_truck->ropeToggle(-1);
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_LOCK))
-				{
-					curr_truck->hookToggle(-1, HOOK_TOGGLE, -1);
-					//SlideNodeLock
-					curr_truck->toggleSlideNodeLock();
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_AUTOLOCK))
-				{
-					//unlock all autolocks
-					curr_truck->hookToggle(-2, HOOK_UNLOCK, -1);
-				}
-				//strap
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_SECURE_LOAD))
-				{
-					curr_truck->tieToggle(-1);
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_RESET_TRUCK) && !curr_truck->replaymode)
-				{
-					// stop any races
-					StopRaceTimer();
-					// init
-					curr_truck->reset();
-				}
-				if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
-				{
-#ifdef USE_OPENAL
-					SoundScriptManager::getSingleton().trigOnce(curr_truck, SS_TRIG_REPAIR);
-#endif //OPENAL
-					curr_truck->reset(true);
-				}
-				//replay mode
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_REPLAY_MODE))
-				{
-					StopRaceTimer();
-					curr_truck->setReplayMode(!curr_truck->replaymode);
-				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_CUSTOM_PARTICLES))
-				{
-					curr_truck->toggleCustomParticles();
-				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_SHOW_SKELETON))
-				{
-					if (curr_truck->m_skeletonview_is_active)
-						curr_truck->hideSkeleton();
-					else
-						curr_truck->showSkeleton(true);
-				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TRUCK_LIGHTS))
-				{
-					curr_truck->lightsToggle();
-				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TRUCK_BEACONS))
-				{
-					curr_truck->beaconsToggle();
-				}
-
-				//camera mode
-				if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_PRESSURE_LESS) && curr_truck)
-				{
-					if (pressure_pressed = curr_truck->addPressure(dt * -10.0))
+					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_DECELERATE_SIMULATION))
 					{
-						if (RoR::Application::GetOverlayWrapper())
-							RoR::Application::GetOverlayWrapper()->showPressureOverlay(true);
-#ifdef USE_OPENAL
-						SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_AIR);
-#endif // OPENAL
-					}
-				} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_PRESSURE_MORE))
-				{
-					if (pressure_pressed = curr_truck->addPressure(dt * 10.0))
-					{
-						if (RoR::Application::GetOverlayWrapper())
-							RoR::Application::GetOverlayWrapper()->showPressureOverlay(true);
-#ifdef USE_OPENAL
-						SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_AIR);
-#endif // OPENAL
-					}
-				} else if (pressure_pressed)
-				{
-#ifdef USE_OPENAL
-					SoundScriptManager::getSingleton().trigStop(curr_truck, SS_TRIG_AIR);
-#endif // OPENAL
-					pressure_pressed = false;
-					if (RoR::Application::GetOverlayWrapper())
-						RoR::Application::GetOverlayWrapper()->showPressureOverlay(false);
-				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESCUE_TRUCK, 0.5f) && !gEnv->network && curr_truck->driveable != AIRPLANE)
-				{
-					if (!BeamFactory::getSingleton().enterRescueTruck())
-					{
+						float simulation_speed = BeamFactory::getSingleton().getSimulationSpeed() * 0.997;
+						BeamFactory::getSingleton().setSimulationSpeed(simulation_speed);
 #ifdef USE_MYGUI
-						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("No rescue truck found!"), "warning.png");
-						RoR::Application::GetGuiManager()->PushNotification("Notice:", _L("No rescue truck found!"));
+						String ssmsg = _L("New simulation speed: ") + TOSTRING(Round(simulation_speed * 100.0f, 1)) + "%";
+						RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+						RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
+#endif //USE_MYGUI
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESET_SIMULATION_PACE, 0.5f))
+					{
+						float simulation_speed = BeamFactory::getSingleton().getSimulationSpeed();
+						if (simulation_speed != 1.0f)
+						{
+							mLastSimulationSpeed = simulation_speed;
+							BeamFactory::getSingleton().setSimulationSpeed(1.0f);
+#ifdef USE_MYGUI
+							UTFString ssmsg = _L("Simulation speed reset.");
+							RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+							RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
+#endif //USE_MYGUI
+						} else if (mLastSimulationSpeed != 1.0f)
+						{
+							BeamFactory::getSingleton().setSimulationSpeed(mLastSimulationSpeed);
+#ifdef USE_MYGUI
+							String ssmsg = _L("New simulation speed: ") + TOSTRING(Round(mLastSimulationSpeed * 100.0f, 1)) + "%";
+							RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+							RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
+#endif //USE_MYGUI
+						}
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TRUCK_REMOVE))
+					{
+						BeamFactory::getSingleton().removeCurrentTruck();
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ROPELOCK))
+					{
+						curr_truck->ropeToggle(-1);
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_LOCK))
+					{
+						curr_truck->hookToggle(-1, HOOK_TOGGLE, -1);
+						//SlideNodeLock
+						curr_truck->toggleSlideNodeLock();
+					}
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_AUTOLOCK))
+					{
+						//unlock all autolocks
+						curr_truck->hookToggle(-2, HOOK_UNLOCK, -1);
+					}
+					//strap
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_SECURE_LOAD))
+					{
+						curr_truck->tieToggle(-1);
+					}
+					
+					//replay mode
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_REPLAY_MODE))
+					{
+						StopRaceTimer();
+						curr_truck->setReplayMode(!curr_truck->replaymode);
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_CUSTOM_PARTICLES))
+					{
+						curr_truck->toggleCustomParticles();
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_SHOW_SKELETON))
+					{
+						if (curr_truck->m_skeletonview_is_active)
+							curr_truck->hideSkeleton();
+						else
+							curr_truck->showSkeleton(true);
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TRUCK_LIGHTS))
+					{
+						curr_truck->lightsToggle();
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TRUCK_BEACONS))
+					{
+						curr_truck->beaconsToggle();
+					}
+
+					//camera mode
+					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_PRESSURE_LESS) && curr_truck)
+					{
+						if (pressure_pressed = curr_truck->addPressure(dt * -10.0))
+						{
+							if (RoR::Application::GetOverlayWrapper())
+								RoR::Application::GetOverlayWrapper()->showPressureOverlay(true);
+#ifdef USE_OPENAL
+							SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_AIR);
+#endif // OPENAL
+						}
+					} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_PRESSURE_MORE))
+					{
+						if (pressure_pressed = curr_truck->addPressure(dt * 10.0))
+						{
+							if (RoR::Application::GetOverlayWrapper())
+								RoR::Application::GetOverlayWrapper()->showPressureOverlay(true);
+#ifdef USE_OPENAL
+							SoundScriptManager::getSingleton().trigStart(curr_truck, SS_TRIG_AIR);
+#endif // OPENAL
+						}
+					} else if (pressure_pressed)
+					{
+#ifdef USE_OPENAL
+						SoundScriptManager::getSingleton().trigStop(curr_truck, SS_TRIG_AIR);
+#endif // OPENAL
+						pressure_pressed = false;
+						if (RoR::Application::GetOverlayWrapper())
+							RoR::Application::GetOverlayWrapper()->showPressureOverlay(false);
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESCUE_TRUCK, 0.5f) && !gEnv->network && curr_truck->driveable != AIRPLANE)
+					{
+						if (!BeamFactory::getSingleton().enterRescueTruck())
+						{
+#ifdef USE_MYGUI
+							RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("No rescue truck found!"), "warning.png");
+							RoR::Application::GetGuiManager()->PushNotification("Notice:", _L("No rescue truck found!"));
 #endif // USE_MYGUI
+						}
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_LEFT))
+					{
+						if (curr_truck->getBlinkType() == BLINK_LEFT)
+							curr_truck->setBlinkType(BLINK_NONE);
+						else
+							curr_truck->setBlinkType(BLINK_LEFT);
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_RIGHT))
+					{
+						if (curr_truck->getBlinkType() == BLINK_RIGHT)
+							curr_truck->setBlinkType(BLINK_NONE);
+						else
+							curr_truck->setBlinkType(BLINK_RIGHT);
+					}
+
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_WARN))
+					{
+						if (curr_truck->getBlinkType() == BLINK_WARN)
+							curr_truck->setBlinkType(BLINK_NONE);
+						else
+							curr_truck->setBlinkType(BLINK_WARN);
 					}
 				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_LEFT))
-				{
-					if (curr_truck->getBlinkType() == BLINK_LEFT)
-						curr_truck->setBlinkType(BLINK_NONE);
-					else
-						curr_truck->setBlinkType(BLINK_LEFT);
-				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_RIGHT))
-				{
-					if (curr_truck->getBlinkType() == BLINK_RIGHT)
-						curr_truck->setBlinkType(BLINK_NONE);
-					else
-						curr_truck->setBlinkType(BLINK_RIGHT);
-				}
-
-				if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_WARN))
-				{
-					if (curr_truck->getBlinkType() == BLINK_WARN)
-						curr_truck->setBlinkType(BLINK_NONE);
-					else
-						curr_truck->setBlinkType(BLINK_WARN);
-				}
-
 			} // end of truck!=-1
 		}
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1253,7 +1253,10 @@ String Beam::getAxleLockName()
 
 void Beam::reset(bool keepPosition)
 {
-	reset_requested = keepPosition ? 2 : 1;
+	if (keepPosition)
+		m_reset_request = REQUEST_RESET_ON_SPOT;
+	else
+		m_reset_request = REQUEST_RESET_ON_INIT_POS;
 }
 
 void Beam::displace(Vector3 translation, float rotation)
@@ -1373,7 +1376,7 @@ void Beam::SyncReset()
 	for (int i=0; i<free_flexbody; i++) flexbodies[i]->reset();
 
 	// reset on spot with backspace
-	if (reset_requested > 1)
+	if (m_reset_request != REQUEST_RESET_ON_INIT_POS)
 	{
 		resetAngle(cur_rot);
 		resetPosition(cur_position.x, cur_position.z, false, yPos);
@@ -1389,12 +1392,12 @@ void Beam::SyncReset()
 
 	resetSlideNodes();
 
-	if (reset_requested != 2)
+	if (m_reset_request != REQUEST_RESET_ON_SPOT)
 	{
-		reset_requested = 0;
+		m_reset_request = REQUEST_RESET_NONE;
 	} else
 	{
-		reset_requested = 3;
+		m_reset_request = REQUEST_RESET_FINAL;
 	}
 }
 
@@ -1527,7 +1530,7 @@ bool Beam::frameStep(int steps)
 		{
 			if (!trucks[t]) continue;
 
-			if (trucks[t]->reset_requested)
+			if (trucks[t]->m_reset_request)
 			{
 				trucks[t]->SyncReset();
 			}
@@ -5762,6 +5765,7 @@ Beam::Beam(
 	, locked(0)
 	, lockedold(0)
 	, m_request_skeletonview_change(0)
+	, m_reset_request(REQUEST_RESET_NONE)
 	, m_skeletonview_is_active(false)
 	, m_spawn_rotation(0.0)
 	, mTimeUntilNextToggle(0)
@@ -5789,7 +5793,6 @@ Beam::Beam(
 	, replaymode(false)
 	, replaypos(0)
 	, requires_wheel_contact(false)
-	, reset_requested(0)
 	, reverselight(false)
 	, rightMirrorAngle(-0.52)
 	, rudder(0)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1268,7 +1268,7 @@ void Beam::displace(Vector3 translation, float rotation)
 		{
 			bb.merge(nodes[i].AbsPosition);
 		}
-		Vector3 center = boundingBox.getCenter();
+		Vector3 center = bb.getCenter();
 
 		Quaternion matrix = Quaternion(Radian(rotation), Vector3::UNIT_Y);
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1010,39 +1010,28 @@ int Beam::loadPosition(int indexPosition)
 
 void Beam::updateTruckPosition()
 {
-	// calculate average position (and smooth)
-	if (externalcameramode == 0)
+	// calculate average position (and smooth) !< smooth is sth. different
+
+	for (int n=0; n<free_node; n++)
 	{
-		// the classic approach: average over all nodes and beams
-		Vector3 aposition = Vector3::ZERO;
-		for (int n=0; n < free_node; n++)
-		{
-			nodes[n].smoothpos = nodes[n].AbsPosition;
-			aposition += nodes[n].smoothpos;
-		}
-		position = aposition / free_node;
-	} else if (externalcameramode == 1 && freecinecamera > 0)
+		nodes[n].smoothpos = nodes[n].AbsPosition;
+		nodes[n].RelPosition = nodes[n].AbsPosition - origin;
+	}
+
+	if (externalcameramode == 1 && freecinecamera > 0)
 	{
 		// the new (strange) approach: reuse the cinecam node
-		for (int n=0; n < free_node; n++)
-		{
-			nodes[n].smoothpos = nodes[n].AbsPosition;
-		}
 		position = nodes[cinecameranodepos[0]].AbsPosition;
 	} else if (externalcameramode == 2 && externalcameranode >= 0)
 	{
 		// the new (strange) approach #2: reuse a specified node
-		for (int n=0; n < free_node; n++)
-		{
-			nodes[n].smoothpos = nodes[n].AbsPosition;
-		}
 		position = nodes[externalcameranode].AbsPosition;
 	} else
 	{
+		// the classic approach: average over all nodes and beams
 		Vector3 aposition = Vector3::ZERO;
-		for (int n=0; n < free_node; n++)
+		for (int n=0; n<free_node; n++)
 		{
-			nodes[n].smoothpos = nodes[n].AbsPosition;
 			aposition += nodes[n].smoothpos;
 		}
 		position = aposition / free_node;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1338,10 +1338,10 @@ void Beam::SyncReset()
 	for (int i=0; i<free_flexbody; i++) flexbodies[i]->reset();
 
 	// reset on spot with backspace
-	if (reset_requested == 2)
+	if (reset_requested > 1)
 	{
 		resetAngle(cur_rot);
-		resetPosition(cur_position.x, cur_position.z, false, yPos + global_dt * 1.0f);
+		resetPosition(cur_position.x, cur_position.z, false, yPos);
 	}
 
 	// reset commands (self centering && push once/twice forced to terminate moving commands)
@@ -1353,7 +1353,14 @@ void Beam::SyncReset()
 	}
 
 	resetSlideNodes();
-	reset_requested = 0;
+
+	if (reset_requested != 2)
+	{
+		reset_requested = 0;
+	} else
+	{
+		reset_requested = 3;
+	}
 }
 
 //integration loop

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1256,6 +1256,41 @@ void Beam::reset(bool keepPosition)
 	reset_requested = keepPosition ? 2 : 1;
 }
 
+void Beam::displace(Vector3 translation, float rotation)
+{
+	if (rotation != 0.0f)
+	{
+		AxisAlignedBox bb(nodes[0].AbsPosition, nodes[0].AbsPosition);
+		for (int i=0; i<free_node; i++)
+		{
+			bb.merge(nodes[i].AbsPosition);
+		}
+		Vector3 center = boundingBox.getCenter();
+
+		Quaternion matrix = Quaternion(Radian(rotation), Vector3::UNIT_Y);
+
+		for (int i=0; i<free_node; i++)
+		{
+			nodes[i].AbsPosition -= center;
+			nodes[i].AbsPosition  = matrix * nodes[i].AbsPosition;
+			nodes[i].AbsPosition += center;
+		}
+	}
+
+	if (translation != Vector3::ZERO)
+	{
+		for (int i=0; i<free_node; i++)
+		{
+			nodes[i].AbsPosition += translation;
+		}
+	}
+
+	if (rotation != 0.0f || translation != Vector3::ZERO)
+	{
+		updateTruckPosition();
+	}
+}
+
 void Beam::SyncReset()
 {
 	hydrodirstate=0.0;

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -645,8 +645,16 @@ protected:
 	int mousenode;
 	Ogre::Vector3 mousepos;
 	float mousemoveforce;
-	int reset_requested;
 	float m_spawn_rotation;
+
+	enum ResetRequest {
+		REQUEST_RESET_NONE,
+		REQUEST_RESET_ON_INIT_POS,
+		REQUEST_RESET_ON_SPOT,
+		REQUEST_RESET_FINAL
+	};
+
+	ResetRequest m_reset_request;
 
 	std::vector<Ogre::String> m_truck_config;
 

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -96,11 +96,11 @@ public:
 	void desactivate();
 	bool addPressure(float v);
 	float getPressure();
-	Ogre::Vector3 getPosition();
 	void resetAngle(float rot);
 	void resetPosition(float px, float pz, bool setInitPosition, float miny);
 
-	Ogre::Vector3 getVehiclePosition();
+	float getRotation();
+	Ogre::Vector3 getPosition();
 
 
 	/**

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -116,6 +116,11 @@ public:
 	void reset(bool keepPosition = false); 
 
 	/**
+	* Call this one to displace a truck
+	*/
+	void displace(Ogre::Vector3 translation, float rotation); 
+
+	/**
 	* Spawns vehicle.
 	*/
 	bool LoadTruck(

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -451,7 +451,7 @@ void Beam::calcForcesEulerCompute(int doUpdate, Real dt, int step, int maxsteps)
 		tBoundingBox.getMinimum().y + tBoundingBox.getMaximum().y +
 		tBoundingBox.getMinimum().z + tBoundingBox.getMaximum().z, -1e9, 1e9))
 	{
-		reset_requested = 1; // truck exploded, schedule reset
+		m_reset_request = REQUEST_RESET_ON_INIT_POS; // truck exploded, schedule reset
 		return; // return early to avoid propagating invalid values
 	}
 
@@ -1449,7 +1449,7 @@ bool Beam::calcForcesEulerPrepare(int doUpdate, Ogre::Real dt, int step, int max
 	if (dt==0.0) return false;
 	if (state >= SLEEPING) return false;
 	if (deleting) return false;
-	if (reset_requested) return false;
+	if (m_reset_request) return false;
 
 	BES_START(BES_CORE_WholeTruckCalc);
 

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -316,7 +316,8 @@ void ScriptEngine::init()
 	result = engine->RegisterObjectMethod("BeamClass", "float getWheelSpeed()", AngelScript::asMETHOD(Beam,getWheelSpeed), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 	result = engine->RegisterObjectMethod("BeamClass", "vector3 getGForces()", AngelScript::asMETHOD(Beam,getGForces), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 
-	result = engine->RegisterObjectMethod("BeamClass", "vector3 getVehiclePosition()", AngelScript::asMETHOD(Beam,getVehiclePosition), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
+	result = engine->RegisterObjectMethod("BeamClass", "float getRotation()", AngelScript::asMETHOD(Beam,getRotation), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
+	result = engine->RegisterObjectMethod("BeamClass", "vector3 getVehiclePosition()", AngelScript::asMETHOD(Beam,getPosition), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 	result = engine->RegisterObjectMethod("BeamClass", "bool navigateTo(vector3 &in)", AngelScript::asMETHOD(Beam,navigateTo), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 
 	


### PR DESCRIPTION
You can now translate and rotate the truck while pressing (and holding) the repair truck key.

This implements @Speciesx awesome idea on how to improve the reset in place feature.

Controls:
* `TRUCK_ACCELERATE` -> translate upward
* `TRUCK_BRAKE` -> translate downward
* `TRUCK_STEER_LEFT` -> rotate left
* `TRUCK_STEER_RIGHT` -> rotate right
* `CHARACTER_FORWARD` -> translate forward
* `CHARACTER_BACKWARDS` -> translate backward
* `CHARACTER_SIDESTEP_RIGHT` -> translate right
* `CHARACTER_SIDESTEP_LEFT` -> translate left