### PR TITLE
[Cleanup] Tidied up the 'node_t' struct some more

### DIFF
--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -34,8 +34,6 @@ struct node_t
 
 	// <-- 64 Bytes -->
 
-	Ogre::Vector3 smoothpos; //!< absolute, per-frame smooth, must be used for visual effects only
-
 	Ogre::Real mass;
 	Ogre::Real buoyancy;
 	Ogre::Real friction_coef;
@@ -54,6 +52,4 @@ struct node_t
 	bool overrideMass;
 	bool loadedMass;
 	bool isHot;    //!< Makes this node emit vapour particles when in contact with water.
-
-	// <-- 128 Bytes -->
 };

--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -40,12 +40,12 @@ struct node_t
 	Ogre::Real volume_coef;
 
 	float wettime; //!< Cumulative time this node has been wet. When wet, dripping particles are produced.
-	int wetstate;  //!< {DRY | DRIPPING | WET}
-	int wheelid;   //!< Wheel index
-	int lockgroup;
-	int pos;       //!< This node's index in rig_t::nodes array.
-	int id;        //!< Numeric identifier assigned in rig-definition file (if used), or -1 if the node was generated dynamically.
-	int collisionBoundingBoxID;
+	short wheelid; //!< Wheel index
+	short lockgroup;
+	short pos;     //!< This node's index in rig_t::nodes array.
+	short id;      //!< Numeric identifier assigned in rig-definition file (if used), or -1 if the node was generated dynamically.
+	char wetstate; //!< {DRY | DRIPPING | WET}
+	char collisionBoundingBoxID;
 
 	bool contacter;
 	bool overrideMass;

--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -22,8 +22,8 @@ struct node_t
 	Ogre::Vector3 Velocity;
 	Ogre::Vector3 Forces;
 	
+	Ogre::Real mass;
 	float collTestTimer;
-	float collRadius;
 	short iswheel; //!< 0=no, 1, 2=wheel1  3,4=wheel2, etc...
 	short locked;  //!< {UNLOCKED | PRELOCK | LOCKED}
 
@@ -34,7 +34,6 @@ struct node_t
 
 	// <-- 64 Bytes -->
 
-	Ogre::Real mass;
 	Ogre::Real buoyancy;
 	Ogre::Real friction_coef;
 	Ogre::Real surface_coef;

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1237,7 +1237,6 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 	m_time += dt;
 
 	BeamFactory::getSingleton().SyncWithSimThread();
-	BeamFactory::getSingleton().updateTruckPositions();
 
 #ifdef USE_SOCKETW
 	if (gEnv->multiplayer)

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1237,6 +1237,7 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
 	m_time += dt;
 
 	BeamFactory::getSingleton().SyncWithSimThread();
+	BeamFactory::getSingleton().updateTruckPositions();
 
 #ifdef USE_SOCKETW
 	if (gEnv->multiplayer)
@@ -1623,7 +1624,6 @@ void RoRFrameListener::reloadCurrentTruck()
 			newBeam->nodes[i].RelPosition = curr_truck->nodes[i].RelPosition;
 			newBeam->nodes[i].Velocity    = curr_truck->nodes[i].Velocity;
 			newBeam->nodes[i].Forces      = curr_truck->nodes[i].Forces;
-			newBeam->nodes[i].smoothpos   = curr_truck->nodes[i].smoothpos;
 			newBeam->initial_node_pos[i]  = curr_truck->initial_node_pos[i];
 			newBeam->origin               = curr_truck->origin;
 		}

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -147,7 +147,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
 					if (trucks[i]->node_mouse_grab_disabled[j]) continue;
 
 					// check if our ray intersects with the node
-					std::pair<bool, Real> pair = mouseRay.intersects(Sphere(trucks[i]->nodes[j].smoothpos, 0.1f));
+					std::pair<bool, Real> pair = mouseRay.intersects(Sphere(trucks[i]->nodes[j].AbsPosition, 0.1f));
 					if (pair.first)
 					{
 						// we hit it, check if its the nearest node
@@ -242,10 +242,10 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
 
 				for (int i = 0; i < truck->free_node; i++)
 				{
-					std::pair<bool, Real> pair = mouseRay.intersects(Sphere(truck->nodes[i].smoothpos, 0.25f));
+					std::pair<bool, Real> pair = mouseRay.intersects(Sphere(truck->nodes[i].AbsPosition, 0.25f));
 					if (pair.first)
 					{
-						Real ray_distance = mouseRay.getDirection().crossProduct(truck->nodes[i].smoothpos - mouseRay.getOrigin()).length();
+						Real ray_distance = mouseRay.getDirection().crossProduct(truck->nodes[i].AbsPosition - mouseRay.getOrigin()).length();
 						if (ray_distance < nearest_ray_distance || (ray_distance == nearest_ray_distance && pair.second < nearest_camera_distance))
 						{
 							nearest_camera_distance = pair.second;

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -257,7 +257,7 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
 				if (truck->m_custom_camera_node != nearest_node_index)
 				{
 					truck->m_custom_camera_node = nearest_node_index;
-					truck->updateTruckPosition();
+					truck->calculateAveragePosition();
 					gEnv->cameraManager->NotifyContextChange();
 				}
 			}

--- a/source/main/gfx/VideoCamera.cpp
+++ b/source/main/gfx/VideoCamera.cpp
@@ -195,19 +195,19 @@ void VideoCamera::update(float dt)
 	if (rwMirror) rwMirror->update();
 
 	// get the normal of the camera plane now
-	Vector3 normal=(-(truck->nodes[nref].smoothpos - truck->nodes[nz].smoothpos)).crossProduct(-(truck->nodes[nref].smoothpos - truck->nodes[ny].smoothpos));
+	Vector3 normal=(-(truck->nodes[nref].AbsPosition - truck->nodes[nz].AbsPosition)).crossProduct(-(truck->nodes[nref].AbsPosition - truck->nodes[ny].AbsPosition));
 	normal.normalise();
 
 	// add user set offset
-	Vector3 pos = truck->nodes[camNode].smoothpos +
+	Vector3 pos = truck->nodes[camNode].AbsPosition +
 		(offset.x * normal) +
-		(offset.y * (truck->nodes[nref].smoothpos - truck->nodes[ny].smoothpos)) +
-		(offset.z * (truck->nodes[nref].smoothpos - truck->nodes[nz].smoothpos));
+		(offset.y * (truck->nodes[nref].AbsPosition - truck->nodes[ny].AbsPosition)) +
+		(offset.z * (truck->nodes[nref].AbsPosition - truck->nodes[nz].AbsPosition));
 
 	//avoid the camera roll
 	// camup orientates to frustrum of world by default -> rotating the cam related to trucks yaw, lets bind cam rotation videocamera base (nref,ny,nz) as frustum
 	// could this be done faster&better with a plane setFrustumExtents ?
-	Vector3 frustumUP = truck->nodes[nref].smoothpos - truck->nodes[ny].smoothpos;
+	Vector3 frustumUP = truck->nodes[nref].AbsPosition - truck->nodes[ny].AbsPosition;
 	frustumUP.normalise();
 	mVidCam->setFixedYawAxis(true, frustumUP);
 
@@ -224,21 +224,21 @@ void VideoCamera::update(float dt)
 		if (camRole == -1)
 		{
 			// rotate the camera according to the nodes orientation and user rotation
-			Vector3 refx = truck->nodes[nz].smoothpos - truck->nodes[nref].smoothpos;
+			Vector3 refx = truck->nodes[nz].AbsPosition - truck->nodes[nref].AbsPosition;
 			refx.normalise();
-			Vector3 refy = truck->nodes[nref].smoothpos - truck->nodes[ny].smoothpos;
+			Vector3 refy = truck->nodes[nref].AbsPosition - truck->nodes[ny].AbsPosition;
 			refy.normalise();
 			Quaternion rot = Quaternion(-refx, -refy, -normal);
 			mVidCam->setOrientation(rot * rotation); // rotate the camera orientation towards the calculated cam direction plus user rotation
 		} else
 		{
 			// we assume this is a tracking videocamera
-			normal = truck->nodes[lookat].smoothpos - pos;
+			normal = truck->nodes[lookat].AbsPosition - pos;
 			normal.normalise();
-			Vector3 refx = truck->nodes[nz].smoothpos - truck->nodes[nref].smoothpos;
+			Vector3 refx = truck->nodes[nz].AbsPosition - truck->nodes[nref].AbsPosition;
 			refx.normalise();
 			// why does this flip ~2-3° around zero orientation and only with trackercam. back to slower crossproduct calc, a bit slower but better .. sigh
-			// Vector3 refy = truck->nodes[nref].smoothpos - truck->nodes[ny].smoothpos;
+			// Vector3 refy = truck->nodes[nref].AbsPosition - truck->nodes[ny].AbsPosition;
 			Vector3 refy = refx.crossProduct(normal);
 			refy.normalise();
 			Quaternion rot = Quaternion(-refx, -refy, -normal);

--- a/source/main/gfx/camera/CameraBehaviorVehicle.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicle.cpp
@@ -90,7 +90,7 @@ bool CameraBehaviorVehicle::mousePressed(const CameraManager::CameraContext &ctx
 		if ( ctx.mCurrTruck && ctx.mCurrTruck->m_custom_camera_node >= 0 )
 		{
 			// Calculate new camera distance
-			Vector3 lookAt = ctx.mCurrTruck->nodes[ctx.mCurrTruck->m_custom_camera_node].smoothpos;
+			Vector3 lookAt = ctx.mCurrTruck->nodes[ctx.mCurrTruck->m_custom_camera_node].AbsPosition;
 			camDist = 2.0f * gEnv->mainCamera->getPosition().distance(lookAt);
 
 			// Calculate new camera pitch

--- a/source/main/gfx/camera/CameraBehaviorVehicleCineCam.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicleCineCam.cpp
@@ -40,11 +40,11 @@ void CameraBehaviorVehicleCineCam::update(const CameraManager::CameraContext &ct
 {
 	CameraBehaviorOrbit::update(ctx);
 
-	Vector3 dir = (ctx.mCurrTruck->nodes[ctx.mCurrTruck->cameranodepos[ctx.mCurrTruck->currentcamera]].smoothpos
-				 - ctx.mCurrTruck->nodes[ctx.mCurrTruck->cameranodedir[ctx.mCurrTruck->currentcamera]].smoothpos).normalisedCopy();
+	Vector3 dir = (ctx.mCurrTruck->nodes[ctx.mCurrTruck->cameranodepos[ctx.mCurrTruck->currentcamera]].AbsPosition
+				 - ctx.mCurrTruck->nodes[ctx.mCurrTruck->cameranodedir[ctx.mCurrTruck->currentcamera]].AbsPosition).normalisedCopy();
 
-	Vector3 roll = (ctx.mCurrTruck->nodes[ctx.mCurrTruck->cameranodepos[ctx.mCurrTruck->currentcamera]].smoothpos
-				  - ctx.mCurrTruck->nodes[ctx.mCurrTruck->cameranoderoll[ctx.mCurrTruck->currentcamera]].smoothpos).normalisedCopy();
+	Vector3 roll = (ctx.mCurrTruck->nodes[ctx.mCurrTruck->cameranodepos[ctx.mCurrTruck->currentcamera]].AbsPosition
+				  - ctx.mCurrTruck->nodes[ctx.mCurrTruck->cameranoderoll[ctx.mCurrTruck->currentcamera]].AbsPosition).normalisedCopy();
 
 	if ( ctx.mCurrTruck->revroll[ctx.mCurrTruck->currentcamera] )
 	{
@@ -57,7 +57,7 @@ void CameraBehaviorVehicleCineCam::update(const CameraManager::CameraContext &ct
 
 	Quaternion orientation = Quaternion(camRotX + camRotXSwivel, up) * Quaternion(Degree(180.0) + camRotY + camRotYSwivel, roll) * Quaternion(roll, up, dir);
 
-	gEnv->mainCamera->setPosition(ctx.mCurrTruck->nodes[ctx.mCurrTruck->cinecameranodepos[ctx.mCurrTruck->currentcamera]].smoothpos);
+	gEnv->mainCamera->setPosition(ctx.mCurrTruck->nodes[ctx.mCurrTruck->cinecameranodepos[ctx.mCurrTruck->currentcamera]].AbsPosition);
 	gEnv->mainCamera->setOrientation(orientation);
 }
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -356,13 +356,11 @@ void Beam::scaleTruck(float value)
 	// scale nodes
 	Vector3 refpos = nodes[0].AbsPosition;
 	Vector3 relpos = nodes[0].RelPosition;
-	Vector3 smopos = nodes[0].smoothpos;
 	for (int i=1;i<free_node;i++)
 	{
 		initial_node_pos[i] = refpos + (initial_node_pos[i]-refpos) * value;
 		nodes[i].AbsPosition = refpos + (nodes[i].AbsPosition-refpos) * value;
 		nodes[i].RelPosition = relpos + (nodes[i].RelPosition-relpos) * value;
-		nodes[i].smoothpos = smopos + (nodes[i].smoothpos-smopos) * value;
 		nodes[i].Velocity *= value;
 		nodes[i].Forces *= value;
 		nodes[i].mass *= value;
@@ -431,9 +429,9 @@ void Beam::initSimpleSkeleton()
 	simpleSkeletonManualObject->begin("vehicle-skeletonview-material", RenderOperation::OT_LINE_LIST);
 	for (int i=0; i<free_beam; i++)
 	{
-		simpleSkeletonManualObject->position(beams[i].p1->smoothpos);
+		simpleSkeletonManualObject->position(beams[i].p1->AbsPosition);
 		simpleSkeletonManualObject->colour(1.0f,1.0f,1.0f);
-		simpleSkeletonManualObject->position(beams[i].p2->smoothpos);
+		simpleSkeletonManualObject->position(beams[i].p2->AbsPosition);
 		simpleSkeletonManualObject->colour(0.0f,0.0f,0.0f);
 	}
 	simpleSkeletonManualObject->end();
@@ -462,14 +460,14 @@ void Beam::updateSimpleSkeleton()
 		else
 			color = ColourValue(color_scale, 1.0f - color_scale, 0.2f, 0.8f);
 		
-		simpleSkeletonManualObject->position(beams[i].p1->smoothpos);
+		simpleSkeletonManualObject->position(beams[i].p1->AbsPosition);
 		simpleSkeletonManualObject->colour(color);
 
 		// remove broken beams
 		if (beams[i].broken || beams[i].disabled)
-			simpleSkeletonManualObject->position(beams[i].p1->smoothpos);
+			simpleSkeletonManualObject->position(beams[i].p1->AbsPosition);
 		else
-			simpleSkeletonManualObject->position(beams[i].p2->smoothpos);
+			simpleSkeletonManualObject->position(beams[i].p2->AbsPosition);
 
 		simpleSkeletonManualObject->colour(color);
 	}
@@ -671,7 +669,6 @@ void Beam::calcNetwork()
 
 		// linear interpolation
 		nodes[i].AbsPosition  = p1 + tratio * (p2 - p1);
-		nodes[i].smoothpos    = nodes[i].AbsPosition;
 		nodes[i].RelPosition  = nodes[i].AbsPosition - origin;
 
 		apos += nodes[i].AbsPosition;
@@ -695,11 +692,9 @@ void Beam::calcNetwork()
 			Vector3 uray = Quaternion(Radian(rp - drp * j), axis) * ray;
 
 			wheels[i].nodes[j*2+0]->AbsPosition = wheels[i].refnode0->AbsPosition + uray;
-			wheels[i].nodes[j*2+0]->smoothpos   = wheels[i].nodes[j*2]->AbsPosition;
 			wheels[i].nodes[j*2+0]->RelPosition = wheels[i].nodes[j*2]->AbsPosition - origin;
 
 			wheels[i].nodes[j*2+1]->AbsPosition = wheels[i].refnode1->AbsPosition + uray;
-			wheels[i].nodes[j*2+1]->smoothpos   = wheels[i].nodes[j*2+1]->AbsPosition;
 			wheels[i].nodes[j*2+1]->RelPosition = wheels[i].nodes[j*2+1]->AbsPosition - origin;
 		}
 	}
@@ -1195,7 +1190,6 @@ int Beam::loadPosition(int indexPosition)
 	{
 		nodes[i].AbsPosition   = nbuff[i];
 		nodes[i].RelPosition   = nbuff[i] - origin;
-		nodes[i].smoothpos     = nbuff[i];
 
 		// reset forces
 		nodes[i].Velocity      = Vector3::ZERO;
@@ -1212,14 +1206,7 @@ int Beam::loadPosition(int indexPosition)
 
 void Beam::updateTruckPosition()
 {
-	// calculate average position (and smooth) !< smooth is sth. different
-
-	for (int n=0; n<free_node; n++)
-	{
-		nodes[n].smoothpos = nodes[n].AbsPosition;
-		nodes[n].RelPosition = nodes[n].AbsPosition - origin;
-	}
-
+	// calculate average position
 	if (m_custom_camera_node >= 0)
 	{
 		position = nodes[m_custom_camera_node].AbsPosition;
@@ -1237,7 +1224,7 @@ void Beam::updateTruckPosition()
 		Vector3 aposition = Vector3::ZERO;
 		for (int n=0; n<free_node; n++)
 		{
-			aposition += nodes[n].smoothpos;
+			aposition += nodes[n].AbsPosition;
 		}
 		position = aposition / free_node;
 	}
@@ -1272,6 +1259,7 @@ void Beam::resetAngle(float rot)
 		nodes[i].AbsPosition -= origin;
 		nodes[i].AbsPosition  = matrix * nodes[i].AbsPosition;
 		nodes[i].AbsPosition += origin;
+		nodes[i].RelPosition = nodes[i].AbsPosition - this->origin;
 	}
 
 	resetSlideNodePositions();
@@ -1286,6 +1274,7 @@ void Beam::resetPosition(float px, float pz, bool setInitPosition, float miny)
 	for (int i=0; i<free_node; i++)
 	{
 		nodes[i].AbsPosition += offset;
+		nodes[i].RelPosition = nodes[i].AbsPosition - origin;
 	}
 
 	// vertical displacement
@@ -1303,6 +1292,7 @@ void Beam::resetPosition(float px, float pz, bool setInitPosition, float miny)
 	for (int i=0; i<free_node; i++)
 	{
 		nodes[i].AbsPosition.y += vertical_offset;
+		nodes[i].RelPosition = nodes[i].AbsPosition - origin;
 	}
 
 	// mesh displacement
@@ -1326,6 +1316,7 @@ void Beam::resetPosition(float px, float pz, bool setInitPosition, float miny)
 	for (int i=0; i<free_node; i++)
 	{
 		nodes[i].AbsPosition.y += mesh_offset;
+		nodes[i].RelPosition = nodes[i].AbsPosition - origin;
 	}
 
 	resetPosition(Vector3::ZERO, setInitPosition);
@@ -1340,6 +1331,7 @@ void Beam::resetPosition(Vector3 translation, bool setInitPosition)
 		for (int i=0; i<free_node; i++)
 		{
 			nodes[i].AbsPosition += offset;
+			nodes[i].RelPosition = nodes[i].AbsPosition - origin;
 		}
 	}
 
@@ -1388,9 +1380,9 @@ void Beam::calculateDriverPos(Vector3 &out_pos, Quaternion &out_rot)
 
 	BES_GFX_START(BES_GFX_calculateDriverPos);
 
-	Vector3 x_pos = nodes[driverSeat->nodex].smoothpos;
-	Vector3 y_pos = nodes[driverSeat->nodey].smoothpos;
-	Vector3 center_pos = nodes[driverSeat->noderef].smoothpos;
+	Vector3 x_pos = nodes[driverSeat->nodex].AbsPosition;
+	Vector3 y_pos = nodes[driverSeat->nodey].AbsPosition;
+	Vector3 center_pos = nodes[driverSeat->noderef].AbsPosition;
 
 	Vector3 x_vec = x_pos - center_pos;
 	Vector3 y_vec = y_pos - center_pos;
@@ -1483,6 +1475,7 @@ void Beam::displace(Vector3 translation, float rotation)
 			nodes[i].AbsPosition -= rotation_center;
 			nodes[i].AbsPosition  = rot * nodes[i].AbsPosition;
 			nodes[i].AbsPosition += rotation_center;
+			nodes[i].RelPosition = nodes[i].AbsPosition - origin;
 		}
 	}
 
@@ -1491,6 +1484,7 @@ void Beam::displace(Vector3 translation, float rotation)
 		for (int i=0; i<free_node; i++)
 		{
 			nodes[i].AbsPosition += translation;
+			nodes[i].RelPosition = nodes[i].AbsPosition - origin;
 		}
 	}
 
@@ -1546,7 +1540,6 @@ void Beam::SyncReset()
 	{
 		nodes[i].AbsPosition=initial_node_pos[i];
 		nodes[i].RelPosition=initial_node_pos[i]-origin;
-		nodes[i].smoothpos=initial_node_pos[i];
 		nodes[i].Velocity=Vector3::ZERO;
 		nodes[i].Forces=Vector3::ZERO;
 	}
@@ -1649,7 +1642,6 @@ bool Beam::replayStep()
 			{
 				nodes[i].AbsPosition = nbuff[i].position;
 				nodes[i].RelPosition = nbuff[i].position - origin;
-				nodes[i].smoothpos   = nbuff[i].position;
 
 				nodes[i].Velocity = nbuff[i].velocity;
 				nodes[i].Forces   = nbuff[i].forces;
@@ -1721,7 +1713,6 @@ void Beam::handleTruckPosition(float dt)
 	{
 		velocity = (position - lastposition) / dt;
 		lastposition = position;
-		updateTruckPosition();
 	}
 	if (nodes[0].RelPosition.squaredLength() > 10000.0)
 	{
@@ -3020,7 +3011,7 @@ void Beam::updateFlares(float dt, bool isCurrent)
 			}
 			if (props[i].beacontype=='R' || props[i].beacontype=='L')
 			{
-				Vector3 mposition=nodes[props[i].noderef].smoothpos+props[i].offsetx*(nodes[props[i].nodex].smoothpos-nodes[props[i].noderef].smoothpos)+props[i].offsety*(nodes[props[i].nodey].smoothpos-nodes[props[i].noderef].smoothpos);
+				Vector3 mposition=nodes[props[i].noderef].AbsPosition+props[i].offsetx*(nodes[props[i].nodex].AbsPosition-nodes[props[i].noderef].AbsPosition)+props[i].offsety*(nodes[props[i].nodey].AbsPosition-nodes[props[i].noderef].AbsPosition);
 				//billboard
 				Vector3 vdir=mposition-mCamera->getPosition();
 				float vlen=vdir.length();
@@ -3031,7 +3022,7 @@ void Beam::updateFlares(float dt, bool isCurrent)
 			}
 			if (props[i].beacontype=='w')
 			{
-				Vector3 mposition=nodes[props[i].noderef].smoothpos+props[i].offsetx*(nodes[props[i].nodex].smoothpos-nodes[props[i].noderef].smoothpos)+props[i].offsety*(nodes[props[i].nodey].smoothpos-nodes[props[i].noderef].smoothpos);
+				Vector3 mposition=nodes[props[i].noderef].AbsPosition+props[i].offsetx*(nodes[props[i].nodex].AbsPosition-nodes[props[i].noderef].AbsPosition)+props[i].offsety*(nodes[props[i].nodey].AbsPosition-nodes[props[i].noderef].AbsPosition);
 				props[i].beacon_light[0]->setPosition(mposition);
 				props[i].beacon_light_rotation_angle[0]+=dt*props[i].beacon_light_rotation_rate[0];//rotate baby!
 				//billboard
@@ -3142,9 +3133,9 @@ void Beam::updateFlares(float dt, bool isCurrent)
 			flares[i].light->setVisible(isvisible && enableAll);
 		flares[i].isVisible=isvisible;
 
-		Vector3 normal=(nodes[flares[i].nodey].smoothpos-nodes[flares[i].noderef].smoothpos).crossProduct(nodes[flares[i].nodex].smoothpos-nodes[flares[i].noderef].smoothpos);
+		Vector3 normal=(nodes[flares[i].nodey].AbsPosition-nodes[flares[i].noderef].AbsPosition).crossProduct(nodes[flares[i].nodex].AbsPosition-nodes[flares[i].noderef].AbsPosition);
 		normal.normalise();
-		Vector3 mposition=nodes[flares[i].noderef].smoothpos+flares[i].offsetx*(nodes[flares[i].nodex].smoothpos-nodes[flares[i].noderef].smoothpos)+flares[i].offsety*(nodes[flares[i].nodey].smoothpos-nodes[flares[i].noderef].smoothpos);
+		Vector3 mposition=nodes[flares[i].noderef].AbsPosition+flares[i].offsetx*(nodes[flares[i].nodex].AbsPosition-nodes[flares[i].noderef].AbsPosition)+flares[i].offsety*(nodes[flares[i].nodey].AbsPosition-nodes[flares[i].noderef].AbsPosition);
 		Vector3 vdir=mposition-mCamera->getPosition();
 		float vlen=vdir.length();
 		// not visible from 500m distance
@@ -3250,12 +3241,12 @@ void Beam::updateProps()
 	{
 		if (!props[i].scene_node) continue;
 
-		Vector3 diffX = nodes[props[i].nodex].smoothpos - nodes[props[i].noderef].smoothpos;
-		Vector3 diffY = nodes[props[i].nodey].smoothpos - nodes[props[i].noderef].smoothpos;
+		Vector3 diffX = nodes[props[i].nodex].AbsPosition - nodes[props[i].noderef].AbsPosition;
+		Vector3 diffY = nodes[props[i].nodey].AbsPosition - nodes[props[i].noderef].AbsPosition;
 
 		Vector3 normal = (diffY.crossProduct(diffX)).normalisedCopy();
 
-		Vector3 mposition = nodes[props[i].noderef].smoothpos + props[i].offsetx * diffX + props[i].offsety * diffY;
+		Vector3 mposition = nodes[props[i].noderef].AbsPosition + props[i].offsetx * diffX + props[i].offsety * diffY;
 		props[i].scene_node->setPosition(mposition + normal * props[i].offsetz);
 
 		Vector3 refx = diffX.normalisedCopy();
@@ -3425,8 +3416,8 @@ void Beam::updateVisual(float dt)
 	//update custom particle systems
 	for (int i=0; i<free_cparticle; i++)
 	{
-		Vector3 pos=nodes[cparticles[i].emitterNode].smoothpos;
-		Vector3 dir=pos-nodes[cparticles[i].directionNode].smoothpos;
+		Vector3 pos=nodes[cparticles[i].emitterNode].AbsPosition;
+		Vector3 dir=pos-nodes[cparticles[i].directionNode].AbsPosition;
 		//dir.normalise();
 		dir=fast_normalise(dir);
 		cparticles[i].snode->setPosition(pos);
@@ -3443,10 +3434,10 @@ void Beam::updateVisual(float dt)
 		{
 			if (!it->smoker)
 				continue;
-			Vector3 dir=nodes[it->emitterNode].smoothpos-nodes[it->directionNode].smoothpos;
+			Vector3 dir=nodes[it->emitterNode].AbsPosition-nodes[it->directionNode].AbsPosition;
 			//			dir.normalise();
 			ParticleEmitter *emit = it->smoker->getEmitter(0);
-			it->smokeNode->setPosition(nodes[it->emitterNode].smoothpos);
+			it->smokeNode->setPosition(nodes[it->emitterNode].AbsPosition);
 			emit->setDirection(dir);
 			if (engine->getSmoke()!=-1.0)
 			{
@@ -3536,9 +3527,9 @@ void Beam::updateVisual(float dt)
 		{
 			if (beams[i].type != BEAM_INVISIBLE && beams[i].type != BEAM_INVISIBLE_HYDRO && beams[i].type != BEAM_VIRTUAL)
 			{
-				beams[i].mSceneNode->setPosition(beams[i].p1->smoothpos.midPoint(beams[i].p2->smoothpos));
-				beams[i].mSceneNode->setOrientation(specialGetRotationTo(ref, beams[i].p1->smoothpos-beams[i].p2->smoothpos));
-				beams[i].mSceneNode->setScale(beams[i].diameter, (beams[i].p1->smoothpos-beams[i].p2->smoothpos).length(), beams[i].diameter);
+				beams[i].mSceneNode->setPosition(beams[i].p1->AbsPosition.midPoint(beams[i].p2->AbsPosition));
+				beams[i].mSceneNode->setOrientation(specialGetRotationTo(ref, beams[i].p1->AbsPosition-beams[i].p2->AbsPosition));
+				beams[i].mSceneNode->setScale(beams[i].diameter, (beams[i].p1->AbsPosition-beams[i].p2->AbsPosition).length(), beams[i].diameter);
 			}
 		}
 	}
@@ -4461,7 +4452,7 @@ void Beam::setDebugOverlayState(int mode)
 			t.node = gEnv->sceneManager->getRootSceneNode()->createChildSceneNode();
 			deletion_sceneNodes.emplace_back(t.node);
 			t.node->attachObject(t.txt);
-			t.node->setPosition(nodes[i].smoothpos);
+			t.node->setPosition(nodes[i].AbsPosition);
 			t.node->setScale(Vector3(0.5,0.5,0.5));
 
 			// collision nodes debug, also mimics as node visual
@@ -4509,7 +4500,7 @@ void Beam::setDebugOverlayState(int mode)
 			deletion_sceneNodes.emplace_back(t.node);
 			t.node->attachObject(t.txt);
 
-			Vector3 pos = beams[i].p1->smoothpos - (beams[i].p1->smoothpos - beams[i].p2->smoothpos)/2;
+			Vector3 pos = beams[i].p1->AbsPosition - (beams[i].p1->AbsPosition - beams[i].p2->AbsPosition)/2;
 			t.node->setPosition(pos);
 			t.node->setVisible(false);
 			t.node->setScale(Vector3(0.1,0.1,0.1));
@@ -4541,24 +4532,24 @@ void Beam::updateDebugOverlay()
 	case 1: // node-numbers
 		// not written dynamically
 		for (std::vector<debugtext_t>::iterator it=nodes_debug.begin(); it!=nodes_debug.end();it++)
-			it->node->setPosition(nodes[it->id].smoothpos);
+			it->node->setPosition(nodes[it->id].AbsPosition);
 		break;
 	case 2: // beam-numbers
 		// not written dynamically
 		for (std::vector<debugtext_t>::iterator it=beams_debug.begin(); it!=beams_debug.end();it++)
-			it->node->setPosition(beams[it->id].p1->smoothpos - (beams[it->id].p1->smoothpos - beams[it->id].p2->smoothpos)/2);
+			it->node->setPosition(beams[it->id].p1->AbsPosition - (beams[it->id].p1->AbsPosition - beams[it->id].p2->AbsPosition)/2);
 		break;
 	case 3: // node-and-beam-numbers
 		// not written dynamically
 		for (std::vector<debugtext_t>::iterator it=nodes_debug.begin(); it!=nodes_debug.end();it++)
-			it->node->setPosition(nodes[it->id].smoothpos);
+			it->node->setPosition(nodes[it->id].AbsPosition);
 		for (std::vector<debugtext_t>::iterator it=beams_debug.begin(); it!=beams_debug.end();it++)
-			it->node->setPosition(beams[it->id].p1->smoothpos - (beams[it->id].p1->smoothpos - beams[it->id].p2->smoothpos)/2);
+			it->node->setPosition(beams[it->id].p1->AbsPosition - (beams[it->id].p1->AbsPosition - beams[it->id].p2->AbsPosition)/2);
 		break;
 	case 4: // node-mass
 		for (std::vector<debugtext_t>::iterator it=nodes_debug.begin(); it!=nodes_debug.end();it++)
 		{
-			it->node->setPosition(nodes[it->id].smoothpos);
+			it->node->setPosition(nodes[it->id].AbsPosition);
 			it->txt->setCaption(TOSTRING(nodes[it->id].mass));
 		}
 		break;
@@ -4566,13 +4557,13 @@ void Beam::updateDebugOverlay()
 		for (std::vector<debugtext_t>::iterator it=nodes_debug.begin(); it!=nodes_debug.end();it++)
 		{
 			it->txt->setCaption((nodes[it->id].locked)?"locked":"unlocked");
-			it->node->setPosition(nodes[it->id].smoothpos);
+			it->node->setPosition(nodes[it->id].AbsPosition);
 		}
 		break;
 	case 6: // beam-compression
 		for (std::vector<debugtext_t>::iterator it=beams_debug.begin(); it!=beams_debug.end();it++)
 		{
-			it->node->setPosition(beams[it->id].p1->smoothpos - (beams[it->id].p1->smoothpos - beams[it->id].p2->smoothpos)/2);
+			it->node->setPosition(beams[it->id].p1->AbsPosition - (beams[it->id].p1->AbsPosition - beams[it->id].p2->AbsPosition)/2);
 			float stress_ratio = beams[it->id].stress / beams[it->id].minmaxposnegstress;
 			float color_scale = std::abs(stress_ratio);
 			color_scale = std::min(color_scale, 1.0f);
@@ -4583,7 +4574,7 @@ void Beam::updateDebugOverlay()
 	case 7: // beam-broken
 		for (std::vector<debugtext_t>::iterator it=beams_debug.begin(); it!=beams_debug.end();it++)
 		{
-			it->node->setPosition(beams[it->id].p1->smoothpos - (beams[it->id].p1->smoothpos - beams[it->id].p2->smoothpos)/2);
+			it->node->setPosition(beams[it->id].p1->AbsPosition - (beams[it->id].p1->AbsPosition - beams[it->id].p2->AbsPosition)/2);
 			if (beams[it->id].broken)
 			{
 				it->node->setVisible(true);
@@ -4597,14 +4588,14 @@ void Beam::updateDebugOverlay()
 	case 8: // beam-stress
 		for (std::vector<debugtext_t>::iterator it=beams_debug.begin(); it!=beams_debug.end();it++)
 		{
-			it->node->setPosition(beams[it->id].p1->smoothpos - (beams[it->id].p1->smoothpos - beams[it->id].p2->smoothpos)/2);
+			it->node->setPosition(beams[it->id].p1->AbsPosition - (beams[it->id].p1->AbsPosition - beams[it->id].p2->AbsPosition)/2);
 			it->txt->setCaption(TOSTRING((float) fabs(beams[it->id].stress)));
 		}
 		break;
 	case 9: // beam-strength
 		for (std::vector<debugtext_t>::iterator it=beams_debug.begin(); it!=beams_debug.end();it++)
 		{
-			it->node->setPosition(beams[it->id].p1->smoothpos - (beams[it->id].p1->smoothpos - beams[it->id].p2->smoothpos)/2);
+			it->node->setPosition(beams[it->id].p1->AbsPosition - (beams[it->id].p1->AbsPosition - beams[it->id].p2->AbsPosition)/2);
 			it->txt->setCaption(TOSTRING(beams[it->id].strength));
 		}
 		break;
@@ -4613,7 +4604,7 @@ void Beam::updateDebugOverlay()
 		{
 			if (beams[it->id].type == BEAM_HYDRO || beams[it->id].type == BEAM_INVISIBLE_HYDRO)
 			{
-				it->node->setPosition(beams[it->id].p1->smoothpos - (beams[it->id].p1->smoothpos - beams[it->id].p2->smoothpos)/2);
+				it->node->setPosition(beams[it->id].p1->AbsPosition - (beams[it->id].p1->AbsPosition - beams[it->id].p2->AbsPosition)/2);
 				int v = (beams[it->id].L / beams[it->id].Lhydro) * 100;
 				it->txt->setCaption(TOSTRING(v));
 				it->node->setVisible(true);
@@ -4626,7 +4617,7 @@ void Beam::updateDebugOverlay()
 	case 11: // beam-commands
 		for (std::vector<debugtext_t>::iterator it=beams_debug.begin(); it!=beams_debug.end();it++)
 		{
-			it->node->setPosition(beams[it->id].p1->smoothpos - (beams[it->id].p1->smoothpos - beams[it->id].p2->smoothpos)/2);
+			it->node->setPosition(beams[it->id].p1->AbsPosition - (beams[it->id].p1->AbsPosition - beams[it->id].p2->AbsPosition)/2);
 			int v = (beams[it->id].L / beams[it->id].commandLong) * 100;
 			it->txt->setCaption(TOSTRING(v));
 		}
@@ -5779,7 +5770,6 @@ bool Beam::LoadTruck(
 	{
 		nodes[i].AbsPosition = spawn_position + spawn_rotation * (nodes[i].AbsPosition - spawn_position);
 		nodes[i].RelPosition = nodes[i].AbsPosition - origin;
-		nodes[i].smoothpos   = nodes[i].AbsPosition;
 	};
 
 	/* Place correctly */

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4464,19 +4464,6 @@ void Beam::setDebugOverlayState(int mode)
 			s->attachObject(b);
 			float f = 0.005f;
 			s->setScale(f,f,f);
-
-			/*
-			// collision nodes
-			if (nodes[i].collRadius > 0.00001)
-			{
-				b->setMaterialName("tracks/transred");
-				f = nodes[i].collRadius;
-			} else
-			{
-				b->setMaterialName("tracks/transgreen");
-			}
-			*/
-
 			nodes_debug.push_back(t);
 		}
 

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -146,7 +146,6 @@ public:
 	void updateAngelScriptEvents(float dt);
 	void updateVideocameras(float dt);
 	void handleResetRequests(float dt);
-	void handleTruckPosition(float dt);
 
 	void setupDefaultSoundSources();
 
@@ -213,7 +212,6 @@ public:
 	void setReplayMode(bool rm);
 	int savePosition(int position);
 	int loadPosition(int position);
-	void updateTruckPosition();
 
 	/**
 	 * Virtually moves the truck at most 'direction.length()' meters towards 'direction' trying to resolve any collisions
@@ -549,7 +547,16 @@ public:
 
 	void updateDashBoards(float dt);
 
+	void updateBoundingBox();
+	void calculateAveragePosition();
+
 	//! @{ physic related functions
+	void preUpdatePhysics(float dt);
+	void postUpdatePhysics(float dt);
+
+	/**
+	* TIGHT LOOP; Physics; 
+	*/
 	bool calcForcesEulerPrepare(int doUpdate, Ogre::Real dt, int step = 0, int maxsteps = 1);
 
 	/**
@@ -618,7 +625,6 @@ protected:
 	void calc_masses2(Ogre::Real total, bool reCalc=false);
 	void calcNodeConnectivityGraph();
 	void moveOrigin(Ogre::Vector3 offset); //move physics origin
-	void changeOrigin(Ogre::Vector3 newOrigin); //change physics origin
 
 	Ogre::Vector3 position; // average node position
 	Ogre::Vector3 iPosition; // initial position

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -913,6 +913,15 @@ void BeamFactory::updateVisual(float dt)
 	RoR::Mirrors::Update(getCurrentTruck());
 }
 
+void BeamFactory::updateTruckPositions()
+{
+	for (int t=0; t < m_free_truck; t++)
+	{
+		if (!m_trucks[t]) continue;
+		m_trucks[t]->updateTruckPosition();
+	}
+}
+
 void BeamFactory::update(float dt)
 {
 	m_physics_frames++;

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -913,15 +913,6 @@ void BeamFactory::updateVisual(float dt)
 	RoR::Mirrors::Update(getCurrentTruck());
 }
 
-void BeamFactory::updateTruckPositions()
-{
-	for (int t=0; t < m_free_truck; t++)
-	{
-		if (!m_trucks[t]) continue;
-		m_trucks[t]->updateTruckPosition();
-	}
-}
-
 void BeamFactory::update(float dt)
 {
 	m_physics_frames++;
@@ -947,7 +938,6 @@ void BeamFactory::update(float dt)
 		if (!m_trucks[t]) continue;
 
 		m_trucks[t]->handleResetRequests(dt);
-		m_trucks[t]->handleTruckPosition(dt);
 		m_trucks[t]->updateAngelScriptEvents(dt);
 
 		if (m_trucks[t]->vehicle_ai && (m_trucks[t]->vehicle_ai->IsActive()))
@@ -1049,6 +1039,11 @@ Beam* BeamFactory::getTruck(int number)
 
 void BeamFactory::UpdatePhysicsSimulation()
 {
+	for (int t=0; t<m_free_truck; t++)
+	{
+		if (!m_trucks[t]) continue;
+		m_trucks[t]->preUpdatePhysics(m_physics_steps * PHYSICS_DT);
+	}
 	if (gEnv->threadPool)
 	{
 		for (int i=0; i<m_physics_steps; i++)
@@ -1173,6 +1168,12 @@ void BeamFactory::UpdatePhysicsSimulation()
 				BES_STOP(BES_CORE_Contacters);
 			}
 		}
+	}
+	for (int t=0; t<m_free_truck; t++)
+	{
+		if (!m_trucks[t]) continue;
+		if (!m_trucks[t]->simulated) continue;
+		m_trucks[t]->postUpdatePhysics(m_physics_steps * PHYSICS_DT);
 	}
 }
 

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -107,6 +107,11 @@ public:
 	void updateFlexbodiesFinal();
 
 	/**
+	* TIGHT-LOOP; Logic: average truck positions 
+	*/
+	void updateTruckPositions();
+
+	/**
 	 * Waits until all flexbody tasks are finished, but does not update the hardware buffers
 	 */
 	void joinFlexbodyTasks();

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -107,11 +107,6 @@ public:
 	void updateFlexbodiesFinal();
 
 	/**
-	* TIGHT-LOOP; Logic: average truck positions 
-	*/
-	void updateTruckPositions();
-
-	/**
 	 * Waits until all flexbody tasks are finished, but does not update the hardware buffers
 	 */
 	void joinFlexbodyTasks();

--- a/source/main/physics/air/AirBrake.cpp
+++ b/source/main/physics/air/AirBrake.cpp
@@ -160,16 +160,16 @@ void Airbrake::updatePosition(float amount)
 {
 	ratio=amount;
 	if (!snode) return;
-	Vector3 normal=(nodey->smoothpos-noderef->smoothpos).crossProduct(nodex->smoothpos-noderef->smoothpos);
+	Vector3 normal=(nodey->AbsPosition-noderef->AbsPosition).crossProduct(nodex->AbsPosition-noderef->AbsPosition);
 	normal.normalise();
 	//position
-	Vector3 mposition=noderef->smoothpos+offset.x*(nodex->smoothpos-noderef->smoothpos)+offset.y*(nodey->smoothpos-noderef->smoothpos);
+	Vector3 mposition=noderef->AbsPosition+offset.x*(nodex->AbsPosition-noderef->AbsPosition)+offset.y*(nodey->AbsPosition-noderef->AbsPosition);
 	snode->setPosition(mposition+normal*offset.z);
 	//orientation
-	Vector3 refx=nodex->smoothpos-noderef->smoothpos;
+	Vector3 refx=nodex->AbsPosition-noderef->AbsPosition;
 	refx.normalise();
 	Vector3 refy=refx.crossProduct(normal);
-	Quaternion orientation=Quaternion(Degree(-ratio*maxangle), (nodex->smoothpos-noderef->smoothpos).normalisedCopy())*Quaternion(refx, normal, refy);
+	Quaternion orientation=Quaternion(Degree(-ratio*maxangle), (nodex->AbsPosition-noderef->AbsPosition).normalisedCopy())*Quaternion(refx, normal, refy);
 	snode->setOrientation(orientation);
 }
 

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -147,7 +147,7 @@ Turbojet::~Turbojet()
 void Turbojet::updateVisuals()
 {
 	//nozzle
-	nzsnode->setPosition(nodes[nodeback].smoothpos);
+	nzsnode->setPosition(nodes[nodeback].AbsPosition);
 	//build a local system
 	Vector3 laxis=nodes[nodefront].RelPosition-nodes[nodeback].RelPosition;
 	laxis.normalise();
@@ -163,14 +163,14 @@ void Turbojet::updateVisuals()
 		float flamelength=(afterburnthrust/15.0)*(rpm/100.0);
 		flamelength=flamelength*(1.0+(((Real)rand()/(Real)RAND_MAX)-0.5)/10.0);
 		absnode->setScale(flamelength, radius*2.0, radius*2.0);
-		absnode->setPosition(nodes[nodeback].smoothpos+dir*Vector3(-0.2, 0.0, 0.0));
+		absnode->setPosition(nodes[nodeback].AbsPosition+dir*Vector3(-0.2, 0.0, 0.0));
 		absnode->setOrientation(dir);
 	}
 	else absnode->setVisible(false);
 	//smoke
 	if (smokeNode)
 	{
-		smokeNode->setPosition(nodes[nodeback].smoothpos);
+		smokeNode->setPosition(nodes[nodeback].AbsPosition);
 		ParticleEmitter *emit=smokePS->getEmitter(0);
 		ParticleEmitter *hemit=0;
 		if (heathazePS)

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -1073,7 +1073,7 @@ bool Collisions::nodeCollision(node_t *node, bool contacted, float dt, float* ns
 			if ((*cell)[k] != (int)UNUSED_CELLELEMENT && (*cell)[k] < MAX_COLLISION_BOXES)
 			{
 				collision_box_t *cbox = &collision_boxes[(*cell)[k]];
-				if (node->AbsPosition > cbox->lo - node->collRadius && node->AbsPosition < cbox->hi + node->collRadius)
+				if (node->AbsPosition > cbox->lo && node->AbsPosition < cbox->hi)
 				{
 					if (cbox->refined || cbox->selfrotated)
 					{
@@ -1087,7 +1087,7 @@ bool Collisions::nodeCollision(node_t *node, bool contacted, float dt, float* ns
 							Pos=Pos+cbox->selfcenter;
 						}
 						// now test with the inner box
-						if (Pos > cbox->relo - node->collRadius && Pos < cbox->rehi + node->collRadius)
+						if (Pos > cbox->relo && Pos < cbox->rehi)
 						{
 							if (cbox->eventsourcenum!=-1 && permitEvent(cbox->event_filter))
 							{
@@ -1108,17 +1108,17 @@ bool Collisions::nodeCollision(node_t *node, bool contacted, float dt, float* ns
 								smoky=true;
 								//*nso=ns;
 								// determine which side collided
-								float min=Pos.z-(cbox->relo - node->collRadius).z;
+								float min=Pos.z-(cbox->relo).z;
 								Vector3 normal=Vector3(0,0,-1);
-								float t=(cbox->rehi + node->collRadius).z-Pos.z;
+								float t=(cbox->rehi).z-Pos.z;
 								if (t<min){min=t; normal=Vector3(0,0,1);}; //north
-								t=Pos.x-(cbox->relo - node->collRadius).x;
+								t=Pos.x-(cbox->relo).x;
 								if (t<min) {min=t; normal=Vector3(-1,0,0);}; //west
-								t=(cbox->rehi + node->collRadius).x-Pos.x;
+								t=(cbox->rehi).x-Pos.x;
 								if (t<min) {min=t; normal=Vector3(1,0,0);}; //east
-								t=Pos.y-(cbox->relo - node->collRadius).y;
+								t=Pos.y-(cbox->relo).y;
 								if (t<min) {min=t; normal=Vector3(0,-1,0);}; //down
-								t=(cbox->rehi + node->collRadius).y-Pos.y;
+								t=(cbox->rehi).y-Pos.y;
 								if (t<min) {min=t; normal=Vector3(0,1,0);}; //up
 
 								// we need the normal, and the depth

--- a/source/main/physics/flex/FlexAirfoil.cpp
+++ b/source/main/physics/flex/FlexAirfoil.cpp
@@ -414,13 +414,13 @@ Vector3 FlexAirfoil::updateVertices()
 {
 	int i;
 	Vector3 center;
-	center=nodes[nfld].smoothpos;
+	center=nodes[nfld].AbsPosition;
 
-	Vector3 vx=nodes[nfrd].smoothpos-nodes[nfld].smoothpos;
-	Vector3 vyl=nodes[nflu].smoothpos-nodes[nfld].smoothpos;
-	Vector3 vzl=nodes[nbld].smoothpos-nodes[nfld].smoothpos;
-	Vector3 vyr=nodes[nfru].smoothpos-nodes[nfrd].smoothpos;
-	Vector3 vzr=nodes[nbrd].smoothpos-nodes[nfrd].smoothpos;
+	Vector3 vx=nodes[nfrd].AbsPosition-nodes[nfld].AbsPosition;
+	Vector3 vyl=nodes[nflu].AbsPosition-nodes[nfld].AbsPosition;
+	Vector3 vzl=nodes[nbld].AbsPosition-nodes[nfld].AbsPosition;
+	Vector3 vyr=nodes[nfru].AbsPosition-nodes[nfrd].AbsPosition;
+	Vector3 vzr=nodes[nbrd].AbsPosition-nodes[nfrd].AbsPosition;
 
 	if (breakable) {broken=broken || (vx.crossProduct(vzl).squaredLength()>sref)||(vx.crossProduct(vzr).squaredLength()>sref);}
 	else {broken=(vx.crossProduct(vzl).squaredLength()>sref)||(vx.crossProduct(vzr).squaredLength()>sref);}
@@ -475,13 +475,13 @@ Vector3 FlexAirfoil::updateVertices()
 		Vector3 rcent, raxis;
 		if (!stabilleft)
 		{
-			rcent=((nodes[nflu].smoothpos+nodes[nbld].smoothpos)/2.0+(nodes[nflu].smoothpos-nodes[nblu].smoothpos)/4.0)-center;
-			raxis=(nodes[nflu].smoothpos-nodes[nfld].smoothpos).crossProduct(nodes[nflu].smoothpos-nodes[nblu].smoothpos);
+			rcent=((nodes[nflu].AbsPosition+nodes[nbld].AbsPosition)/2.0+(nodes[nflu].AbsPosition-nodes[nblu].AbsPosition)/4.0)-center;
+			raxis=(nodes[nflu].AbsPosition-nodes[nfld].AbsPosition).crossProduct(nodes[nflu].AbsPosition-nodes[nblu].AbsPosition);
 		}
 		else
 		{
-			rcent=((nodes[nfru].smoothpos+nodes[nbrd].smoothpos)/2.0+(nodes[nfru].smoothpos-nodes[nbru].smoothpos)/4.0)-center;
-			raxis=(nodes[nfru].smoothpos-nodes[nfrd].smoothpos).crossProduct(nodes[nfru].smoothpos-nodes[nbru].smoothpos);
+			rcent=((nodes[nfru].AbsPosition+nodes[nbrd].AbsPosition)/2.0+(nodes[nfru].AbsPosition-nodes[nbru].AbsPosition)/4.0)-center;
+			raxis=(nodes[nfru].AbsPosition-nodes[nfrd].AbsPosition).crossProduct(nodes[nfru].AbsPosition-nodes[nbru].AbsPosition);
 		}
 		raxis.normalise();
 		Quaternion rot=Quaternion(Degree(deflection), raxis);
@@ -553,13 +553,13 @@ Vector3 FlexAirfoil::updateShadowVertices()
 {
 	 int i;
 	Vector3 center;
-	center=nodes[nfld].smoothpos;
+	center=nodes[nfld].AbsPosition;
 
-	Vector3 vx=nodes[nfrd].smoothpos-nodes[nfld].smoothpos;
-	Vector3 vyl=nodes[nflu].smoothpos-nodes[nfld].smoothpos;
-	Vector3 vzl=nodes[nbld].smoothpos-nodes[nfld].smoothpos;
-	Vector3 vyr=nodes[nfru].smoothpos-nodes[nfrd].smoothpos;
-	Vector3 vzr=nodes[nbrd].smoothpos-nodes[nfrd].smoothpos;
+	Vector3 vx=nodes[nfrd].AbsPosition-nodes[nfld].AbsPosition;
+	Vector3 vyl=nodes[nflu].AbsPosition-nodes[nfld].AbsPosition;
+	Vector3 vzl=nodes[nbld].AbsPosition-nodes[nfld].AbsPosition;
+	Vector3 vyr=nodes[nfru].AbsPosition-nodes[nfrd].AbsPosition;
+	Vector3 vzr=nodes[nbrd].AbsPosition-nodes[nfrd].AbsPosition;
 
 	if (breakable) {broken=broken || (vx.crossProduct(vzl).squaredLength()>sref)||(vx.crossProduct(vzr).squaredLength()>sref);}
 	else {broken=(vx.crossProduct(vzl).squaredLength()>sref)||(vx.crossProduct(vzr).squaredLength()>sref);}
@@ -614,13 +614,13 @@ Vector3 FlexAirfoil::updateShadowVertices()
 		Vector3 rcent, raxis;
 		if (!stabilleft)
 		{
-			rcent=((nodes[nflu].smoothpos+nodes[nbld].smoothpos)/2.0+(nodes[nflu].smoothpos-nodes[nblu].smoothpos)/4.0)-center;
-			raxis=(nodes[nflu].smoothpos-nodes[nfld].smoothpos).crossProduct(nodes[nflu].smoothpos-nodes[nblu].smoothpos);
+			rcent=((nodes[nflu].AbsPosition+nodes[nbld].AbsPosition)/2.0+(nodes[nflu].AbsPosition-nodes[nblu].AbsPosition)/4.0)-center;
+			raxis=(nodes[nflu].AbsPosition-nodes[nfld].AbsPosition).crossProduct(nodes[nflu].AbsPosition-nodes[nblu].AbsPosition);
 		}
 		else
 		{
-			rcent=((nodes[nfru].smoothpos+nodes[nbrd].smoothpos)/2.0+(nodes[nfru].smoothpos-nodes[nbru].smoothpos)/4.0)-center;
-			raxis=(nodes[nfru].smoothpos-nodes[nfrd].smoothpos).crossProduct(nodes[nfru].smoothpos-nodes[nbru].smoothpos);
+			rcent=((nodes[nfru].AbsPosition+nodes[nbrd].AbsPosition)/2.0+(nodes[nfru].AbsPosition-nodes[nbru].AbsPosition)/4.0)-center;
+			raxis=(nodes[nfru].AbsPosition-nodes[nfrd].AbsPosition).crossProduct(nodes[nfru].AbsPosition-nodes[nbru].AbsPosition);
 		}
 		raxis.normalise();
 		Quaternion rot=Quaternion(Degree(deflection), raxis);

--- a/source/main/physics/flex/FlexBody.cpp
+++ b/source/main/physics/flex/FlexBody.cpp
@@ -77,13 +77,13 @@ FlexBody::FlexBody(
 
 	if (ref >= 0)
 	{
-		Vector3 diffX = m_nodes[nx].smoothpos-m_nodes[ref].smoothpos;
-		Vector3 diffY = m_nodes[ny].smoothpos-m_nodes[ref].smoothpos;
+		Vector3 diffX = m_nodes[nx].AbsPosition-m_nodes[ref].AbsPosition;
+		Vector3 diffY = m_nodes[ny].AbsPosition-m_nodes[ref].AbsPosition;
 
 		normal = fast_normalise(diffY.crossProduct(diffX));
 
 		// position
-		position = m_nodes[ref].smoothpos + offset.x * diffX + offset.y * diffY;
+		position = m_nodes[ref].AbsPosition + offset.x * diffX + offset.y * diffY;
 		position = position + offset.z * normal;
 
 		// orientation
@@ -94,7 +94,7 @@ FlexBody::FlexBody(
 	{
 		// special case!
 		normal = Vector3::UNIT_Y;
-		position = m_nodes[0].smoothpos + offset;
+		position = m_nodes[0].AbsPosition + offset;
 		orientation = rot;
 	}
     FLEXBODY_PROFILER_ENTER("Find mesh resource");
@@ -487,7 +487,7 @@ FlexBody::FlexBody(
 			auto itor = node_indices.begin();
 			for (; itor != end; ++itor)
 			{
-				float node_distance = vertices[i].squaredDistance(m_nodes[*itor].smoothpos);
+				float node_distance = vertices[i].squaredDistance(m_nodes[*itor].AbsPosition);
 				if (node_distance < closest_node_distance)
 				{
 					closest_node_distance = node_distance;
@@ -510,7 +510,7 @@ FlexBody::FlexBody(
 				{
 					continue;
 				}
-				float node_distance = vertices[i].squaredDistance(m_nodes[*itor].smoothpos);
+				float node_distance = vertices[i].squaredDistance(m_nodes[*itor].AbsPosition);
 				if (node_distance < closest_node_distance)
 				{
 					closest_node_distance = node_distance;
@@ -527,17 +527,17 @@ FlexBody::FlexBody(
 			closest_node_distance=1000000.0;
 			closest_node_index=-1;
 			itor = node_indices.begin();
-			Vector3 vx = fast_normalise(m_nodes[m_locators[i].nx].smoothpos - m_nodes[m_locators[i].ref].smoothpos);
+			Vector3 vx = fast_normalise(m_nodes[m_locators[i].nx].AbsPosition - m_nodes[m_locators[i].ref].AbsPosition);
 			for (; itor != end; ++itor)
 			{
 				if (*itor == m_locators[i].ref || *itor == m_locators[i].nx)
 				{
 					continue;
 				}
-				float node_distance = vertices[i].squaredDistance(m_nodes[*itor].smoothpos);
+				float node_distance = vertices[i].squaredDistance(m_nodes[*itor].AbsPosition);
 				if (node_distance < closest_node_distance)
 				{
-					Vector3 vt = fast_normalise(m_nodes[*itor].smoothpos - m_nodes[m_locators[i].ref].smoothpos);
+					Vector3 vt = fast_normalise(m_nodes[*itor].AbsPosition - m_nodes[m_locators[i].ref].AbsPosition);
 					float cost = vx.dotProduct(vt);
 					if (cost>0.707 || cost<-0.707)
 					{
@@ -554,17 +554,17 @@ FlexBody::FlexBody(
 			m_locators[i].ny=closest_node_index;
 
 			Matrix3 mat;
-			Vector3 diffX = m_nodes[m_locators[i].nx].smoothpos-m_nodes[m_locators[i].ref].smoothpos;
-			Vector3 diffY = m_nodes[m_locators[i].ny].smoothpos-m_nodes[m_locators[i].ref].smoothpos;
+			Vector3 diffX = m_nodes[m_locators[i].nx].AbsPosition-m_nodes[m_locators[i].ref].AbsPosition;
+			Vector3 diffY = m_nodes[m_locators[i].ny].AbsPosition-m_nodes[m_locators[i].ref].AbsPosition;
 
 			mat.SetColumn(0, diffX);
 			mat.SetColumn(1, diffY);
-			mat.SetColumn(2, fast_normalise(diffX.crossProduct(diffY))); // Old version: mat.SetColumn(2, m_nodes[loc.nz].smoothpos-m_nodes[loc.ref].smoothpos);
+			mat.SetColumn(2, fast_normalise(diffX.crossProduct(diffY))); // Old version: mat.SetColumn(2, m_nodes[loc.nz].AbsPosition-m_nodes[loc.ref].AbsPosition);
 
 			mat = mat.Inverse();
 
 			//compute coordinates in the newly formed Euclidean basis
-			m_locators[i].coords = mat * (vertices[i] - m_nodes[m_locators[i].ref].smoothpos);
+			m_locators[i].coords = mat * (vertices[i] - m_nodes[m_locators[i].ref].AbsPosition);
 
 			// that's it!
 		}
@@ -604,12 +604,12 @@ FlexBody::FlexBody(
 		for (int i=0; i<(int)m_vertex_count; i++)
 		{
 			Matrix3 mat;
-			Vector3 diffX = m_nodes[m_locators[i].nx].smoothpos-m_nodes[m_locators[i].ref].smoothpos;
-			Vector3 diffY = m_nodes[m_locators[i].ny].smoothpos-m_nodes[m_locators[i].ref].smoothpos;
+			Vector3 diffX = m_nodes[m_locators[i].nx].AbsPosition-m_nodes[m_locators[i].ref].AbsPosition;
+			Vector3 diffY = m_nodes[m_locators[i].ny].AbsPosition-m_nodes[m_locators[i].ref].AbsPosition;
 
 			mat.SetColumn(0, diffX);
 			mat.SetColumn(1, diffY);
-			mat.SetColumn(2, fast_normalise(diffX.crossProduct(diffY))); // Old version: mat.SetColumn(2, m_nodes[loc.nz].smoothpos-m_nodes[loc.ref].smoothpos);
+			mat.SetColumn(2, fast_normalise(diffX.crossProduct(diffY))); // Old version: mat.SetColumn(2, m_nodes[loc.nz].AbsPosition-m_nodes[loc.ref].AbsPosition);
 
 			mat = mat.Inverse();
 
@@ -724,16 +724,16 @@ bool FlexBody::flexitPrepare()
 
 	if (m_node_center >= 0)
 	{
-		Vector3 diffX = m_nodes[m_node_x].smoothpos - m_nodes[m_node_center].smoothpos;
-		Vector3 diffY = m_nodes[m_node_y].smoothpos - m_nodes[m_node_center].smoothpos;
+		Vector3 diffX = m_nodes[m_node_x].AbsPosition - m_nodes[m_node_center].AbsPosition;
+		Vector3 diffY = m_nodes[m_node_y].AbsPosition - m_nodes[m_node_center].AbsPosition;
 		flexit_normal = fast_normalise(diffY.crossProduct(diffX));
 
-		flexit_center = m_nodes[m_node_center].smoothpos + m_center_offset.x * diffX + m_center_offset.y * diffY;
+		flexit_center = m_nodes[m_node_center].AbsPosition + m_center_offset.x * diffX + m_center_offset.y * diffY;
 		flexit_center += m_center_offset.z * flexit_normal;
 	} else
 	{
 		flexit_normal = Vector3::UNIT_Y;
-		flexit_center = m_nodes[0].smoothpos;
+		flexit_center = m_nodes[0].AbsPosition;
 	}
 
 	return true;
@@ -743,15 +743,15 @@ void FlexBody::flexitCompute()
 {
 	for (int i=0; i<(int)m_vertex_count; i++)
 	{
-		Vector3 diffX = m_nodes[m_locators[i].nx].smoothpos - m_nodes[m_locators[i].ref].smoothpos;
-		Vector3 diffY = m_nodes[m_locators[i].ny].smoothpos - m_nodes[m_locators[i].ref].smoothpos;
+		Vector3 diffX = m_nodes[m_locators[i].nx].AbsPosition - m_nodes[m_locators[i].ref].AbsPosition;
+		Vector3 diffY = m_nodes[m_locators[i].ny].AbsPosition - m_nodes[m_locators[i].ref].AbsPosition;
 		Vector3 nCross = fast_normalise(diffX.crossProduct(diffY)); //nCross.normalise();
 
 		m_dst_pos[i].x = diffX.x * m_locators[i].coords.x + diffY.x * m_locators[i].coords.y + nCross.x * m_locators[i].coords.z;
 		m_dst_pos[i].y = diffX.y * m_locators[i].coords.x + diffY.y * m_locators[i].coords.y + nCross.y * m_locators[i].coords.z;
 		m_dst_pos[i].z = diffX.z * m_locators[i].coords.x + diffY.z * m_locators[i].coords.y + nCross.z * m_locators[i].coords.z;
 
-		m_dst_pos[i] += m_nodes[m_locators[i].ref].smoothpos - flexit_center;
+		m_dst_pos[i] += m_nodes[m_locators[i].ref].AbsPosition - flexit_center;
 
 		m_dst_normals[i].x = diffX.x * m_src_normals[i].x + diffY.x * m_src_normals[i].y + nCross.x * m_src_normals[i].z;
 		m_dst_normals[i].y = diffX.y * m_src_normals[i].x + diffY.y * m_src_normals[i].y + nCross.y * m_src_normals[i].z;
@@ -763,14 +763,14 @@ void FlexBody::flexitCompute()
 	for (int i=0; i<(int)m_vertex_count; i++)
 	{
 		Matrix3 mat;
-		Vector3 diffX = m_nodes[m_locators[i].nx].smoothpos - m_nodes[m_locators[i].ref].smoothpos;
-		Vector3 diffY = m_nodes[m_locators[i].ny].smoothpos - m_nodes[m_locators[i].ref].smoothpos;
+		Vector3 diffX = m_nodes[m_locators[i].nx].AbsPosition - m_nodes[m_locators[i].ref].AbsPosition;
+		Vector3 diffY = m_nodes[m_locators[i].ny].AbsPosition - m_nodes[m_locators[i].ref].AbsPosition;
 
 		mat.SetColumn(0, diffX);
 		mat.SetColumn(1, diffY);
-		mat.SetColumn(2, fast_normalise(diffX.crossProduct(diffY))); // Old version: mat.SetColumn(2, m_nodes[loc.nz].smoothpos-m_nodes[loc.ref].smoothpos);
+		mat.SetColumn(2, fast_normalise(diffX.crossProduct(diffY))); // Old version: mat.SetColumn(2, m_nodes[loc.nz].AbsPosition-m_nodes[loc.ref].AbsPosition);
 
-		m_dst_pos[i] = mat * m_locators[i].coords + m_nodes[m_locators[i].ref].smoothpos - flexit_center;
+		m_dst_pos[i] = mat * m_locators[i].coords + m_nodes[m_locators[i].ref].AbsPosition - flexit_center;
 		m_dst_normals[i] = fast_normalise(mat * m_src_normals[i]);
 	}
 #endif

--- a/source/main/physics/flex/FlexMesh.cpp
+++ b/source/main/physics/flex/FlexMesh.cpp
@@ -241,36 +241,36 @@ FlexMesh::~FlexMesh()
 
 Vector3 FlexMesh::updateVertices()
 {
-	Vector3 center = (nodes[nodeIDs[0]].smoothpos + nodes[nodeIDs[1]].smoothpos) / 2.0;
+	Vector3 center = (nodes[nodeIDs[0]].AbsPosition + nodes[nodeIDs[1]].AbsPosition) / 2.0;
 
 	//optimization possible here : just copy bands on face
 
-	covertices[0].vertex=nodes[nodeIDs[0]].smoothpos-center;
+	covertices[0].vertex=nodes[nodeIDs[0]].AbsPosition-center;
 	//normals
-	covertices[0].normal=approx_normalise(nodes[nodeIDs[0]].smoothpos-nodes[nodeIDs[1]].smoothpos);
+	covertices[0].normal=approx_normalise(nodes[nodeIDs[0]].AbsPosition-nodes[nodeIDs[1]].AbsPosition);
 
-	covertices[1].vertex=nodes[nodeIDs[1]].smoothpos-center;
+	covertices[1].vertex=nodes[nodeIDs[1]].AbsPosition-center;
 	//normals
 	covertices[1].normal=-covertices[0].normal;
 
 	for (int i=0; i<nbrays*2; i++)
 	{
-		covertices[2+i].vertex=nodes[nodeIDs[2+i]].smoothpos-center;
+		covertices[2+i].vertex=nodes[nodeIDs[2+i]].AbsPosition-center;
 		//normals
 		if ((i%2)==0)
 		{
-			covertices[2+i].normal=approx_normalise(nodes[nodeIDs[0]].smoothpos-nodes[nodeIDs[1]].smoothpos);
+			covertices[2+i].normal=approx_normalise(nodes[nodeIDs[0]].AbsPosition-nodes[nodeIDs[1]].AbsPosition);
 		} else
 		{
 			covertices[2+i].normal=-covertices[2+i-1].normal;
 		}
 		if (is_rimmed)
 		{
-			covertices[2+4*nbrays+i].vertex=nodes[nodeIDs[2+4*nbrays+i]].smoothpos-center;
+			covertices[2+4*nbrays+i].vertex=nodes[nodeIDs[2+4*nbrays+i]].AbsPosition-center;
 			//normals
 			if ((i%2)==0)
 			{
-				covertices[2+4*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+4*nbrays+i]].smoothpos-nodes[nodeIDs[2+4*nbrays+i+1]].smoothpos);
+				covertices[2+4*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+4*nbrays+i]].AbsPosition-nodes[nodeIDs[2+4*nbrays+i+1]].AbsPosition);
 			} else
 			{
 				covertices[2+4*nbrays+i].normal=-covertices[2+4*nbrays+i-1].normal;
@@ -290,38 +290,38 @@ Vector3 FlexMesh::updateVertices()
 
 Vector3 FlexMesh::updateShadowVertices()
 {
-	Vector3 center = (nodes[nodeIDs[0]].smoothpos + nodes[nodeIDs[1]].smoothpos) / 2.0;
+	Vector3 center = (nodes[nodeIDs[0]].AbsPosition + nodes[nodeIDs[1]].AbsPosition) / 2.0;
 
-	coshadowposvertices[0].vertex=nodes[nodeIDs[0]].smoothpos-center;
+	coshadowposvertices[0].vertex=nodes[nodeIDs[0]].AbsPosition-center;
 	//normals
-	coshadownorvertices[0].normal=approx_normalise(nodes[nodeIDs[0]].smoothpos-nodes[nodeIDs[1]].smoothpos);
+	coshadownorvertices[0].normal=approx_normalise(nodes[nodeIDs[0]].AbsPosition-nodes[nodeIDs[1]].AbsPosition);
 
-	coshadowposvertices[1].vertex=nodes[nodeIDs[1]].smoothpos-center;
+	coshadowposvertices[1].vertex=nodes[nodeIDs[1]].AbsPosition-center;
 	//normals
 	coshadownorvertices[1].normal=-coshadownorvertices[0].normal;
 
 	for (int i=0; i<nbrays*2; i++)
 	{
-		coshadowposvertices[2+i].vertex=nodes[nodeIDs[2+i]].smoothpos-center;
+		coshadowposvertices[2+i].vertex=nodes[nodeIDs[2+i]].AbsPosition-center;
 
-		coshadownorvertices[2+i].normal=approx_normalise(nodes[nodeIDs[2+i]].smoothpos-center);
+		coshadownorvertices[2+i].normal=approx_normalise(nodes[nodeIDs[2+i]].AbsPosition-center);
 		//normals
 		if ((i%2)==0)
 		{
-			coshadownorvertices[2+i].normal=approx_normalise(nodes[nodeIDs[0]].smoothpos-nodes[nodeIDs[1]].smoothpos);
+			coshadownorvertices[2+i].normal=approx_normalise(nodes[nodeIDs[0]].AbsPosition-nodes[nodeIDs[1]].AbsPosition);
 		} else
 		{
 			coshadownorvertices[2+i].normal=-coshadownorvertices[2+i-1].normal;
 		}
 		if (is_rimmed)
 		{
-			coshadowposvertices[2+4*nbrays+i].vertex=nodes[nodeIDs[2+4*nbrays+i]].smoothpos-center;
+			coshadowposvertices[2+4*nbrays+i].vertex=nodes[nodeIDs[2+4*nbrays+i]].AbsPosition-center;
 
-			coshadownorvertices[2+4*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+4*nbrays+i]].smoothpos-center);
+			coshadownorvertices[2+4*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+4*nbrays+i]].AbsPosition-center);
 			//normals
 			if ((i%2)==0)
 			{
-				coshadownorvertices[2+4*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+4*nbrays+i]].smoothpos-nodes[nodeIDs[2+4*nbrays+i+1]].smoothpos);
+				coshadownorvertices[2+4*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+4*nbrays+i]].AbsPosition-nodes[nodeIDs[2+4*nbrays+i+1]].AbsPosition);
 			} else
 			{
 				coshadownorvertices[2+4*nbrays+i].normal=-coshadownorvertices[2+4*nbrays+i-1].normal;
@@ -330,10 +330,10 @@ Vector3 FlexMesh::updateShadowVertices()
 			coshadowposvertices[2+2*nbrays+i].vertex=coshadowposvertices[2+4*nbrays+i].vertex;
 			if ((i%2)==0)
 			{
-				coshadownorvertices[2+2*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+i]].smoothpos-nodes[nodeIDs[0]].smoothpos);
+				coshadownorvertices[2+2*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+i]].AbsPosition-nodes[nodeIDs[0]].AbsPosition);
 			} else
 			{
-				coshadownorvertices[2+2*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+i]].smoothpos-nodes[nodeIDs[1]].smoothpos);
+				coshadownorvertices[2+2*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+i]].AbsPosition-nodes[nodeIDs[1]].AbsPosition);
 			}
 		} else
 		{
@@ -341,10 +341,10 @@ Vector3 FlexMesh::updateShadowVertices()
 			coshadowposvertices[2+2*nbrays+i].vertex=coshadowposvertices[2+i].vertex;
 			if ((i%2)==0)
 			{
-				coshadownorvertices[2+2*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+i]].smoothpos-nodes[nodeIDs[0]].smoothpos);
+				coshadownorvertices[2+2*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+i]].AbsPosition-nodes[nodeIDs[0]].AbsPosition);
 			} else
 			{
-				coshadownorvertices[2+2*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+i]].smoothpos-nodes[nodeIDs[1]].smoothpos);
+				coshadownorvertices[2+2*nbrays+i].normal=approx_normalise(nodes[nodeIDs[2+i]].AbsPosition-nodes[nodeIDs[1]].AbsPosition);
 			}
 		}
 

--- a/source/main/physics/flex/FlexMeshWheel.cpp
+++ b/source/main/physics/flex/FlexMeshWheel.cpp
@@ -210,30 +210,30 @@ FlexMeshWheel::~FlexMeshWheel()
 
 Vector3 FlexMeshWheel::updateVertices()
 {
-	Vector3 center = (nodes[id0].smoothpos + nodes[id1].smoothpos) / 2.0;
-	Vector3 ray = nodes[idstart].smoothpos - nodes[id0].smoothpos;
-	Vector3 axis = nodes[id0].smoothpos - nodes[id1].smoothpos;
+	Vector3 center = (nodes[id0].AbsPosition + nodes[id1].AbsPosition) / 2.0;
+	Vector3 ray = nodes[idstart].AbsPosition - nodes[id0].AbsPosition;
+	Vector3 axis = nodes[id0].AbsPosition - nodes[id1].AbsPosition;
 
 	axis.normalise();
 	
 	for (int i=0; i<nbrays; i++)
 	{
-		Plane pl=Plane(axis, nodes[id0].smoothpos);
-		ray=nodes[idstart+i*2].smoothpos-nodes[id0].smoothpos;
+		Plane pl=Plane(axis, nodes[id0].AbsPosition);
+		ray=nodes[idstart+i*2].AbsPosition-nodes[id0].AbsPosition;
 		ray=pl.projectVector(ray);
 		ray.normalise();
-		covertices[i*6  ].vertex=nodes[id0].smoothpos+rim_radius*ray-center;
+		covertices[i*6  ].vertex=nodes[id0].AbsPosition+rim_radius*ray-center;
 
-		covertices[i*6+1].vertex=nodes[idstart+i*2].smoothpos-0.05*(nodes[idstart+i*2].smoothpos-nodes[id0].smoothpos)-center;
-		covertices[i*6+2].vertex=nodes[idstart+i*2].smoothpos-0.1*(nodes[idstart+i*2].smoothpos-nodes[idstart+i*2+1].smoothpos)-center;
-		covertices[i*6+3].vertex=nodes[idstart+i*2+1].smoothpos-0.1*(nodes[idstart+i*2+1].smoothpos-nodes[idstart+i*2].smoothpos)-center;
-		covertices[i*6+4].vertex=nodes[idstart+i*2+1].smoothpos-0.05*(nodes[idstart+i*2+1].smoothpos-nodes[id1].smoothpos)-center;
+		covertices[i*6+1].vertex=nodes[idstart+i*2].AbsPosition-0.05*(nodes[idstart+i*2].AbsPosition-nodes[id0].AbsPosition)-center;
+		covertices[i*6+2].vertex=nodes[idstart+i*2].AbsPosition-0.1*(nodes[idstart+i*2].AbsPosition-nodes[idstart+i*2+1].AbsPosition)-center;
+		covertices[i*6+3].vertex=nodes[idstart+i*2+1].AbsPosition-0.1*(nodes[idstart+i*2+1].AbsPosition-nodes[idstart+i*2].AbsPosition)-center;
+		covertices[i*6+4].vertex=nodes[idstart+i*2+1].AbsPosition-0.05*(nodes[idstart+i*2+1].AbsPosition-nodes[id1].AbsPosition)-center;
 
-		pl=Plane(-axis, nodes[id1].smoothpos);
-		ray=nodes[idstart+i*2+1].smoothpos-nodes[id1].smoothpos;
+		pl=Plane(-axis, nodes[id1].AbsPosition);
+		ray=nodes[idstart+i*2+1].AbsPosition-nodes[id1].AbsPosition;
 		ray=pl.projectVector(ray);
 		ray.normalise();
-		covertices[i*6+5].vertex=nodes[id1].smoothpos+rim_radius*ray-center;
+		covertices[i*6+5].vertex=nodes[id1].AbsPosition+rim_radius*ray-center;
 
 		//normals
 		covertices[i*6  ].normal=axis;
@@ -254,30 +254,30 @@ Vector3 FlexMeshWheel::updateVertices()
 
 Vector3 FlexMeshWheel::updateShadowVertices()
 {
-	Vector3 center = (nodes[id0].smoothpos + nodes[id1].smoothpos) / 2.0;
-	Vector3 ray = nodes[idstart].smoothpos - nodes[id0].smoothpos;
-	Vector3 axis = nodes[id0].smoothpos - nodes[id1].smoothpos;
+	Vector3 center = (nodes[id0].AbsPosition + nodes[id1].AbsPosition) / 2.0;
+	Vector3 ray = nodes[idstart].AbsPosition - nodes[id0].AbsPosition;
+	Vector3 axis = nodes[id0].AbsPosition - nodes[id1].AbsPosition;
 	
 	axis.normalise();
 
 	for (int i=0; i<nbrays; i++)
 	{
-		Plane pl=Plane(axis, nodes[id0].smoothpos);
-		ray=nodes[idstart+i*2].smoothpos-nodes[id0].smoothpos;
+		Plane pl=Plane(axis, nodes[id0].AbsPosition);
+		ray=nodes[idstart+i*2].AbsPosition-nodes[id0].AbsPosition;
 		ray=pl.projectVector(ray);
 		ray.normalise();
-		coshadowposvertices[i*6  ].vertex=nodes[id0].smoothpos+rim_radius*ray-center;
+		coshadowposvertices[i*6  ].vertex=nodes[id0].AbsPosition+rim_radius*ray-center;
 
-		coshadowposvertices[i*6+1].vertex=nodes[idstart+i*2].smoothpos-0.05*(nodes[idstart+i*2].smoothpos-nodes[id0].smoothpos)-center;
-		coshadowposvertices[i*6+2].vertex=nodes[idstart+i*2].smoothpos-0.1*(nodes[idstart+i*2].smoothpos-nodes[idstart+i*2+1].smoothpos)-center;
-		coshadowposvertices[i*6+3].vertex=nodes[idstart+i*2+1].smoothpos-0.1*(nodes[idstart+i*2+1].smoothpos-nodes[idstart+i*2].smoothpos)-center;
-		coshadowposvertices[i*6+4].vertex=nodes[idstart+i*2+1].smoothpos-0.05*(nodes[idstart+i*2+1].smoothpos-nodes[id1].smoothpos)-center;
+		coshadowposvertices[i*6+1].vertex=nodes[idstart+i*2].AbsPosition-0.05*(nodes[idstart+i*2].AbsPosition-nodes[id0].AbsPosition)-center;
+		coshadowposvertices[i*6+2].vertex=nodes[idstart+i*2].AbsPosition-0.1*(nodes[idstart+i*2].AbsPosition-nodes[idstart+i*2+1].AbsPosition)-center;
+		coshadowposvertices[i*6+3].vertex=nodes[idstart+i*2+1].AbsPosition-0.1*(nodes[idstart+i*2+1].AbsPosition-nodes[idstart+i*2].AbsPosition)-center;
+		coshadowposvertices[i*6+4].vertex=nodes[idstart+i*2+1].AbsPosition-0.05*(nodes[idstart+i*2+1].AbsPosition-nodes[id1].AbsPosition)-center;
 
-		pl=Plane(-axis, nodes[id1].smoothpos);
-		ray=nodes[idstart+i*2+1].smoothpos-nodes[id1].smoothpos;
+		pl=Plane(-axis, nodes[id1].AbsPosition);
+		ray=nodes[idstart+i*2+1].AbsPosition-nodes[id1].AbsPosition;
 		ray=pl.projectVector(ray);
 		ray.normalise();
-		coshadowposvertices[i*6+5].vertex=nodes[id1].smoothpos+rim_radius*ray-center;
+		coshadowposvertices[i*6+5].vertex=nodes[id1].AbsPosition+rim_radius*ray-center;
 
 		//normals
 		coshadownorvertices[i*6  ].normal=axis;
@@ -312,14 +312,14 @@ void FlexMeshWheel::setVisible(bool visible)
 
 bool FlexMeshWheel::flexitPrepare()
 {
-	Vector3 center = (nodes[id0].smoothpos + nodes[id1].smoothpos) / 2.0;
+	Vector3 center = (nodes[id0].AbsPosition + nodes[id1].AbsPosition) / 2.0;
 	rnode->setPosition(center);
 
-	Vector3 axis = nodes[id0].smoothpos - nodes[id1].smoothpos;
+	Vector3 axis = nodes[id0].AbsPosition - nodes[id1].AbsPosition;
 	axis.normalise();
 
 	if (revrim) axis = -axis;
-	Vector3 ray = nodes[idstart].smoothpos - nodes[id0].smoothpos;
+	Vector3 ray = nodes[idstart].AbsPosition - nodes[id0].AbsPosition;
 	Vector3 onormal = axis.crossProduct(ray);
 	onormal.normalise();
 	ray = axis.crossProduct(onormal);

--- a/source/main/physics/flex/FlexObj.cpp
+++ b/source/main/physics/flex/FlexObj.cpp
@@ -250,11 +250,11 @@ Vector3 FlexObj::updateVertices()
 {
 	unsigned int i;
 	Vector3 center;
-	center=(nodes[nodeIDs[0]].smoothpos+nodes[nodeIDs[1]].smoothpos)/2.0;
+	center=(nodes[nodeIDs[0]].AbsPosition+nodes[nodeIDs[1]].AbsPosition)/2.0;
 	for (i=0; i<nVertices; i++)
 	{
 		//set position
-		covertices[i].vertex=nodes[nodeIDs[i]].smoothpos-center;
+		covertices[i].vertex=nodes[nodeIDs[i]].AbsPosition-center;
 		//reset normals
 		covertices[i].normal=Vector3::ZERO;
 	}
@@ -262,8 +262,8 @@ Vector3 FlexObj::updateVertices()
 	for (i=0; i<ibufCount/3; i++)
 	{
 		Vector3 v1, v2;
-		v1=nodes[nodeIDs[faces[i*3+1]]].smoothpos-nodes[nodeIDs[faces[i*3]]].smoothpos;
-		v2=nodes[nodeIDs[faces[i*3+2]]].smoothpos-nodes[nodeIDs[faces[i*3]]].smoothpos;
+		v1=nodes[nodeIDs[faces[i*3+1]]].AbsPosition-nodes[nodeIDs[faces[i*3]]].AbsPosition;
+		v2=nodes[nodeIDs[faces[i*3+2]]].AbsPosition-nodes[nodeIDs[faces[i*3]]].AbsPosition;
 		v1=v1.crossProduct(v2);
 		float s=v1.length();
 		//avoid large tris
@@ -292,13 +292,13 @@ Vector3 FlexObj::updateVertices()
 //with normals
 Vector3 FlexObj::updateShadowVertices()
 {
-	Vector3 center = (nodes[nodeIDs[0]].smoothpos + nodes[nodeIDs[1]].smoothpos) / 2.0;
+	Vector3 center = (nodes[nodeIDs[0]].AbsPosition + nodes[nodeIDs[1]].AbsPosition) / 2.0;
 
 	for (unsigned int i=0; i<nVertices; i++)
 	{
 		//set position
-		coshadowposvertices[i].vertex=nodes[nodeIDs[i]].smoothpos-center;
-		coshadowposvertices[i+nVertices].vertex=nodes[nodeIDs[i]].smoothpos-center;
+		coshadowposvertices[i].vertex=nodes[nodeIDs[i]].AbsPosition-center;
+		coshadowposvertices[i+nVertices].vertex=nodes[nodeIDs[i]].AbsPosition-center;
 		//reset normals
 		coshadownorvertices[i].normal=Vector3::ZERO;
 	}
@@ -306,8 +306,8 @@ Vector3 FlexObj::updateShadowVertices()
 	for (unsigned int i=0; i<ibufCount/3; i++)
 	{
 		Vector3 v1, v2;
-		v1=nodes[nodeIDs[faces[i*3+1]]].smoothpos-nodes[nodeIDs[faces[i*3]]].smoothpos;
-		v2=nodes[nodeIDs[faces[i*3+2]]].smoothpos-nodes[nodeIDs[faces[i*3]]].smoothpos;
+		v1=nodes[nodeIDs[faces[i*3+1]]].AbsPosition-nodes[nodeIDs[faces[i*3]]].AbsPosition;
+		v2=nodes[nodeIDs[faces[i*3+2]]].AbsPosition-nodes[nodeIDs[faces[i*3]]].AbsPosition;
 		v1=v1.crossProduct(v2);
 		float s=v1.length();
 		//avoid large tris

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -6439,7 +6439,6 @@ void RigSpawner::ProcessNode(RigDef::Node & def)
 	Ogre::Vector3 node_position = m_spawn_position + def.position;
 	node.AbsPosition = node_position; 
 	node.RelPosition = node_position - m_rig->origin;
-	node.smoothpos   = node_position;
 		
 	node.wetstate = DRY; // orig = hardcoded (init_node)
 	node.iswheel = NOWHEEL;
@@ -6700,7 +6699,6 @@ void RigSpawner::InitNode(node_t & node, Ogre::Vector3 const & position)
     /* Position */
 	node.AbsPosition = position;
 	node.RelPosition = position - m_rig->origin;
-	node.smoothpos = position;
 
 	/* Misc. */
 	node.collisionBoundingBoxID = -1; // orig = hardcoded (init_node)


### PR DESCRIPTION
Main product:
* Removed redundant `node_t` member `smoothpos`
* Removed unused `node_t` member `collRadius`
* Reduced the size of some `node_t` members

Secondary product:
* Refactored `updateTruckPosition` into `calculateAveragePosition` and `updateBoundingBox`
* Refactored `handleTruckPosition` into `preUpdatePhysics` and `postUpdatePhysics`

Both `preUpdatePhysics` and `postUpdatePhysics` are now run by the sim thread.