### PR TITLE
[Codechange] Changed the advanced repair toggle behavior

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -553,7 +553,6 @@ bool RoRFrameListener::updateEvents(float dt)
 					if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
 					{
 						m_advanced_truck_repair = m_advanced_truck_repair_timer > 1.0f;
-						m_advanced_truck_repair_timer += dt;
 					} else
 					{
 						m_advanced_truck_repair_timer = 0.0f;
@@ -605,6 +604,11 @@ bool RoRFrameListener::updateEvents(float dt)
 						scale      *= RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) ? 3.0f : 1.0f;
 
 						curr_truck->displace(translation * scale, rotation * std::max(1.0f, scale));
+
+						m_advanced_truck_repair_timer = 0.0f;
+					} else
+					{
+						m_advanced_truck_repair_timer += dt;
 					}
 
 					curr_truck->reset(true);


### PR DESCRIPTION
Advanced repair will only be toggled on when you hold 'Backspace' without translating or rotating the truck for 1 seconds