### PR TITLE
[Codechange] Added linker flag '-lboost_system' on unix

### DIFF
--- a/source/configurator/CMakeLists.txt
+++ b/source/configurator/CMakeLists.txt
@@ -65,7 +65,7 @@ ELSEIF(UNIX)
    PKG_CHECK_MODULES  (Ogre OGRE REQUIRED)
    PKG_CHECK_MODULES  (Ois OIS REQUIRED)
 
-   set(OS_LIBS "")
+   set(OS_LIBS "-lboost_system")
 
 ENDIF(WIN32)
 

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -444,7 +444,7 @@ IF(WIN32)
   add_definitions("/wd4305 /wd4244 /wd4193 -DNOMINMAX")
 ELSEIF(UNIX)
   include_directories(${GTK_INCLUDE_DIRS})
-  set(OS_LIBS "X11 -l${CMAKE_DL_LIBS} -lrt -lpthread")
+  set(OS_LIBS "X11 -l${CMAKE_DL_LIBS} -lrt -lpthread -lboost_system")
 ENDIF(WIN32)
 
 


### PR DESCRIPTION
Fixes linker error on Linux, when Ogre is build with Boost enabled:
```
/usr/bin/ld: CMakeFiles/RoRConfig.dir/Configurator.cpp.o: undefined reference to symbol '_ZN5boost6system15system_categoryEv'
/usr/lib/libboost_system.so.1.60.0: error adding symbols: DSO missing from command line
```