### PR TITLE
replaced boost::shared_ptr with std::shared_ptr

### DIFF
--- a/source/main/gui/panels/GUI_RigEditorLandVehiclePropertiesWindow.cpp
+++ b/source/main/gui/panels/GUI_RigEditorLandVehiclePropertiesWindow.cpp
@@ -133,8 +133,8 @@ void CLASS::ResetEngineEngoptionForm()
 }
 
 void CLASS::Import(
-	boost::shared_ptr<RigDef::Engine> engine,
-	boost::shared_ptr<RigDef::Engoption> engoption
+	std::shared_ptr<RigDef::Engine> engine,
+	std::shared_ptr<RigDef::Engoption> engoption
 	)
 {
     if (!engine || !engoption)
@@ -184,13 +184,13 @@ void CLASS::Import(
     this->SetEngineType(engoption->type);
 }
 
-boost::shared_ptr<RigDef::Engine>    CLASS::ExportEngine()
+std::shared_ptr<RigDef::Engine>    CLASS::ExportEngine()
 {
     if (!m_vehicle_has_engine)
     {
-        return boost::shared_ptr<RigDef::Engine>();
+        return std::shared_ptr<RigDef::Engine>();
     }
-    auto engine = boost::shared_ptr<RigDef::Engine>(new RigDef::Engine());
+    auto engine = std::shared_ptr<RigDef::Engine>(new RigDef::Engine());
 
     engine->shift_down_rpm   = PARSEREAL(m_editbox_shift_down_rpm->getCaption());
 	engine->shift_up_rpm     = PARSEREAL(m_editbox_shift_up_rpm->getCaption());
@@ -217,13 +217,13 @@ boost::shared_ptr<RigDef::Engine>    CLASS::ExportEngine()
     return engine;
 }
 
-boost::shared_ptr<RigDef::Engoption> CLASS::ExportEngoption()
+std::shared_ptr<RigDef::Engoption> CLASS::ExportEngoption()
 {
     if (!m_vehicle_has_engine)
     {
-        return boost::shared_ptr<RigDef::Engoption>();
+        return std::shared_ptr<RigDef::Engoption>();
     }
-    auto engoption = boost::shared_ptr<RigDef::Engoption>(new RigDef::Engoption());
+    auto engoption = std::shared_ptr<RigDef::Engoption>(new RigDef::Engoption());
 
     engoption->inertia           = PARSEREAL(m_editbox_engoption_engine_inertia  ->getCaption());
 	engoption->clutch_force      = PARSEREAL(m_editbox_engoption_clutch_force    ->getCaption());

--- a/source/main/gui/panels/GUI_RigEditorLandVehiclePropertiesWindow.h
+++ b/source/main/gui/panels/GUI_RigEditorLandVehiclePropertiesWindow.h
@@ -48,13 +48,13 @@ public:
 	RigEditorLandVehiclePropertiesWindow(RigEditor::IMain* rig_editor_interface);
 
 	void Import(
-			boost::shared_ptr<RigDef::Engine> engine,
-			boost::shared_ptr<RigDef::Engoption> engoption
+			std::shared_ptr<RigDef::Engine> engine,
+			std::shared_ptr<RigDef::Engoption> engoption
 		);
     
     // Export
-	boost::shared_ptr<RigDef::Engine>    ExportEngine();
-    boost::shared_ptr<RigDef::Engoption> ExportEngoption();
+	std::shared_ptr<RigDef::Engine>    ExportEngine();
+    std::shared_ptr<RigDef::Engoption> ExportEngoption();
 
 private:
 

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -86,7 +86,7 @@ using namespace RoR;
 
 void RigSpawner::Setup( 
 	Beam *rig,
-	boost::shared_ptr<RigDef::File> file,
+	std::shared_ptr<RigDef::File> file,
 	Ogre::SceneNode *parent,
 	Ogre::Vector3 const & spawn_position,
 	Ogre::Quaternion const & spawn_rotation,
@@ -1817,7 +1817,7 @@ void RigSpawner::ProcessSubmesh(RigDef::Submesh & def)
 	}
 }
 
-void RigSpawner::ProcessFlexbody(boost::shared_ptr<RigDef::Flexbody> def)
+void RigSpawner::ProcessFlexbody(std::shared_ptr<RigDef::Flexbody> def)
 {
 	SPAWNER_PROFILE_SCOPED();
 
@@ -3895,7 +3895,7 @@ void RigSpawner::ProcessAnimator(RigDef::Animator & def)
 beam_t & RigSpawner::AddBeam(
 	node_t & node_1, 
 	node_t & node_2, 
-	boost::shared_ptr<RigDef::BeamDefaults> & beam_defaults,
+	std::shared_ptr<RigDef::BeamDefaults> & beam_defaults,
 	int detacher_group
 )
 {
@@ -4722,7 +4722,7 @@ unsigned int RigSpawner::BuildWheelObjectAndNodes(
 	float wheel_radius,
 	RigDef::Wheels::Propulsion propulsion,
 	RigDef::Wheels::Braking braking,
-	boost::shared_ptr<RigDef::NodeDefaults> node_defaults,
+	std::shared_ptr<RigDef::NodeDefaults> node_defaults,
 	float wheel_mass,
 	bool set_param_iswheel, /* Default: true */
 	float wheel_width       /* Default: -1.f */
@@ -4841,7 +4841,7 @@ unsigned int RigSpawner::BuildWheelObjectAndNodes(
 	return wheel_index;
 }
 
-void RigSpawner::AdjustNodeBuoyancy(node_t & node, RigDef::Node & node_def, boost::shared_ptr<RigDef::NodeDefaults> defaults)
+void RigSpawner::AdjustNodeBuoyancy(node_t & node, RigDef::Node & node_def, std::shared_ptr<RigDef::NodeDefaults> defaults)
 {
 	SPAWNER_PROFILE_SCOPED();
 
@@ -4849,7 +4849,7 @@ void RigSpawner::AdjustNodeBuoyancy(node_t & node, RigDef::Node & node_def, boos
 	node.buoyancy = BITMASK_IS_1(options, RigDef::Node::OPTION_b_EXTRA_BUOYANCY) ? 10000.f : m_rig->truckmass/15.f;
 }
 
-void RigSpawner::AdjustNodeBuoyancy(node_t & node, boost::shared_ptr<RigDef::NodeDefaults> defaults)
+void RigSpawner::AdjustNodeBuoyancy(node_t & node, std::shared_ptr<RigDef::NodeDefaults> defaults)
 {
 	SPAWNER_PROFILE_SCOPED();
 
@@ -4906,7 +4906,7 @@ void RigSpawner::BuildWheelBeams(
 	float tyre_damping,
 	float rim_spring,
 	float rim_damping,
-	boost::shared_ptr<RigDef::BeamDefaults> beam_defaults,
+	std::shared_ptr<RigDef::BeamDefaults> beam_defaults,
 	RigDef::Node::Ref const & rigidity_node_id,
 	float max_extension // = 0.f
 )
@@ -5513,7 +5513,7 @@ unsigned int RigSpawner::AddWheelBeam(
 	node_t *node_2, 
 	float spring, 
 	float damping, 
-	boost::shared_ptr<RigDef::BeamDefaults> beam_defaults,
+	std::shared_ptr<RigDef::BeamDefaults> beam_defaults,
 	float max_contraction,   /* Default: -1.f */
 	float max_extension,     /* Default: -1.f */
 	int type                 /* Default: BEAM_INVISIBLE */
@@ -5795,8 +5795,8 @@ void RigSpawner::ProcessEngturbo(RigDef::Engturbo & def)
 	}
 	
 		/* Find it */
-	boost::shared_ptr<RigDef::Engturbo> engturbo;
-	std::list<boost::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
+	std::shared_ptr<RigDef::Engturbo> engturbo;
+	std::list<std::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
 	for (; module_itor != m_selected_modules.end(); module_itor++)
 	{
 		if (module_itor->get()->engturbo != nullptr)
@@ -5821,8 +5821,8 @@ void RigSpawner::ProcessEngoption(RigDef::Engoption & def)
 	}
 
 	/* Find it */
-	boost::shared_ptr<RigDef::Engoption> engoption;
-	std::list<boost::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
+	std::shared_ptr<RigDef::Engoption> engoption;
+	std::list<std::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
 	for (; module_itor != m_selected_modules.end(); module_itor++)
 	{
 		if (module_itor->get()->engoption != nullptr)
@@ -5893,7 +5893,7 @@ void RigSpawner::ProcessHelp()
     SetCurrentKeyword(RigDef::File::KEYWORD_HELP);
 	unsigned int material_count = 0;
 
-	std::list<boost::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
+	std::list<std::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
 	for (; module_itor != m_selected_modules.end(); module_itor++)
 	{
 		auto module = module_itor->get();
@@ -6088,7 +6088,7 @@ void RigSpawner::ProcessBeam(RigDef::Beam & def)
 	CreateBeamVisuals(beam, beam_index, def.defaults, BITMASK_IS_0(def.options, RigDef::Beam::OPTION_i_INVISIBLE));
 }
 
-void RigSpawner::SetBeamDeformationThreshold(beam_t & beam, boost::shared_ptr<RigDef::BeamDefaults> beam_defaults)
+void RigSpawner::SetBeamDeformationThreshold(beam_t & beam, std::shared_ptr<RigDef::BeamDefaults> beam_defaults)
 {
 	SPAWNER_PROFILE_SCOPED();
 
@@ -6217,7 +6217,7 @@ void RigSpawner::SetBeamDeformationThreshold(beam_t & beam, boost::shared_ptr<Ri
 	beam.maxnegstress       = -(deformation_threshold);
 }
 
-void RigSpawner::CreateBeamVisuals(beam_t & beam, int beam_index, boost::shared_ptr<RigDef::BeamDefaults> beam_defaults, bool activate)
+void RigSpawner::CreateBeamVisuals(beam_t & beam, int beam_index, std::shared_ptr<RigDef::BeamDefaults> beam_defaults, bool activate)
 {
 	SPAWNER_PROFILE_SCOPED();
 
@@ -6633,7 +6633,7 @@ bool RigSpawner::AddModule(Ogre::String const & module_name)
 {
 	SPAWNER_PROFILE_SCOPED();
 
-    std::map< Ogre::String, boost::shared_ptr<RigDef::File::Module> >::iterator result 
+    std::map< Ogre::String, std::shared_ptr<RigDef::File::Module> >::iterator result 
 		= m_file->modules.find(module_name);
 
 	if (result != m_file->modules.end())
@@ -6718,7 +6718,7 @@ void RigSpawner::InitNode(node_t & node, Ogre::Vector3 const & position)
 void RigSpawner::InitNode(
 	node_t & node, 
 	Ogre::Vector3 const & position,
-	boost::shared_ptr<RigDef::NodeDefaults> node_defaults
+	std::shared_ptr<RigDef::NodeDefaults> node_defaults
 )
 {
 	SPAWNER_PROFILE_SCOPED();

--- a/source/main/physics/input_output/RigSpawner.h
+++ b/source/main/physics/input_output/RigSpawner.h
@@ -95,7 +95,7 @@ public:
 
 	void Setup( 
 		Beam *rig,
-		boost::shared_ptr<RigDef::File> file,
+		std::shared_ptr<RigDef::File> file,
 		Ogre::SceneNode *parent,
 		Ogre::Vector3 const & spawn_position,
 		Ogre::Quaternion const & spawn_rotation,
@@ -114,7 +114,7 @@ public:
 	* Adds a vehicle module to the validated configuration.
 	* @param module_name A module from the validated rig-def file.
 	*/
-	void AddModule(boost::shared_ptr<RigDef::File::Module> module)
+	void AddModule(std::shared_ptr<RigDef::File::Module> module)
 	{
 		m_selected_modules.push_back(module);
 	}
@@ -269,7 +269,7 @@ protected:
 	/**
 	* Section 'flexbodies'.
 	*/
-	void ProcessFlexbody(boost::shared_ptr<RigDef::Flexbody> def);
+	void ProcessFlexbody(std::shared_ptr<RigDef::Flexbody> def);
 
 	/**
 	* Section 'flexbodywheels'.
@@ -484,7 +484,7 @@ protected:
 	beam_t & AddBeam(
 		node_t & node_1, 
 		node_t & node_2, 
-		boost::shared_ptr<RigDef::BeamDefaults> & defaults,
+		std::shared_ptr<RigDef::BeamDefaults> & defaults,
 		int detacher_group
 	);
 
@@ -509,7 +509,7 @@ protected:
 	*/
 	unsigned int AddWheel2(RigDef::Wheel2 & wheel_2_def);
 
-	void CreateBeamVisuals(beam_t & beam, int beam_index, boost::shared_ptr<RigDef::BeamDefaults> beam_defaults, bool activate);
+	void CreateBeamVisuals(beam_t & beam, int beam_index, std::shared_ptr<RigDef::BeamDefaults> beam_defaults, bool activate);
 
 	Rail *CreateRail(std::vector<RigDef::Node::Range> & node_ranges);
 
@@ -764,7 +764,7 @@ protected:
 	void InitNode(
 		node_t & node, 
 		Ogre::Vector3 const & position,
-		boost::shared_ptr<RigDef::NodeDefaults> node_defaults
+		std::shared_ptr<RigDef::NodeDefaults> node_defaults
 	);
 
 	/**
@@ -832,7 +832,7 @@ protected:
 
 	beam_t *FindBeamInRig(unsigned int node_a, unsigned int node_b);
 
-	void SetBeamDeformationThreshold(beam_t & beam, boost::shared_ptr<RigDef::BeamDefaults> beam_defaults);
+	void SetBeamDeformationThreshold(beam_t & beam, std::shared_ptr<RigDef::BeamDefaults> beam_defaults);
 
 	void UpdateCollcabContacterNodes();
 
@@ -846,14 +846,14 @@ protected:
 	*/
 	int FindLowestContactingNodeInRig();
 
-	//void SetBeamPlasticCoefficient(beam_t & beam, boost::shared_ptr<RigDef::BeamDefaults> beam_defaults);
+	//void SetBeamPlasticCoefficient(beam_t & beam, std::shared_ptr<RigDef::BeamDefaults> beam_defaults);
 
 	/**
 	* Checks a section only appears in one module and reports a warning if not.
 	*/
 	void CheckSectionSingleModule(
 		Ogre::String const & section_name,
-		std::list<boost::shared_ptr<RigDef::File::Module>> & found_items	
+		std::list<std::shared_ptr<RigDef::File::Module>> & found_items	
 	);
 
 	/**
@@ -905,7 +905,7 @@ protected:
 		float wheel_radius,
 		RigDef::Wheels::Propulsion propulsion,
 		RigDef::Wheels::Braking braking,
-		boost::shared_ptr<RigDef::NodeDefaults> node_defaults,
+		std::shared_ptr<RigDef::NodeDefaults> node_defaults,
 		float wheel_mass,
 		bool set_param_iswheel = true,
 		float wheel_width = -1.f
@@ -923,7 +923,7 @@ protected:
 		float tyre_damping,
 		float rim_spring,
 		float rim_damping,
-		boost::shared_ptr<RigDef::BeamDefaults> beam_defaults,
+		std::shared_ptr<RigDef::BeamDefaults> beam_defaults,
 		RigDef::Node::Ref const & rigidity_node_id,
 		float max_extension = 0.f
 	);
@@ -936,7 +936,7 @@ protected:
 		node_t *node_2,
 		float spring,
 		float damping,
-		boost::shared_ptr<RigDef::BeamDefaults> beam_defaults,
+		std::shared_ptr<RigDef::BeamDefaults> beam_defaults,
 		float max_contraction = -1.f,
 		float max_extension = -1.f,
 		int type = BEAM_INVISIBLE /* Anonymous enum in BeamData.h */
@@ -980,12 +980,12 @@ protected:
 	/** 
 	* For specified nodes
 	*/
-	void AdjustNodeBuoyancy(node_t & node, RigDef::Node & node_def, boost::shared_ptr<RigDef::NodeDefaults> defaults);
+	void AdjustNodeBuoyancy(node_t & node, RigDef::Node & node_def, std::shared_ptr<RigDef::NodeDefaults> defaults);
 
 	/** 
 	* For generated nodes
 	*/
-	void AdjustNodeBuoyancy(node_t & node, boost::shared_ptr<RigDef::NodeDefaults> defaults);
+	void AdjustNodeBuoyancy(node_t & node, std::shared_ptr<RigDef::NodeDefaults> defaults);
 
 	/**
 	* Ported from SerializedRig::loadTruck() [v0.4.0.7]
@@ -997,10 +997,10 @@ protected:
 	*/
 	void InitializeRig();
 
-	boost::shared_ptr<RigDef::File> m_file; //!< The parsed input file.
+	std::shared_ptr<RigDef::File> m_file; //!< The parsed input file.
     int m_cache_entry_number;
 	Beam *m_rig; //!< The output rig.
-	std::list<boost::shared_ptr<RigDef::File::Module>> m_selected_modules;
+	std::list<std::shared_ptr<RigDef::File::Module>> m_selected_modules;
 	std::map<Ogre::String, unsigned int> m_named_nodes;
 	
 	bool m_enable_background_loading;

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1319,7 +1319,7 @@ void CacheSystem::fillTruckDetailInfo(CacheEntry &entry, Ogre::DataStreamPtr str
 
 	/* RETRIEVE DATA */
 
-	boost::shared_ptr<RigDef::File> def = parser.GetFile();
+	std::shared_ptr<RigDef::File> def = parser.GetFile();
 
 	/* Description */
 	std::vector<Ogre::String>::iterator desc_itor = def->description.begin();
@@ -1342,7 +1342,7 @@ void CacheSystem::fillTruckDetailInfo(CacheEntry &entry, Ogre::DataStreamPtr str
 	}
 
 	/* Modules (previously called "sections") */
-	std::map<Ogre::String, boost::shared_ptr<RigDef::File::Module>>::iterator module_itor = def->modules.begin();
+	std::map<Ogre::String, std::shared_ptr<RigDef::File::Module>>::iterator module_itor = def->modules.begin();
 	for ( ; module_itor != def->modules.end(); module_itor++ )
 	{
 		entry.sectionconfigs.push_back(module_itor->second->name);
@@ -1352,7 +1352,7 @@ void CacheSystem::fillTruckDetailInfo(CacheEntry &entry, Ogre::DataStreamPtr str
 	/* TODO: Handle engines in modules */
 	if (def->root_module->engine != nullptr)
 	{
-		boost::shared_ptr<RigDef::Engine> engine = def->root_module->engine;
+		std::shared_ptr<RigDef::Engine> engine = def->root_module->engine;
 		entry.numgears   = engine->gear_ratios.size();
 		entry.minrpm     = engine->shift_down_rpm;
 		entry.maxrpm     = engine->shift_up_rpm;
@@ -1448,7 +1448,7 @@ void CacheSystem::fillTruckDetailInfo(CacheEntry &entry, Ogre::DataStreamPtr str
 		+ def->root_module->mesh_wheels_2.size() 
 		);
 
-	/* NOTE: boost::shared_ptr cleans everything up. */
+	/* NOTE: std::shared_ptr cleans everything up. */
 }
 
 int CacheSystem::addUniqueString(std::set<Ogre::String> &list, Ogre::String str)

--- a/source/main/rig_editor/RigEditor_Main.cpp
+++ b/source/main/rig_editor/RigEditor_Main.cpp
@@ -1106,9 +1106,9 @@ void Main::CommandCreateNewEmptyRig()
 
     m_rig = new RigEditor::Rig(m_config);
     // Create definition
-	auto def = boost::shared_ptr<RigDef::File>(new RigDef::File());
+	auto def = std::shared_ptr<RigDef::File>(new RigDef::File());
     def->name = "Unnamed rig (created in editor)";
-	auto module = boost::shared_ptr<RigDef::File::Module>(new RigDef::File::Module("_Root_"));
+	auto module = std::shared_ptr<RigDef::File::Module>(new RigDef::File::Module("_Root_"));
 	def->root_module = module;
     // Create special node 0 in _Root_ module
     RigDef::Node node_0;

--- a/source/main/rig_editor/rig_data/RigEditor_MeshWheel2.cpp
+++ b/source/main/rig_editor/rig_data/RigEditor_MeshWheel2.cpp
@@ -43,7 +43,7 @@ MeshWheel2::MeshWheel2(RigDef::MeshWheel2 const & def,  Node* inner, Node* outer
 	m_rigidity_node = rigidity;
 	m_reference_arm_node = reference_arm_node;
     // Create private copy of BeamDefaults, which act as additional data container (rim parameters)
-    m_definition.beam_defaults = boost::shared_ptr<RigDef::BeamDefaults>(new RigDef::BeamDefaults(*def.beam_defaults));
+    m_definition.beam_defaults = std::shared_ptr<RigDef::BeamDefaults>(new RigDef::BeamDefaults(*def.beam_defaults));
 }
 
 void MeshWheel2::ReGenerateMeshData()

--- a/source/main/rig_editor/rig_data/RigEditor_Rig.cpp
+++ b/source/main/rig_editor/rig_data/RigEditor_Rig.cpp
@@ -126,7 +126,7 @@ Node* Rig::FindNode(RigDef::Node::Ref const & node_ref, RigBuildingReport* logge
 
 
 void Rig::Build(
-		boost::shared_ptr<RigDef::File> rig_def,
+		std::shared_ptr<RigDef::File> rig_def,
 		RigEditor::Main* rig_editor,
 		Ogre::SceneNode* parent_scene_node,
 		RigBuildingReport* report // = nullptr
@@ -1173,13 +1173,13 @@ RigProperties* Rig::GetProperties()
 	return m_properties.get();
 }
 
-boost::shared_ptr<RigDef::File> Rig::Export()
+std::shared_ptr<RigDef::File> Rig::Export()
 {
 	using namespace RigDef;
 
 	// Allocate
-	auto def = boost::shared_ptr<File>(new RigDef::File());
-	auto module = boost::shared_ptr<File::Module>(new File::Module("_Root_"));
+	auto def = std::shared_ptr<File>(new RigDef::File());
+	auto module = std::shared_ptr<File::Module>(new File::Module("_Root_"));
 	def->root_module = module;
 
 	// Fill node data

--- a/source/main/rig_editor/rig_data/RigEditor_Rig.h
+++ b/source/main/rig_editor/rig_data/RigEditor_Rig.h
@@ -147,7 +147,7 @@ public:
 	void DeleteBeam(std::vector<RigEditor::Beam*>::iterator & delete_itor);
 
 	void Build(
-		boost::shared_ptr<RigDef::File> rig_def, 
+		std::shared_ptr<RigDef::File> rig_def, 
 		RigEditor::Main* rig_editor,
 		Ogre::SceneNode* parent_scene_node,
 		RigBuildingReport* report // = nullptr
@@ -165,7 +165,7 @@ public:
 
 	RigProperties* GetProperties();
 
-	boost::shared_ptr<RigDef::File> Export();
+	std::shared_ptr<RigDef::File> Export();
 
 	void QuerySelectedNodesData(RigAggregateNodesData* result);
 

--- a/source/main/rig_editor/rig_data/RigEditor_RigProperties.cpp
+++ b/source/main/rig_editor/rig_data/RigEditor_RigProperties.cpp
@@ -47,7 +47,7 @@ RigProperties::RigProperties():
 RigProperties::~RigProperties()
 {}
 
-void RigProperties::Import(boost::shared_ptr<RigDef::File> def_file)
+void RigProperties::Import(std::shared_ptr<RigDef::File> def_file)
 {
 	m_title             = def_file->name;
 	m_guid              = def_file->guid;
@@ -104,7 +104,7 @@ void RigProperties::Import(boost::shared_ptr<RigDef::File> def_file)
 	m_engoption = def_file->root_module->engoption;
 }
 
-void RigProperties::Export(boost::shared_ptr<RigDef::File> def_file)
+void RigProperties::Export(std::shared_ptr<RigDef::File> def_file)
 {
 	def_file->name              = m_title;           
 	def_file->guid              = m_guid;            
@@ -119,18 +119,18 @@ void RigProperties::Export(boost::shared_ptr<RigDef::File> def_file)
 	def_file->disable_default_sounds      = m_disable_default_sounds;
 
 	def_file->file_info 
-		= boost::shared_ptr<RigDef::Fileinfo>(new RigDef::Fileinfo(m_fileinfo));
+		= std::shared_ptr<RigDef::Fileinfo>(new RigDef::Fileinfo(m_fileinfo));
 	def_file->root_module->ext_camera 
-		= boost::shared_ptr<RigDef::ExtCamera>(new RigDef::ExtCamera(m_extcamera));
+		= std::shared_ptr<RigDef::ExtCamera>(new RigDef::ExtCamera(m_extcamera));
 	def_file->root_module->skeleton_settings 
-		= boost::shared_ptr<RigDef::SkeletonSettings>(new RigDef::SkeletonSettings(m_skeleton_settings));
+		= std::shared_ptr<RigDef::SkeletonSettings>(new RigDef::SkeletonSettings(m_skeleton_settings));
 
 	// Globals
 	RigDef::Globals globals;
 	globals.cargo_mass               = m_globals_load_mass;
 	globals.dry_mass                 = m_globals_dry_mass;
 	globals.material_name            = m_globals_cab_material_name;
-	def_file->root_module->globals   = boost::shared_ptr<RigDef::Globals>(new RigDef::Globals(globals));
+	def_file->root_module->globals   = std::shared_ptr<RigDef::Globals>(new RigDef::Globals(globals));
 
 	// Description
 	for (auto itor = m_description.begin(); itor != m_description.end(); ++itor)
@@ -149,12 +149,12 @@ void RigProperties::Export(boost::shared_ptr<RigDef::File> def_file)
 	def_file->root_module->engoption   = m_engoption;
 }
 
-boost::shared_ptr<RigDef::Engine> RigProperties::GetEngine()
+std::shared_ptr<RigDef::Engine> RigProperties::GetEngine()
 {
 	return m_engine;
 }
 
-boost::shared_ptr<RigDef::Engoption> RigProperties::GetEngoption()
+std::shared_ptr<RigDef::Engoption> RigProperties::GetEngoption()
 {
 	return m_engoption;
 }

--- a/source/main/rig_editor/rig_data/RigEditor_RigProperties.h
+++ b/source/main/rig_editor/rig_data/RigEditor_RigProperties.h
@@ -32,7 +32,7 @@
 #include "RigEditor_ForwardDeclarations.h"
 #include "RoRPrerequisites.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace RoR
 {
@@ -51,15 +51,15 @@ public:
 
 	~RigProperties();
 
-	boost::shared_ptr<RigDef::Engine>    GetEngine();
-	boost::shared_ptr<RigDef::Engoption> GetEngoption();
-    inline void SetEngine(boost::shared_ptr<RigDef::Engine> engine) { m_engine = engine; }
-    inline void SetEngoption(boost::shared_ptr<RigDef::Engoption> engoption) { m_engoption = engoption; }
+	std::shared_ptr<RigDef::Engine>    GetEngine();
+	std::shared_ptr<RigDef::Engoption> GetEngoption();
+    inline void SetEngine(std::shared_ptr<RigDef::Engine> engine) { m_engine = engine; }
+    inline void SetEngoption(std::shared_ptr<RigDef::Engoption> engoption) { m_engoption = engoption; }
 
 protected:	
 
-	void Import(boost::shared_ptr<RigDef::File> def_file);
-	void Export(boost::shared_ptr<RigDef::File> def_file);
+	void Import(std::shared_ptr<RigDef::File> def_file);
+	void Export(std::shared_ptr<RigDef::File> def_file);
 
 	// BASIC tab
 	
@@ -95,8 +95,8 @@ protected:
 
 	// LAND VEHICLE window
 
-	boost::shared_ptr<RigDef::Engine>      m_engine;
-	boost::shared_ptr<RigDef::Engoption>   m_engoption;
+	std::shared_ptr<RigDef::Engine>      m_engine;
+	std::shared_ptr<RigDef::Engoption>   m_engoption;
 };
 
 } // namespace RigEditor

--- a/source/rig_file_input_output/RigDef_File.h
+++ b/source/rig_file_input_output/RigDef_File.h
@@ -45,8 +45,8 @@
 #include "RigDef_Node.h"
 
 #include <list>
+#include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 #include <OgreString.h>
 #include <OgreVector3.h>
 #include <OgreStringConverter.h>
@@ -425,7 +425,7 @@ struct Beam
 	float extension_break_limit;
 	bool _has_extension_break_limit;
 	int detacher_group;
-	boost::shared_ptr<BeamDefaults> defaults;
+	std::shared_ptr<BeamDefaults> defaults;
 };
 
 /* -------------------------------------------------------------------------- */
@@ -469,8 +469,8 @@ struct Cinecam
 	Node::Ref nodes[8];
 	float spring;
 	float damping;
-	boost::shared_ptr<BeamDefaults> beam_defaults;
-	boost::shared_ptr<NodeDefaults> node_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<NodeDefaults> node_defaults;
 };
 
 /* -------------------------------------------------------------------------- */
@@ -795,8 +795,8 @@ struct BaseWheel
 	Wheels::Propulsion propulsion;
 	Node::Ref reference_arm_node;
 	float mass;
-	boost::shared_ptr<NodeDefaults> node_defaults;
-	boost::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<NodeDefaults> node_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
 };
 
 /** The actual wheel */
@@ -1044,7 +1044,7 @@ struct Shock
 	float long_bound;          ///< Maximum extension. The longest length a shock can be, as a proportion of its original length. "0" means the shock will not be able to extend at all. "1" means the shock will be able to double its length. Higher values allow for longer extension.
 	float precompression;      ///< Changes compression or extension of the suspension when the truck spawns. This can be used to "level" the suspension of a truck if it sags in game. The default value is 1.0. 
 	unsigned int options;      ///< Bit flags.
-	boost::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
 	int detacher_group;
 };
 
@@ -1077,7 +1077,7 @@ struct Shock2
 	float long_bound;                 ///< Maximum extension limit, in percentage ( 1.00 = 100% )
 	float precompression;             ///< Changes compression or extension of the suspension when the truck spawns. This can be used to "level" the suspension of a truck if it sags in game. The default value is 1.0.  
 	unsigned int options;             ///< Bit flags.
-	boost::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
 	int detacher_group;
 };
 
@@ -1144,8 +1144,8 @@ struct Hydro
 	float lenghtening_factor;
 	std::string options;
 	Inertia inertia;
-	boost::shared_ptr<Inertia> inertia_defaults;
-	boost::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<Inertia> inertia_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
 	int detacher_group;
 };
 
@@ -1216,8 +1216,8 @@ struct Animator
 	float short_limit;
 	float long_limit;
 	AeroAnimator aero_animator;
-	boost::shared_ptr<Inertia> inertia_defaults;
-	boost::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<Inertia> inertia_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
 	int detacher_group;
 };
 
@@ -1249,8 +1249,8 @@ struct Command2
 	Inertia inertia;
 	float affect_engine;
 	bool needs_engine;
-	boost::shared_ptr<BeamDefaults> beam_defaults;
-	boost::shared_ptr<Inertia> inertia_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<Inertia> inertia_defaults;
 	int detacher_group;
 
 	inline bool HasOption(unsigned int option) const
@@ -1281,7 +1281,7 @@ struct Rotator
 	unsigned int spin_left_key;
 	unsigned int spin_right_key;
 	Inertia inertia;
-	boost::shared_ptr<Inertia> inertia_defaults;
+	std::shared_ptr<Inertia> inertia_defaults;
 	float engine_coupling;
 	bool needs_engine;
 };
@@ -1408,7 +1408,7 @@ struct Trigger
 	float expansion_trigger_limit;
 	unsigned int options;
 	float boundary_timer;
-	boost::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
 	int detacher_group;
 	int shortbound_trigger_action;
 	int longbound_trigger_action;
@@ -1657,7 +1657,7 @@ struct Rope
 	Node::Ref end_node;
 	bool invisible;
 	bool _has_invisible_set;
-	boost::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
 	int detacher_group;
 };
 
@@ -1828,7 +1828,7 @@ struct Tie
 	float max_length;
 	Options options;
 	float max_stress;
-	boost::shared_ptr<BeamDefaults> beam_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults;
 	int detacher_group;
 	unsigned int group;
 	bool _group_set;
@@ -1990,29 +1990,29 @@ struct File
 		/* Sections*/
 		std::vector<Airbrake>              airbrakes;
 		std::vector<Animator>              animators;
-		boost::shared_ptr<AntiLockBrakes>  anti_lock_brakes;
+		std::shared_ptr<AntiLockBrakes>    anti_lock_brakes;
 		std::vector<Axle>                  axles;
 		std::vector<Beam>                  beams;
-		boost::shared_ptr<Brakes>          brakes;
+		std::shared_ptr<Brakes>            brakes;
 		std::vector<Camera>                cameras;
 		std::vector<CameraRail>            camera_rails;
 		std::vector<CollisionBox>          collision_boxes;
 		std::vector<Cinecam>               cinecam;
 		std::vector<Command2>              commands_2; /* sections 'commands' & 'commands2' are unified */
-		boost::shared_ptr<CruiseControl>   cruise_control;
+		std::shared_ptr<CruiseControl>     cruise_control;
 		std::vector<Node::Ref>             contacters;
-		boost::shared_ptr<Engine>          engine;
-		boost::shared_ptr<Engoption>       engoption;
-		boost::shared_ptr<Engturbo>        engturbo;
+		std::shared_ptr<Engine>            engine;
+		std::shared_ptr<Engoption>         engoption;
+		std::shared_ptr<Engturbo>          engturbo;
 		std::vector<Exhaust>               exhausts;
-		boost::shared_ptr<ExtCamera>       ext_camera;
+		std::shared_ptr<ExtCamera>         ext_camera;
 		std::vector<Node::Ref>              fixes;
 		std::vector<Flare2>                flares_2;
-		std::vector<boost::shared_ptr<Flexbody>>	flexbodies;
+		std::vector<std::shared_ptr<Flexbody>>	flexbodies;
 		std::vector<FlexBodyWheel>         flex_body_wheels;
 		std::vector<Fusedrag>              fusedrag;
-		boost::shared_ptr<Globals>         globals;
-		boost::shared_ptr<GuiSettings>     gui_settings;
+		std::shared_ptr<Globals>           globals;
+		std::shared_ptr<GuiSettings>       gui_settings;
 		std::vector<Hook>                  hooks;
 		std::vector<Hydro>                 hydros;
 		std::vector<Lockgroup>             lockgroups;
@@ -2033,19 +2033,17 @@ struct File
 		std::vector<Screwprop>             screwprops;
 		std::vector<Shock>                 shocks;
 		std::vector<Shock2>                shocks_2;
-		boost::shared_ptr<
-			SkeletonSettings
-		>                                  skeleton_settings;
+		std::shared_ptr<SkeletonSettings>  skeleton_settings;
 		std::vector<SlideNode>             slidenodes;
-		boost::shared_ptr<SlopeBrake>      slope_brake;
+		std::shared_ptr<SlopeBrake>        slope_brake;
 		std::vector<SoundSource>           soundsources;
 		std::vector<SoundSource2>          soundsources2;
-		boost::shared_ptr<SpeedLimiter>    speed_limiter;
+		std::shared_ptr<SpeedLimiter>      speed_limiter;
 		Ogre::String                       submeshes_ground_model_name;
 		std::vector<Submesh>               submeshes;
 		std::vector<Tie>                   ties;
-		boost::shared_ptr<TorqueCurve>     torque_curve;
-		boost::shared_ptr<TractionControl> traction_control;
+		std::shared_ptr<TorqueCurve>       torque_curve;
+		std::shared_ptr<TractionControl>   traction_control;
 		std::vector<Trigger>               triggers;
 		std::vector<Turbojet>              turbojets;
 		std::vector<Turboprop2>            turboprops_2;
@@ -2285,12 +2283,12 @@ struct File
 	bool _minimum_mass_set;
 
 	/* Vehicle sections */
-	boost::shared_ptr<Module> root_module;
-	std::map< Ogre::String, boost::shared_ptr<Module> > modules;
+	std::shared_ptr<Module> root_module;
+	std::map< Ogre::String, std::shared_ptr<Module> > modules;
 
 	/* File sections */
 	std::vector<Author> authors;
-	boost::shared_ptr<Fileinfo> file_info;
+	std::shared_ptr<Fileinfo> file_info;
 };
 
 } // namespace RigParser

--- a/source/rig_file_input_output/RigDef_Node.h
+++ b/source/rig_file_input_output/RigDef_Node.h
@@ -31,9 +31,9 @@
 
 #include "RigDef_Prerequisites.h"
 
+#include <memory>
 #include <OgreVector3.h>
 #include <string>
-#include <boost/shared_ptr.hpp>
 
 namespace RigDef
 {
@@ -163,8 +163,8 @@ struct Node
 	unsigned int options; ///< Bit flags
 	float load_weight_override;
 	bool _has_load_weight_override;
-	boost::shared_ptr<NodeDefaults> node_defaults;
-	boost::shared_ptr<BeamDefaults> beam_defaults; /* Needed for hook */
+	std::shared_ptr<NodeDefaults> node_defaults;
+	std::shared_ptr<BeamDefaults> beam_defaults; /* Needed for hook */
 	int detacher_group;
 };
 

--- a/source/rig_file_input_output/RigDef_Parser.cpp
+++ b/source/rig_file_input_output/RigDef_Parser.cpp
@@ -68,9 +68,9 @@ Parser::Parser():
 	m_ror_minimass(0)
 {
 	/* Push defaults */
-	m_ror_default_inertia = boost::shared_ptr<Inertia>(new Inertia);
-	m_ror_beam_defaults = boost::shared_ptr<BeamDefaults>(new BeamDefaults);
-	m_ror_node_defaults = boost::shared_ptr<NodeDefaults>(new NodeDefaults);
+	m_ror_default_inertia = std::shared_ptr<Inertia>(new Inertia);
+	m_ror_beam_defaults = std::shared_ptr<BeamDefaults>(new BeamDefaults);
+	m_ror_node_defaults = std::shared_ptr<NodeDefaults>(new NodeDefaults);
 }
 
 Parser::~Parser()
@@ -765,11 +765,11 @@ void Parser::ParseLine(Ogre::String const & line_unchecked)
 		/* Enter sections */
 		if (new_section == File::SECTION_SUBMESH)
 		{
-			m_current_submesh = boost::shared_ptr<Submesh>( new Submesh() );
+			m_current_submesh = std::shared_ptr<Submesh>( new Submesh() );
 		}
 		else if (new_section == File::SECTION_CAMERA_RAIL)
 		{
-			m_current_camera_rail = boost::shared_ptr<CameraRail>( new CameraRail() );
+			m_current_camera_rail = std::shared_ptr<CameraRail>( new CameraRail() );
 		}
 		else if (new_section == File::SECTION_FLEXBODIES)
 		{
@@ -779,7 +779,7 @@ void Parser::ParseLine(Ogre::String const & line_unchecked)
 		{
 			if (m_current_module->gui_settings == nullptr)
 			{
-				m_current_module->gui_settings = boost::shared_ptr<GuiSettings> ( new GuiSettings() );
+				m_current_module->gui_settings = std::shared_ptr<GuiSettings> ( new GuiSettings() );
 			}
 		}
 
@@ -1441,7 +1441,7 @@ void Parser::ParseTractionControl(Ogre::String const & line)
 	{
 		AddMessage(line, Message::TYPE_WARNING, "Multiple inline-sections 'TractionControl' in a module, using last one ...");
 	}
-	m_current_module->traction_control = boost::shared_ptr<TractionControl>( new TractionControl(traction_control) );
+	m_current_module->traction_control = std::shared_ptr<TractionControl>( new TractionControl(traction_control) );
 }
 
 void Parser::ParseSubmeshGroundModel(Ogre::String const & line)
@@ -1463,7 +1463,7 @@ void Parser::ParseSpeedLimiter(Ogre::String const & line)
 	{
 		AddMessage(line, Message::TYPE_WARNING, "Multiple inline-sections 'speedlimiter' in a module, using last one ...");
 	}
-	m_current_module->speed_limiter = boost::shared_ptr<SpeedLimiter>( new SpeedLimiter() );
+	m_current_module->speed_limiter = std::shared_ptr<SpeedLimiter>( new SpeedLimiter() );
 
 	boost::smatch results;
 	if (! boost::regex_search(line, results, Regexes::INLINE_SECTION_SPEEDLIMITER))
@@ -1482,7 +1482,7 @@ void Parser::ParseSlopeBrake(Ogre::String const & line)
 	{
 		AddMessage(line, Message::TYPE_WARNING, "Multiple inline-sections 'SlopeBrake' in a module, using last one ...");
 	}
-	m_current_module->slope_brake = boost::shared_ptr<SlopeBrake>( new SlopeBrake() );
+	m_current_module->slope_brake = std::shared_ptr<SlopeBrake>( new SlopeBrake() );
 
 	boost::smatch results;
 	if (! boost::regex_search(line, results, Regexes::INLINE_SECTION_SLOPE_BRAKE))
@@ -1520,7 +1520,7 @@ void Parser::ParseSetSkeletonSettings(Ogre::String const & line)
 
 	if (m_current_module->skeleton_settings == nullptr)
 	{
-		m_current_module->skeleton_settings = boost::shared_ptr<RigDef::SkeletonSettings>(new SkeletonSettings());
+		m_current_module->skeleton_settings = std::shared_ptr<RigDef::SkeletonSettings>(new SkeletonSettings());
 	}
 
 	float visibility_meters = STR_PARSE_REAL(results[1]);
@@ -1555,7 +1555,7 @@ void Parser::VerifyAndProcessDirectiveSetNodeDefaults(
 	float surface, 
 	unsigned int options)
 {
-	m_user_node_defaults = boost::shared_ptr<NodeDefaults>( new NodeDefaults(*m_user_node_defaults) );
+	m_user_node_defaults = std::shared_ptr<NodeDefaults>( new NodeDefaults(*m_user_node_defaults) );
 
 	m_user_node_defaults->load_weight = (load_weight < 0) ? m_ror_node_defaults->load_weight : load_weight;
 	m_user_node_defaults->friction    = (friction    < 0) ? m_ror_node_defaults->friction    : friction;
@@ -1724,7 +1724,7 @@ void Parser::ParseDirectiveSetBeamDefaultsScale(Ogre::String const & line)
 	}
 	/* NOTE: Positions in 'results' array match E_CAPTURE*() positions (starting with 1) in the respective regex. */
 
-	m_user_beam_defaults = boost::shared_ptr<BeamDefaults>( new BeamDefaults(*m_user_beam_defaults) );
+	m_user_beam_defaults = std::shared_ptr<BeamDefaults>( new BeamDefaults(*m_user_beam_defaults) );
 
 	m_user_beam_defaults->scale.springiness = STR_PARSE_REAL(results[1]);
 
@@ -1754,7 +1754,7 @@ void Parser::ParseDirectiveSetBeamDefaults(Ogre::String const & line)
 	}
 	/* NOTE: Positions in 'results' array match E_CAPTURE*() positions (starting with 1) in the respective regex. */
 
-	m_user_beam_defaults = boost::shared_ptr<BeamDefaults>( new BeamDefaults(*m_user_beam_defaults) );
+	m_user_beam_defaults = std::shared_ptr<BeamDefaults>( new BeamDefaults(*m_user_beam_defaults) );
 	/*
 	What's the state of "enable_advanced_deformation" feature at this point?
 	Directive "enable_advanced_deformation" alters the effects of BeamDefaults
@@ -2327,7 +2327,7 @@ void Parser::ParseGlobals(Ogre::String const & line)
 		globals.material_name = results[4];
 	}
 
-	m_current_module->globals = boost::shared_ptr<Globals>( new Globals(globals) );
+	m_current_module->globals = std::shared_ptr<Globals>( new Globals(globals) );
 }
 
 void Parser::ParseFusedrag(Ogre::String const & line)
@@ -2616,7 +2616,7 @@ void Parser::ParseFlexbodyUnsafe(Ogre::String const & line)
 
 void Parser::ProcessFlexbody(Flexbody& flexbody)
 {
-    m_last_flexbody = boost::shared_ptr<Flexbody>( new Flexbody(flexbody) );
+    m_last_flexbody = std::shared_ptr<Flexbody>( new Flexbody(flexbody) );
     m_current_module->flexbodies.push_back(m_last_flexbody);
 
     // Switch subsection
@@ -2791,7 +2791,7 @@ void Parser::ParseExtCamera(Ogre::String const & line)
 
 	if (m_current_module->ext_camera == nullptr)
 	{
-		m_current_module->ext_camera = boost::shared_ptr<RigDef::ExtCamera>( new RigDef::ExtCamera() );
+		m_current_module->ext_camera = std::shared_ptr<RigDef::ExtCamera>( new RigDef::ExtCamera() );
 	}
 
 	if (results[2].matched)
@@ -2897,7 +2897,7 @@ void Parser::ParseCruiseControl(Ogre::String const & line)
 	{
 		AddMessage(line, Message::TYPE_WARNING, "Found multiple inline sections 'cruise_control' in one module, using last one.");
 	}
-	m_current_module->cruise_control = boost::shared_ptr<CruiseControl>( new CruiseControl(cruise_control) );
+	m_current_module->cruise_control = std::shared_ptr<CruiseControl>( new CruiseControl(cruise_control) );
 }
 
 void Parser::_ParseDirectiveAddAnimationMode(Animation & animation, Ogre::String mode_string)
@@ -3292,7 +3292,7 @@ void Parser::ParseAntiLockBrakes(Ogre::String const & line)
 	{
 		AddMessage(line, Message::TYPE_WARNING, "Found multiple sections 'AntiLockBrakes' in one module, using last one.");
 	}
-	m_current_module->anti_lock_brakes = boost::shared_ptr<AntiLockBrakes>( new AntiLockBrakes(anti_lock_brakes) );
+	m_current_module->anti_lock_brakes = std::shared_ptr<AntiLockBrakes>( new AntiLockBrakes(anti_lock_brakes) );
 }
 
 void Parser::ParseEngoption(Ogre::String const & line)
@@ -3372,7 +3372,7 @@ void Parser::ParseEngoption(Ogre::String const & line)
 		AddMessage(line, Message::TYPE_WARNING, msg.str());
 	}
 	
-	m_current_module->engoption = boost::shared_ptr<Engoption>( new Engoption(engoption) );
+	m_current_module->engoption = std::shared_ptr<Engoption>( new Engoption(engoption) );
 }
 
 void Parser::ParseEngturbo(Ogre::String const & line)
@@ -3408,7 +3408,7 @@ void Parser::ParseEngturbo(Ogre::String const & line)
 	engturbo.param10 = STR_PARSE_REAL(results[22]);
 	engturbo.param11 = STR_PARSE_REAL(results[24]);
 
-	m_current_module->engturbo = boost::shared_ptr<Engturbo>(new Engturbo(engturbo));
+	m_current_module->engturbo = std::shared_ptr<Engturbo>(new Engturbo(engturbo));
 }
 
 void Parser::ParseEngine(Ogre::String const & line)
@@ -3462,7 +3462,7 @@ void Parser::ParseEngine(Ogre::String const & line)
 		AddMessage(line, Message::TYPE_WARNING, "Forward gears list is not terminated using '-1.0'. Please fix.");
 	}
 
-	m_current_module->engine = boost::shared_ptr<Engine>( new Engine(engine) );
+	m_current_module->engine = std::shared_ptr<Engine>( new Engine(engine) );
 }
 
 void Parser::ParseContacter(Ogre::String const & line)
@@ -3765,7 +3765,7 @@ void Parser::ParseBrakes(Ogre::String line)
 
 	if (m_current_module->brakes == nullptr)
 	{
-		m_current_module->brakes = boost::shared_ptr<Brakes>( new Brakes() );
+		m_current_module->brakes = std::shared_ptr<Brakes>( new Brakes() );
 	}
 
 	m_current_module->brakes->default_braking_force = STR_PARSE_REAL(results[1]);
@@ -4101,7 +4101,7 @@ void Parser::ParseTorqueCurve(Ogre::String const & line)
 
 	if (m_current_module->torque_curve == nullptr)
 	{
-		m_current_module->torque_curve = boost::shared_ptr<RigDef::TorqueCurve>(new RigDef::TorqueCurve());
+		m_current_module->torque_curve = std::shared_ptr<RigDef::TorqueCurve>(new RigDef::TorqueCurve());
 	}
 
 	if (results[1].matched)
@@ -4668,7 +4668,7 @@ void Parser::ParseDirectiveSetInertiaDefaults(Ogre::String const & line)
 	else
 	{
 		// Create
-		m_user_default_inertia = boost::shared_ptr<Inertia>(new Inertia(*m_user_default_inertia.get()));
+		m_user_default_inertia = std::shared_ptr<Inertia>(new Inertia(*m_user_default_inertia.get()));
 
 		// Update
 		m_user_default_inertia->start_delay_factor = start_delay;
@@ -4867,7 +4867,7 @@ void Parser::ParseFileinfo(Ogre::String const & line)
 				report << "\n\tFile version: [not set]";
 			}
 			this->AddMessage(line, Message::TYPE_INVALID, report.str());
-			m_definition->file_info = boost::shared_ptr<Fileinfo>( new Fileinfo(fileinfo) );
+			m_definition->file_info = std::shared_ptr<Fileinfo>( new Fileinfo(fileinfo) );
 		})
 		return;
 	}
@@ -4931,7 +4931,7 @@ void Parser::ParseFileinfo(Ogre::String const & line)
 		fileinfo._has_file_version_set = true;
 	}
 
-	m_definition->file_info = boost::shared_ptr<Fileinfo>( new Fileinfo(fileinfo) );
+	m_definition->file_info = std::shared_ptr<Fileinfo>( new Fileinfo(fileinfo) );
 }
 
 void Parser::ParseRopes(Ogre::String const & line)
@@ -5942,7 +5942,7 @@ std::pair<bool, Ogre::String> Parser::GetModuleName(Ogre::String const & line)
 void Parser::SetCurrentModule(Ogre::String const & name)
 {
 
-	std::map< Ogre::String, boost::shared_ptr<File::Module> >::iterator itor
+	std::map< Ogre::String, std::shared_ptr<File::Module> >::iterator itor
 		= m_definition->modules.find(name);
 
 	if (itor != m_definition->modules.end())
@@ -5951,9 +5951,9 @@ void Parser::SetCurrentModule(Ogre::String const & name)
 	}
 	else
 	{
-		m_current_module = boost::shared_ptr<File::Module>( new File::Module(name) );
+		m_current_module = std::shared_ptr<File::Module>( new File::Module(name) );
 		m_definition->modules.insert( 
-				std::pair< Ogre::String, boost::shared_ptr<File::Module> >(name, m_current_module) 
+				std::pair< Ogre::String, std::shared_ptr<File::Module> >(name, m_current_module) 
 			);
 	}
 }
@@ -6036,7 +6036,7 @@ void Parser::Prepare()
 	m_current_subsection = File::SUBSECTION_NONE;
 	m_current_line_number = 1;
 	m_num_contiguous_blank_lines = 0;
-	m_definition = boost::shared_ptr<File>(new File());
+	m_definition = std::shared_ptr<File>(new File());
 	m_in_block_comment = false;
 	m_in_description_section = false;
     m_any_named_node_defined = false;
@@ -6048,7 +6048,7 @@ void Parser::Prepare()
 	m_user_node_defaults = m_ror_node_defaults;
 	m_current_managed_material_options = ManagedMaterialsOptions();
 
-	m_root_module = boost::shared_ptr<File::Module>( new File::Module("_Root_") );
+	m_root_module = std::shared_ptr<File::Module>( new File::Module("_Root_") );
 	m_definition->root_module = m_root_module;
 	m_current_module = m_root_module;
 

--- a/source/rig_file_input_output/RigDef_Parser.h
+++ b/source/rig_file_input_output/RigDef_Parser.h
@@ -31,9 +31,9 @@
 #include "RigDef_File.h"
 #include "RigDef_SequentialImporter.h"
 
+#include <memory>
 #include <string>
 #include <boost/regex.hpp>
-#include <boost/shared_ptr.hpp>
 
 namespace RigDef
 {
@@ -117,7 +117,7 @@ public:
 		return m_messages;
 	}
 
-	boost::shared_ptr<RigDef::File> GetFile()
+	std::shared_ptr<RigDef::File> GetFile()
 	{
 		return m_definition;
 	}
@@ -418,38 +418,38 @@ protected:
 
 	/* RoR defaults */
 
-	boost::shared_ptr<Inertia>           m_ror_default_inertia;
-	boost::shared_ptr<BeamDefaults>      m_ror_beam_defaults;
-	boost::shared_ptr<NodeDefaults>      m_ror_node_defaults;
+	std::shared_ptr<Inertia>             m_ror_default_inertia;
+	std::shared_ptr<BeamDefaults>        m_ror_beam_defaults;
+	std::shared_ptr<NodeDefaults>        m_ror_node_defaults;
 	float                                m_ror_minimass;
 	SkeletonSettings                     m_ror_skeleton_settings;
 
 	/* Data from user directives */
 	/* Each affected section-struct has a shared_ptr to it's respective defaults */
-	boost::shared_ptr<Inertia>           m_user_default_inertia;
-	boost::shared_ptr<BeamDefaults>      m_user_beam_defaults;
-	boost::shared_ptr<NodeDefaults>      m_user_node_defaults;
+	std::shared_ptr<Inertia>             m_user_default_inertia;
+	std::shared_ptr<BeamDefaults>        m_user_beam_defaults;
+	std::shared_ptr<NodeDefaults>        m_user_node_defaults;
 	int                                  m_current_detacher_group;
 	ManagedMaterialsOptions              m_current_managed_material_options;
 
 	/* Parser state */
-	boost::shared_ptr<File::Module>      m_root_module;
-	boost::shared_ptr<File::Module>      m_current_module;
+	std::shared_ptr<File::Module>        m_root_module;
+	std::shared_ptr<File::Module>        m_current_module;
 
 	File::Section                        m_current_section;        ///< Parser state.
 	File::Subsection                     m_current_subsection;     ///< Parser state.
 	bool                                 m_in_block_comment;       ///< Parser state.
 	bool                                 m_in_description_section; ///< Parser state.
     bool                                 m_any_named_node_defined; ///< Parser state.
-	boost::shared_ptr<Submesh>           m_current_submesh;        ///< Parser state.
-	boost::shared_ptr<CameraRail>        m_current_camera_rail;    ///< Parser state.
-	boost::shared_ptr<Flexbody>          m_last_flexbody;
+	std::shared_ptr<Submesh>             m_current_submesh;        ///< Parser state.
+	std::shared_ptr<CameraRail>          m_current_camera_rail;    ///< Parser state.
+	std::shared_ptr<Flexbody>            m_last_flexbody;
 	unsigned int                         m_num_contiguous_blank_lines; ///< Parser state; Num. blank lines right above the current one
 
     SequentialImporter                   m_sequential_importer;
 
 	unsigned int                         m_current_line_number; ///< Only for reports. Initialised to 1
-	boost::shared_ptr<RigDef::File>      m_definition;
+	std::shared_ptr<RigDef::File>        m_definition;
 	std::list<Message>                   m_messages;
     int                                  m_messages_num_errors;
     int                                  m_messages_num_warnings;

--- a/source/rig_file_input_output/RigDef_SequentialImporter.cpp
+++ b/source/rig_file_input_output/RigDef_SequentialImporter.cpp
@@ -85,7 +85,7 @@ void SequentialImporter::GenerateNodesForWheel(File::Keyword generated_from, int
     }
 }
 
-void SequentialImporter::Process(boost::shared_ptr<RigDef::File> def)
+void SequentialImporter::Process(std::shared_ptr<RigDef::File> def)
 {
     this->ProcessModule(def->root_module);
 
@@ -378,7 +378,7 @@ void SequentialImporter::ResolveNodeRanges(std::vector<Node::Range>& ranges)
 // airbrakes = yes,yes
 // axles = NO, NO
 
-void SequentialImporter::ProcessModule(boost::shared_ptr<RigDef::File::Module> module)
+void SequentialImporter::ProcessModule(std::shared_ptr<RigDef::File::Module> module)
 {
     m_current_module = module;
 

--- a/source/rig_file_input_output/RigDef_SequentialImporter.h
+++ b/source/rig_file_input_output/RigDef_SequentialImporter.h
@@ -30,7 +30,7 @@
 #include "RigDef_Prerequisites.h"
 #include "RigDef_File.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 namespace RigDef
@@ -141,7 +141,7 @@ public:
     void GenerateNodesForWheel(File::Keyword generated_from, int num_rays, bool has_rigidity_node);
 
     /// Traverse whole rig definition and resolve all node references
-    void Process(boost::shared_ptr<RigDef::File> def);
+    void Process(std::shared_ptr<RigDef::File> def);
 
     int GetMessagesNumErrors()   const { return m_messages_num_errors;   }
     int GetMessagesNumWarnings() const { return m_messages_num_warnings; }
@@ -153,7 +153,7 @@ public:
 
 private:
 
-    void ProcessModule(boost::shared_ptr<RigDef::File::Module> module);
+    void ProcessModule(std::shared_ptr<RigDef::File::Module> module);
 
     Node::Ref ResolveNode(Node::Ref const & noderef_in);
     Node::Ref ResolveNodeByIndex(unsigned int index, unsigned int def_line_number);
@@ -179,7 +179,7 @@ private:
     int                                 m_total_resolved;
     int                                 m_num_resolved_to_self;
     File::Keyword                       m_current_keyword;
-    boost::shared_ptr<File::Module>     m_current_module;
+    std::shared_ptr<File::Module>       m_current_module;
     std::list<Message>                  m_messages;
     int                                 m_messages_num_errors;
     int                                 m_messages_num_warnings;

--- a/source/rig_file_input_output/RigDef_Serializer.cpp
+++ b/source/rig_file_input_output/RigDef_Serializer.cpp
@@ -35,7 +35,7 @@
 using namespace RigDef;
 using namespace std;
 
-Serializer::Serializer(boost::shared_ptr<RigDef::File> def_file, Ogre::String const & file_path):
+Serializer::Serializer(std::shared_ptr<RigDef::File> def_file, Ogre::String const & file_path):
 	m_file_path(file_path),
 	m_rig_def(def_file),
 	m_node_id_width(5),

--- a/source/rig_file_input_output/RigDef_Serializer.h
+++ b/source/rig_file_input_output/RigDef_Serializer.h
@@ -43,7 +43,7 @@ class Serializer
 
 public:
 
-	Serializer(boost::shared_ptr<RigDef::File> rig_def, Ogre::String const & file_path);
+	Serializer(std::shared_ptr<RigDef::File> rig_def, Ogre::String const & file_path);
 
 	virtual ~Serializer();
 
@@ -156,7 +156,7 @@ protected:
 
 	std::ofstream                     m_stream;
 	Ogre::String                      m_file_path;
-	boost::shared_ptr<RigDef::File>   m_rig_def;
+	std::shared_ptr<RigDef::File>   m_rig_def;
 	int                               m_float_precision;
 	int                               m_float_width;
 	int                               m_bool_width;

--- a/source/rig_file_input_output/RigDef_Validator.cpp
+++ b/source/rig_file_input_output/RigDef_Validator.cpp
@@ -31,7 +31,7 @@
 
 #define CHECK_SECTION_IN_ALL_MODULES(_CLASS_, _FIELD_, _FUNCTION_) \
 { \
-	std::list<boost::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin(); \
+	std::list<std::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin(); \
 	for (; module_itor != m_selected_modules.end(); module_itor++) \
 	{ \
 		std::vector<_CLASS_>::iterator section_itor = module_itor->get()->_FIELD_.begin(); \
@@ -106,7 +106,7 @@ bool Validator::Validate()
 	return valid;
 }
 
-void Validator::Setup(boost::shared_ptr<RigDef::File> file)
+void Validator::Setup(std::shared_ptr<RigDef::File> file)
 {
 	m_file = file;
 	m_selected_modules.push_back(file->root_module);
@@ -139,7 +139,7 @@ bool Validator::CheckSectionSubmeshGroundmodel()
 {
 	Ogre::String *containing_module_name = nullptr;
 
-	std::list<boost::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
+	std::list<std::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
 	for (; module_itor != m_selected_modules.end(); module_itor++)
 	{
 		if (! module_itor->get()->submeshes_ground_model_name.empty())
@@ -166,7 +166,7 @@ bool Validator::CheckSection(RigDef::File::Keyword keyword, bool unique, bool re
 {
 	Ogre::String *containing_module_name = nullptr;
 
-	std::list<boost::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
+	std::list<std::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
 	for (; module_itor != m_selected_modules.end(); module_itor++)
 	{
 		if (HasModuleKeyword(*module_itor, keyword))
@@ -197,7 +197,7 @@ bool Validator::CheckSection(RigDef::File::Keyword keyword, bool unique, bool re
 	return true;
 }
 
-bool Validator::HasModuleKeyword(boost::shared_ptr<RigDef::File::Module> module, RigDef::File::Keyword keyword)
+bool Validator::HasModuleKeyword(std::shared_ptr<RigDef::File::Module> module, RigDef::File::Keyword keyword)
 {
 	using namespace RigDef;
 
@@ -253,7 +253,7 @@ bool Validator::HasModuleKeyword(boost::shared_ptr<RigDef::File::Module> module,
 
 bool Validator::AddModule(Ogre::String const & module_name)
 {
-	std::map< Ogre::String, boost::shared_ptr<RigDef::File::Module> >::iterator result 
+	std::map< Ogre::String, std::shared_ptr<RigDef::File::Module> >::iterator result 
 		= m_file->modules.find(module_name);
 
 	if (result != m_file->modules.end())
@@ -267,8 +267,8 @@ bool Validator::AddModule(Ogre::String const & module_name)
 bool Validator::CheckGearbox()
 {
 	/* Find it */
-	boost::shared_ptr<RigDef::Engine> engine;
-	std::list<boost::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
+	std::shared_ptr<RigDef::Engine> engine;
+	std::list<std::shared_ptr<RigDef::File::Module>>::iterator module_itor = m_selected_modules.begin();
 	for (; module_itor != m_selected_modules.end(); module_itor++)
 	{
 		if (module_itor->get()->engine != nullptr)

--- a/source/rig_file_input_output/RigDef_Validator.h
+++ b/source/rig_file_input_output/RigDef_Validator.h
@@ -35,8 +35,8 @@
 
 #include "RigDef_File.h"
 
+#include <memory>
 #include <OgreString.h>
-#include <boost/shared_ptr.hpp>
 
 namespace RigDef
 {
@@ -72,7 +72,7 @@ public:
 	/**
 	* Prepares the validation.
 	*/
-	void Setup(boost::shared_ptr<RigDef::File> file);
+	void Setup(std::shared_ptr<RigDef::File> file);
 
 	/**
 	* Adds a vehicle module to the validated configuration.
@@ -111,7 +111,7 @@ private:
 	/**
 	* Checks if a module contains a section.
 	*/
-	bool HasModuleKeyword(boost::shared_ptr<RigDef::File::Module> module, RigDef::File::Keyword keyword);
+	bool HasModuleKeyword(std::shared_ptr<RigDef::File::Module> module, RigDef::File::Keyword keyword);
 
 	/**
 	* Inline-ection 'submesh_groundmodel', unique across all modules.
@@ -152,8 +152,8 @@ private:
     int m_messages_num_errors;
     int m_messages_num_warnings;
     int m_messages_num_other;
-	boost::shared_ptr<RigDef::File> m_file; //!< The parsed input file.
-	std::list<boost::shared_ptr<RigDef::File::Module>> m_selected_modules;
+	std::shared_ptr<RigDef::File> m_file; //!< The parsed input file.
+	std::list<std::shared_ptr<RigDef::File::Module>> m_selected_modules;
 	bool m_check_beams;
 
 };


### PR DESCRIPTION
Since everyone use a newer compiler, i think we could replace `boost::shared_ptr` with `std::shared_ptr`.
