### PR TITLE
[Cleanup] Streamlined the physics simulation update routine

### DIFF
--- a/source/main/MainThread.cpp
+++ b/source/main/MainThread.cpp
@@ -1266,20 +1266,8 @@ void MainThread::ChangedCurrentVehicle(Beam *previous_vehicle, Beam *current_veh
 		SoundScriptManager::getSingleton().trigStop(previous_vehicle, SS_TRIG_PUMP);
 #endif // OPENAL
 
-		if (!BeamFactory::getSingleton().allTrucksForcedActive())
-		{
-			int free_truck = BeamFactory::getSingleton().getTruckCount();
-			Beam **trucks =  BeamFactory::getSingleton().getTrucks();
-
-			for (int t = 0; t < free_truck; t++)
-			{
-				if (!trucks[t]) continue;
-				trucks[t]->sleepcount = 9;
-			} // make trucks synchronous
-		}
-
 		TRIGGER_EVENT(SE_TRUCK_EXIT, previous_vehicle?previous_vehicle->trucknum:-1);
-	} 
+	}
 	else
 	{
 		//getting inside

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1502,7 +1502,7 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 		if (!m_is_sim_paused)
 		{
 			BeamFactory::getSingleton().updateFlexbodiesFinal();   // Waits until all flexbody tasks are finished 
-			BeamFactory::getSingleton().calcPhysics(dt);           // we simulate one truck, it will take care of the others (except networked ones)
+			BeamFactory::getSingleton().calcPhysics(dt);
 		}
 	}
 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1501,8 +1501,9 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 
 		if (!m_is_sim_paused)
 		{
-			BeamFactory::getSingleton().updateFlexbodiesFinal();   // Waits until all flexbody tasks are finished 
+			BeamFactory::getSingleton().joinFlexbodyTasks();       // Waits until all flexbody tasks are finished
 			BeamFactory::getSingleton().calcPhysics(dt);
+			BeamFactory::getSingleton().updateFlexbodiesFinal();   // Updates the harware buffers 
 		}
 	}
 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1293,7 +1293,7 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 	dt = std::min(dt, 0.05f);
 	m_time += dt;
 
-	BeamFactory::getSingleton().syncWithSimThread();
+	BeamFactory::getSingleton().SyncWithSimThread();
 
 	RoR::Application::GetInputEngine()->Capture();
 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1442,34 +1442,23 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 		m_time_until_next_toggle -= dt;
 	}
 
-	if (curr_truck)
-		RoR::Application::GetGuiManager()->UpdateSimUtils(dt, nullptr);
-	
 	RoR::Application::GetGuiManager()->framestep(dt);
 
 	// one of the input modes is immediate, so update the movement vector
 	if (m_loading_state == ALL_LOADED)
 	{
-		// we simulate one truck, it will take care of the others (except networked ones)
-		if (!m_is_sim_paused)
-		{
-			BeamFactory::getSingleton().updateFlexbodiesFinal();   // Waits until all flexbody tasks are finished 
-			BeamFactory::getSingleton().calcPhysics(dt);           // we simulate one truck, it will take care of the others (except networked ones)
-		}
-
 		updateForceFeedback(dt);
 
 		if (RoR::Application::GetOverlayWrapper() != nullptr)
 		{
 
 #ifdef USE_MYGUI
-
-			Beam** vehicles  = BeamFactory::getSingleton().getTrucks();
-			int num_vehicles = BeamFactory::getSingleton().getTruckCount();
-
-			// Update survey map
+			// update survey map
 			if (gEnv->surveyMap != nullptr && gEnv->surveyMap->getVisibility())
 			{
+				Beam** vehicles  = BeamFactory::getSingleton().getTrucks();
+				int num_vehicles = BeamFactory::getSingleton().getTruckCount();
+
 				gEnv->surveyMap->Update(vehicles, num_vehicles);
 			}
 
@@ -1477,9 +1466,8 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 
 			if (curr_truck != nullptr)
 			{
-				//update the truck info gui (also if not displayed!)
+				// update the truck info gui (also if not displayed!)
 				RoR::Application::GetOverlayWrapper()->truckhud->update(dt, curr_truck, m_truck_info_on);
-				RoR::Application::GetGuiManager()->UpdateSimUtils(dt, curr_truck);
 #ifdef FEAT_TIMING
 				BES.updateGUI(dt);
 #endif // FEAT_TIMING
@@ -1508,6 +1496,13 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 					RoR::Application::GetOverlayWrapper()->UpdateAerialHUD(curr_truck);
 				}
 			}
+			RoR::Application::GetGuiManager()->UpdateSimUtils(dt, curr_truck);
+		}
+
+		if (!m_is_sim_paused)
+		{
+			BeamFactory::getSingleton().updateFlexbodiesFinal();   // Waits until all flexbody tasks are finished 
+			BeamFactory::getSingleton().calcPhysics(dt);           // we simulate one truck, it will take care of the others (except networked ones)
 		}
 	}
 

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -78,7 +78,7 @@ protected:
 	void windowFocusChange(Ogre::RenderWindow* rw);
 
 	bool updateTruckMirrors(float dt);
-	void updateIO(float dt);
+	void updateForceFeedback(float dt);
 
 #ifdef USE_MPLATFORM
 	MPlatform_Base *m_mplatform;

--- a/source/main/gfx/camera/CameraBehaviorOrbit.cpp
+++ b/source/main/gfx/camera/CameraBehaviorOrbit.cpp
@@ -23,7 +23,6 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Application.h"
 #include "Beam.h"
-#include "BeamFactory.h"
 #include "Collisions.h"
 #include "Console.h"
 #include "GUIManager.h"
@@ -49,6 +48,7 @@ CameraBehaviorOrbit::CameraBehaviorOrbit() :
 	, targetDirection(0.0f)
 	, targetPitch(0.0f)
 {
+	isMultiThreaded = BSETTING("Multi-threading", true);
 }
 
 void CameraBehaviorOrbit::update(const CameraManager::CameraContext &ctx)
@@ -142,7 +142,7 @@ void CameraBehaviorOrbit::update(const CameraManager::CameraContext &ctx)
 	
 	if ( ctx.mCurrTruck )
 	{
-		if (BeamFactory::getSingleton().getThreadingMode() == THREAD_MULTI)
+		if ( isMultiThreaded )
 			precedingPosition += ctx.mCurrTruck->nodes[0].Velocity * ctx.mCurrTruck->oldframe_global_dt;
 		else
 			precedingPosition += ctx.mCurrTruck->nodes[0].Velocity * ctx.mCurrTruck->global_dt;

--- a/source/main/gfx/camera/CameraBehaviorOrbit.h
+++ b/source/main/gfx/camera/CameraBehaviorOrbit.h
@@ -52,6 +52,7 @@ protected:
 	Ogre::Vector3 camLookAt;
 
 	bool limitCamMovement;
+	bool isMultiThreaded;
 };
 
 #endif // __CAMERA_BEHAVIOR_ORBIT_H_

--- a/source/main/gfx/camera/CameraBehaviorVehicle.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicle.cpp
@@ -23,7 +23,6 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Application.h"
 #include "Beam.h"
-#include "BeamFactory.h"
 #include "InputEngine.h"
 #include "Settings.h"
 
@@ -54,7 +53,7 @@ void CameraBehaviorVehicle::update(const CameraManager::CameraContext &ctx)
 
 	float dt = ctx.mDt;
 
-	if ( BeamFactory::getSingleton().getThreadingMode() == THREAD_MULTI )
+	if ( isMultiThreaded )
 		dt = ctx.mCurrTruck->oldframe_global_dt / ctx.mCurrTruck->oldframe_global_simulation_speed;
 	else
 		dt = ctx.mCurrTruck->global_dt / ctx.mCurrTruck->global_simulation_speed;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -3390,7 +3390,7 @@ void Beam::updateVisual(float dt)
 	BES_GFX_STOP(BES_GFX_updateVisual);
 }
 
-void Beam::updateFlexbodiesFinal()
+void Beam::joinFlexbodyTasks()
 {
 	if (gEnv->threadPool)
 	{
@@ -3399,6 +3399,14 @@ void Beam::updateFlexbodiesFinal()
 			t->join();
 		}
 		flexbody_tasks.clear();
+	}
+}
+
+void Beam::updateFlexbodiesFinal()
+{
+	if (gEnv->threadPool)
+	{
+		joinFlexbodyTasks();
 
 		for (int i=0; i<free_wheel; i++)
 		{

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1439,63 +1439,6 @@ void Beam::SyncReset()
 	}
 }
 
-
-static void UpdatePhysicsSimulation(const int steps, Beam* trucks[], const int numtrucks)
-{
-		for (int i=0; i<steps; i++)
-		{
-			int num_simulated_trucks = 0;
-
-			for (int t=0; t<numtrucks; t++)
-			{
-				if (trucks[t] && (trucks[t]->simulated = trucks[t]->calcForcesEulerPrepare(i==0, PHYSICS_DT, i, steps)))
-				{
-					num_simulated_trucks++;
-					trucks[t]->calcForcesEulerCompute(i==0, PHYSICS_DT, i, steps);
-					trucks[t]->calcForcesEulerFinal(i==0, PHYSICS_DT, i, steps);
-					if (!trucks[t]->disableTruckTruckSelfCollisions)
-					{
-						trucks[t]->IntraPointCD()->update(trucks[t]);
-						intraTruckCollisions(PHYSICS_DT,
-								*(trucks[t]->IntraPointCD()),
-								trucks[t]->free_collcab,
-								trucks[t]->collcabs,
-								trucks[t]->cabs,
-								trucks[t]->intra_collcabrate,
-								trucks[t]->nodes,
-								trucks[t]->collrange,
-								*(trucks[t]->submesh_ground_model));
-					}
-				}
-			}
-			BES_START(BES_CORE_Contacters);
-			for (int t=0; t<numtrucks; t++)
-			{
-				if (!trucks[t]->disableTruckTruckCollisions && num_simulated_trucks > 1)
-				{
-					if (trucks[t] && trucks[t]->simulated)
-					{
-						trucks[t]->InterPointCD()->update(trucks[t], trucks, numtrucks);
-						if (trucks[t]->collisionRelevant) {
-							interTruckCollisions(
-									PHYSICS_DT,
-									*(trucks[t]->InterPointCD()),
-									trucks[t]->free_collcab,
-									trucks[t]->collcabs,
-									trucks[t]->cabs,
-									trucks[t]->inter_collcabrate,
-									trucks[t]->nodes,
-									trucks[t]->collrange,
-									trucks, numtrucks,
-									*(trucks[t]->submesh_ground_model));
-						}
-					}
-				}
-				BES_STOP(BES_CORE_Contacters);
-			}
-		}
-}
-
 //integration loop
 //bool frameStarted(const FrameEvent& evt)
 //this will be called once by frame and is responsible for animation of all the trucks!
@@ -1578,7 +1521,7 @@ bool Beam::frameStep(int steps)
 		// simulation update
 		if (BeamFactory::getSingleton().getThreadingMode() == THREAD_SINGLE)
 		{
-			UpdatePhysicsSimulation(steps, trucks, numtrucks);
+			BeamFactory::getSingleton().UpdatePhysicsSimulation();
 		} else
 		{
 			BeamFactory::getSingleton()._WorkerWaitForSync();

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1644,7 +1644,6 @@ bool Beam::frameStep(int steps)
 		if (BeamFactory::getSingleton().getThreadingMode() == THREAD_MULTI)
 		{
 			tsteps = steps;
-			BeamFactory::getSingleton()._WorkerPrepareStart();
 			BeamFactory::getSingleton()._WorkerSignalStart();
 		}
 	}

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1586,7 +1586,6 @@ bool Beam::frameStep(int steps)
 
 		if (BeamFactory::getSingleton().getThreadingMode() == THREAD_MULTI)
 		{
-			tsteps = steps;
 			BeamFactory::getSingleton()._WorkerSignalStart();
 		}
 	}
@@ -5452,7 +5451,6 @@ Beam::Beam(
 	, replaylen(10000)
 	, replaymode(false)
 	, replaypos(0)
-	, requires_wheel_contact(false)
 	, reverselight(false)
 	, rightMirrorAngle(-0.52)
 	, rudder(0)
@@ -5468,7 +5466,6 @@ Beam::Beam(
 	, global_dt(0.1)
 	, global_simulation_speed(1.0)
 	, totalmass(0)
-	, tsteps(100)
 	, oldframe_global_dt(0.1)
 	, oldframe_global_simulation_speed(1.0)
 	, watercontact(false)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -23,9 +23,6 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include <OgrePrerequisites.h>
 #include <OgreTimer.h>
 
-#include <vector>
-#include <thread>
-
 #include "RoRPrerequisites.h"
 #include "PerVehicleCameraContext.h"
 #include "RigDef_Prerequisites.h"

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -104,6 +104,10 @@ public:
 	float getRotation();
 	Ogre::Vector3 getPosition();
 
+	/**
+	* Returns the average truck velocity calculated using the truck positions of the last two frames
+	*/
+	Ogre::Vector3 getVelocity() { return velocity; };
 
 	/**
 	* Moves vehicle.
@@ -136,11 +140,13 @@ public:
         int cache_entry_number = -1
 	);
 
-	/**
-	* TIGHT-LOOP; Called once by frame and is responsible for animation of all the trucks!
-	* the instance called is the one of the current ACTIVATED truck
-	*/
-	bool frameStep(int steps);
+	bool replayStep();
+
+	void updateForceFeedback(int steps);
+	void updateAngelScriptEvents(float dt);
+	void updateFrameTimeInformation(float dt);
+	void handleResetRequests(float dt);
+	void handleTruckPosition(float dt);
 
 	void setupDefaultSoundSources();
 
@@ -519,6 +525,8 @@ public:
 	DashBoardManager *dash;
 #endif // USE_MYGUI
 
+	void updateDashBoards(float dt);
+
 	//! @{ physic related functions
 	bool calcForcesEulerPrepare(int doUpdate, Ogre::Real dt, int step = 0, int maxsteps = 1);
 
@@ -590,13 +598,12 @@ protected:
 	void moveOrigin(Ogre::Vector3 offset); //move physics origin
 	void changeOrigin(Ogre::Vector3 newOrigin); //change physics origin
 
-	void updateDashBoards(float &dt);
-	
-	Ogre::Vector3 position;
+	Ogre::Vector3 position; // average node position
 	Ogre::Vector3 iPosition; // initial position
-	Ogre::Vector3 lastposition;
-	Ogre::Vector3 lastlastposition;
 	Ogre::Real minCameraRadius;
+
+	Ogre::Vector3 lastposition;
+	Ogre::Vector3 velocity; // average node velocity (compared to the previous frame step)
 
 	Ogre::Real replayTimer;
 	Ogre::Real replayPrecision;

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -371,7 +371,6 @@ public:
 	//can this be driven?
 	int previousGear;
 	ground_model_t *submesh_ground_model;
-	bool requires_wheel_contact;
 	int parkingbrake;
 	int lights;
 	bool reverselight;
@@ -536,9 +535,6 @@ public:
         // TODO may be removed soon
 	PointColDetector* IntraPointCD() { return intraPointCD; }
 	PointColDetector* InterPointCD() { return interPointCD; }
-
-	int curtstep;
-	int tsteps;
 
 protected:
 

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -251,10 +251,15 @@ public:
 	void updateVisual(float dt=0);
 
 	/**
-	* TIGHT-LOOP; Logic: flexbodies, threading
+	* TIGHT-LOOP; Logic: flexbodies
 	*/
 	void updateFlexbodiesPrepare();
 	void updateFlexbodiesFinal();
+
+	/**
+	 * Waits until all flexbody tasks are finished, but does not update the hardware buffers
+	 */
+	void joinFlexbodyTasks();
 
 	/**
 	* TIGHT-LOOP; Logic: display

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -126,9 +126,6 @@ static const float HOOK_SPEED_DEFAULT           = 0.00025f;
 static const float HOOK_LOCK_TIMER_DEFAULT      = 5.0;
 static const int   NODE_LOCKGROUP_DEFAULT		= -1; // all hooks scan all nodes
 
-#define THREAD_SINGLE false	//!< single threading mode
-#define THREAD_MULTI  true  //!< multi threading mode
-
 /* Enumerations */
 enum {
 	BEAM_NORMAL,

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -824,6 +824,17 @@ void BeamFactory::updateFlexbodiesPrepare()
 	}
 }
 
+void BeamFactory::joinFlexbodyTasks()
+{
+	for (int t=0; t < m_free_truck; t++)
+	{
+		if (m_trucks[t] && m_trucks[t]->state < SLEEPING)
+		{
+			m_trucks[t]->joinFlexbodyTasks();
+		}
+	}
+}
+
 void BeamFactory::updateFlexbodiesFinal()
 {
 	for (int t=0; t < m_free_truck; t++)

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -832,7 +832,7 @@ void BeamFactory::updateFlexbodiesPrepare()
 {
 	for (int t=0; t < free_truck; t++)
 	{
-		if (trucks[t] && trucks[t]->state < SLEEPING && trucks[t]->loading_finished)
+		if (trucks[t] && trucks[t]->state < SLEEPING)
 		{
 			trucks[t]->updateFlexbodiesPrepare();
 		}
@@ -843,7 +843,7 @@ void BeamFactory::updateFlexbodiesFinal()
 {
 	for (int t=0; t < free_truck; t++)
 	{
-		if (trucks[t] && trucks[t]->state < SLEEPING && trucks[t]->loading_finished)
+		if (trucks[t] && trucks[t]->state < SLEEPING)
 		{
 			trucks[t]->updateFlexbodiesFinal();
 		}
@@ -861,7 +861,7 @@ void BeamFactory::updateVisual(float dt)
 		// always update the labels
 		trucks[t]->updateLabels(dt);
 
-		if (trucks[t]->state < SLEEPING && trucks[t]->loading_finished)
+		if (trucks[t]->state < SLEEPING)
 		{
 			trucks[t]->updateVisual(dt);
 			trucks[t]->updateSkidmarks();
@@ -896,7 +896,6 @@ void BeamFactory::calcPhysics(float dt)
 	for (int t=0; t < free_truck; t++)
 	{
 		if (!trucks[t]) continue;
-		if (!trucks[t]->loading_finished) continue;
 
 		trucks[t]->handleResetRequests(dt);
 		trucks[t]->handleTruckPosition(dt);
@@ -937,7 +936,7 @@ void BeamFactory::calcPhysics(float dt)
 		}
 	}
 
-	if (simulatedTruck >= 0 && simulatedTruck < free_truck && trucks[simulatedTruck]->loading_finished)
+	if (simulatedTruck >= 0 && simulatedTruck < free_truck)
 	{
 		if (simulatedTruck == current_truck)
 		{

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -606,19 +606,6 @@ void BeamFactory::checkSleepingState()
 			}
 		}
 	}
-
-#if 0   // obsolete for now
-	// special stuff for rollable gear
-	bool rollmode = false;
-	for (int t=0; t < free_truck; t++)
-	{
-		if (!trucks[t]) continue;
-		if (trucks[t]->state != SLEEPING)
-			rollmode = rollmode || trucks[t]->wheel_contact_requested;
-
-		trucks[t]->requires_wheel_contact = rollmode;// && !trucks[t]->wheel_contact_requested;
-	}
-#endif
 }
 
 int BeamFactory::getFreeTruckSlot()
@@ -1053,11 +1040,7 @@ void BeamFactory::UpdatePhysicsSimulation()
 			for (int t=0; t<free_truck; t++)
 			{
 				if (trucks[t] && (trucks[t]->simulated = trucks[t]->calcForcesEulerPrepare(i==0, PHYSICS_DT, i, m_physics_steps)))
-				{
 					num_simulated_trucks++;
-					trucks[t]->curtstep = i;
-					trucks[t]->tsteps   = m_physics_steps;
-				}
 			}
 
 			{

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -28,11 +28,12 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Beam.h"
 #include "StreamableFactory.h"
-#include "TwoDReplay.h"
 
 #include <future>
 
 #define PHYSICS_DT 0.0005 // fixed dt of 0.5 ms
+
+class TwoDReplay;
 
 /**
 * Builds and manages vehicles; Manages multithreading.
@@ -40,7 +41,6 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 class BeamFactory : public StreamableFactory < BeamFactory, Beam >, public ZeroedMemoryAllocator
 {
 	friend class Network;
-	friend class RoRFrameListener;
 
 public:
 
@@ -87,7 +87,6 @@ public:
 	void setSimulationSpeed(float speed) { m_simulation_speed = std::max(0.0f, speed); };
 	float getSimulationSpeed() { return m_simulation_speed; };
 
-	bool removeBeam(Beam *b);
 	void removeCurrentTruck();
 	void removeAllTrucks();
 	void removeTruck(Collisions *collisions, const Ogre::String &inst, const Ogre::String &box);
@@ -153,7 +152,7 @@ public:
 	void release(){};
 #endif
 
-	void syncWithSimThread();
+	void SyncWithSimThread();
 
 protected:
 	
@@ -183,22 +182,22 @@ protected:
 	void LogParserMessages();
 	void LogSpawnerMessages();
 
-	bool checkForActive(int j, std::bitset<MAX_TRUCKS> &sleepyList);
-	void recursiveActivation(int j);
+	bool CheckForActive(int j, std::bitset<MAX_TRUCKS> &sleepyList);
+	void RecursiveActivation(int j);
 
-	void updateSleepingState(float dt);
+	void UpdateSleepingState(float dt);
 
-	int getFreeTruckSlot();
-	int findTruckInsideBox(Collisions *collisions, const Ogre::String &inst, const Ogre::String &box);
+	int GetFreeTruckSlot();
+	int FindTruckInsideBox(Collisions *collisions, const Ogre::String &inst, const Ogre::String &box);
 
 	// functions used by friends
 	void netUserAttributesChanged(int source, int streamid);
 	void localUserAttributesChanged(int newid);
 
-	bool syncRemoteStreams();
-	void removeInstance(Beam *b);
-	void removeInstance(stream_del_t *del);
-	void _deleteTruck(Beam *b);
+	void RemoveInstance(Beam *b);
+	void RemoveInstance(stream_del_t *del);
+	bool RemoveBeam(Beam *b);
+	void DeleteTruck(Beam *b);
 };
 
 #endif // __BeamFactory_H_

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -29,10 +29,9 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "Beam.h"
 #include "StreamableFactory.h"
 
-#include <future>
-
 #define PHYSICS_DT 0.0005 // fixed dt of 0.5 ms
 
+class ThreadPool;
 class TwoDReplay;
 
 /**
@@ -155,9 +154,10 @@ public:
 	void SyncWithSimThread();
 
 protected:
-	
-	std::shared_future<void> m_thread_future;
 
+	ThreadPool* m_sim_thread_pool;
+	std::shared_ptr<Task> m_sim_task;
+	
 	bool m_thread_mode;
 	int m_num_cpu_cores;
 

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -123,6 +123,8 @@ public:
 	void updateFlexbodiesPrepare();
 	void updateFlexbodiesFinal();
 
+	void UpdatePhysicsSimulation();
+
 	inline unsigned long getPhysFrame() { return m_physics_frames; };
 
 	void calcPhysics(float dt);
@@ -156,8 +158,6 @@ public:
 	void prepareShutdown();
 
 	void windowResized();
-
-	void threadentry();
 
 #ifdef USE_ANGELSCRIPT
 	// we have to add this to be able to use the class as reference inside scripts

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -69,8 +69,6 @@ public:
 	
 	Beam *createRemoteInstance(stream_reg_t *reg);
 
-	bool getThreadingMode() { return m_thread_mode; };
-
 	int getNumCpuCores() { return m_num_cpu_cores; };
 
 	Beam *getBeam(int source_id, int stream_id); // used by character
@@ -160,10 +158,9 @@ public:
 
 protected:
 
-	ThreadPool* m_sim_thread_pool;
+	std::unique_ptr<ThreadPool> m_sim_thread_pool;
 	std::shared_ptr<Task> m_sim_task;
 	
-	bool m_thread_mode;
 	int m_num_cpu_cores;
 
 	Beam *m_trucks[MAX_TRUCKS];
@@ -174,7 +171,7 @@ protected:
 
 	bool m_forced_active; // disables sleepcount
 
-	TwoDReplay *m_tdr;
+	std::unique_ptr<TwoDReplay> m_tdr;
 
 	unsigned long m_physics_frames;
 	int m_physics_steps;

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -110,6 +110,11 @@ public:
 	void updateFlexbodiesPrepare();
 	void updateFlexbodiesFinal();
 
+	/**
+	 * Waits until all flexbody tasks are finished, but does not update the hardware buffers
+	 */
+	void joinFlexbodyTasks();
+
 	void UpdatePhysicsSimulation();
 
 	inline unsigned long getPhysFrame() { return m_physics_frames; };

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -30,7 +30,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "StreamableFactory.h"
 #include "TwoDReplay.h"
 
-#include <pthread.h>
+#include <future>
 
 #define PHYSICS_DT 0.0005 // fixed dt of 0.5 ms
 
@@ -77,11 +77,6 @@ public:
 	*/
 	void _WorkerWaitForSync();
 	
-	/**
-	* Threading; Prepare to start working
-	*/
-	void _WorkerPrepareStart(); 
-
 	/**
 	* Threading; Signals to start working
 	*/
@@ -162,15 +157,6 @@ public:
 
 	void windowResized();
 
-	bool thread_done;
-	pthread_cond_t thread_done_cv;
-	pthread_mutex_t thread_done_mutex;
-
-	bool work_done;
-	pthread_cond_t work_done_cv;
-	pthread_mutex_t work_done_mutex;
-	pthread_t worker_thread;
-
 	void threadentry();
 
 #ifdef USE_ANGELSCRIPT
@@ -181,6 +167,8 @@ public:
 
 protected:
 	
+	std::shared_future<void> thread_future;
+
 	bool thread_mode;
 	int num_cpu_cores;
 
@@ -188,6 +176,7 @@ protected:
 	int free_truck;
 	int previous_truck;
 	int current_truck;
+	int simulatedTruck;
 
 	bool forced_active; // disables sleepcount
 

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -70,18 +70,18 @@ public:
 	
 	Beam *createRemoteInstance(stream_reg_t *reg);
 
-	bool getThreadingMode() { return thread_mode; };
+	bool getThreadingMode() { return m_thread_mode; };
 
-	int getNumCpuCores() { return num_cpu_cores; };
+	int getNumCpuCores() { return m_num_cpu_cores; };
 
 	Beam *getBeam(int source_id, int stream_id); // used by character
 
 	Beam *getCurrentTruck();
 	Beam *getTruck(int number);
-	Beam **getTrucks() { return trucks; };
-	int getPreviousTruckNumber() { return previous_truck; };
-	int getCurrentTruckNumber() { return current_truck; };
-	int getTruckCount() { return free_truck; };
+	Beam **getTrucks() { return m_trucks; };
+	int getPreviousTruckNumber() { return m_previous_truck; };
+	int getCurrentTruckNumber() { return m_current_truck; };
+	int getTruckCount() { return m_free_truck; };
 
 	void setCurrentTruck(int new_truck);
 	void setSimulationSpeed(float speed) { m_simulation_speed = std::max(0.0f, speed); };
@@ -141,7 +141,7 @@ public:
 
 	void activateAllTrucks();
 	void sendAllTrucksSleeping();
-	void setTrucksForcedActive(bool forced) { forced_active = forced; };
+	void setTrucksForcedActive(bool forced) { m_forced_active = forced; };
 
 	void prepareShutdown();
 
@@ -157,20 +157,20 @@ public:
 
 protected:
 	
-	std::shared_future<void> thread_future;
+	std::shared_future<void> m_thread_future;
 
-	bool thread_mode;
-	int num_cpu_cores;
+	bool m_thread_mode;
+	int m_num_cpu_cores;
 
-	Beam *trucks[MAX_TRUCKS];
-	int free_truck;
-	int previous_truck;
-	int current_truck;
-	int simulatedTruck;
+	Beam *m_trucks[MAX_TRUCKS];
+	int m_free_truck;
+	int m_previous_truck;
+	int m_current_truck;
+	int m_simulated_truck;
 
-	bool forced_active; // disables sleepcount
+	bool m_forced_active; // disables sleepcount
 
-	TwoDReplay *tdr;
+	TwoDReplay *m_tdr;
 
 	unsigned long m_physics_frames;
 	int m_physics_steps;

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -72,16 +72,6 @@ public:
 
 	bool getThreadingMode() { return thread_mode; };
 
-	/**
-	* Threading; Waits until work is done
-	*/
-	void _WorkerWaitForSync();
-	
-	/**
-	* Threading; Signals to start working
-	*/
-	void _WorkerSignalStart(); 
-
 	int getNumCpuCores() { return num_cpu_cores; };
 
 	Beam *getBeam(int source_id, int stream_id); // used by character
@@ -92,7 +82,6 @@ public:
 	int getPreviousTruckNumber() { return previous_truck; };
 	int getCurrentTruckNumber() { return current_truck; };
 	int getTruckCount() { return free_truck; };
-	bool allTrucksForcedActive() { return forced_active; };
 
 	void setCurrentTruck(int new_truck);
 	void setSimulationSpeed(float speed) { m_simulation_speed = std::max(0.0f, speed); };
@@ -151,7 +140,6 @@ public:
 	bool predictTruckIntersectionCollAABB(int a, int b);
 
 	void activateAllTrucks();
-	void checkSleepingState();
 	void sendAllTrucksSleeping();
 	void setTrucksForcedActive(bool forced) { forced_active = forced; };
 
@@ -164,6 +152,8 @@ public:
 	void addRef(){};
 	void release(){};
 #endif
+
+	void syncWithSimThread();
 
 protected:
 	
@@ -196,6 +186,8 @@ protected:
 	bool checkForActive(int j, std::bitset<MAX_TRUCKS> &sleepyList);
 	void recursiveActivation(int j);
 
+	void updateSleepingState(float dt);
+
 	int getFreeTruckSlot();
 	int findTruckInsideBox(Collisions *collisions, const Ogre::String &inst, const Ogre::String &box);
 
@@ -204,7 +196,6 @@ protected:
 	void localUserAttributesChanged(int newid);
 
 	bool syncRemoteStreams();
-	void updateGUI();
 	void removeInstance(Beam *b);
 	void removeInstance(stream_del_t *del);
 	void _deleteTruck(Beam *b);

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1450,7 +1450,6 @@ bool Beam::calcForcesEulerPrepare(int doUpdate, Ogre::Real dt, int step, int max
 	if (deleting) return false;
 	if (m_reset_request) return false;
 	if (state >= SLEEPING) return false;
-	if (!loading_finished) return false;
 
 	BES_START(BES_CORE_WholeTruckCalc);
 

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -915,6 +915,8 @@ void Beam::calcForcesEulerCompute(int doUpdate, Real dt, int step, int maxsteps)
 	//auto shock adjust
 	if (free_active_shock && doUpdate)
 	{
+		stabsleep -= dt * maxsteps;
+
 		Vector3 dir = nodes[cameranodepos[0]].RelPosition-nodes[cameranoderoll[0]].RelPosition;
 		dir.normalise();
 		float roll = asin(dir.dotProduct(Vector3::UNIT_Y));
@@ -1445,9 +1447,10 @@ void Beam::calcForcesEulerCompute(int doUpdate, Real dt, int step, int maxsteps)
 bool Beam::calcForcesEulerPrepare(int doUpdate, Ogre::Real dt, int step, int maxsteps)
 {
 	if (dt==0.0) return false;
-	if (state >= SLEEPING) return false;
 	if (deleting) return false;
 	if (m_reset_request) return false;
+	if (state >= SLEEPING) return false;
+	if (!loading_finished) return false;
 
 	BES_START(BES_CORE_WholeTruckCalc);
 

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -357,7 +357,6 @@ void ScriptEngine::init()
 	result = engine->RegisterObjectProperty("BeamClass", "int sleepcount", offsetof(Beam, sleepcount)); MYASSERT(result>=0);
 	result = engine->RegisterObjectProperty("BeamClass", "int driveable", offsetof(Beam, driveable)); MYASSERT(result>=0);
 	result = engine->RegisterObjectProperty("BeamClass", "int importcommands", offsetof(Beam, importcommands)); MYASSERT(result>=0);
-	result = engine->RegisterObjectProperty("BeamClass", "bool requires_wheel_contact", offsetof(Beam, requires_wheel_contact)); MYASSERT(result>=0);
 	result = engine->RegisterObjectProperty("BeamClass", "bool wheel_contact_requested", offsetof(Beam, wheel_contact_requested)); MYASSERT(result>=0);
 	result = engine->RegisterObjectProperty("BeamClass", "bool rescuer", offsetof(Beam, rescuer)); MYASSERT(result>=0);
 	result = engine->RegisterObjectProperty("BeamClass", "int parkingbrake", offsetof(Beam, parkingbrake)); MYASSERT(result>=0);


### PR DESCRIPTION
Read this first: https://github.com/RigsOfRods/rigs-of-rods/pull/858#issuecomment-216222555

* Removed the BeamFactory worker thread
* Merged threadentry() with UpdatePhysicsSimulation()
* Moved UpdatePhysicsSimulation() from Beam to BeamFactory
* Fixed crash when `DisableThreadPool=Yes`

**Edit:**
* Moved all physics related updates into `BeamFactory::calcPhysics`
* Chopped the  `Beam::frameStep` into several smaller functions
* Added new `syncWithSimThread` method, which is now called at the beginning of the `RoRFrameListener::frameStarted()` method
* SimThread and MainThread no longer access the truck engine at the same time
* `updateFlexbodiesPrepare()` and `UpdateEvents()` no longer run in parallel with the SimThread