### PR TITLE
[Feature] Overworked the cinematic camera

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -324,7 +324,11 @@ bool RoRFrameListener::updateEvents(float dt)
 	{
 		std::time_t t = std::time(nullptr);
 		std::stringstream date;
+#if defined(__GNUC__) && (__GNUC__ < 5)
+		date << std::asctime(std::localtime(&t));
+#else
 		date << std::put_time(std::localtime(&t), "%Y-%m-%d_%H-%M-%S");
+#endif
 
 		String fn_prefix = SSETTING("User Path", "") + String("screenshot_");
 		String fn_name = date.str() + String("_");

--- a/source/main/gfx/camera/CameraBehaviorStatic.cpp
+++ b/source/main/gfx/camera/CameraBehaviorStatic.cpp
@@ -21,38 +21,106 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <Ogre.h>
 
+#include "Application.h"
 #include "Beam.h"
 #include "Character.h"
 #include "IHeightFinder.h"
+#include "InputEngine.h"
 #include "TerrainManager.h"
 
 using namespace Ogre;
 
+CameraBehaviorStatic::CameraBehaviorStatic() :
+	camPosition(Vector3::ZERO)
+{
+	updateTimer.reset();
+}
+
+bool intersectsTerrain(Vector3 a, Vector3 b)
+{
+	int steps = std::max(10.0f, a.distance(b));
+	for (int i=0; i<steps; i++)
+	{
+		Vector3 pos = a + (b - a) * (float)i / steps;
+		float y = a.y + (b.y - a.y) * (float)i / steps;
+		float h = gEnv->terrainManager->getHeightFinder()->getHeightAt(pos.x, pos.z);
+		if (h > y)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 void CameraBehaviorStatic::update(const CameraManager::CameraContext &ctx)
 {
-	Vector3 lookAt(Vector3::ZERO);
-	Vector3 camPosition(Vector3::ZERO);
+	Vector3 lookAt   = Vector3::ZERO;
+	Vector3 velocity = Vector3::ZERO;
+	Radian angle     = Degree(90);
+	float rotation   = 0.0f;
+	float speed      = 0.0f;
 
 	if ( ctx.mCurrTruck )
 	{
-		lookAt = ctx.mCurrTruck->getPosition();
+		lookAt   = ctx.mCurrTruck->getPosition();
+		velocity = ctx.mCurrTruck->nodes[0].Velocity;
+		rotation = ctx.mCurrTruck->getRotation();
+		angle    = (lookAt - camPosition).angleBetween(velocity);
+		speed    = velocity.length();
 	} else
 	{
-		lookAt = gEnv->player->getPosition();
+		lookAt   = gEnv->player->getPosition();
+		rotation = gEnv->player->getRotation().valueRadians();
+		angle    = (lookAt - camPosition).angleBetween(velocity);
 	}
 
-	camPosition.x = ((int)(lookAt.x) / 100) * 100 + 50;
-	camPosition.z = ((int)(lookAt.z) / 100) * 100 + 50;
-	camPosition.y =        lookAt.y;
+	bool forceUpdate = RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_RESET, 2.0f);
+	forceUpdate = forceUpdate || (camPosition.distance(lookAt) > 200.0f && speed < 1.0f);
 
-	if ( gEnv->terrainManager && gEnv->terrainManager->getHeightFinder() )
-	{
-		float h = gEnv->terrainManager->getHeightFinder()->getHeightAt(camPosition.x, camPosition.z);
+	if ( forceUpdate || updateTimer.getMilliseconds() > 2000 )
+	{ 
+		float distance = camPosition.distance(lookAt);
+		bool terrainIntersection = intersectsTerrain(camPosition, lookAt + Vector3::UNIT_Y) || intersectsTerrain(camPosition, lookAt + velocity + Vector3::UNIT_Y);
 
-		camPosition.y = std::max(h, camPosition.y);
+		if ( forceUpdate || terrainIntersection || distance > std::max(75.0f, speed * 3.5f) || (distance > 25.0f && angle < Degree(30)) )
+		{
+			if ( speed < 0.1f )
+			{
+				velocity = Vector3(cos(rotation), 0.0f, sin(rotation));
+			}
+			speed = std::max(5.0f, speed);
+			camPosition = lookAt + velocity.normalisedCopy() * speed * 3.0f;
+			Vector3 offset = (velocity.crossProduct(Vector3::UNIT_Y)).normalisedCopy() * speed;
+			float r = (float)std::rand() / RAND_MAX;
+			if ( gEnv->terrainManager && gEnv->terrainManager->getHeightFinder() )
+			{
+				for (int i=0; i<100; i++)
+				{
+					r = (float)std::rand() / RAND_MAX;
+					Vector3 pos = camPosition + offset * (0.5f - r) * 2.0f;
+					float h = gEnv->terrainManager->getHeightFinder()->getHeightAt(pos.x, pos.z);
+					pos.y = std::max(h, pos.y);
+					if ( !intersectsTerrain(pos, lookAt + Vector3::UNIT_Y) )
+					{
+						camPosition = pos;
+						break;
+					}
+				}
+			}
+			camPosition += offset * (0.5f - r) * 2.0f;
+
+			if ( gEnv->terrainManager && gEnv->terrainManager->getHeightFinder() )
+			{
+				float h = gEnv->terrainManager->getHeightFinder()->getHeightAt(camPosition.x, camPosition.z);
+
+				camPosition.y = std::max(h, camPosition.y);
+			}
+
+			camPosition.y += 5.0f;
+
+			updateTimer.reset();
+		}
 	}
-
-	camPosition.y += 5.0f;
 	
 	float camDist = camPosition.distance(lookAt);
 	float fov = atan2(20.0f, camDist);

--- a/source/main/gfx/camera/CameraBehaviorStatic.h
+++ b/source/main/gfx/camera/CameraBehaviorStatic.h
@@ -27,9 +27,13 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "CameraManager.h"
 #include "IBehavior.h"
 
+#include <Ogre.h>
+
 class CameraBehaviorStatic : public IBehavior<CameraManager::CameraContext>
 {
 public:
+
+	CameraBehaviorStatic();
 
 	void update(const CameraManager::CameraContext &ctx);
 
@@ -46,6 +50,8 @@ public:
 protected:
 
 	Ogre::Radian fovPreviously;
+	Ogre::Vector3 camPosition;
+	Ogre::Timer updateTimer;
 };
 
 #endif // __CAMERA_BEHAVIOR_STATIC_H_


### PR DESCRIPTION
* Added a minimum update interval of two seconds
* Added line-of-sight checks (terrain only)
* Added truck movement prediction (for both new camera position and line-of-sight checks)
* Pressing `CAMERA_RESET` will initiate a camera position re-evaluation

Fixes: #403