### PR TITLE
[Bugfix] Fixes build errors with older GCC versions

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -324,7 +324,11 @@ bool RoRFrameListener::updateEvents(float dt)
 	{
 		std::time_t t = std::time(nullptr);
 		std::stringstream date;
+#if defined(__GNUC__) && (__GNUC__ < 5)
+		date << std::asctime(std::localtime(&t));
+#else
 		date << std::put_time(std::localtime(&t), "%Y-%m-%d_%H-%M-%S");
+#endif
 
 		String fn_prefix = SSETTING("User Path", "") + String("screenshot_");
 		String fn_name = date.str() + String("_");


### PR DESCRIPTION
The `std::asctime` output is less pretty, but good enough as fallback.