### PR TITLE
[Bugfix] Fixes truck reset not aborting switching operations

### DIFF
--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -982,7 +982,10 @@ void BeamEngine::offstart()
 	curClutchTorque = 0.0f;
 	curEngineRPM = 0.0f;
 	curGear = 0;
+	postshifting = 0;
 	running = false;
+	shifting = 0;
+	shiftval = 0;
 	if (automode == AUTOMATIC)
 	{
 		autoselect = NEUTRAL;


### PR DESCRIPTION
Prevents being stuck in 'NEUTRAL'.