### PR TITLE
[Feature] Added RoR.cfg option to skip the main menu

### DIFF
--- a/source/main/MainThread.cpp
+++ b/source/main/MainThread.cpp
@@ -430,9 +430,9 @@ void MainThread::Go()
 			//if (!RoR::Application::GetGuiManager()->getMainSelector()->IsVisible())
 			RoR::Application::GetGuiManager()->ShowMainMenu(true);
 
-			if (gEnv->network != nullptr)
+			if (gEnv->network != nullptr || BSETTING("SkipMainMenu", false))
 			{
-				// Multiplayer started from configurator -> go directly to map selector (traditional behavior)
+				// Multiplayer started from configurator / MainMenu disabled -> go directly to map selector (traditional behavior)
 				RoR::Application::GetGuiManager()->getMainSelector()->Show(LT_Terrain);
 				RoR::Application::GetGuiManager()->ShowMainMenu(false);
 			}


### PR DESCRIPTION
Appending `SkipMainMenu=Yes` to your RoR.cfg file allows you to skip the main menu during startup.