### PR TITLE
[Fix] Build without Angelscript

### DIFF
--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -148,7 +148,11 @@ void LandVehicleSimulation::UpdateVehicle(Beam* curr_truck, float seconds_since_
 
 	} // end of (!curr_truck->replaymode) block
 
+#ifdef USE_ANGELSCRIPT
 	if (!curr_truck->replaymode && !curr_truck->vehicle_ai->IsActive())
+#else
+    if (!curr_truck->replaymode)
+#endif // USE_ANGELSCRIPT
 	{
 		// steering
 		float tmp_left_digital  = RoR::Application::GetInputEngine()->getEventValue(EV_TRUCK_STEER_LEFT,  false, InputEngine::ET_DIGITAL);

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -20,6 +20,7 @@
 	along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef USE_ANGELSCRIPT
 
 #include "VehicleAI.h"
 
@@ -336,3 +337,5 @@ void VehicleAI::update(float dt, int doUpdate)
 		}
 		*/
 }
+
+#endif // USE_ANGELSCRIPT

--- a/source/main/gameplay/VehicleAI.h
+++ b/source/main/gameplay/VehicleAI.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef USE_ANGELSCRIPT
+
 #include "RoRPrerequisites.h"
 #include "scriptdictionary/scriptdictionary.h"
 
@@ -142,3 +144,5 @@ private:
 	int free_waypoints = 0;//!< The amount of waypoints.
 	float acc_power = 0.8;//!< The engine power.
 };
+
+#endif // USE_ANGELSCRIPT

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -953,8 +953,10 @@ void BeamFactory::update(float dt)
 		m_trucks[t]->handleResetRequests(dt);
 		m_trucks[t]->updateAngelScriptEvents(dt);
 
+#ifdef USE_ANGELSCRIPT
 		if (m_trucks[t]->vehicle_ai && (m_trucks[t]->vehicle_ai->IsActive()))
 			m_trucks[t]->vehicle_ai->update(dt, 0);
+#endif // USE_ANGELSCRIPT
 
 		switch(m_trucks[t]->state)
 		{

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -336,7 +336,9 @@ void RigSpawner::InitializeRig()
 
 	m_rig->beamHash = "";
 
+#ifdef USE_ANGELSCRIPT
 	m_rig->vehicle_ai = new VehicleAI(m_rig);
+#endif // USE_ANGELSCRIPT
 
 	/* Init code from Beam::Beam() */
 

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -22,6 +22,9 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 #ifndef SCRIPTENGINE_H__
 #define SCRIPTENGINE_H__
+
+#ifdef USE_ANGELSCRIPT
+
 #include <Ogre.h>
 
 #include "RoRPrerequisites.h"
@@ -202,5 +205,6 @@ protected:
 	void LineCallback(AngelScript::asIScriptContext *ctx, unsigned long *timeOut);
 };
 
+#endif // USE_ANGELSCRIPT
 
 #endif //SCRIPTENGINE_H__


### PR DESCRIPTION
Additionally, to avoid crashing when loading terrains, in resources/particles/water.particle this needs to be removed:
```
	affector FireExtinguisher
	{
		effectiveness 	1
	}
```