### PR TITLE
[CMake] Make boost_system optional

### DIFF
--- a/cmake/DependenciesConfig.cmake
+++ b/cmake/DependenciesConfig.cmake
@@ -179,6 +179,7 @@ endmacro(importLib)
 
 ELSEIF(UNIX)
    find_package(PkgConfig)
+   find_package(Boost COMPONENTS system)
    PKG_CHECK_MODULES  (GTK gtk+-2.0 REQUIRED)
    PKG_CHECK_MODULES  (GTK_PIXBUF gdk-pixbuf-2.0 REQUIRED)
    include_directories(${GTK_INCLUDE_DIRS})

--- a/source/configurator/CMakeLists.txt
+++ b/source/configurator/CMakeLists.txt
@@ -62,12 +62,17 @@ ELSEIF(UNIX)
    PKG_CHECK_MODULES  (Ogre OGRE REQUIRED)
    PKG_CHECK_MODULES  (Ois OIS REQUIRED)
 
-   set(OS_LIBS "-lboost_system")
+   set(OS_LIBS "")
 
 ENDIF(WIN32)
 
 setup_lib(OPENCL)
 setup_lib(OPENAL)
+
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+  link_directories   (${Boost_LIBRARY_DIRS})
+endif()
 include_directories(${Ogre_INCLUDE_DIRS})
 link_directories   (${Ogre_LIBRARY_DIRS})
 include_directories(${Ois_INCLUDE_DIRS})
@@ -91,7 +96,7 @@ ELSE(WIN32)
 	add_executable(RoRConfig ${sources} ${headers} ${OS_SOURCE} ../main/utils/Settings.cpp ../main/utils/SHA1.cpp ../main/utils/ErrorUtils.cpp ../main/utils/Utils.cpp ../main/utils/ConfigFile.cpp)
 ENDIF(WIN32)
 
-TARGET_LINK_LIBRARIES(RoRConfig ${Ogre_LIBRARIES} ${Ois_LIBRARIES} ${OS_LIBS} ${optional_libs} ${wxWidgets_LIBRARIES} version_info)
+TARGET_LINK_LIBRARIES(RoRConfig ${Boost_LIBRARIES} ${Ogre_LIBRARIES} ${Ois_LIBRARIES} ${OS_LIBS} ${optional_libs} ${wxWidgets_LIBRARIES} version_info)
 
 
 

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -296,6 +296,9 @@ endif()
 #  EXECUTABLE TARGET
 ####################################################################################################
 
+if(Boost_FOUND)
+  link_directories   (${Boost_LIBRARY_DIRS})
+endif()
 link_directories   (${Ogre_LIBRARY_DIRS})
 link_directories   (${Ogre_Terrain_LIBRARY_DIRS})
 link_directories   (${Ogre_Overlay_LIBRARY_DIRS})
@@ -351,6 +354,7 @@ add_custom_command(
 ####################################################################################################
 
 target_compile_definitions( ${BINNAME} PRIVATE
+  BOOST_ALL_NO_LIB
   USE_MUMBLE  # build with support for Mumble positional audio, has no dependencies but requires linking against librt on UNIX
   USE_RTSHADER_SYSTEM
   #FEAT_DEBUG_MUTEX
@@ -378,7 +382,9 @@ endif()
 #  INCLUDE DIRECTORIES
 ####################################################################################################
 
-
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()
 include_directories(${Ogre_INCLUDE_DIRS})
 include_directories(${Ogre_Terrain_INCLUDE_DIRS})
 include_directories(${Ogre_Overlay_INCLUDE_DIRS})
@@ -441,7 +447,7 @@ IF(WIN32)
   add_definitions("/wd4305 /wd4244 /wd4193 -DNOMINMAX")
 ELSEIF(UNIX)
   include_directories(${GTK_INCLUDE_DIRS})
-  set(OS_LIBS "X11 -l${CMAKE_DL_LIBS} -lrt -lboost_system")
+  set(OS_LIBS "X11 -l${CMAKE_DL_LIBS} -lrt")
 ENDIF(WIN32)
 
 
@@ -464,6 +470,7 @@ endif()
 
 
 target_link_libraries(${BINNAME}
+  ${Boost_LIBRARIES}
   ${Ogre_LIBRARIES}
   ${Ogre_Terrain_LIBRARIES}
   ${Ogre_Overlay_LIBRARIES}


### PR DESCRIPTION
If Ogre was built with Boost RoR needs to be linked to boost_system library. The idea here is that if boost_system is present on the system Ogre was likely compiled with Boost support. If boost_system is not present then Ogre was probably build without Boost support.

Note: this was not test on a system without Boost yet. I'd appreciate it if somebody could do that.
