### PR TITLE
[Bugfix] Finish flexbody update before displacing a truck

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -604,6 +604,7 @@ bool RoRFrameListener::updateEvents(float dt)
 						float scale = RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LMENU)  ? 0.1f : 1.0f;
 						scale      *= RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) ? 3.0f : 1.0f;
 
+						curr_truck->updateFlexbodiesFinal();
 						curr_truck->displace(translation * scale, rotation * std::max(1.0f, scale));
 					}
 


### PR DESCRIPTION
Fixes the flexbody artefacts during advanced reset in place