### PR TITLE
[Codechange] Rounding the truck rotation is no longer needed

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -604,7 +604,7 @@ bool RoRFrameListener::updateEvents(float dt)
 						scale      *= RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) ? 3.0f : 1.0f;
 
 						curr_truck->updateFlexbodiesFinal();
-						curr_truck->displace(translation * scale, rotation * std::max(1.0f, scale));
+						curr_truck->displace(translation * scale, rotation * scale);
 
 						m_advanced_truck_repair_timer = 0.0f;
 					} else

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -74,7 +74,6 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "ThreadPool.h"
 #include "TurboJet.h"
 #include "TurboProp.h"
-#include "Utils.h"
 #include "Water.h"
 #include "GUIManager.h"
 
@@ -1312,7 +1311,7 @@ void Beam::SyncReset()
 	float yPos = nodes[lowestcontactingnode].AbsPosition.y;
 
 	Vector3 cur_position = nodes[0].AbsPosition;
-	float cur_rot = Round(getRotation(), 2);
+	float cur_rot = getRotation();
 	if (engine) engine->start();
 	for (int i=0; i<free_node; i++)
 	{


### PR DESCRIPTION
This also fixes the advanced repair rotation on big vehicles (and on slow rotations).

Rounding is no longer needed since the reset-in-place revamp: https://github.com/RigsOfRods/rigs-of-rods/pull/703