### PR TITLE
[Codechange] Proper multiplayer truck deletion

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1478,6 +1478,8 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 			RoR::Application::GetGuiManager()->UpdateSimUtils(dt, curr_truck);
 		}
 
+		BeamFactory::getSingleton().handleTruckDeletion();
+
 		if (!m_is_sim_paused)
 		{
 			BeamFactory::getSingleton().joinFlexbodyTasks();       // Waits until all flexbody tasks are finished

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -717,7 +717,18 @@ void BeamFactory::removeTruck(int truck)
 		this->DeleteTruck(m_trucks[truck]);
 }
 
-void BeamFactory::p_removeAllTrucks()
+void BeamFactory::DeleteTruck(Beam *b)
+{
+	std::lock_guard<std::mutex> lock(m_delete_queue_mutex);
+	m_delete_queue.push_back(b);
+}
+
+void BeamFactory::removeCurrentTruck()
+{
+	removeTruck(m_current_truck);
+}
+
+void BeamFactory::removeAllTrucks()
 {
 	for (int i = 0; i < m_free_truck; i++)
 	{
@@ -734,31 +745,6 @@ void BeamFactory::p_removeAllTrucks()
 				this->DeleteTruck(m_trucks[i]);
 		}
 	}
-}
-
-void BeamFactory::DeleteTruck(Beam *b)
-{
-	if (b == 0)	return;
-
-	this->SyncWithSimThread();
-
-	m_trucks[b->trucknum] = 0;
-	delete b;
-	//m_free_truck = m_free_truck - 1;
-
-#ifdef USE_MYGUI
-	GUI_MainMenu::getSingleton().triggerUpdateVehicleList();
-#endif // USE_MYGUI
-}
-
-void BeamFactory::removeCurrentTruck()
-{
-	removeTruck(m_current_truck);
-}
-
-void BeamFactory::removeAllTrucks()
-{
-	p_removeAllTrucks();
 }
 
 void BeamFactory::setCurrentTruck(int new_truck)
@@ -861,6 +847,27 @@ void BeamFactory::updateVisual(float dt)
 	}
 }
 
+void BeamFactory::handleTruckDeletion()
+{
+	this->SyncWithSimThread();
+
+	std::lock_guard<std::mutex> lock(m_delete_queue_mutex);
+
+	for (Beam* b : m_delete_queue)
+	{
+		if (b)
+		{
+			m_trucks[b->trucknum] = 0;
+			delete b;
+		}
+	}
+	m_delete_queue.clear();
+
+#ifdef USE_MYGUI
+	GUI_MainMenu::getSingleton().triggerUpdateVehicleList();
+#endif // USE_MYGUI
+}
+
 void BeamFactory::calcPhysics(float dt)
 {
 	m_physics_frames++;
@@ -957,14 +964,6 @@ void BeamFactory::calcPhysics(float dt)
 	}
 }
 
-void BeamFactory::RemoveInstance(Beam *b)
-{
-	if (b == 0) return;
-	// hide the truck
-	b->deleteNetTruck();
-	//this->DeleteTruck(b);
-}
-
 void BeamFactory::RemoveInstance(stream_del_t *del)
 {
 	// we override this here so we can also delete the truck array content
@@ -982,13 +981,13 @@ void BeamFactory::RemoveInstance(stream_del_t *del)
 	{
 		// delete all streams
 		for (it_beam=it_stream->second.begin(); it_beam != it_stream->second.end(); it_beam++)
-			this->RemoveInstance(it_beam->second);
+			this->DeleteTruck(it_beam->second);
 	} else
 	{
 		// find the stream matching the streamid
 		it_beam = it_stream->second.find(del->streamid);
 		if (it_beam != it_stream->second.end())
-			this->RemoveInstance(it_beam->second);
+			this->DeleteTruck(it_beam->second);
 	}
 	// unlockStreams();
 }
@@ -1008,7 +1007,6 @@ void BeamFactory::windowResized()
 
 void BeamFactory::prepareShutdown()
 {
-	this->SyncWithSimThread();
 }
 
 Beam* BeamFactory::getCurrentTruck()

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -92,8 +92,6 @@ public:
 	void MuteAllTrucks();
 	void UnmuteAllTrucks();
 
-	void p_removeAllTrucks();
-
 	bool enterRescueTruck();
 	void repairTruck(Collisions *collisions, const Ogre::String &inst, const Ogre::String &box, bool keepPosition=false);
 
@@ -144,6 +142,8 @@ public:
 	void sendAllTrucksSleeping();
 	void setTrucksForcedActive(bool forced) { m_forced_active = forced; };
 
+	void handleTruckDeletion();
+
 	void prepareShutdown();
 
 	void windowResized();
@@ -157,6 +157,9 @@ public:
 	void SyncWithSimThread();
 
 protected:
+
+	std::mutex m_delete_queue_mutex;
+	std::vector<Beam*> m_delete_queue;
 
 	std::unique_ptr<ThreadPool> m_sim_thread_pool;
 	std::shared_ptr<Task> m_sim_task;
@@ -196,7 +199,6 @@ protected:
 	void netUserAttributesChanged(int source, int streamid);
 	void localUserAttributesChanged(int newid);
 
-	void RemoveInstance(Beam *b);
 	void RemoveInstance(stream_del_t *del);
 	bool RemoveBeam(Beam *b);
 	void DeleteTruck(Beam *b);


### PR DESCRIPTION
Fixes: #27 

**Edit:** Not working properly. It does not produce any crashes, but it leaves dummy vehicles in the scene and corrupts the data stream.