### PR TITLE
[Codechange] Overworked the truck rotation during spawning

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -5821,7 +5821,7 @@ bool Beam::LoadTruck(
 	LOG(" == Spawning vehicle: " + parser.GetFile()->name);
 
 	RigSpawner spawner;
-	spawner.Setup(this, parser.GetFile(), parent_scene_node, spawn_position, spawn_rotation, cache_entry_number);
+	spawner.Setup(this, parser.GetFile(), parent_scene_node, cache_entry_number);
     LOAD_RIG_PROFILE_CHECKPOINT(ENTRY_BEAM_LOADTRUCK_SPAWNER_SETUP);
 	/* Setup modules */
 	spawner.AddModule(parser.GetFile()->root_module);
@@ -5865,6 +5865,14 @@ bool Beam::LoadTruck(
 	}
     LOAD_RIG_PROFILE_CHECKPOINT(ENTRY_BEAM_LOADTRUCK_SPAWNER_LOG);
 	/* POST-PROCESSING (Old-spawn code from Beam::loadTruck2) */
+
+	// Apply spawn position & spawn rotation
+	for (int i=0; i<free_node; i++)
+	{
+		nodes[i].AbsPosition = spawn_position + spawn_rotation * nodes[i].AbsPosition;
+		nodes[i].RelPosition = nodes[i].AbsPosition - origin;
+		nodes[i].smoothpos   = nodes[i].AbsPosition;
+	};
 
 	/* Place correctly */
     if (! parser.GetFile()->HasFixes())

--- a/source/main/physics/input_output/RigSpawner.h
+++ b/source/main/physics/input_output/RigSpawner.h
@@ -97,8 +97,6 @@ public:
 		Beam *rig,
 		std::shared_ptr<RigDef::File> file,
 		Ogre::SceneNode *parent,
-		Ogre::Vector3 const & spawn_position,
-		Ogre::Quaternion const & spawn_rotation,
         int cache_entry_number = -1
 		);
 
@@ -960,7 +958,7 @@ protected:
 	/**
 	* From SerializedRig::wash_calculator()
 	*/
-	void WashCalculator(Ogre::Quaternion const & rot);
+	void WashCalculator();
 
 	void FetchAxisNodes(
 		node_t* & axis_node_1, 
@@ -1015,8 +1013,6 @@ protected:
 	/* RIG CONTEXT */
 
 	Ogre::SceneNode *m_parent_scene_node;
-	Ogre::Vector3 m_spawn_position;
-	Ogre::Quaternion m_spawn_rotation;
 	float m_wing_area;
 	int m_airplane_left_light;
 	int m_airplane_right_light;


### PR DESCRIPTION
The truck nodes are now translated and rotated after the RigSpawner is done.

Fixes: #820 

Positive side effect: Trucks load a lot faster.