### PR TITLE
[Codechange] 'Jitter' free slow motion capable orbit camera

### DIFF
--- a/source/main/gfx/camera/CameraBehaviorVehicle.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicle.cpp
@@ -52,7 +52,14 @@ void CameraBehaviorVehicle::update(const CameraManager::CameraContext &ctx)
 		targetPitch = -asin(dir.dotProduct(Vector3::UNIT_Y));
 	}
 
-	camRatio = 1.0f / (ctx.mDt * 4.0f);
+	float dt = ctx.mDt;
+
+	if ( BeamFactory::getSingleton().getThreadingMode() == THREAD_MULTI )
+		dt = ctx.mCurrTruck->oldframe_global_dt / ctx.mCurrTruck->oldframe_global_simulation_speed;
+	else
+		dt = ctx.mCurrTruck->global_dt / ctx.mCurrTruck->global_simulation_speed;
+
+	camRatio = 1.0f / (dt * 4.0f);
 
 	camDistMin = std::min(ctx.mCurrTruck->getMinimalCameraRadius() * 2.0f, 33.0f);
 

--- a/source/main/gfx/camera/CameraBehaviorVehicle.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicle.cpp
@@ -106,17 +106,16 @@ bool CameraBehaviorVehicle::mousePressed(const CameraManager::CameraContext &ctx
 
 			// Corner case handling
 			Radian angle = dir.angleBetween(camDir);
-			if (angle > Radian(Math::HALF_PI))
+			if ( angle > Radian(Math::HALF_PI) )
 			{
-				if (std::abs(Radian(camRotX).valueRadians()) < Math::HALF_PI)
+				if ( std::abs(Radian(camRotX).valueRadians()) < Math::HALF_PI )
 				{
-					if (camRotX < Radian(0.0f))
+					if ( camRotX < Radian(0.0f) )
 						camRotX -= Radian(Math::HALF_PI);
 					else
 						camRotX += Radian(Math::HALF_PI);
 				}
 			}
-
 		}
 	}
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1536,7 +1536,9 @@ bool Beam::frameStep(int steps)
 		}
 		
 		oldframe_global_dt = global_dt;
+		oldframe_global_simulation_speed = global_simulation_speed;
 		global_dt = dt;
+		global_simulation_speed = BeamFactory::getSingleton().getSimulationSpeed();
 
 		ffforce = affforce / steps;
 		ffhydro = affhydro / steps;
@@ -5826,10 +5828,12 @@ Beam::Beam(
 	, stabratio(0.0)
 	, stabsleep(0.0)
 	, global_dt(0.1)
+	, global_simulation_speed(1.0)
 	, thread_task(THREAD_BEAMFORCESEULER)
 	, totalmass(0)
 	, tsteps(100)
 	, oldframe_global_dt(0.1)
+	, oldframe_global_simulation_speed(1.0)
 	, watercontact(false)
 	, watercontactold(false)
 {

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -465,7 +465,9 @@ public:
 	void preMapLabelRenderUpdate(bool mode, float cheight=0);
 	
 	float global_dt;
+	float global_simulation_speed;
 	float oldframe_global_dt;
+	float oldframe_global_simulation_speed;
 	bool simulated;
 	int airbrakeval;
 	Ogre::Vector3 cameranodeacc;


### PR DESCRIPTION
This re-implements the old "anti-jitter" `dt` calculation while maintaining a smooth orbit camera rotation when the simulation speed is changed.

Reverts this: RigsOfRods@059c8c9

Fixes: #734