### PR TITLE
[Codechange] Hiding the GUI will also hide the notice messages

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1781,14 +1781,14 @@ void RoRFrameListener::pauseSim(bool value)
 	}
 }
 
-void RoRFrameListener::hideGUI(bool visible)
+void RoRFrameListener::hideGUI(bool hidden)
 {
 #ifdef USE_MYGUI
 	Beam *curr_truck = BeamFactory::getSingleton().getCurrentTruck();
 	//Console *c = RoR::Application::GetConsole();
 	//if (c) c->setVisible(!visible);
 
-	if (visible)
+	if (hidden)
 	{
 		if (RoR::Application::GetOverlayWrapper()) RoR::Application::GetOverlayWrapper()->showDashboardOverlays(false, curr_truck);
 		if (RoR::Application::GetOverlayWrapper()) RoR::Application::GetOverlayWrapper()->truckhud->show(false);
@@ -1809,6 +1809,7 @@ void RoRFrameListener::hideGUI(bool visible)
 		if (gEnv->network) GUI_Multiplayer::getSingleton().setVisible(true);
 #endif // USE_SOCKETW
 	}
+	Application::GetGuiManager()->hideGUI(hidden);
 #endif // USE_MYGUI
 }
 
@@ -1817,7 +1818,6 @@ void RoRFrameListener::setNetPointToUID(int uid)
 	// TODO: setup arrow
 	netPointToUID = uid;
 }
-
 
 void RoRFrameListener::checkRemoteStreamResultsChanged()
 {

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -123,7 +123,7 @@ public: // public methods
 	int getNetPointToUID() { return netPointToUID; }
 
 	void checkRemoteStreamResultsChanged();
-	void hideGUI(bool visible);
+	void hideGUI(bool hidden);
 	void hideMap();
 	void InitTrucks(
         bool loadmanual, 

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -503,3 +503,17 @@ void GUIManager::ToggleVehicleDescription()
 	else
 		HideVehicleDescription();
 }
+
+void GUIManager::hideGUI(bool hidden)
+{
+	if (m_gui_SimUtils)
+	{
+		if (hidden)
+		{
+			m_gui_SimUtils->HideNotification();
+			m_gui_SimUtils->HideFPSBox();
+			m_gui_SimUtils->HideTruckInfoBox();
+		}
+		m_gui_SimUtils->DisableNotifications(hidden);
+	}
+}

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -112,6 +112,8 @@ public:
 	void HideVehicleDescription();
 	void ToggleVehicleDescription();
 
+	void hideGUI(bool visible);
+
 	virtual void UnfocusGui();
 
 	virtual void AddRigLoadingReport(std::string const & vehicle_name, std::string const & text, int num_errors, int num_warnings, int num_other);

--- a/source/main/gui/panels/GUI_SimUtils.cpp
+++ b/source/main/gui/panels/GUI_SimUtils.cpp
@@ -77,6 +77,8 @@ CLASS::CLASS()
 
 	alpha = 1.0f;
 
+	m_notifications_disabled = false;
+
 	ShowMain(); //It's invisible and unclickable, so no worrys
 }
 
@@ -103,15 +105,28 @@ void CLASS::ToggleFPSBox()
 	m_fpscounter_box->setVisible(b_fpsbox);
 }
 
+void CLASS::HideFPSBox()
+{
+	if (b_fpsbox)
+		ToggleFPSBox();
+}
+
 void CLASS::ToggleTruckInfoBox()
 {
 	b_truckinfo = !b_truckinfo;
 	m_truckinfo_box->setVisible(b_truckinfo);
 }
 
+void CLASS::HideTruckInfoBox()
+{
+	if (b_truckinfo)
+		ToggleTruckInfoBox();
+}
+
 void CLASS::PushNotification(Ogre::String Title, Ogre::String text)
 {
 	if (!MAIN_WIDGET->getVisible()) return;
+	if (m_notifications_disabled) return;
 
 	m_not_title->setCaption(Title);
 	m_not_text->setCaption(text);
@@ -122,6 +137,11 @@ void CLASS::PushNotification(Ogre::String Title, Ogre::String text)
 void CLASS::HideNotification()
 {
 	m_notification->setVisible(false);
+}
+
+void CLASS::DisableNotifications(bool disabled)
+{
+	m_notifications_disabled = disabled;
 }
 
 void CLASS::framestep(float dt)

--- a/source/main/gui/panels/GUI_SimUtils.h
+++ b/source/main/gui/panels/GUI_SimUtils.h
@@ -56,13 +56,18 @@ public:
 	void HideMain();
 	
 	void ToggleFPSBox();
+	void HideFPSBox();
+
 	void ToggleTruckInfoBox();
+	void HideTruckInfoBox();
 
 	void UpdateStats(float dt, Beam *truck); //different from Framestep!
 	void framestep(float dt);
 
 	void PushNotification(Ogre::String Title, Ogre::String text);
 	void HideNotification();
+
+	void DisableNotifications(bool disabled);
 	
 private:
 	bool b_fpsbox;
@@ -93,6 +98,7 @@ private:
 	// logic
 	float alpha;
 	long pushTime;
+	bool m_notifications_disabled;
 };
 
 } // namespace GUI


### PR DESCRIPTION
The `COMMON_HIDE_GUI` event now hides:

* The current and all upcoming notice messages
* The fps box (if visible)
* The truck info box (if visible)
* The truck hud

Fixes: #240