### PR TITLE
[Codechange] Implemented a thread-safe truck deletion queue

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1483,6 +1483,8 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 			RoR::Application::GetGuiManager()->UpdateSimUtils(dt, curr_truck);
 		}
 
+		BeamFactory::getSingleton().handleTruckDeletion();
+
 		if (!m_is_sim_paused)
 		{
 			BeamFactory::getSingleton().joinFlexbodyTasks();       // Waits until all flexbody tasks are finished
@@ -1678,12 +1680,6 @@ void RoRFrameListener::reloadCurrentTruck()
 		return;
 	}
 
-	// exit the old truck
-	BeamFactory::getSingleton().setCurrentTruck(-1);
-
-	// remove the old truck
-	curr_truck->state = RECYCLE;
-
 	// copy over the most basic info
 	if (curr_truck->free_node == newBeam->free_node)
 	{
@@ -1712,10 +1708,7 @@ void RoRFrameListener::reloadCurrentTruck()
 	RoR::Application::GetGuiManager()->PushNotification("Notice:", msg);
 #endif //USE_MYGUI
 
-	// dislocate the old truck, so its out of sight
-	curr_truck->resetPosition(100000, 100000, false, 100000);
-	// note: in some point in the future we would delete the truck here,
-	// but since this function is buggy we don't do it yet.
+	BeamFactory::getSingleton().removeCurrentTruck();
 
 	// reset the new truck (starts engine, resets gui, ...)
 	newBeam->reset();

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -119,6 +119,7 @@ Beam::~Beam()
 	{
 		SoundScriptManager::getSingleton().trigStop(this->trucknum, i);
 	}
+	StopAllSounds();
 #endif // USE_OPENAL
 
 	// destruct and remove every tiny bit of stuff we created :-|
@@ -4560,6 +4561,7 @@ void Beam::deleteNetTruck()
 	updateFlexbodiesPrepare();
 	updateFlexbodiesFinal();
 	updateVisual();
+	StopAllSounds();
 }
 
 float Beam::getHeadingDirectionAngle()

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -906,16 +906,16 @@ void BeamFactory::calcPhysics(float dt)
 			m_trucks[t]->calcNetwork();
 			break;
 
-		case RECYCLE:
+		case NETWORKED_INVALID:
 			break;
 
-		case NETWORKED_INVALID:
+		case DELETED:
 			break;
 
 		default:
 			if (m_trucks[t]->state > DESACTIVATED && m_trucks[t]->engine)
 				m_trucks[t]->engine->update(dt, 1);
-			if (m_trucks[t]->state < SLEEPING && m_trucks[t]->networking)
+			if (m_trucks[t]->networking)
 				m_trucks[t]->sendStreamData();
 			break;
 		}

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -712,7 +712,18 @@ void BeamFactory::removeTruck(int truck)
 		this->DeleteTruck(m_trucks[truck]);
 }
 
-void BeamFactory::p_removeAllTrucks()
+void BeamFactory::DeleteTruck(Beam *b)
+{
+	std::lock_guard<std::mutex> lock(m_delete_queue_mutex);
+	m_delete_queue.push_back(b);
+}
+
+void BeamFactory::removeCurrentTruck()
+{
+	removeTruck(m_current_truck);
+}
+
+void BeamFactory::removeAllTrucks()
 {
 	for (int i = 0; i < m_free_truck; i++)
 	{
@@ -729,31 +740,6 @@ void BeamFactory::p_removeAllTrucks()
 				this->DeleteTruck(m_trucks[i]);
 		}
 	}
-}
-
-void BeamFactory::DeleteTruck(Beam *b)
-{
-	if (b == 0)	return;
-
-	this->SyncWithSimThread();
-
-	m_trucks[b->trucknum] = 0;
-	delete b;
-	//m_free_truck = m_free_truck - 1;
-
-#ifdef USE_MYGUI
-	GUI_MainMenu::getSingleton().triggerUpdateVehicleList();
-#endif // USE_MYGUI
-}
-
-void BeamFactory::removeCurrentTruck()
-{
-	removeTruck(m_current_truck);
-}
-
-void BeamFactory::removeAllTrucks()
-{
-	p_removeAllTrucks();
 }
 
 void BeamFactory::setCurrentTruck(int new_truck)
@@ -856,6 +842,33 @@ void BeamFactory::updateVisual(float dt)
 	}
 }
 
+void BeamFactory::handleTruckDeletion()
+{
+	this->SyncWithSimThread();
+
+	std::lock_guard<std::mutex> lock(m_delete_queue_mutex);
+
+	for (Beam* b : m_delete_queue)
+	{
+		if (b)
+		{
+			if (!b->networking)
+			{
+				m_trucks[b->trucknum] = 0;
+				delete b;
+			} else
+			{
+				b->deleteNetTruck();
+			}
+		}
+	}
+	m_delete_queue.clear();
+
+#ifdef USE_MYGUI
+	GUI_MainMenu::getSingleton().triggerUpdateVehicleList();
+#endif // USE_MYGUI
+}
+
 void BeamFactory::calcPhysics(float dt)
 {
 	m_physics_frames++;
@@ -952,14 +965,6 @@ void BeamFactory::calcPhysics(float dt)
 	}
 }
 
-void BeamFactory::RemoveInstance(Beam *b)
-{
-	if (b == 0) return;
-	// hide the truck
-	b->deleteNetTruck();
-	//this->DeleteTruck(b);
-}
-
 void BeamFactory::RemoveInstance(stream_del_t *del)
 {
 	// we override this here so we can also delete the truck array content
@@ -977,13 +982,13 @@ void BeamFactory::RemoveInstance(stream_del_t *del)
 	{
 		// delete all streams
 		for (it_beam=it_stream->second.begin(); it_beam != it_stream->second.end(); it_beam++)
-			this->RemoveInstance(it_beam->second);
+			this->DeleteTruck(it_beam->second);
 	} else
 	{
 		// find the stream matching the streamid
 		it_beam = it_stream->second.find(del->streamid);
 		if (it_beam != it_stream->second.end())
-			this->RemoveInstance(it_beam->second);
+			this->DeleteTruck(it_beam->second);
 	}
 	// unlockStreams();
 }
@@ -1003,7 +1008,6 @@ void BeamFactory::windowResized()
 
 void BeamFactory::prepareShutdown()
 {
-	this->SyncWithSimThread();
 }
 
 Beam* BeamFactory::getCurrentTruck()

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -92,8 +92,6 @@ public:
 	void MuteAllTrucks();
 	void UnmuteAllTrucks();
 
-	void p_removeAllTrucks();
-
 	bool enterRescueTruck();
 	void repairTruck(Collisions *collisions, const Ogre::String &inst, const Ogre::String &box, bool keepPosition=false);
 
@@ -144,6 +142,8 @@ public:
 	void sendAllTrucksSleeping();
 	void setTrucksForcedActive(bool forced) { m_forced_active = forced; };
 
+	void handleTruckDeletion();
+
 	void prepareShutdown();
 
 	void windowResized();
@@ -157,6 +157,9 @@ public:
 	void SyncWithSimThread();
 
 protected:
+
+	std::mutex m_delete_queue_mutex;
+	std::vector<Beam*> m_delete_queue;
 
 	std::unique_ptr<ThreadPool> m_sim_thread_pool;
 	std::shared_ptr<Task> m_sim_task;
@@ -196,7 +199,6 @@ protected:
 	void netUserAttributesChanged(int source, int streamid);
 	void localUserAttributesChanged(int newid);
 
-	void RemoveInstance(Beam *b);
 	void RemoveInstance(stream_del_t *del);
 	bool RemoveBeam(Beam *b);
 	void DeleteTruck(Beam *b);

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -200,7 +200,6 @@ protected:
 	void localUserAttributesChanged(int newid);
 
 	void RemoveInstance(stream_del_t *del);
-	bool RemoveBeam(Beam *b);
 	void DeleteTruck(Beam *b);
 };
 


### PR DESCRIPTION
Trucks can no longer be deleted while the sim thread is running.

**Singleplayer:**
* Reloading a truck now properly deletes the old truck

**Multiplayer:**
* Fixes crash (on linux) when a remote player disconnects after he has spawned a truck