### PR TITLE
[Codechange] Emulates the character spawn rotation of older RoR versions

### DIFF
--- a/source/main/main_sim/MainThread.cpp
+++ b/source/main/main_sim/MainThread.cpp
@@ -1220,6 +1220,10 @@ void MainThread::LoadTerrain(Ogre::String const & a_terrain_file)
 	{
 		gEnv->player->setVisible(true);
 		gEnv->player->setPosition(gEnv->terrainManager->getSpawnPos());
+		if (!gEnv->terrainManager->hasPreloadedTrucks())
+		{
+			gEnv->player->setRotation(Degree(180));
+		}
 	}
 
 	// hide loading window

--- a/source/main/main_sim/MainThread.cpp
+++ b/source/main/main_sim/MainThread.cpp
@@ -1220,6 +1220,9 @@ void MainThread::LoadTerrain(Ogre::String const & a_terrain_file)
 	{
 		gEnv->player->setVisible(true);
 		gEnv->player->setPosition(gEnv->terrainManager->getSpawnPos());
+
+		// Classic behavior, retained for compatibility.
+		// Required for maps like N-Labs or F1 Track.
 		if (!gEnv->terrainManager->hasPreloadedTrucks())
 		{
 			gEnv->player->setRotation(Degree(180));


### PR DESCRIPTION
Fixes the initial character orientation on maps like N-Labs or F1 Track

Temporary until we allow defining a spawn rotation in the terrn file