### PR TITLE
[Codechange] Hiding the GUI now also hides the chatbox

### DIFF
--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -512,6 +512,7 @@ void GUIManager::hideGUI(bool hidden)
 			m_gui_SimUtils->HideNotification();
 			m_gui_SimUtils->HideFPSBox();
 			m_gui_SimUtils->HideTruckInfoBox();
+			m_gui_ChatBox->Hide();
 		}
 		m_gui_SimUtils->DisableNotifications(hidden);
 	}

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -79,18 +79,14 @@ void CLASS::setNetChat(ChatSystem *c)
 
 void CLASS::Show()
 {
-	if (!MAIN_WIDGET->getVisible())
-	{
-		MAIN_WIDGET->setVisibleSmooth(true);
-	}
-
+	MAIN_WIDGET->setVisible(true);
 	m_Chatbox_TextBox->setEnabled(true);
 	MyGUI::InputManager::getInstance().setKeyFocusWidget(m_Chatbox_TextBox);
 }
 
 void CLASS::Hide()
 {
-	MAIN_WIDGET->setVisibleSmooth(false);
+	MAIN_WIDGET->setVisible(false);
 }
 
 bool CLASS::IsVisible()
@@ -174,12 +170,11 @@ void CLASS::Update(float dt)
 		{
 			alpha = 1 - ((ot - startTime) / 1000.0f);
 		}
-
-		MAIN_WIDGET->setAlpha(alpha);
-
-		if (alpha <= 0.1)
+		if (alpha <= 0.0f)
 		{
 			MAIN_WIDGET->setVisible(false);
+		} else {
+			MAIN_WIDGET->setAlpha(alpha);
 		}
 	} else if (MAIN_WIDGET->getVisible())
 	{


### PR DESCRIPTION
But only if you have enabled the 'auto-hide' chat box option.

The default key for hiding the GUI is `u`.