### PR TITLE
[Feature] collcabrate calculation based on collision velocity

### DIFF
--- a/source/main/datatypes/rig_t.h
+++ b/source/main/datatypes/rig_t.h
@@ -100,7 +100,6 @@ struct rig_t
 	int free_sub;
 
 	int collcabs[MAX_CABS];
-	int collcabstype[MAX_CABS];
 	collcab_rate_t inter_collcabrate[MAX_CABS];
 	collcab_rate_t intra_collcabrate[MAX_CABS];
 	int free_collcab;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2588,19 +2588,28 @@ void Beam::interTruckCollisions(Real dt)
 
 	for (int i=0; i<free_collcab; i++)
 	{
+		int tmpv = collcabs[i]*3;
+		no = &nodes[cabs[tmpv]];
+		na = &nodes[cabs[tmpv+1]];
+		nb = &nodes[cabs[tmpv+2]];
+
+		// upper bound of the relative collision velocity
+		float vdiff = interPointCD->max_contacter_speed + no->Velocity.length();
+		if (vdiff > 0.0f)
+		{
+			// upper bound of the amount of physics cycles which can be skipped
+			int skip_rate = floor(collrange / (vdiff * PHYSICS_DT));
+			inter_collcabrate[i].rate = std::min(skip_rate - inter_collcabrate[i].distance, inter_collcabrate[i].rate);
+		}
+
 		if (inter_collcabrate[i].rate > 0)
 		{
 			inter_collcabrate[i].distance++;
 			inter_collcabrate[i].rate--;
 			continue;
 		}
-		inter_collcabrate[i].rate = std::min(inter_collcabrate[i].distance, 12);
+		inter_collcabrate[i].rate = std::min(inter_collcabrate[i].distance, 80);
 		inter_collcabrate[i].distance = 0;
-
-		int tmpv = collcabs[i]*3;
-		no = &nodes[cabs[tmpv]];
-		na = &nodes[cabs[tmpv+1]];
-		nb = &nodes[cabs[tmpv+2]];
 
 		interPointCD->query(no->AbsPosition
 			, na->AbsPosition
@@ -2740,19 +2749,29 @@ void Beam::intraTruckCollisions(Real dt)
 
 	for (int i=0; i<free_collcab; i++)
 	{
+		int tmpv = collcabs[i]*3;
+		no = &nodes[cabs[tmpv]];
+		na = &nodes[cabs[tmpv+1]];
+		nb = &nodes[cabs[tmpv+2]];
+
+		// upper bound of the relative collision velocity
+		float vdiff = intraPointCD->max_contacter_speed + (no->Velocity - nodes[0].Velocity).length();
+		if (vdiff > 0.0f)
+		{
+			// upper bound of the amount of physics cycles which can be skipped
+			int skip_rate = floor(collrange / (vdiff * PHYSICS_DT));
+			intra_collcabrate[i].rate = std::min(skip_rate - intra_collcabrate[i].distance, intra_collcabrate[i].rate);
+		}
+
 		if (intra_collcabrate[i].rate > 0)
 		{
 			intra_collcabrate[i].distance++;
 			intra_collcabrate[i].rate--;
 			continue;
 		}
-		intra_collcabrate[i].rate = std::min(intra_collcabrate[i].distance, 12);
-		intra_collcabrate[i].distance = 0;
 
-		int tmpv = collcabs[i]*3;
-		no = &nodes[cabs[tmpv]];
-		na = &nodes[cabs[tmpv+1]];
-		nb = &nodes[cabs[tmpv+2]];
+		intra_collcabrate[i].rate = std::min(intra_collcabrate[i].distance, 80);
+		intra_collcabrate[i].distance = 0;
 
 		intraPointCD->query(no->AbsPosition
 			, na->AbsPosition

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -504,11 +504,6 @@ float Beam::getRotation()
 	return atan2(cur_dir.dotProduct(Vector3::UNIT_X), cur_dir.dotProduct(-Vector3::UNIT_Z));
 }
 
-Vector3 Beam::getPosition()
-{
-	return position; //the position is already in absolute position
-}
-
 void Beam::CreateSimpleSkeletonMaterial()
 {
 	if (MaterialManager::getSingleton().resourceExists("vehicle-skeletonview-material"))
@@ -1063,6 +1058,18 @@ void Beam::updateTruckPosition()
 	}
 }
 
+void Beam::updateTruckVelocity()
+{
+	// calculate average velocity
+
+	Vector3 avelocity = Vector3::ZERO;
+	for (int n=0; n<free_node; n++)
+	{
+		avelocity += nodes[n].Velocity;
+	}
+	velocity = avelocity / free_node;
+}
+
 void Beam::resetAngle(float rot)
 {
 	// Set origin of rotation to camera node
@@ -1577,6 +1584,7 @@ bool Beam::frameStep(int steps)
 				trucks[t]->lastlastposition = trucks[t]->lastposition;
 				trucks[t]->lastposition = trucks[t]->position;
 				trucks[t]->updateTruckPosition();
+				trucks[t]->updateTruckVelocity();
 			}
 			if (trucks[t]->nodes[0].RelPosition.squaredLength() > 10000.0)
 			{
@@ -2748,7 +2756,7 @@ void Beam::intraTruckCollisions(Real dt)
 		nb = &nodes[cabs[tmpv+2]];
 
 		// upper bound of the relative collision velocity
-		float vdiff = intraPointCD->max_contacter_speed + (no->Velocity - nodes[0].Velocity).length();
+		float vdiff = intraPointCD->max_contacter_speed + (no->Velocity - this->velocity).length();
 		if (vdiff == 0.0f) continue;
 		// upper bound of the amount of physics cycles which can be skipped
 		int max_rate = floor(collrange / (vdiff * PHYSICS_DT));
@@ -5825,6 +5833,7 @@ Beam::Beam(
 	, tsteps(100)
 	, oldframe_global_dt(0.1)
 	, oldframe_global_simulation_speed(1.0)
+	, velocity(Vector3::ZERO)
 	, watercontact(false)
 	, watercontactold(false)
 {

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2581,10 +2581,6 @@ void Beam::interTruckCollisions(Real dt)
 
 	interPointCD->update(this, trucks, numtrucks);
 	if (!collisionRelevant) return;
-	//If you change any of the below "ifs" concerning trucks then you should
-	//also consider changing the parallel "ifs" inside PointColDetector
-	//see "pointCD" above.
-	//Performance some times forces ugly architectural designs....
 
 	for (int i=0; i<free_collcab; i++)
 	{

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2706,10 +2706,9 @@ void Beam::interTruckCollisions(Real dt)
 				float fl = (vi + trfnormal - pfnormal) * 0.5f;
 
 				forcevec = Vector3::ZERO;
-				float nso;
 
 				//Calculate the collision forces
-				gEnv->collisions->primitiveCollision(hitnode, forcevec, vecrelVel, plnormal, ((float) dt), submesh_ground_model, &nso, penetration, fl);
+				gEnv->collisions->primitiveCollision(hitnode, forcevec, vecrelVel, plnormal, dt, submesh_ground_model, 0, penetration, fl);
 
 				hitnode->Forces += forcevec;
 
@@ -2842,10 +2841,9 @@ void Beam::intraTruckCollisions(Real dt)
 				float fl = (vi + trfnormal - pfnormal) * 0.5f;
 
 				forcevec = Vector3::ZERO;
-				float nso;
 
 				//Calculate the collision forces
-				gEnv->collisions->primitiveCollision(hitnode, forcevec, vecrelVel, plnormal, ((float) dt), submesh_ground_model, &nso, penetration, fl);
+				gEnv->collisions->primitiveCollision(hitnode, forcevec, vecrelVel, plnormal, dt, submesh_ground_model, 0, penetration, fl);
 
 				hitnode->Forces += forcevec;
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2591,12 +2591,10 @@ void Beam::interTruckCollisions(Real dt)
 
 		// upper bound of the relative collision velocity
 		float vdiff = interPointCD->max_contacter_speed + no->Velocity.length();
-		if (vdiff > 0.0f)
-		{
-			// upper bound of the amount of physics cycles which can be skipped
-			int skip_rate = floor(collrange / (vdiff * PHYSICS_DT));
-			inter_collcabrate[i].rate = std::min(skip_rate - inter_collcabrate[i].distance, inter_collcabrate[i].rate);
-		}
+		if (vdiff == 0.0f) continue;
+		// upper bound of the amount of physics cycles which can be skipped
+		int max_rate = floor(collrange / (vdiff * PHYSICS_DT));
+		inter_collcabrate[i].rate = std::min(max_rate - inter_collcabrate[i].distance, inter_collcabrate[i].rate);
 
 		if (inter_collcabrate[i].rate > 0)
 		{
@@ -2604,7 +2602,7 @@ void Beam::interTruckCollisions(Real dt)
 			inter_collcabrate[i].rate--;
 			continue;
 		}
-		inter_collcabrate[i].rate = std::min(inter_collcabrate[i].distance, 80);
+		inter_collcabrate[i].rate = std::min(inter_collcabrate[i].distance, max_rate);
 		inter_collcabrate[i].distance = 0;
 
 		interPointCD->query(no->AbsPosition
@@ -2752,12 +2750,10 @@ void Beam::intraTruckCollisions(Real dt)
 
 		// upper bound of the relative collision velocity
 		float vdiff = intraPointCD->max_contacter_speed + (no->Velocity - nodes[0].Velocity).length();
-		if (vdiff > 0.0f)
-		{
-			// upper bound of the amount of physics cycles which can be skipped
-			int skip_rate = floor(collrange / (vdiff * PHYSICS_DT));
-			intra_collcabrate[i].rate = std::min(skip_rate - intra_collcabrate[i].distance, intra_collcabrate[i].rate);
-		}
+		if (vdiff == 0.0f) continue;
+		// upper bound of the amount of physics cycles which can be skipped
+		int max_rate = floor(collrange / (vdiff * PHYSICS_DT));
+		intra_collcabrate[i].rate = std::min(max_rate - intra_collcabrate[i].distance, intra_collcabrate[i].rate);
 
 		if (intra_collcabrate[i].rate > 0)
 		{
@@ -2766,7 +2762,7 @@ void Beam::intraTruckCollisions(Real dt)
 			continue;
 		}
 
-		intra_collcabrate[i].rate = std::min(intra_collcabrate[i].distance, 80);
+		intra_collcabrate[i].rate = std::min(intra_collcabrate[i].distance, max_rate);
 		intra_collcabrate[i].distance = 0;
 
 		intraPointCD->query(no->AbsPosition

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -100,8 +100,8 @@ public:
 	void resetPosition(float px, float pz, bool setInitPosition, float miny);
 
 	float getRotation();
-	Ogre::Vector3 getPosition();
-
+	Ogre::Vector3 getPosition() { return position; };
+	Ogre::Vector3 getVelocity() { return velocity; };
 
 	/**
 	* Moves vehicle.
@@ -206,6 +206,7 @@ public:
 	int savePosition(int position);
 	int loadPosition(int position);
 	void updateTruckPosition();
+	void updateTruckVelocity();
 
 	/**
 	* Ground.
@@ -603,6 +604,7 @@ protected:
 
 	void updateDashBoards(float &dt);
 	
+	Ogre::Vector3 velocity;
 	Ogre::Vector3 position;
 	Ogre::Vector3 iPosition; // initial position
 	Ogre::Vector3 lastposition;

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -50,7 +50,7 @@ void PointColDetector::update(Beam* truck) {
 		max_contacter_speed = 0.0f;
 		contacters_size += truck->free_contacter;
 		for (int i = 0; i < truck->free_contacter; ++i) {
-			max_contacter_speed = std::max(max_contacter_speed, (truck->nodes[truck->contacters[i].nodeid].Velocity - truck->nodes[0].Velocity).squaredLength());
+			max_contacter_speed = std::max(max_contacter_speed, (truck->nodes[truck->contacters[i].nodeid].Velocity - truck->getVelocity()).squaredLength());
 		}
 		max_contacter_speed = std::sqrt(max_contacter_speed);
 	} else {
@@ -82,7 +82,7 @@ void PointColDetector::update(Beam* truck, Beam** trucks, const int numtrucks) {
 				truck->collisionRelevant = true;
 				contacters_size += trucks[t]->free_contacter;
 				for (int i = 0; i < trucks[t]->free_contacter; ++i) {
-					Vector3 relative_contacter_speed = trucks[t]->nodes[trucks[t]->contacters[i].nodeid].Velocity - truck->nodes[0].Velocity;
+					Vector3 relative_contacter_speed = trucks[t]->nodes[trucks[t]->contacters[i].nodeid].Velocity - truck->getVelocity();
 					max_contacter_speed = std::max(max_contacter_speed, relative_contacter_speed.squaredLength());
 				}
 			} else {

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -47,7 +47,12 @@ void PointColDetector::update(Beam* truck) {
 
 	if (truck && truck->state < SLEEPING) {
 		m_trucks.resize(1, truck);
+		max_contacter_speed = 0.0f;
 		contacters_size += truck->free_contacter;
+		for (int i = 0; i < truck->free_contacter; ++i) {
+			max_contacter_speed = std::max(max_contacter_speed, (truck->nodes[truck->contacters[i].nodeid].Velocity - truck->nodes[0].Velocity).squaredLength());
+		}
+		max_contacter_speed = std::sqrt(max_contacter_speed);
 	} else {
 		m_trucks.clear();
 	}
@@ -69,29 +74,22 @@ void PointColDetector::update(Beam* truck, Beam** trucks, const int numtrucks) {
 	if (truck && truck->state < SLEEPING) {
 		truck->collisionRelevant = false;
 		m_trucks.resize(numtrucks);
+		max_contacter_speed = 0.0f;
 		for (int t = 0; t < numtrucks; t++) {
 			if (t != truck->trucknum && trucks[t] && trucks[t]->state < SLEEPING && truck->boundingBox.intersects(trucks[t]->boundingBox)) {
 				update_required = update_required || (m_trucks[t] != trucks[t]);
 				m_trucks[t] = trucks[t];
 				truck->collisionRelevant = true;
 				contacters_size += trucks[t]->free_contacter;
-				if (truck->nodes[0].Velocity.squaredDistance(trucks[t]->nodes[0].Velocity) > 25)
-				{
-					for (int i=0; i<truck->free_collcab; i++)
-					{
-						truck->intra_collcabrate[i].rate = 0;
-						truck->inter_collcabrate[i].rate = 0;
-					}
-					for (int i=0; i<trucks[t]->free_collcab; i++)
-					{
-						trucks[t]->intra_collcabrate[i].rate = 0;
-						trucks[t]->inter_collcabrate[i].rate = 0;
-					}
+				for (int i = 0; i < trucks[t]->free_contacter; ++i) {
+					Vector3 relative_contacter_speed = trucks[t]->nodes[trucks[t]->contacters[i].nodeid].Velocity - truck->nodes[0].Velocity;
+					max_contacter_speed = std::max(max_contacter_speed, relative_contacter_speed.squaredLength());
 				}
 			} else {
 				m_trucks[t] = 0;
 			}
 		}
+		max_contacter_speed = std::sqrt(max_contacter_speed);
 	} else {
 		m_trucks.clear();
 	}

--- a/source/main/physics/collision/PointColDetector.h
+++ b/source/main/physics/collision/PointColDetector.h
@@ -32,9 +32,10 @@ public:
 		int truckid;
 	} pointid_t;
 
-	std::vector< Ogre::Vector3 > *object_list;
 	std::vector< pointid_t* > hit_list;
 	int hit_count;
+
+	float max_contacter_speed;
 
 	PointColDetector();
 	~PointColDetector();

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -202,7 +202,6 @@ void RigSpawner::InitializeRig()
 	m_rig->free_sub = 0;
 	memset(m_rig->subcabs, 0, sizeof(int) * MAX_SUBMESHES);
 	memset(m_rig->collcabs, 0, sizeof(int) * MAX_CABS);
-	memset(m_rig->collcabstype, 0, sizeof(int) * MAX_CABS);
 	memset(m_rig->inter_collcabrate, 0, sizeof(collcab_rate_t) * MAX_CABS);
 	m_rig->free_collcab = 0;
 	memset(m_rig->intra_collcabrate, 0, sizeof(collcab_rate_t) * MAX_CABS);
@@ -1647,28 +1646,24 @@ void RigSpawner::ProcessSubmesh(RigDef::Submesh & def)
 		if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_c_CONTACT))
 		{
 			m_rig->collcabs[m_rig->free_collcab]=m_rig->free_cab; 
-			m_rig->collcabstype[m_rig->free_collcab]=0; 
 			m_rig->free_collcab++;
 		}
 		//if (type=='p') 
 		if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_p_10xTOUGHER))
 		{
 			m_rig->collcabs[m_rig->free_collcab]=m_rig->free_cab; 
-			m_rig->collcabstype[m_rig->free_collcab]=1; 
 			m_rig->free_collcab++;
 		}
 		//if (type=='u') 
 		if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_u_INVULNERABLE))
 		{
 			m_rig->collcabs[m_rig->free_collcab]=m_rig->free_cab; 
-			m_rig->collcabstype[m_rig->free_collcab]=2; 
 			m_rig->free_collcab++;
 		}
 		//if (type=='b')
 		if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_b_BUOYANT))
 		{
 			m_rig->buoycabs[m_rig->free_buoycab]=m_rig->free_cab; 
-			m_rig->collcabstype[m_rig->free_collcab]=0; 
 			m_rig->buoycabtypes[m_rig->free_buoycab]=Buoyance::BUOY_NORMAL; 
 			m_rig->free_buoycab++;   
 			if (m_rig->buoyance == nullptr)
@@ -1680,7 +1675,6 @@ void RigSpawner::ProcessSubmesh(RigDef::Submesh & def)
 		if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_r_BUOYANT_ONLY_DRAG))
 		{
 			m_rig->buoycabs[m_rig->free_buoycab]=m_rig->free_cab; 
-			m_rig->collcabstype[m_rig->free_collcab]=0; 
 			m_rig->buoycabtypes[m_rig->free_buoycab]=Buoyance::BUOY_DRAGONLY; 
 			m_rig->free_buoycab++; 
 			if (m_rig->buoyance == nullptr)
@@ -1692,7 +1686,6 @@ void RigSpawner::ProcessSubmesh(RigDef::Submesh & def)
 		if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_s_BUOYANT_NO_DRAG))
 		{
 			m_rig->buoycabs[m_rig->free_buoycab]=m_rig->free_cab; 
-			m_rig->collcabstype[m_rig->free_collcab]=0; 
 			m_rig->buoycabtypes[m_rig->free_buoycab]=Buoyance::BUOY_DRAGLESS; 
 			m_rig->free_buoycab++; 
 			if (m_rig->buoyance == nullptr)
@@ -1735,7 +1728,6 @@ void RigSpawner::ProcessSubmesh(RigDef::Submesh & def)
 			}
 
 			m_rig->collcabs[m_rig->free_collcab]=m_rig->free_cab;
-			m_rig->collcabstype[m_rig->free_collcab]=collcabs_type;
 			m_rig->free_collcab++;
 			m_rig->buoycabs[m_rig->free_buoycab]=m_rig->free_cab; 
 			m_rig->buoycabtypes[m_rig->free_buoycab]=Buoyance::BUOY_NORMAL; 


### PR DESCRIPTION
What this does:

a) Estimate the maximum relative velocity at which `contacters` and `cabs` collide.

b) Use this estimate to calculate the maximum amount of physics steps (`collcabrate`) that can be skipped without "missing" any collision.