### PR TITLE
[Bugfix] Fixes truck starts moving when using commands

### DIFF
--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -553,7 +553,7 @@ void BeamEngine::update(float dt, int doUpdate)
 
 		// auto clutch
 		float declutchRPM = (minRPM + stallRPM) / 2.0f;
-		if (curGear == 0 || curEngineRPM < declutchRPM || (curEngineRPM < minRPM * 1.01f && fabs(curWheelRevolutions) < 1.0f))
+		if (curGear == 0 || curEngineRPM < declutchRPM || (fabs(curWheelRevolutions) < 1.0f && (curEngineRPM < minRPM * 1.01f || autocurAcc == 0.0f)))
 		{
 			curClutch = 0.0f;
 		} else if (curEngineRPM < minRPM && minRPM > declutchRPM)


### PR DESCRIPTION
Prevents releasing the clutch without throttle input while standing still.

Only affects `AUTOMATIC` and `SEMIAUTO` transmission modes.