### PR TITLE
[Bugfix] Fixes build error with Ogre 1.8

### DIFF
--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -30,6 +30,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "BeamData.h"
 #include "Streamable.h"
 
+#include <memory>
 #include <mutex>
 
 class Task;


### PR DESCRIPTION
Beam.h:593:14: error: ‘shared_ptr’ is not a member of ‘std’