### PR TITLE
[Bugfix] Fixed up the truck spawning code

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1276,7 +1276,6 @@ void RoRFrameListener::hideMap()
 #endif //USE_MYGUI
 }
 
-
 void RoRFrameListener::InitTrucks(
     bool loadmanual, 
     std::string const & selected, 
@@ -1325,8 +1324,6 @@ void RoRFrameListener::InitTrucks(
 			b->engine->start();
 		}
 	}
-	
-	gEnv->terrainManager->loadPreloadedTrucks();
 
 	LOG("EFL: beam instanciated");
 
@@ -1343,22 +1340,8 @@ void RoRFrameListener::InitTrucks(
 		BeamFactory::getSingleton().setCurrentTruck(-1);
 	}
 
-	loading_state = ALL_LOADED;
-
-	if (ISETTING("OutGauge Mode", 0) > 0)
-	{
-		new OutProtocol();
-	}
-
 	LOG("initTrucks done");
-
-#ifdef USE_MYGUI
-	RoR::Application::GetGuiManager()->UnfocusGui();
-#endif //USE_MYGUI
 }
-
-
-
 
 bool RoRFrameListener::updateTruckMirrors(float dt)
 {

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -37,8 +37,6 @@ public:
 
 	ChatSystem *netChat;
 
-	bool freeTruckPosition; // Used for initial truck loading
-
 	float netcheckGUITimer;
 
 	int loading_state;

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -124,16 +124,6 @@ public: // public methods
 
 	void checkRemoteStreamResultsChanged();
 	void hideGUI(bool hidden);
-	void hideMap();
-	void InitTrucks(
-        bool loadmanual, 
-        std::string const & selected, 
-        int cache_entry_number = -1,
-        std::string const & selectedExtension = "",
-        const std::vector<Ogre::String> *truckconfig = nullptr,
-        bool enterTruck = false,
-        Skin *skin = nullptr
-        );
 
 	void netDisconnectTruck(int number);
 	void pauseSim(bool value);

--- a/source/main/gui/GUIMenu.cpp
+++ b/source/main/gui/GUIMenu.cpp
@@ -338,7 +338,6 @@ void GUI_MainMenu::onMenuBtn(MyGUI::MenuCtrlPtr _sender, MyGUI::MenuItemPtr _ite
 		// get out first
 		if (BeamFactory::getSingleton().getCurrentTruckNumber() != -1) BeamFactory::getSingleton().setCurrentTruck(-1);
 		gEnv->frameListener->reload_pos = gEnv->player->getPosition();
-		gEnv->frameListener->freeTruckPosition = true;
 		gEnv->frameListener->loading_state = RELOADING;
 		Application::GetGuiManager()->getMainSelector()->Show(LT_AllBeam);
 

--- a/source/main/main_sim/MainThread.cpp
+++ b/source/main/main_sim/MainThread.cpp
@@ -870,6 +870,13 @@ bool MainThread::SetupGameplayLoop(bool enable_network, Ogre::String preselected
 		gEnv->frameListener->InitTrucks(false, map_file_name, -1, "", 0, false, selected_skin);
 	}
 
+	gEnv->terrainManager->loadPreloadedTrucks();
+
+	if (ISETTING("OutGauge Mode", 0) > 0)
+	{
+		new OutProtocol();
+	}
+
 	if (BSETTING("MainMenuMusic", true))
 		SoundScriptManager::getSingleton().trigKill(-1, SS_TRIG_MAIN_MENU);
 		//SoundScriptManager::getSingleton().modulate(nullptr, SS_MOD_MUSIC_VOLUME, 0);

--- a/source/main/main_sim/MainThread.cpp
+++ b/source/main/main_sim/MainThread.cpp
@@ -869,20 +869,6 @@ bool MainThread::SetupGameplayLoop(bool enable_network, Ogre::String preselected
 		Skin* selected_skin = RoR::Application::GetGuiManager()->getMainSelector()->GetSelectedSkin();
 		gEnv->frameListener->InitTrucks(false, map_file_name, -1, "", 0, false, selected_skin);
 	}
-	else
-	{
-		// show truck selector
-		if (gEnv->terrainManager->getWater())
-		{
-			ShowSurveyMap(false);
-			RoR::Application::GetGuiManager()->getMainSelector()->Show(LT_NetworkWithBoat);
-		} 
-		else
-		{
-			ShowSurveyMap(false);
-			RoR::Application::GetGuiManager()->getMainSelector()->Show(LT_Network);
-		}
-	}
 
 	if (BSETTING("MainMenuMusic", true))
 		SoundScriptManager::getSingleton().trigKill(-1, SS_TRIG_MAIN_MENU);

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -6183,11 +6183,23 @@ bool Beam::LoadTruck(
 		RigSpawner::RecalculateBoundingBoxes(this);
 		vehicle_position.x -= (boundingBox.getMaximum().x + boundingBox.getMinimum().x) / 2.0 - vehicle_position.x;
 		vehicle_position.z -= (boundingBox.getMaximum().z + boundingBox.getMinimum().z) / 2.0 - vehicle_position.z;
-		
+
+		float miny = 0.0f;
+
+		if (!preloaded_with_terrain)
+		{
+			miny = vehicle_position.y;
+		}
+
+		if (spawn_box != nullptr)
+		{
+			miny = spawn_box->relo.y + spawn_box->center.y;
+		}
+
 		if (freePositioned)
-			resetPosition(vehicle_position.x, vehicle_position.z, true, vehicle_position.y);
+			resetPosition(vehicle_position, true);
 		else
-			resetPosition(vehicle_position.x, vehicle_position.z, true, 0.0f);
+			resetPosition(vehicle_position.x, vehicle_position.z, true, miny);
 
 		if (spawn_box != nullptr)
 		{
@@ -6198,7 +6210,6 @@ bool Beam::LoadTruck(
 
 			if (!inside)
 			{
-				float miny = spawn_box->relo.y + spawn_box->center.y + 0.01f;
 				Vector3 gpos = Vector3(vehicle_position.x, 0.0f, vehicle_position.z);
 
 				gpos -= spawn_rotation * Vector3((spawn_box->hi.x - spawn_box->lo.x + boundingBox.getMaximum().x - boundingBox.getMinimum().x) * 0.6f, 0.0f, 0.0f);


### PR DESCRIPTION
* Fixes the position of all kinds of pre-spawned trucks

* Fixes the position of trucks spawned in spawnboxes

* Fixes the position of trucks spawned on mesh terrains

Side-effect: Terrains without pre-spawned trucks won't automatically open a vehicle selector.

Plays nicely with: #752