### PR TITLE
[Feature] Selectable orbit camera center

### DIFF
--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -219,6 +219,41 @@ void SceneMouse::update(float dt)
 
 bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id)
 {
+	if (Application::GetGuiManager()->GetPauseMenuVisible()) return true; //Stop everything when pause menu is visible
+
+	const OIS::MouseState ms = _arg.state;
+
+	if (ms.buttonDown(OIS::MB_Middle))
+	{
+		Beam *truck = BeamFactory::getSingleton().getCurrentTruck();
+
+		if (truck)
+		{
+			lastMouseY = ms.Y.abs;
+			lastMouseX = ms.X.abs;
+			Ray mouseRay = getMouseRay();
+
+			float nearest_distance = std::numeric_limits<float>::max();
+			float nearest_node_index = -1;
+
+			for (int i = 0; i < truck->free_node; i++)
+			{
+				std::pair<bool, Real> pair = mouseRay.intersects(Sphere(truck->nodes[i].smoothpos, 0.1f));
+				if (pair.first && pair.second < nearest_distance)
+				{
+					nearest_distance   = pair.second;
+					nearest_node_index = i;
+				}
+			}
+			truck->m_custom_camera_node = nearest_node_index;
+		}
+	}
+
+	if (gEnv->cameraManager)
+	{
+		gEnv->cameraManager->mousePressed(_arg, _id);
+	}
+
 	return true;
 }
 
@@ -229,6 +264,11 @@ bool SceneMouse::mouseReleased(const OIS::MouseEvent& _arg, OIS::MouseButtonID _
 	if (mouseGrabState == 1)
 	{
 		releaseMousePick();
+	}
+
+	if (gEnv->cameraManager)
+	{
+		gEnv->cameraManager->mouseReleased(_arg, _id);
 	}
 
 	return true;

--- a/source/main/gfx/camera/CameraBehaviorVehicle.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicle.cpp
@@ -19,8 +19,12 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "CameraBehaviorVehicle.h"
 
+#include <Ogre.h>
+
+#include "Application.h"
 #include "Beam.h"
 #include "BeamFactory.h"
+#include "InputEngine.h"
 #include "Settings.h"
 
 using namespace Ogre;
@@ -77,4 +81,26 @@ void CameraBehaviorVehicle::reset(const CameraManager::CameraContext &ctx)
 	camRotY = 0.35f;
 	camDistMin = std::min(ctx.mCurrTruck->getMinimalCameraRadius() * 2.0f, 33.0f);
 	camDist = camDistMin * 1.5f + 2.0f;
+}
+
+bool CameraBehaviorVehicle::mousePressed(const CameraManager::CameraContext &ctx, const OIS::MouseEvent& _arg, OIS::MouseButtonID _id)
+{
+	const OIS::MouseState ms = _arg.state;
+
+	if ( ms.buttonDown(OIS::MB_Middle) && RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) )
+	{
+		if ( ctx.mCurrTruck && ctx.mCurrTruck->m_custom_camera_node >= 0 )
+		{
+			Vector3 lookAt = ctx.mCurrTruck->nodes[ctx.mCurrTruck->m_custom_camera_node].smoothpos;
+			Vector3 old_direction = camLookAt - gEnv->mainCamera->getPosition();
+			Vector3 new_direction =    lookAt - gEnv->mainCamera->getPosition();
+			Quaternion rotation = old_direction.getRotationTo(new_direction);
+
+			camDist = 2.0f * gEnv->mainCamera->getPosition().distance(lookAt);
+			camRotX += rotation.getYaw();
+			camRotY += rotation.getPitch();
+		}
+	}
+
+	return false;
 }

--- a/source/main/gfx/camera/CameraBehaviorVehicle.h
+++ b/source/main/gfx/camera/CameraBehaviorVehicle.h
@@ -39,6 +39,8 @@ public:
 
 	bool switchBehavior(const CameraManager::CameraContext &ctx) { return true; };
 
+	bool mousePressed(const CameraManager::CameraContext &ctx, const OIS::MouseEvent& _arg, OIS::MouseButtonID _id);
+
 protected:
 
 	bool camPitching;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1039,7 +1039,10 @@ void Beam::updateTruckPosition()
 		nodes[n].RelPosition = nodes[n].AbsPosition - origin;
 	}
 
-	if (externalcameramode == 1 && freecinecamera > 0)
+	if (m_custom_camera_node >= 0)
+	{
+		position = nodes[m_custom_camera_node].AbsPosition;
+	} else if (externalcameramode == 1 && freecinecamera > 0)
 	{
 		// the new (strange) approach: reuse the cinecam node
 		position = nodes[cinecameranodepos[0]].AbsPosition;
@@ -5764,6 +5767,7 @@ Beam::Beam(
 	, lights(1)
 	, locked(0)
 	, lockedold(0)
+	, m_custom_camera_node(-1)
 	, m_request_skeletonview_change(0)
 	, m_reset_request(REQUEST_RESET_NONE)
 	, m_skeletonview_is_active(false)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -397,6 +397,7 @@ public:
 	bool disableTruckTruckCollisions;
 	bool disableTruckTruckSelfCollisions;
 	int currentcamera;
+	int m_custom_camera_node;
 	
 	int first_wheel_node;
 	int netbuffersize;


### PR DESCRIPTION
You can now choose any node as orbit camera center by clicking on it with the middle mouse button.

Holding `LSHIFT` while clicking will keep your current camera position, otherwise you keep your relative angle to the orbit center.

If you want to disable the custom orbit center just click anywhere with the middle mouse button.

Fixes: #712