### PR TITLE
Add FreeBSD specific include

### DIFF
--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -48,6 +48,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef __FreeBSD__
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#endif
 
 #ifdef USE_MYGUI
 #include "GUIMp.h"

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -45,6 +45,10 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include <sys/sysinfo.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
 #ifdef USE_MYGUI
 #include "GUIMp.h"
 #include "GUIMenu.h"


### PR DESCRIPTION
I am trying to get rigs of rods working again on FreeBSD.
Since I get some linking error with 270e084 (like multiple definition of function located at paged geometry). That's why I am looking to build the latest commit instead.
I finished the build but I am still getting multiple definition of function.
Example:
```
/usr/local/lib/libMyGUI.OgrePlatform.a(MyGUI_OgreRenderManager.cpp.o): In function `MyGUI::OgreRenderManager::getTexture(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)':
/usr/ports/x11-toolkits/mygui-ogre/work/mygui-MyGUI3.2.2/Platforms/Ogre/OgrePlatform/src/MyGUI_OgreRenderManager.cpp:(.text+0x3060): multiple definition of `MyGUI::OgreRenderManager::getTexture(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)'
/usr/local/lib/libMyGUI.OgrePlatform.a(MyGUI_OgreRenderManager.cpp.o):/usr/ports/x11-toolkits/mygui-ogre/work/mygui-MyGUI3.2.2/Platforms/Ogre/OgrePlatform/src/MyGUI_OgreRenderManager.cpp:(.text+0x3060): first defined here
```
I get same kind of error with paged geometry. And finally I get undefined reference for
`Ogre::SharedPtr<Ogre::Texture>::~SharedPtr()`
For the last one, I think it's an issue with mygui ogre plugin (because it is in libMyGUI.OgrePlatform.a).
