### PR TITLE
[Codechange] ESC cancels selector window

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -272,8 +272,13 @@ bool RoRFrameListener::updateEvents(float dt)
 
 	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_QUIT_GAME))
 	{
-		//shutdown_final();
-		Application::GetGuiManager()->TogglePauseMenu();
+		if (Application::GetGuiManager()->getMainSelector()->IsVisible())
+		{
+			Application::GetGuiManager()->getMainSelector()->Cancel();
+		} else
+		{
+			Application::GetGuiManager()->TogglePauseMenu();
+		}
 	}
 
 	if (Application::GetGuiManager()->GetPauseMenuVisible()) return true; //Stop everything when pause menu is visible

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -249,13 +249,7 @@ void CLASS::EventKeyButtonPressed_Main(MyGUI::WidgetPtr _sender, MyGUI::KeyCode 
 	}
 }
 
-void CLASS::EventMouseButtonClickOkButton(MyGUI::WidgetPtr _sender)
-{
-	if (!m_ready) return;
-	OnSelectionDone();
-}
-
-void CLASS::EventMouseButtonClickCancelButton(MyGUI::WidgetPtr _sender)
+void CLASS::Cancel()
 {
 	if (!m_ready) return;
 	m_selected_entry = nullptr;
@@ -264,6 +258,17 @@ void CLASS::EventMouseButtonClickCancelButton(MyGUI::WidgetPtr _sender)
 	//Do this on cancel only
 	if (gEnv->frameListener->m_loading_state == NONE_LOADED)
 		Application::GetGuiManager()->ShowMainMenu(true);
+}
+
+void CLASS::EventMouseButtonClickOkButton(MyGUI::WidgetPtr _sender)
+{
+	if (!m_ready) return;
+	OnSelectionDone();
+}
+
+void CLASS::EventMouseButtonClickCancelButton(MyGUI::WidgetPtr _sender)
+{
+	Cancel();
 }
 
 void CLASS::EventComboChangePositionTypeComboBox(MyGUI::ComboBoxPtr _sender, size_t _index)
@@ -1001,12 +1006,6 @@ void CLASS::NotifyWindowButtonPressed(MyGUI::WidgetPtr _sender, const std::strin
 {
 	if (_name == "close")
 	{
-		if (!m_ready) return;
-		m_selected_entry = nullptr;
-		m_selection_done = true;
-		Hide();
-		//Do this on cancel only
-		if (gEnv->frameListener->m_loading_state == NONE_LOADED)
-			Application::GetGuiManager()->ShowMainMenu(true);
+		Cancel();
 	}
 }

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -50,6 +50,7 @@ public:
 	bool IsVisible();
 	void BackToMenu();
 	void Reset();
+	void Cancel();
 
 	CacheEntry *GetSelectedEntry() { return m_selected_entry; }
 	Skin *GetSelectedSkin() { return m_selected_skin; }


### PR DESCRIPTION
Selector window needs to be focused (can be achieved by pressing `/`).

`ESC` needs to be pressed twice, for some reason.