### PR TITLE
[Feature] Added key shortcut to toggle videocamera on/off

### DIFF
--- a/bin/resources/skeleton/config/input.map
+++ b/bin/resources/skeleton/config/input.map
@@ -260,4 +260,5 @@ TRUCK_TOGGLE_AXLE_LOCK         Keyboard             W
 TRUCK_TOGGLE_CONTACT           Keyboard             X 
 TRUCK_TOGGLE_FORWARDCOMMANDS   Keyboard             EXPL+CTRL+SHIFT+F 
 TRUCK_TOGGLE_IMPORTCOMMANDS    Keyboard             EXPL+CTRL+SHIFT+I 
+TRUCK_TOGGLE_VIDEOCAMERA       Keyboard             EXPL+CTRL+V 
 TRUCK_TRACTION_CONTROL         Keyboard             EXPL+SHIFT+V 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -900,6 +900,12 @@ bool RoRFrameListener::updateEvents(float dt)
 						}
 					}
 
+					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_VIDEOCAMERA, 0.5f))
+					{
+						curr_truck->m_is_videocamera_disabled = !curr_truck->m_is_videocamera_disabled;
+						LOG("m_is_videocamera_disabled: " + TOSTRING(curr_truck->m_is_videocamera_disabled));
+					}
+
 					if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_LEFT))
 					{
 						if (curr_truck->getBlinkType() == BLINK_LEFT)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1725,6 +1725,8 @@ void Beam::updateFrameTimeInformation(float dt)
 
 void Beam::updateTruckMirrors(float dt)
 {
+	if (m_is_videocamera_disabled) return;
+
 	for (VideoCamera* v : vidcams)
 	{
 		v->update(dt);
@@ -5529,6 +5531,8 @@ Beam::Beam(
 	, velocity(Ogre::Vector3::ZERO)
 	, m_custom_camera_node(-1)
 	, m_hide_own_net_label(BSETTING("HideOwnNetLabel", false))
+	, m_is_cinecam_rotation_center(false)
+	, m_is_videocamera_disabled(false)
 	, m_preloaded_with_terrain(preloaded_with_terrain)
 	, m_request_skeletonview_change(0)
 	, m_reset_request(REQUEST_RESET_NONE)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -507,6 +507,8 @@ public:
 	Ogre::Vector3 cameranodeacc;
 	int cameranodecount;
 
+	bool m_is_videocamera_disabled;
+
 	/**
 	* Sets visibility of all beams on this vehicle
 	* @param visible Toggle

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -1376,6 +1376,12 @@ eventInfo_t eventInfo[] = {
 		_L("toggle antilock brake")
 	},
 	{
+		"TRUCK_TOGGLE_VIDEOCAMERA",
+		EV_TRUCK_TOGGLE_VIDEOCAMERA,
+		"Keyboard EXPL+CTRL+V",
+		_L("toggle videocamera")
+	},
+	{
 		"TRUCK_TRACTION_CONTROL",
 		EV_TRUCK_TRACTION_CONTROL,
 		"Keyboard EXPL+SHIFT+T",

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -350,6 +350,7 @@ enum events
 	EV_TRUCK_TOGGLE_CONTACT, //!< toggle ignition
 	EV_TRUCK_TOGGLE_FORWARDCOMMANDS, //!< toggle forwardcommands
 	EV_TRUCK_TOGGLE_IMPORTCOMMANDS, //!< toggle importcommands
+	EV_TRUCK_TOGGLE_VIDEOCAMERA, //!< toggle videocamera update
 	EV_TRUCK_TRACTION_CONTROL, //!< toggle antilockbrake system
 
 	// position storage now


### PR DESCRIPTION
The videocamera state is stored per truck

Default key: 'CTRL+V'