### PR TITLE
[Codechange] Cinematic camera takes the simulation speed into account

### DIFF
--- a/source/main/gfx/camera/CameraBehaviorStatic.cpp
+++ b/source/main/gfx/camera/CameraBehaviorStatic.cpp
@@ -63,7 +63,7 @@ void CameraBehaviorStatic::update(const CameraManager::CameraContext &ctx)
 	if ( ctx.mCurrTruck )
 	{
 		lookAt   = ctx.mCurrTruck->getPosition();
-		velocity = ctx.mCurrTruck->nodes[0].Velocity;
+		velocity = ctx.mCurrTruck->nodes[0].Velocity * ctx.mCurrTruck->global_simulation_speed;
 		rotation = ctx.mCurrTruck->getRotation();
 		angle    = (lookAt - camPosition).angleBetween(velocity);
 		speed    = velocity.length();


### PR DESCRIPTION
Prevents premature or delayed updating of the camera position, when the simulation speed is modified.