### PR TITLE
[Feature] Added command line parameter '-joinserver'

### DIFF
--- a/source/main/MainThread.cpp
+++ b/source/main/MainThread.cpp
@@ -280,49 +280,7 @@ void MainThread::Go()
 	else
 		strncpy(gEnv->frameListener->m_screenshot_format, screenshotFormatString.c_str(), 10);
 
-	// PROCESS COMMAND LINE ARGUMENTS
-
-	String cmd = SSETTING("cmdline CMD", "");
-	String cmdAction = "";
-	String cmdServerIP = "";
-	String modName = "";
-	long cmdServerPort = 0;
-	Vector3 spawnLocation = Vector3::ZERO;
-	if (!cmd.empty())
-	{
-		StringVector str = StringUtil::split(cmd, "/");
-		// process args now
-		for (StringVector::iterator it = str.begin(); it!=str.end(); it++)
-		{
-
-			String argstr = *it;
-			StringVector args = StringUtil::split(argstr, ":");
-			if (args.size()<2) continue;
-			if (args[0] == "action" && args.size() == 2) cmdAction = args[1];
-			if (args[0] == "serverpass" && args.size() == 2) SETTINGS.setSetting("Server password", args[1]);
-			if (args[0] == "modname" && args.size() == 2) modName = args[1];
-			if (args[0] == "ipport" && args.size() == 3)
-			{
-				cmdServerIP = args[1];
-				cmdServerPort = StringConverter::parseLong(args[2]);
-			}
-			if (args[0] == "loc" && args.size() == 4)
-			{
-				spawnLocation = Vector3(StringConverter::parseInt(args[1]), StringConverter::parseInt(args[2]), StringConverter::parseInt(args[3]));
-				SETTINGS.setSetting("net spawn location", TOSTRING(spawnLocation));
-			}
-		}
-	}
-
-	if (cmdAction == "regencache") SETTINGS.setSetting("regen-cache-only", "Yes");
-	if (cmdAction == "installmod")
-	{
-		// use modname!
-	}
 	bool enable_network = BSETTING("Network enable", false);
-	// check if we enable netmode based on cmdline
-	if (!enable_network && cmdAction == "joinserver")
-		enable_network = true;
 
 	String preselected_map = SSETTING("Preselected Map", "");
 
@@ -343,14 +301,10 @@ void MainThread::Go()
 	{
 		RoR::Application::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::MESHES);
 		RoR::Application::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::MATERIALS);
-		// cmdline overrides config
+
 		std::string server_name = SSETTING("Server name", "").c_str();
-		if (cmdAction == "joinserver" && !cmdServerIP.empty())
-			server_name = cmdServerIP;
 
 		long server_port = ISETTING("Server port", 1337);
-		if (cmdAction == "joinserver" && cmdServerPort)
-			server_port = cmdServerPort;
 
 		if (server_port==0)
 		{

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -64,7 +64,8 @@ enum {
 	OPT_REPOMODE,
 	OPT_VEHICLEOUT,
 	OPT_NOCACHE,
-	OPT_IMGPATH
+	OPT_IMGPATH,
+	OPT_JOINMPSERVER
 };
 
 // option array
@@ -96,6 +97,7 @@ CSimpleOpt::SOption cmdline_options[] = {
 	{ OPT_NOCACHE,        ("-nocache"),       SO_NONE },
 	{ OPT_VEHICLEOUT,     ("-vehicleout"),       SO_REQ_SEP },
 	{ OPT_IMGPATH,        ("-imgpath"),       SO_REQ_SEP },
+	{ OPT_JOINMPSERVER,	  ("-joinserver"),		SO_REQ_CMB },
 	
 SO_END_OF_OPTIONS
 };
@@ -203,6 +205,11 @@ int main(int argc, char *argv[])
 				SETTINGS.setSetting("USE_OGRE_CONFIG", "Yes");
 			} else if (args.OptionId() == OPT_VEHICLEOUT) {
 				SETTINGS.setSetting("vehicleOutputFile", args.OptionArg());
+			} else if (args.OptionId() == OPT_JOINMPSERVER) {
+				String serveragrs = args.OptionArg();
+				SETTINGS.setSetting("Network enable", "Yes");
+				SETTINGS.setSetting("Server name", serveragrs.substr(0, serveragrs.find(":")));
+				SETTINGS.setSetting("Server port", serveragrs.substr(serveragrs.find(":") + 1, serveragrs.length()));
 			} else if (args.OptionId() == OPT_VER) {
 				showVersion();
 				return 0;

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -206,10 +206,21 @@ int main(int argc, char *argv[])
 			} else if (args.OptionId() == OPT_VEHICLEOUT) {
 				SETTINGS.setSetting("vehicleOutputFile", args.OptionArg());
 			} else if (args.OptionId() == OPT_JOINMPSERVER) {
-				String serveragrs = args.OptionArg();
 				SETTINGS.setSetting("Network enable", "Yes");
-				SETTINGS.setSetting("Server name", serveragrs.substr(0, serveragrs.find(":")));
-				SETTINGS.setSetting("Server port", serveragrs.substr(serveragrs.find(":") + 1, serveragrs.length()));
+
+				String server_args = args.OptionArg();
+				const int colon = server_args.rfind(":");
+
+				// Windows URI Scheme retuns rorserver://server:port/
+				if (server_args.find("rorserver://") != String::npos)
+				{
+					SETTINGS.setSetting("Server name", server_args.substr(12, colon - 12));
+					SETTINGS.setSetting("Server port", server_args.substr(colon + 1, server_args.length() - colon - 2));
+				} else
+				{
+					SETTINGS.setSetting("Server name", server_args.substr(0, colon));
+					SETTINGS.setSetting("Server port", server_args.substr(colon + 1, server_args.length()));
+				}
 			} else if (args.OptionId() == OPT_VER) {
 				showVersion();
 				return 0;


### PR DESCRIPTION
Adapted from @AnotherFoxGuy: https://github.com/RigsOfRods/rigs-of-rods/pull/807/commits/8dd75006c42cd054347f8ef27178a980edada9fa, https://github.com/RigsOfRods/rigs-of-rods/pull/807/commits/7d4f96f8561241db708cfb0814bce9f81d14c6c1 and https://github.com/RigsOfRods/rigs-of-rods/pull/807/commits/55add7cf8702fbaaeec93e255bd9cc657c1a1eec

Closes: https://github.com/RigsOfRods/rigs-of-rods/pull/807

>Now you can join an MP-server with
>```
>RoR.exe -joinserver="server:port"
>```
>for example
>```
>RoR.exe -joinserver="ror.ezzg.be:14151"
>```