### PR TITLE
[Cleanup] Remove redundant ColoredTextAreaOverlayElementFactory

### DIFF
--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -174,9 +174,6 @@ bool ContentManager::init(void)
 	// by default, display everything in the depth map
 	Ogre::MovableObject::setDefaultVisibilityFlags(DEPTHMAP_ENABLED);
 
-	ColoredTextAreaOverlayElementFactory *cef = new ColoredTextAreaOverlayElementFactory();
-	OverlayManager::getSingleton().addOverlayElementFactory(cef);
-
 #ifdef USE_MYGUI
 	AddResourcePack(ResourcePack::MYGUI);
 	AddResourcePack(ResourcePack::DASHBOARDS);


### PR DESCRIPTION
Already created and registered at https://github.com/mikadou/rigs-of-rods/blob/23a8968ff946b1b1a707a925f4be714770190db5/source/main/resources/ContentManager.cpp#L234