### PR TITLE
[Feature] Implemented a simple terrain editor

### DIFF
--- a/bin/resources/skeleton/config/input.map
+++ b/bin/resources/skeleton/config/input.map
@@ -185,7 +185,7 @@ COMMON_RESET_TRUCK             Keyboard             EXPL+I
 COMMON_SCREENSHOT              Keyboard             SYSRQ 
 COMMON_SECURE_LOAD             Keyboard             O 
 COMMON_SHOW_SKELETON           Keyboard             K 
-COMMON_START_TRUCK_EDITOR      Keyboard             SHIFT+Y 
+COMMON_TOGGLE_TERRAIN_EDITOR   Keyboard             EXPL+CTRL+Y 
 COMMON_TOGGLE_CUSTOM_PARTICLES Keyboard             G 
 COMMON_TOGGLE_MAT_DEBUG        Keyboard             EXPL+CTRL+SHIFT+F 
 COMMON_TOGGLE_RENDER_MODE      Keyboard             E 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -506,7 +506,7 @@ bool RoRFrameListener::updateEvents(float dt)
 	static std::vector<TerrainObjectManager::object_t> object_list;
 	static bool terrain_editing_track_object = true;
 	static bool terrain_editing_mode = false;
-	static int terrain_editing_rotation_axis = 2;
+	static int terrain_editing_rotation_axis = 1;
 	static int object_index = -1;
 
 	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TERRAIN_EDITOR))
@@ -582,7 +582,7 @@ bool RoRFrameListener::updateEvents(float dt)
 		}
 		if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESCUE_TRUCK))
 		{
-			UTFString axis = _L("rz");
+			UTFString axis = _L("ry");
 			if (terrain_editing_rotation_axis == 0)
 			{
 				axis = _L("ry");
@@ -624,7 +624,18 @@ bool RoRFrameListener::updateEvents(float dt)
 				//gEnv->cameraManager->NotifyContextChange();
 			}
 		}
+		if (object_index != -1 && RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESET_TRUCK))
+		{
+			SceneNode *sn = object_list[object_index].node; 
 
+			object_list[object_index].position = object_list[object_index].initial_position;
+			sn->setPosition(object_list[object_index].position);
+
+			object_list[object_index].rotation = object_list[object_index].initial_rotation;
+			Vector3 rot = object_list[object_index].rotation;
+			sn->setOrientation(Quaternion(Degree(rot.x), Vector3::UNIT_X) * Quaternion(Degree(rot.y), Vector3::UNIT_Y) * Quaternion(Degree(rot.z), Vector3::UNIT_Z));
+			sn->pitch(Degree(-90));
+		}
 		if (object_index != -1 && gEnv->cameraManager && !gEnv->cameraManager->gameControlsLocked())
 		{
 			SceneNode *sn = object_list[object_index].node; 
@@ -641,24 +652,24 @@ bool RoRFrameListener::updateEvents(float dt)
 			}
 			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_ACCELERATE))
 			{
-				translation.y += 1.0f;
+				translation.y += 0.5f;
 			} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_BRAKE))
 			{
-				translation.y -= 1.0f;
+				translation.y -= 0.5f;
 			}
 			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_FORWARD))
 			{
-				translation.x += 1.0f;
+				translation.x += 0.5f;
 			} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_BACKWARDS))
 			{
-				translation.x -= 1.0f;
+				translation.x -= 0.5f;
 			}
 			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_SIDESTEP_RIGHT))
 			{
-				translation.z += 1.0f;
+				translation.z += 0.5f;
 			} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_SIDESTEP_LEFT))
 			{
-				translation.z -= 1.0f;
+				translation.z -= 0.5f;
 			}
 
 			if (translation != Vector3::ZERO || rotation != 0.0f)
@@ -672,7 +683,8 @@ bool RoRFrameListener::updateEvents(float dt)
 
 				object_list[object_index].rotation[terrain_editing_rotation_axis] += rotation * scale * dt;
 				Vector3 rot = object_list[object_index].rotation;
-				sn->setOrientation(Quaternion(Degree(rot.x - 90), Vector3::UNIT_X) * Quaternion(Degree(rot.y), Vector3::UNIT_Y) * Quaternion(Degree(rot.z), Vector3::UNIT_Z));
+				sn->setOrientation(Quaternion(Degree(rot.x), Vector3::UNIT_X) * Quaternion(Degree(rot.y), Vector3::UNIT_Y) * Quaternion(Degree(rot.z), Vector3::UNIT_Z));
+				sn->pitch(Degree(-90));
 
 				if (terrain_editing_track_object)
 				{

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -512,7 +512,7 @@ bool RoRFrameListener::updateEvents(float dt)
 	{
 		terrain_editing_mode = !terrain_editing_mode;
 #ifdef USE_MYGUI
-		String ssmsg = terrain_editing_mode ? _L("Entered terrain editing mode") : _L("Left terrain editing mode");
+		UTFString ssmsg = terrain_editing_mode ? _L("Entered terrain editing mode") : _L("Left terrain editing mode");
 		RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
 		RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
 #endif //USE_MYGUI
@@ -583,7 +583,7 @@ bool RoRFrameListener::updateEvents(float dt)
 		{
 			terrain_editing_track_object = !terrain_editing_track_object;
 #ifdef USE_MYGUI
-			String ssmsg = terrain_editing_track_object ? _L("Enabled object tracking") : _L("Disabled object tracking");
+			UTFString ssmsg = terrain_editing_track_object ? _L("Enabled object tracking") : _L("Disabled object tracking");
 			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
 			RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
 #endif //USE_MYGUI

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -56,6 +56,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "SkyManager.h"
 #include "SoundScriptManager.h"
 #include "TerrainManager.h"
+#include "TerrainObjectManager.h"
 #include "TruckHUD.h"
 #include "Utils.h"
 #include "Water.h"
@@ -69,9 +70,12 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include "SurveyMapEntity.h"
 #endif //USE_MYGUI
 
-#include <sstream>
-#include <iomanip>
 #include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
 
 #ifdef USE_MPLATFORM
 #include "MPlatformFD.h"
@@ -499,8 +503,159 @@ bool RoRFrameListener::updateEvents(float dt)
 		}
 	}
 
+	static std::vector<TerrainObjectManager::object_t> object_list;
+	static bool terrain_editing_track_object = true;
+	static bool terrain_editing_mode = false;
+	static int object_index = -1;
 
-	if (m_loading_state == ALL_LOADED)
+	if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TERRAIN_EDITOR))
+	{
+		terrain_editing_mode = !terrain_editing_mode;
+#ifdef USE_MYGUI
+		String ssmsg = terrain_editing_mode ? _L("Entered terrain editing mode") : _L("Left terrain editing mode");
+		RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+		RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
+#endif //USE_MYGUI
+
+		if (terrain_editing_mode)
+		{
+			object_list = gEnv->terrainManager->getObjectManager()->getObjects();
+			object_index = -1;
+		} else
+		{
+			String path = SSETTING("Config Root", "") + "editor_out.cfg";
+			std::ofstream file (path);
+			if (file.is_open())
+			{
+				for (auto object : object_list)
+				{
+					SceneNode *sn = object.node; 
+					if (sn != nullptr)
+					{
+						String pos = TOSTRING(sn->getPosition().x) + ", " + TOSTRING(sn->getPosition().y) + ", " + TOSTRING(sn->getPosition().z);
+						String rot = TOSTRING(sn->getOrientation().getPitch().valueDegrees()) + ", " + TOSTRING(sn->getOrientation().getYaw().valueDegrees()) + ", " + TOSTRING(sn->getOrientation().getRoll().valueDegrees());
+
+						file << pos + ", " + rot + ", " + object.name + "\n";
+					}
+				}
+				file.close();
+			} else
+			{
+				LOG("Cannot write '" + path + "'");
+			}
+		}
+	}
+
+	if (m_loading_state == ALL_LOADED && terrain_editing_mode && object_list.size() > 0)
+	{
+		bool update = false;
+		if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_OR_EXIT_TRUCK))
+		{
+			if (object_index == -1)
+			{
+				// Select nearest object
+				Vector3 ref_pos = gEnv->cameraManager->gameControlsLocked() ? gEnv->mainCamera->getPosition() : gEnv->player->getPosition();
+				float min_dist = std::numeric_limits<float>::max();
+				for (int i=0; i < (int)object_list.size(); i++)
+				{
+					float dist = ref_pos.squaredDistance(object_list[i].node->getPosition());
+					if (dist < min_dist)
+					{
+						object_index = i;
+						min_dist = dist;
+						update = true;
+					}
+				}
+			} else
+			{
+				object_index = -1;
+			}
+		} else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_NEXT_TRUCK, 0.25f))
+		{
+			object_index = (object_index + 1 + (int)object_list.size()) % object_list.size(); 
+			update = true;
+		} else if (RoR::Application::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_PREVIOUS_TRUCK, 0.25f))
+		{
+			object_index = (object_index - 1 + (int)object_list.size()) % object_list.size(); 
+			update = true;
+		}
+		if (RoR::Application::GetInputEngine()->isKeyDownValueBounce(OIS::KC_SPACE))
+		{
+			terrain_editing_track_object = !terrain_editing_track_object;
+#ifdef USE_MYGUI
+			String ssmsg = terrain_editing_track_object ? _L("Enabled object tracking") : _L("Disabled object tracking");
+			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+			RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
+#endif //USE_MYGUI
+		}
+		if (object_index != -1 && update)
+		{
+#ifdef USE_MYGUI
+			String ssmsg = _L("Selected object: [") + TOSTRING(object_index) + "/" + TOSTRING(object_list.size()) + "] (" + object_list[object_index].name + ")";
+			RoR::Application::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+			RoR::Application::GetGuiManager()->PushNotification("Notice:", ssmsg);
+#endif //USE_MYGUI
+			if (terrain_editing_track_object)
+			{
+				gEnv->player->setPosition(object_list[object_index].node->getPosition());
+				//gEnv->cameraManager->NotifyContextChange();
+			}
+		}
+
+		if (object_index != -1 && gEnv->cameraManager && !gEnv->cameraManager->gameControlsLocked())
+		{
+			SceneNode *sn = object_list[object_index].node; 
+
+			Vector3 translation = Vector3::ZERO;
+			float rotation = 0.0f;
+
+			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_STEER_LEFT))
+			{
+				rotation += 0.25f;
+			} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_STEER_RIGHT))
+			{
+				rotation -= 0.25f;
+			}
+			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_ACCELERATE))
+			{
+				translation.y += 1.0f;
+			} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_TRUCK_BRAKE))
+			{
+				translation.y -= 1.0f;
+			}
+			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_FORWARD))
+			{
+				translation.x += 1.0f;
+			} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_BACKWARDS))
+			{
+				translation.x -= 1.0f;
+			}
+			if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_SIDESTEP_RIGHT))
+			{
+				translation.z += 1.0f;
+			} else if (RoR::Application::GetInputEngine()->getEventBoolValue(EV_CHARACTER_SIDESTEP_LEFT))
+			{
+				translation.z -= 1.0f;
+			}
+
+			if (translation != Vector3::ZERO || rotation != 0.0f)
+			{
+				float scale = RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LMENU)    ? 0.1f : 1.0f;
+				scale      *= RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT)   ? 3.0f : 1.0f;
+				scale      *= RoR::Application::GetInputEngine()->isKeyDown(OIS::KC_LCONTROL) ? 10.0f : 1.0f;
+
+				sn->setPosition(sn->getPosition() + translation * scale * dt);
+				sn->setOrientation(Quaternion(Radian(rotation) * scale * dt, Vector3::UNIT_Y) * sn->getOrientation());
+				if (terrain_editing_track_object)
+				{
+					gEnv->player->setPosition(object_list[object_index].node->getPosition());
+				}
+			}
+		} else
+		{
+			CharacterFactory::getSingleton().update(dt);
+		}
+	} else if (m_loading_state == ALL_LOADED)
 	{
 		CharacterFactory::getSingleton().update(dt);
 		if (gEnv->cameraManager && !gEnv->cameraManager->gameControlsLocked())
@@ -1069,7 +1224,7 @@ bool RoRFrameListener::updateEvents(float dt)
 	} else
 	{
 		//no terrain or truck loaded
-
+		terrain_editing_mode = false;
 #ifdef USE_MYGUI
 		if (Application::GetGuiManager()->getMainSelector()->IsFinishedSelecting())
 		{

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -815,6 +815,8 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 		object.name = name; 
 		object.position = pos;
 		object.rotation = rot;
+		object.initial_position = pos;
+		object.initial_rotation = rot;
 		object.node = tenode; 
 		objects.push_back(object);
 

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -813,6 +813,8 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 
 		object_t object;
 		object.name = name; 
+		object.position = pos;
+		object.rotation = rot;
 		object.node = tenode; 
 		objects.push_back(object);
 

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -807,10 +807,14 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 		// register in map
 		loadedObject_t *obj = &loadedObjects[instancename];
 		obj->instanceName = instancename;
-		obj->loadType     = 0;
 		obj->enabled      = true;
 		obj->sceneNode    = tenode;
 		obj->collTris.clear();
+
+		object_t object;
+		object.name = name; 
+		object.node = tenode; 
+		objects.push_back(object);
 
 		if (mo && uniquifyMaterial && !instancename.empty())
 		{
@@ -1259,13 +1263,13 @@ void TerrainObjectManager::loadPreloadedTrucks()
 
 }
 
-bool TerrainObjectManager::update( float dt )
+bool TerrainObjectManager::update(float dt)
 {
 #ifdef USE_PAGED
 	// paged geometry
-	for (std::vector<paged_geometry_t>::iterator it=pagedGeometry.begin();it!=pagedGeometry.end();it++)
+	for (auto it : pagedGeometry)
 	{
-		if (it->geom) it->geom->update();
+		if (it.geom) it.geom->update();
 	}
 #endif //USE_PAGED
 

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -63,6 +63,8 @@ public:
 	typedef struct object_t
 	{
 		Ogre::String name;
+		Ogre::Vector3 position;
+		Ogre::Vector3 rotation;
 		Ogre::SceneNode *node;
 	} object_t;
 

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -65,6 +65,8 @@ public:
 		Ogre::String name;
 		Ogre::Vector3 position;
 		Ogre::Vector3 rotation;
+		Ogre::Vector3 initial_position;
+		Ogre::Vector3 initial_rotation;
 		Ogre::SceneNode *node;
 	} object_t;
 

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -60,6 +60,14 @@ public:
 		Ogre::Quaternion rotation;
 	} localizer_t;
 
+	typedef struct object_t
+	{
+		Ogre::String name;
+		Ogre::SceneNode *node;
+	} object_t;
+
+	std::vector<object_t> getObjects() { return objects; };
+
 	bool update(float dt);
 
 protected:
@@ -120,11 +128,13 @@ protected:
 		Ogre::SceneNode *sceneNode;
 		Ogre::String instanceName;
 		bool enabled;
-		int loadType;
 		std::vector <int> collBoxes;
 		std::vector <int> collTris;
 	} loadedObject_t;
+
 	std::map< std::string, loadedObject_t> loadedObjects;
+
+	std::vector< object_t > objects;
 
 	void proceduralTests();
 };

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -1064,10 +1064,10 @@ eventInfo_t eventInfo[] = {
 		_L("toggle skeleton display mode")
 	},
 	{
-		"COMMON_START_TRUCK_EDITOR",
-		EV_COMMON_START_TRUCK_EDITOR,
+		"COMMON_TOGGLE_TERRAIN_EDITOR",
+		EV_COMMON_TOGGLE_TERRAIN_EDITOR,
 		"Keyboard EXPL+SHIFT+Y",
-		_L("start the old truck editor")
+		_L("toggle terrain editor")
 	},
 	{
 		"COMMON_TOGGLE_CUSTOM_PARTICLES",

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -257,7 +257,7 @@ enum events
 	EV_COMMON_SECURE_LOAD, //!< tie a load to the truck
 	EV_COMMON_SEND_CHAT, //!< send the chat text
 	EV_COMMON_SHOW_SKELETON, //!< toggle skeleton display mode
-	EV_COMMON_START_TRUCK_EDITOR, //!< start the old truck editor
+	EV_COMMON_TOGGLE_TERRAIN_EDITOR, //!< toggle terrain editor
 	EV_COMMON_TOGGLE_CUSTOM_PARTICLES, //!< toggle particle cannon
 	EV_COMMON_TOGGLE_MAT_DEBUG, //!< debug purpose - dont use
 	EV_COMMON_TOGGLE_RENDER_MODE, //!< toggle render mode (solid, wireframe and points)


### PR DESCRIPTION
Controls:

* Toggle Editor `CTRL+Y` (`editor_out.cfg` is overwritten when you leave the terrain  #editor)
* Toggle object auto tracking (aligns the character with the currently selected object) `SPACE`
* Enter nearest object (in relation to character / free camera position) `Enter`
* Translate / Rotate object (similar to advanced truck reset)
* Cycle through all terrain objects `CTRL+[` and `CTRL+]`
* Cycle through all rotation axes `r`
* Reset the current object `i`

Structurally complete, but far from perfect.