### PR TITLE
[Update] Replaced rigsofrods.com with rigsofrods.org

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,5 @@
 # Building instructions
-Please refer to http://www.rigsofrods.com/wiki/pages/Compiling_Sources
+Please refer to https://github.com/RigsOfRods/rigs-of-rods/wiki
 
 # Dependencies
 core requirements:
@@ -16,10 +16,10 @@ core requirements:
 * wxWidgets >= 2.6
 
 optional but recommended:
-* angelscript: 2.22.1 
+* angelscript: 2.22.1
   * required for scripting (AI, racing, server mods...)
   * when building without AS this has to be removed in resources/particles/water.particle: "affector FireExtinguisher {	effectiveness 	1 }"
-* caelum: >= 0.6.2, compatible with the OGRE version you chose 
+* caelum: >= 0.6.2, compatible with the OGRE version you chose
   * sky plugin: provides dynamic sky with time of day, weather and clouds
 * mysocketw: latest from git
   * required for network play

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ e.g. screenshot of graphical glitch
 
   <br>
   <br>
-  
+
 ## Contribute code
 
 
@@ -63,8 +63,8 @@ e.g. screenshot of graphical glitch
 * [Developer Wiki Portal][devwiki]
 * [Doxygen documentation][doxy]
 
-[compile]: http://www.rigsofrods.com/wiki/pages/Compiling_Sources
-[style]: http://www.rigsofrods.com/wiki/pages/Coding_style
-[commit]: http://www.rigsofrods.com/wiki/pages/Commit_style
-[devwiki]: http://www.rigsofrods.com/wiki/pages/Developer_Wiki_Portal
-[doxy]: http://ror.ezzg.be/docs/
+[compile]: https://github.com/RigsOfRods/rigs-of-rods/wiki
+[style]: https://github.com/RigsOfRods/rigs-of-rods/wiki/Coding-style
+[commit]: https://github.com/RigsOfRods/rigs-of-rods/wiki/Commit-style
+[devwiki]: http://www.developer.rigsofrods.org/
+[doxy]: http://www.developer.rigsofrods.org/doxygen/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rigs of Rods 
+# Rigs of Rods
 
 [![Build Status](https://travis-ci.org/RigsOfRods/rigs-of-rods.png?branch=master)](https://travis-ci.org/RigsOfRods/rigs-of-rods)
 [![Join the chat at https://gitter.im/RigsOfRods/rigs-of-rods](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/RigsOfRods/rigs-of-rods?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -17,11 +17,11 @@ For a simple overview of the features Rigs of Rods provides please refer to [doc
 
 
 ## Further documentation
-* Website: http://www.rigsofrods.com/
-* Wiki: http://www.rigsofrods.com/wiki/
-* Developer Wiki: http://www.rigsofrods.com/wiki/pages/Developer_Wiki_Portal
-* Forum: http://www.rigsofrods.com/forum/
-* Mod Repository: http://www.rigsofrods.com/repository/
+* Website: http://www.rigsofrods.org/
+* Wiki: http://docs.rigsofrods.org/
+* Developer Wiki: http://www.developer.rigsofrods.org/
+* Forum: http://www.forum.rigsofrods.org/
+* Mod Repository: http://www.repository.rigsofrods.org/
 * Github: https://github.com/RigsOfRods/rigs-of-rods
 * IRC: #rigsofrods and #rigsofrods-dev on irc.freenode.net
 * [doc/](doc/)
@@ -73,10 +73,10 @@ Rigs is Rods can also be played with Gamepads, Joysticks, Wheels and other contr
 | Page Up/Down                   | aircrafts: increase/decrease throttle                |
 | F1/F2                          | helicopters: lift up/down                            |
 | Print Screen                   | create screenshot in $user/ folder                   |
- 
- 
+
+
 ## Content/Mods
-Rigs of Rods only comes with a very small selection of vehicles and terrains. For the best experience download some mods from the [Rigs of Rods Mod Repository](http://www.rigsofrods.com/repository/). The [Showroom Subforum](http://www.rigsofrods.com/forums/103-Showrooms-and-WIP) may contain additional content not found in the Mod Repository.  
+Rigs of Rods only comes with a very small selection of vehicles and terrains. For the best experience download some mods from the [Rigs of Rods Mod Repository](http://www.repository.rigsofrods.org/). The [Showroom Subforum](http://forum.rigsofrods.org/forum-6.html) may contain additional content not found in the Mod Repository.  
 If you want to get going quickly have a look at modpacks which can be found in the Mod Repository as well.
 
 
@@ -93,17 +93,17 @@ If you want to get going quickly have a look at modpacks which can be found in t
         * ``` RoR.exe -map aspen ```
     * note: do not add .terrn file format extension
 * -truck \<truckfile\>
-    * loads a truck on startup. Example: 
+    * loads a truck on startup. Example:
         * ``` RoR.exe -map oahu -truck semi.truck ```
         * ``` RoR.exe -map oahu -truck an-12.airplane ```
 * -enter
     * enter selected truck by -truck option on startup
-* -setup 
-    * displays OGRE3D settings dialog instead of loading settings from ogre.cfg 
+* -setup
+    * displays OGRE3D settings dialog instead of loading settings from ogre.cfg
 * -help
     * displays help for command line arguments
 
-	
+
 ## Compiling
 For instructions refer to [BUILDING.md](BUILDING.md)
 
@@ -119,7 +119,7 @@ Rigs of Rods went open source under GPLv2 or later on the 8th of February, 2009.
 Rigs of Rods is now licensed under GPLv3 or later:
 ```
 Rigs of Rods is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License version 3, as 
+it under the terms of the GNU General Public License version 3, as
 published by the Free Software Foundation.
 
 Rigs of Rods is distributed in the hope that it will be useful,

--- a/bin/resources/scripts/races.as
+++ b/bin/resources/scripts/races.as
@@ -5,7 +5,7 @@ You've found your way to the race system of Rigs of Rods.
 
 If you are looking for more information on how to use this
 class or what arguments should be given to certain functions,
-please visit http://docs.rigsofrods.com/
+please visit http://docs.rigsofrods.org/
 
 If you are looking for examples on how to use this class,
 please look at the scripting files of other terrains or
@@ -14,7 +14,7 @@ search the forum.
 If you have questions that cannot be answerred using the
 methods mentioned above, then please ask your question in
 the scripting section of the Rigs of Rods forum:
-http://www.rigsofrods.com/forums/167-Scripting
+http://www.rigsofrods.org/forums/167-Scripting
 
 This class was designed to be as simple as possible for
 normal users, while being as flexible as possible for
@@ -23,7 +23,7 @@ If you're here because this class doesn't provide the
 functionality that you need for your terrain, then try
 to improve the class and submit your additions using
 the issue tracker of Rigs of Rods.
-http://redmine.rigsofrods.com
+http://redmine.rigsofrods.org
 
 Don't forget to increase the version numbers after every
 edit! (racesManager::raceManagerVersion and

--- a/doc/angelscript/VehicleAI.h
+++ b/doc/angelscript/VehicleAI.h
@@ -5,7 +5,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2016 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/doc/angelscript/game.h
+++ b/doc/angelscript/game.h
@@ -1,7 +1,7 @@
 /*
 This source file is part of Rigs of Rods
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as 
@@ -25,7 +25,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 	If you cannot find the answer here, then search the forum for your question.
 	If that didn't provide an answer either, then ask your question in the Scripting forum:
-	http://www.rigsofrods.com/forums/167-Scripting
+	http://www.rigsofrods.org/forums/167-Scripting
 
 	Please note that the documentation is work in progress.
 */

--- a/doc/angelscript/global_functions.h
+++ b/doc/angelscript/global_functions.h
@@ -1,7 +1,7 @@
 /*
 This source file is part of Rigs of Rods
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as 

--- a/doc/doxygen/MainPage.h
+++ b/doc/doxygen/MainPage.h
@@ -13,11 +13,11 @@
  * 
  * 
  * ## Further documentation
- * * Website: http://www.rigsofrods.com/
- * * Wiki: http://www.rigsofrods.com/wiki/
- * * Developer Wiki: http://www.rigsofrods.com/wiki/pages/Developer_Wiki_Portal
- * * Forum: http://www.rigsofrods.com/forum/
- * * Mod Repository: http://www.rigsofrods.com/repository/
+ * * Website: http://www.rigsofrods.org/
+ * * Wiki: http://www.rigsofrods.org/wiki/
+ * * Developer Wiki: http://www.rigsofrods.org/wiki/pages/Developer_Wiki_Portal
+ * * Forum: http://www.rigsofrods.org/forum/
+ * * Mod Repository: http://www.rigsofrods.org/repository/
  * * Github: https://github.com/RigsOfRods/rigs-of-rods
  * * IRC: #rigsofrods and #rigsofrods-dev on irc.freenode.net
  * 
@@ -50,7 +50,7 @@
  * 
  * 
  * ## Content/Mods
- * Rigs of Rods only comes with a very small selection of vehicles and terrains. For the best experience download some mods from the [Rigs of Rods Mod Repository](http://www.rigsofrods.com/repository/). The [Showroom Subforum](http://www.rigsofrods.com/forums/103-Showrooms-and-WIP) may contain additional content not found in the Mod Repository.  
+ * Rigs of Rods only comes with a very small selection of vehicles and terrains. For the best experience download some mods from the [Rigs of Rods Mod Repository](http://www.rigsofrods.org/repository/). The [Showroom Subforum](http://www.rigsofrods.org/forums/103-Showrooms-and-WIP) may contain additional content not found in the Mod Repository.  
  * If you want to get going quickly have a look at modpacks which can be found in the Mod Repository as well.
  * 
  * 

--- a/doc/footer.html
+++ b/doc/footer.html
@@ -1,4 +1,4 @@
 <div style="font-size:xx-small;text-align:right;">
 created on $datetime<br/>
-<a target="_parent" href="http://docs.rigsofrods.com/">docs.rigsofrods.com</a>
+<a target="_parent" href="http://docs.rigsofrods.org/">docs.rigsofrods.org</a>
 </div></BODY></HTML>

--- a/doc/updateDoc.sh
+++ b/doc/updateDoc.sh
@@ -2,7 +2,7 @@
 
 # update trunk first
 BASE=/var/svn-co/trunk
-WEBDIR=/var/www/docs.rigsofrods.com/htdocs
+WEBDIR=/var/www/docs.rigsofrods.org/htdocs
 WEBUSER=lighttpd
 WEBGROUP=lighttpd
 INDEX=${WEBDIR}/index.html

--- a/source/configurator/Configurator.cpp
+++ b/source/configurator/Configurator.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005,2006,2007,2008,2009 Pierre-Michel Ricordel
 Copyright 2007,2008,2009 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as
@@ -1065,7 +1065,7 @@ MyDialog::MyDialog(const wxString& title, MyApp *_app) : wxDialog(NULL, wxID_ANY
 
 	dText = new wxStaticText(gamePanel, -1, _("User Token: "), wxPoint(10,y+3));
 	usertoken=new wxTextCtrl(gamePanel, -1, wxString(), wxPoint(x_row1, y), wxSize(200, -1));
-	usertoken->SetToolTip(_("Your rigsofrods.com User Token."));
+	usertoken->SetToolTip(_("Your rigsofrods.org User Token."));
 	btnToken = new wxButton(gamePanel, button_get_user_token, _("Get Token"), wxPoint(x_row1+210, y), wxSize(90,25));
 	y+=35;
 
@@ -1123,12 +1123,12 @@ MyDialog::MyDialog(const wxString& title, MyApp *_app) : wxDialog(NULL, wxID_ANY
 	y += 20;
 
 	addAboutTitle(_("Authors"), x_row1, y);
-	addAboutEntry(_("Authors"), _("You can find a complete list of the RoR's authors ingame: about->credits."), wxT("mailto:support@rigsofrods.com"), x_row1, y);
+	addAboutEntry(_("Authors"), _("You can find a complete list of the RoR's authors ingame: about->credits."), wxT("mailto:support@rigsofrods.org"), x_row1, y);
 
 	y += 20;
 
 	addAboutTitle(_("Missing someone?"), x_row1, y);
-	addAboutEntry(_("Missing someone?"), _("If we are missing someone on this list, please drop us a line at:\nsupport@rigsofrods.com"), wxT("mailto:support@rigsofrods.com"), x_row1, y);
+	addAboutEntry(_("Missing someone?"), _("If we are missing someone on this list, please drop us a line at:\nsupport@rigsofrods.org"), wxT("mailto:support@rigsofrods.org"), x_row1, y);
 
 	wxSize size = nbook->GetBestVirtualSize();
 	size.x = 400;
@@ -1210,7 +1210,7 @@ MyDialog::MyDialog(const wxString& title, MyApp *_app) : wxDialog(NULL, wxID_ANY
 	y+=25;
 
 #if wxCHECK_VERSION(2, 8, 0)
-	wxHyperlinkCtrl *link = new wxHyperlinkCtrl(debugPanel, -1, _("(Read more on how to use these options here)"), _("http://www.rigsofrods.com/wiki/pages/Debugging_Trucks"), wxPoint(10, y));
+	wxHyperlinkCtrl *link = new wxHyperlinkCtrl(debugPanel, -1, _("(Read more on how to use these options here)"), _("http://www.rigsofrods.org/wiki/pages/Debugging_Trucks"), wxPoint(10, y));
 #endif // version 2.8
 
 	// graphics panel
@@ -3028,7 +3028,7 @@ void MyDialog::OnTimerReset(wxTimerEvent& event)
 
 void MyDialog::OnButGetUserToken(wxCommandEvent& event)
 {
-	wxLaunchDefaultBrowser(wxT("http://usertoken.rigsofrods.com"));
+	wxLaunchDefaultBrowser(wxT("http://usertoken.rigsofrods.org"));
 }
 
 void MyDialog::OnButTestNet(wxCommandEvent& event)

--- a/source/configurator/icon.rc
+++ b/source/configurator/icon.rc
@@ -68,11 +68,11 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "rigsofrods.com"
+            VALUE "CompanyName", "rigsofrods.org"
             VALUE "FileDescription", "Rigs of Rods Configurator"
             VALUE "FileVersion", ROR_RESOURCE_VERSION_STRING
             VALUE "InternalName", "rorconfig"
-            VALUE "LegalCopyright", "Copyright (C) 2005-2015 rigsofrods.com"
+            VALUE "LegalCopyright", "Copyright (C) 2005-2015 rigsofrods.org"
             VALUE "OriginalFilename", "rorconfig.exe"
             VALUE "ProductName", "Rigs of Rods"
             VALUE "ProductVersion", ROR_RESOURCE_VERSION_STRING

--- a/source/configurator/wxValueChoice.h
+++ b/source/configurator/wxValueChoice.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005,2006,2007,2008,2009 Pierre-Michel Ricordel
 Copyright 2007,2008,2009 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/GlobalEnvironment.h
+++ b/source/main/GlobalEnvironment.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/MainThread.cpp
+++ b/source/main/MainThread.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/MainThread.h
+++ b/source/main/MainThread.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/RoRPrerequisites.h
+++ b/source/main/RoRPrerequisites.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/audio/Sound.cpp
+++ b/source/main/audio/Sound.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/audio/Sound.h
+++ b/source/main/audio/Sound.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/audio/SoundManager.h
+++ b/source/main/audio/SoundManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/audio/SoundScriptManager.h
+++ b/source/main/audio/SoundScriptManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/AircraftSimulation.cpp
+++ b/source/main/gameplay/AircraftSimulation.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/AircraftSimulation.h
+++ b/source/main/gameplay/AircraftSimulation.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/AutoPilot.cpp
+++ b/source/main/gameplay/AutoPilot.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/AutoPilot.h
+++ b/source/main/gameplay/AutoPilot.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/CharacterFactory.cpp
+++ b/source/main/gameplay/CharacterFactory.cpp
@@ -4,7 +4,7 @@ Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 Copyright 2013-2016 Petr Ohlidal
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/CharacterFactory.h
+++ b/source/main/gameplay/CharacterFactory.h
@@ -4,7 +4,7 @@ Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 Copyright 2013-2016 Petr Ohlidal
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/ChatSystem.cpp
+++ b/source/main/gameplay/ChatSystem.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2016 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/ChatSystem.h
+++ b/source/main/gameplay/ChatSystem.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2016 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/LandVehicleSimulation.h
+++ b/source/main/gameplay/LandVehicleSimulation.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Landusemap.cpp
+++ b/source/main/gameplay/Landusemap.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Landusemap.h
+++ b/source/main/gameplay/Landusemap.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/MaterialReplacer.cpp
+++ b/source/main/gameplay/MaterialReplacer.cpp
@@ -1,7 +1,7 @@
 // This source file is part of Rigs of Rods
 // Copyright 2005-2015 Rigs of Rods contributors
 
-// For more information, see http://www.rigsofrods.com/
+// For more information, see http://www.rigsofrods.org/
 
 // Rigs of Rods is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/MaterialReplacer.h
+++ b/source/main/gameplay/MaterialReplacer.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/OutProtocol.cpp
+++ b/source/main/gameplay/OutProtocol.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/OutProtocol.h
+++ b/source/main/gameplay/OutProtocol.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/PlayerColours.cpp
+++ b/source/main/gameplay/PlayerColours.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/PlayerColours.h
+++ b/source/main/gameplay/PlayerColours.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/PositionStorage.cpp
+++ b/source/main/gameplay/PositionStorage.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/PositionStorage.h
+++ b/source/main/gameplay/PositionStorage.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/ProceduralManager.cpp
+++ b/source/main/gameplay/ProceduralManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/ProceduralManager.h
+++ b/source/main/gameplay/ProceduralManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/RandomTreeLoader.h
+++ b/source/main/gameplay/RandomTreeLoader.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Replay.cpp
+++ b/source/main/gameplay/Replay.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Replay.h
+++ b/source/main/gameplay/Replay.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Road.cpp
+++ b/source/main/gameplay/Road.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Road.h
+++ b/source/main/gameplay/Road.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Road2.cpp
+++ b/source/main/gameplay/Road2.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Road2.h
+++ b/source/main/gameplay/Road2.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/ScriptEvents.h
+++ b/source/main/gameplay/ScriptEvents.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Scripting.h
+++ b/source/main/gameplay/Scripting.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Skin.cpp
+++ b/source/main/gameplay/Skin.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/Skin.h
+++ b/source/main/gameplay/Skin.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/SkinManager.cpp
+++ b/source/main/gameplay/SkinManager.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/SkinManager.h
+++ b/source/main/gameplay/SkinManager.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/TorqueCurve.cpp
+++ b/source/main/gameplay/TorqueCurve.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/TorqueCurve.h
+++ b/source/main/gameplay/TorqueCurve.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -5,7 +5,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2016 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gameplay/VehicleAI.h
+++ b/source/main/gameplay/VehicleAI.h
@@ -5,7 +5,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2016 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/AdvancedScreen.h
+++ b/source/main/gfx/AdvancedScreen.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/ColoredTextAreaOverlayElement.cpp
+++ b/source/main/gfx/ColoredTextAreaOverlayElement.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/ColoredTextAreaOverlayElement.h
+++ b/source/main/gfx/ColoredTextAreaOverlayElement.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/ColoredTextAreaOverlayElementFactory.h
+++ b/source/main/gfx/ColoredTextAreaOverlayElementFactory.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/DecalManager.cpp
+++ b/source/main/gfx/DecalManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/DecalManager.h
+++ b/source/main/gfx/DecalManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/DustManager.cpp
+++ b/source/main/gfx/DustManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/DustManager.h
+++ b/source/main/gfx/DustManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/DustPool.cpp
+++ b/source/main/gfx/DustPool.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/DustPool.h
+++ b/source/main/gfx/DustPool.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/GlowMaterialListener.h
+++ b/source/main/gfx/GlowMaterialListener.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/HDRListener.cpp
+++ b/source/main/gfx/HDRListener.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/HDRListener.h
+++ b/source/main/gfx/HDRListener.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/Heathaze.cpp
+++ b/source/main/gfx/Heathaze.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/Heathaze.h
+++ b/source/main/gfx/Heathaze.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/HydraxWater.cpp
+++ b/source/main/gfx/HydraxWater.cpp
@@ -4,7 +4,7 @@ Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 Copyright 2013-2016 Petr Ohlidal
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as
 published by the Free Software Foundation.

--- a/source/main/gfx/HydraxWater.h
+++ b/source/main/gfx/HydraxWater.h
@@ -4,7 +4,7 @@ Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 Copyright 2013-2016 Petr Ohlidal
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as
 published by the Free Software Foundation.

--- a/source/main/gfx/IWater.h
+++ b/source/main/gfx/IWater.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/MaterialFunctionMapper.cpp
+++ b/source/main/gfx/MaterialFunctionMapper.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/MaterialFunctionMapper.h
+++ b/source/main/gfx/MaterialFunctionMapper.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/Mirrors.cpp
+++ b/source/main/gfx/Mirrors.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/Mirrors.h
+++ b/source/main/gfx/Mirrors.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/MovableText.cpp
+++ b/source/main/gfx/MovableText.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/MovableText.h
+++ b/source/main/gfx/MovableText.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/OgreSubsystem.cpp
+++ b/source/main/gfx/OgreSubsystem.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as
@@ -154,7 +154,7 @@ bool OgreSubsystem::StartOgre(Ogre::String const & name, Ogre::String const & hw
 	} 
 	catch(Ogre::Exception& e)
 	{
-		Ogre::String url = "http://wiki.rigsofrods.com/index.php?title=Error_" + TOSTRING(e.getNumber())+"#"+e.getSource();
+		Ogre::String url = "http://wiki.rigsofrods.org/index.php?title=Error_" + TOSTRING(e.getNumber())+"#"+e.getSource();
 		ErrorUtils::ShowOgreWebError(_L("A fatal exception has occured!"), ANSI_TO_UTF(e.getFullDescription()), ANSI_TO_UTF(url));
 		ErrorUtils::ShowStoredOgreWebErrors();
 		exit(1);

--- a/source/main/gfx/OgreSubsystem.h
+++ b/source/main/gfx/OgreSubsystem.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/PreviewRenderer.cpp
+++ b/source/main/gfx/PreviewRenderer.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/PreviewRenderer.h
+++ b/source/main/gfx/PreviewRenderer.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/ShadowManager.cpp
+++ b/source/main/gfx/ShadowManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/ShadowManager.h
+++ b/source/main/gfx/ShadowManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/Skidmark.cpp
+++ b/source/main/gfx/Skidmark.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/Skidmark.h
+++ b/source/main/gfx/Skidmark.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/SkyManager.cpp
+++ b/source/main/gfx/SkyManager.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as
@@ -125,7 +125,7 @@ void SkyManager::loadScript(String script, int fogStart, int fogEnd)
 			mCaelumSystem->setManageSceneFog(FOG_NONE);
 		}
 #else
-#error please use a recent Caelum version, see http://www.rigsofrods.com/wiki/pages/Compiling_3rd_party_libraries#Caelum
+#error please use a recent Caelum version, see http://www.rigsofrods.org/wiki/pages/Compiling_3rd_party_libraries#Caelum
 #endif // CAELUM_VERSION
 		// now optimize the moon a bit
 		if (mCaelumSystem->getMoon())

--- a/source/main/gfx/SkyManager.h
+++ b/source/main/gfx/SkyManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/VideoCamera.cpp
+++ b/source/main/gfx/VideoCamera.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as
@@ -237,7 +237,7 @@ void VideoCamera::update(float dt)
 			normal.normalise();
 			Vector3 refx = truck->nodes[nz].AbsPosition - truck->nodes[nref].AbsPosition;
 			refx.normalise();
-			// why does this flip ~2-3° around zero orientation and only with trackercam. back to slower crossproduct calc, a bit slower but better .. sigh
+			// why does this flip ~2-3Â° around zero orientation and only with trackercam. back to slower crossproduct calc, a bit slower but better .. sigh
 			// Vector3 refy = truck->nodes[nref].AbsPosition - truck->nodes[ny].AbsPosition;
 			Vector3 refy = refx.crossProduct(normal);
 			refy.normalise();
@@ -305,7 +305,7 @@ VideoCamera *VideoCamera::Setup(RigSpawner *rig_spawner, RigDef::VideoCamera & d
 			v->vidCamName = def.material_name; /* Fallback */
 		}
 
-		//rotate camera picture 180°, skip for mirrors
+		//rotate camera picture 180ï¿½, skip for mirrors
 		float rotation_z = (def.camera_role != 1) ? def.rotation.z + 180 : def.rotation.z;
 		v->rotation 
 			= Ogre::Quaternion(Ogre::Degree(rotation_z), Ogre::Vector3::UNIT_Z) 

--- a/source/main/gfx/VideoCamera.h
+++ b/source/main/gfx/VideoCamera.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/Water.cpp
+++ b/source/main/gfx/Water.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/Water.h
+++ b/source/main/gfx/Water.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorCharacter.cpp
+++ b/source/main/gfx/camera/CameraBehaviorCharacter.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorCharacter.h
+++ b/source/main/gfx/camera/CameraBehaviorCharacter.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorFixed.cpp
+++ b/source/main/gfx/camera/CameraBehaviorFixed.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorFixed.h
+++ b/source/main/gfx/camera/CameraBehaviorFixed.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorFree.cpp
+++ b/source/main/gfx/camera/CameraBehaviorFree.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorFree.h
+++ b/source/main/gfx/camera/CameraBehaviorFree.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorIsometric.cpp
+++ b/source/main/gfx/camera/CameraBehaviorIsometric.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorIsometric.h
+++ b/source/main/gfx/camera/CameraBehaviorIsometric.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorOrbit.cpp
+++ b/source/main/gfx/camera/CameraBehaviorOrbit.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorOrbit.h
+++ b/source/main/gfx/camera/CameraBehaviorOrbit.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorStatic.cpp
+++ b/source/main/gfx/camera/CameraBehaviorStatic.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorStatic.h
+++ b/source/main/gfx/camera/CameraBehaviorStatic.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorVehicle.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicle.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorVehicle.h
+++ b/source/main/gfx/camera/CameraBehaviorVehicle.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorVehicleCineCam.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicleCineCam.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorVehicleCineCam.h
+++ b/source/main/gfx/camera/CameraBehaviorVehicleCineCam.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorVehicleSpline.cpp
+++ b/source/main/gfx/camera/CameraBehaviorVehicleSpline.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraBehaviorVehicleSpline.h
+++ b/source/main/gfx/camera/CameraBehaviorVehicleSpline.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/dof/DepthOfFieldEffect.cpp
+++ b/source/main/gfx/dof/DepthOfFieldEffect.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/dof/DepthOfFieldEffect.h
+++ b/source/main/gfx/dof/DepthOfFieldEffect.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/dof/Lens.cpp
+++ b/source/main/gfx/dof/Lens.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/dof/Lens.h
+++ b/source/main/gfx/dof/Lens.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/particle/ExtinguishableFireAffector.cpp
+++ b/source/main/gfx/particle/ExtinguishableFireAffector.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/particle/ExtinguishableFireAffector.h
+++ b/source/main/gfx/particle/ExtinguishableFireAffector.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/particle/ExtinguishableFireAffectorFactory.h
+++ b/source/main/gfx/particle/ExtinguishableFireAffectorFactory.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/particle/FireExtinguisherAffector.cpp
+++ b/source/main/gfx/particle/FireExtinguisherAffector.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/particle/FireExtinguisherAffector.h
+++ b/source/main/gfx/particle/FireExtinguisherAffector.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gfx/particle/FireExtinguisherAffectorFactory.h
+++ b/source/main/gfx/particle/FireExtinguisherAffectorFactory.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/Console.cpp
+++ b/source/main/gui/Console.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/Console.h
+++ b/source/main/gui/Console.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/DashBoardManager.h
+++ b/source/main/gui/DashBoardManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/Dashboard.cpp
+++ b/source/main/gui/Dashboard.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/Dashboard.h
+++ b/source/main/gui/Dashboard.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIFriction.cpp
+++ b/source/main/gui/GUIFriction.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIFriction.h
+++ b/source/main/gui/GUIFriction.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIInputManager.cpp
+++ b/source/main/gui/GUIInputManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIInputManager.h
+++ b/source/main/gui/GUIInputManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIMenu.cpp
+++ b/source/main/gui/GUIMenu.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIMenu.h
+++ b/source/main/gui/GUIMenu.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIMp.cpp
+++ b/source/main/gui/GUIMp.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GUIMp.h
+++ b/source/main/gui/GUIMp.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/GuiManagerInterface.h
+++ b/source/main/gui/GuiManagerInterface.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/LoadingWindow.cpp
+++ b/source/main/gui/LoadingWindow.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/LoadingWindow.h
+++ b/source/main/gui/LoadingWindow.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as
@@ -158,7 +158,7 @@ int OverlayWrapper::init()
 		directionArrowText = (TextAreaOverlayElement*)loadOverlayElement("tracks/DirectionArrow/Text");
 	} catch(...)
 	{
-		String url = "http://wiki.rigsofrods.com/index.php?title=Error_Resources_Not_Found";
+		String url = "http://wiki.rigsofrods.org/index.php?title=Error_Resources_Not_Found";
 		ErrorUtils::ShowOgreWebError("Resources not found!", "please ensure that your installation is complete and the resources are installed properly. If this error persists please re-install RoR.", url);
 	}
 	directionArrowDistance = (TextAreaOverlayElement*)loadOverlayElement("tracks/DirectionArrow/Distance");

--- a/source/main/gui/OverlayWrapper.h
+++ b/source/main/gui/OverlayWrapper.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/TextureToolWindow.cpp
+++ b/source/main/gui/TextureToolWindow.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/TextureToolWindow.h
+++ b/source/main/gui/TextureToolWindow.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/TruckHUD.cpp
+++ b/source/main/gui/TruckHUD.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/TruckHUD.h
+++ b/source/main/gui/TruckHUD.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/mygui/Attribute.h
+++ b/source/main/gui/mygui/Attribute.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/mygui/BaseLayout.h
+++ b/source/main/gui/mygui/BaseLayout.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/mygui/Dialog.cpp
+++ b/source/main/gui/mygui/Dialog.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/mygui/Dialog.h
+++ b/source/main/gui/mygui/Dialog.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/mygui/GuiPanelBase.h
+++ b/source/main/gui/mygui/GuiPanelBase.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/mygui/WrapsAttribute.h
+++ b/source/main/gui/mygui/WrapsAttribute.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_DebugOptions.cpp
+++ b/source/main/gui/panels/GUI_DebugOptions.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_DebugOptions.h
+++ b/source/main/gui/panels/GUI_DebugOptions.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GameAbout.cpp
+++ b/source/main/gui/panels/GUI_GameAbout.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GameAbout.h
+++ b/source/main/gui/panels/GUI_GameAbout.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GameChatBox.h
+++ b/source/main/gui/panels/GUI_GameChatBox.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GameMainMenu.cpp
+++ b/source/main/gui/panels/GUI_GameMainMenu.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GameMainMenu.h
+++ b/source/main/gui/panels/GUI_GameMainMenu.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GamePauseMenu.cpp
+++ b/source/main/gui/panels/GUI_GamePauseMenu.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GamePauseMenu.h
+++ b/source/main/gui/panels/GUI_GamePauseMenu.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_GameSettings.h
+++ b/source/main/gui/panels/GUI_GameSettings.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_MessageBox.cpp
+++ b/source/main/gui/panels/GUI_MessageBox.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_MessageBox.h
+++ b/source/main/gui/panels/GUI_MessageBox.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_MultiplayerSelector.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerSelector.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_MultiplayerSelector.h
+++ b/source/main/gui/panels/GUI_MultiplayerSelector.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_OpenSaveFileDialog.cpp
+++ b/source/main/gui/panels/GUI_OpenSaveFileDialog.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_OpenSaveFileDialog.h
+++ b/source/main/gui/panels/GUI_OpenSaveFileDialog.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_RigSpawnerReportWindow.cpp
+++ b/source/main/gui/panels/GUI_RigSpawnerReportWindow.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_RigSpawnerReportWindow.h
+++ b/source/main/gui/panels/GUI_RigSpawnerReportWindow.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_SimUtils.cpp
+++ b/source/main/gui/panels/GUI_SimUtils.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_SimUtils.h
+++ b/source/main/gui/panels/GUI_SimUtils.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_VehicleDescription.cpp
+++ b/source/main/gui/panels/GUI_VehicleDescription.cpp
@@ -4,7 +4,7 @@ Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 Copyright 2013-2014 Petr Ohlidal
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/gui/panels/GUI_VehicleDescription.h
+++ b/source/main/gui/panels/GUI_VehicleDescription.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/icon.rc
+++ b/source/main/icon.rc
@@ -68,11 +68,11 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "rigsofrods.com"
+            VALUE "CompanyName", "rigsofrods.org"
             VALUE "FileDescription", "Rigs of Rods Simulator"
             VALUE "FileVersion", ROR_RESOURCE_VERSION_STRING
             VALUE "InternalName", "RoR"
-            VALUE "LegalCopyright", "Copyright (C) 2005-2015 rigsofrods.com"
+            VALUE "LegalCopyright", "Copyright (C) 2005-2015 rigsofrods.org"
             VALUE "OriginalFilename", "RoR.exe"
             VALUE "ProductName", "Rigs of Rods"
             VALUE "ProductVersion", ROR_RESOURCE_VERSION_STRING

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as
@@ -240,7 +240,7 @@ int main(int argc, char *argv[])
 	} 
 	catch (Ogre::Exception& e)
 	{
-		String url = "http://wiki.rigsofrods.com/index.php?title=Error_" + TOSTRING(e.getNumber())+"#"+e.getSource();
+		String url = "http://wiki.rigsofrods.org/index.php?title=Error_" + TOSTRING(e.getNumber())+"#"+e.getSource();
 		ErrorUtils::ShowOgreWebError(_L("An exception has occured!"), e.getFullDescription(), url);
 	}
 	catch (std::runtime_error& e)

--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2016 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2016 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/network/protocol/rornet.h
+++ b/source/main/network/protocol/rornet.h
@@ -1,7 +1,7 @@
 /*
 This file is part of "Rigs of Rods Server" (Relay mode)
 Copyright 2007 Pierre-Michel Ricordel
-Contact: pricorde@rigsofrods.com
+Contact: pricorde@rigsofrods.org
 "Rigs of Rods Server" is distributed under the terms of the GNU General Public License.
 
 "Rigs of Rods Server" is free software; you can redistribute it and/or modify
@@ -41,12 +41,12 @@ static const int   MAX_USERNAME_LEN   = 40;  //!< port used to send the broadcas
 static const char VARIABLE_IS_NOT_USED *RORNET_VERSION = "RoRnet_2.38"; //!< the protocol version information
 
 // REGISTRY STUFF
-static const char VARIABLE_IS_NOT_USED *REPO_SERVER = "api.rigsofrods.com"; //!< the web API URL
+static const char VARIABLE_IS_NOT_USED *REPO_SERVER = "api.rigsofrods.org"; //!< the web API URL
 static const char VARIABLE_IS_NOT_USED *REPO_URLPREFIX = "";                //!< prefix for the API
 
 // used by configurator
-static const char VARIABLE_IS_NOT_USED *REPO_HTML_SERVERLIST = "http://api.rigsofrods.com/serverlist/"; //!< server list URL
-static const char VARIABLE_IS_NOT_USED *NEWS_HTML_PAGE = "http://api.rigsofrods.com/news/"; //!< news html page URL
+static const char VARIABLE_IS_NOT_USED *REPO_HTML_SERVERLIST = "http://multiplayer.rigsofrods.org/server-list/"; //!< server list URL
+static const char VARIABLE_IS_NOT_USED *NEWS_HTML_PAGE = "http://api.rigsofrods.org/news/"; //!< news html page URL
 
 // ENUMs
 

--- a/source/main/physics/ApproxMath.h
+++ b/source/main/physics/ApproxMath.h
@@ -2,7 +2,7 @@
 This source file is part of Rigs of Rods
 Copyright 2009 Lefteris Stamatogiannakis
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/BeamSlideNode.cpp
+++ b/source/main/physics/BeamSlideNode.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as
@@ -25,7 +25,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 This source file is part of Rigs of Rods
 Copyright 2009 Christopher Ritchey
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/CmdKeyInertia.cpp
+++ b/source/main/physics/CmdKeyInertia.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/CmdKeyInertia.h
+++ b/source/main/physics/CmdKeyInertia.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/Differentials.cpp
+++ b/source/main/physics/Differentials.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/Differentials.h
+++ b/source/main/physics/Differentials.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/SlideNode.cpp
+++ b/source/main/physics/SlideNode.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as
@@ -25,7 +25,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 This source file is part of Rigs of Rods
 Copyright 2009 Christopher Ritchey
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/SlideNode.h
+++ b/source/main/physics/SlideNode.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as
@@ -25,7 +25,7 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 This source file is part of Rigs of Rods
 Copyright 2009 Christopher Ritchey
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/AeroEngine.h
+++ b/source/main/physics/air/AeroEngine.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/AirBrake.cpp
+++ b/source/main/physics/air/AirBrake.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/AirBrake.h
+++ b/source/main/physics/air/AirBrake.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/Airfoil.cpp
+++ b/source/main/physics/air/Airfoil.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/Airfoil.h
+++ b/source/main/physics/air/Airfoil.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/TurboJet.h
+++ b/source/main/physics/air/TurboJet.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/air/TurboProp.h
+++ b/source/main/physics/air/TurboProp.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/collision/CartesianToTriangleTransform.h
+++ b/source/main/physics/collision/CartesianToTriangleTransform.h
@@ -2,7 +2,7 @@
 This source file is part of Rigs of Rods
 Copyright 2016 Fabian Killus
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as
@@ -228,7 +228,7 @@ int Collisions::loadGroundModelsConfigFile(Ogre::String filename)
 	if (this->collision_version != LATEST_GROUND_MODEL_VERSION)
 	{
 		// message box
-		String url = "http://wiki.rigsofrods.com/index.php?title=Error_Old_ground_model#"+TOSTRING(this->collision_version)+"to"+TOSTRING(LATEST_GROUND_MODEL_VERSION);
+		String url = "http://wiki.rigsofrods.org/index.php?title=Error_Old_ground_model#"+TOSTRING(this->collision_version)+"to"+TOSTRING(LATEST_GROUND_MODEL_VERSION);
 		ErrorUtils::ShowOgreWebError(_L("Configuration error"), _L("Your ground configuration is too old, please copy skeleton/config/ground_models.cfg to My Documents/Rigs of Rods/config"), url);
 		ErrorUtils::ShowStoredOgreWebErrors();
 		exit(124);

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -5,7 +5,7 @@
 	Copyright 2009      Lefteris Stamatogiannakis
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/collision/DynamicCollisions.cpp
+++ b/source/main/physics/collision/DynamicCollisions.cpp
@@ -4,7 +4,7 @@
    Copyright 2007-2012 Thomas Fischer
    Copyright 2016 Fabian Killus
 
-   For more information, see http://www.rigsofrods.com/
+   For more information, see http://www.rigsofrods.org/
 
    Rigs of Rods is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/collision/DynamicCollisions.h
+++ b/source/main/physics/collision/DynamicCollisions.h
@@ -4,7 +4,7 @@
    Copyright 2007-2012 Thomas Fischer
    Copyright 2016 Fabian Killus
 
-   For more information, see http://www.rigsofrods.com/
+   For more information, see http://www.rigsofrods.org/
 
    Rigs of Rods is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -2,7 +2,7 @@
 This source file is part of Rigs of Rods
 Copyright 2009 Lefteris Stamatogiannakis
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/collision/PointColDetector.h
+++ b/source/main/physics/collision/PointColDetector.h
@@ -2,7 +2,7 @@
 This source file is part of Rigs of Rods
 Copyright 2009 Lefteris Stamatogiannakis
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/collision/Triangle.h
+++ b/source/main/physics/collision/Triangle.h
@@ -2,7 +2,7 @@
 This source file is part of Rigs of Rods
 Copyright 2016 Fabian Killus
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexAirfoil.cpp
+++ b/source/main/physics/flex/FlexAirfoil.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexAirfoil.h
+++ b/source/main/physics/flex/FlexAirfoil.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexBody.cpp
+++ b/source/main/physics/flex/FlexBody.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexBody.h
+++ b/source/main/physics/flex/FlexBody.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexFactory.cpp
+++ b/source/main/physics/flex/FlexFactory.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexFactory.h
+++ b/source/main/physics/flex/FlexFactory.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexMesh.cpp
+++ b/source/main/physics/flex/FlexMesh.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexMesh.h
+++ b/source/main/physics/flex/FlexMesh.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexMeshWheel.cpp
+++ b/source/main/physics/flex/FlexMeshWheel.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexMeshWheel.h
+++ b/source/main/physics/flex/FlexMeshWheel.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexObj.cpp
+++ b/source/main/physics/flex/FlexObj.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/FlexObj.h
+++ b/source/main/physics/flex/FlexObj.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/flex/Flexable.h
+++ b/source/main/physics/flex/Flexable.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/input_output/ForceFeedback.cpp
+++ b/source/main/physics/input_output/ForceFeedback.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/input_output/ForceFeedback.h
+++ b/source/main/physics/input_output/ForceFeedback.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/input_output/RigSpawner.h
+++ b/source/main/physics/input_output/RigSpawner.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/input_output/RigSpawner_ProcessControl.cpp
+++ b/source/main/physics/input_output/RigSpawner_ProcessControl.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/mplatform/MPlatformBase.cpp
+++ b/source/main/physics/mplatform/MPlatformBase.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/mplatform/MPlatformBase.h
+++ b/source/main/physics/mplatform/MPlatformBase.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/mplatform/MPlatformFD.cpp
+++ b/source/main/physics/mplatform/MPlatformFD.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/mplatform/MPlatformFD.h
+++ b/source/main/physics/mplatform/MPlatformFD.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/utils/BeamStats.cpp
+++ b/source/main/physics/utils/BeamStats.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/utils/BeamStats.h
+++ b/source/main/physics/utils/BeamStats.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/utils/RigLoadingProfiler.h
+++ b/source/main/physics/utils/RigLoadingProfiler.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/water/Buoyance.cpp
+++ b/source/main/physics/water/Buoyance.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/water/Buoyance.h
+++ b/source/main/physics/water/Buoyance.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/water/ScrewProp.cpp
+++ b/source/main/physics/water/ScrewProp.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/physics/water/ScrewProp.h
+++ b/source/main/physics/water/ScrewProp.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as
@@ -194,7 +194,7 @@ void CacheSystem::Startup(bool force_check)
 	// show error on zero content
 	if (entries.empty())
 	{
-		ErrorUtils::ShowOgreWebError(_L("No content installed"), _L("You have no content installed"), _L("http://www.rigsofrods.com/wiki/pages/Install_Content"));
+		ErrorUtils::ShowOgreWebError(_L("No content installed"), _L("You have no content installed"), _L("http://www.rigsofrods.org/wiki/pages/Install_Content"));
 		ErrorUtils::ShowStoredOgreWebErrors();
 		exit(1337);
 	}

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/resources/CacheSystemTable.h
+++ b/source/main/resources/CacheSystemTable.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/resources/ContentManager.h
+++ b/source/main/resources/ContentManager.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/CBytecodeStream.cpp
+++ b/source/main/scripting/CBytecodeStream.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/CBytecodeStream.h
+++ b/source/main/scripting/CBytecodeStream.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/LocalStorage.cpp
+++ b/source/main/scripting/LocalStorage.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/LocalStorage.h
+++ b/source/main/scripting/LocalStorage.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/OgreAngelscript.cpp
+++ b/source/main/scripting/OgreAngelscript.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/OgreAngelscript.h
+++ b/source/main/scripting/OgreAngelscript.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/OgreScriptBuilder.cpp
+++ b/source/main/scripting/OgreScriptBuilder.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/OgreScriptBuilder.h
+++ b/source/main/scripting/OgreScriptBuilder.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/IHeightFinder.h
+++ b/source/main/terrain/IHeightFinder.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/TerrainGeometryManager.h
+++ b/source/main/terrain/TerrainGeometryManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/TerrainManager.h
+++ b/source/main/terrain/TerrainManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/map/SurveyMapEntity.cpp
+++ b/source/main/terrain/map/SurveyMapEntity.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/map/SurveyMapEntity.h
+++ b/source/main/terrain/map/SurveyMapEntity.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/map/SurveyMapManager.cpp
+++ b/source/main/terrain/map/SurveyMapManager.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/map/SurveyMapManager.h
+++ b/source/main/terrain/map/SurveyMapManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/map/SurveyMapTextureCreator.cpp
+++ b/source/main/terrain/map/SurveyMapTextureCreator.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/terrain/map/SurveyMapTextureCreator.h
+++ b/source/main/terrain/map/SurveyMapTextureCreator.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/threadpool/ThreadPool.h
+++ b/source/main/threadpool/ThreadPool.h
@@ -2,7 +2,7 @@
 This source file is part of Rigs of Rods
 Copyright 2016 Fabian Killus
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/CollisionTools.cpp
+++ b/source/main/utils/CollisionTools.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/CollisionTools.h
+++ b/source/main/utils/CollisionTools.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/ConfigFile.cpp
+++ b/source/main/utils/ConfigFile.cpp
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/ConfigFile.h
+++ b/source/main/utils/ConfigFile.h
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/ErrorUtils.cpp
+++ b/source/main/utils/ErrorUtils.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/ErrorUtils.h
+++ b/source/main/utils/ErrorUtils.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/FileSystemInfo.h
+++ b/source/main/utils/FileSystemInfo.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/IBehavior.h
+++ b/source/main/utils/IBehavior.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/IBehaviorManager.h
+++ b/source/main/utils/IBehaviorManager.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/ImprovedConfigFile.h
+++ b/source/main/utils/ImprovedConfigFile.h
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/InterThreadStoreVector.h
+++ b/source/main/utils/InterThreadStoreVector.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/Language.cpp
+++ b/source/main/utils/Language.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/Language.h
+++ b/source/main/utils/Language.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/MeshObject.cpp
+++ b/source/main/utils/MeshObject.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/MeshObject.h
+++ b/source/main/utils/MeshObject.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/MumbleIntegration.cpp
+++ b/source/main/utils/MumbleIntegration.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/MumbleIntegration.h
+++ b/source/main/utils/MumbleIntegration.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/PlatformUtils.cpp
+++ b/source/main/utils/PlatformUtils.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/PlatformUtils.h
+++ b/source/main/utils/PlatformUtils.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/RoRWindowEventUtilities.cpp
+++ b/source/main/utils/RoRWindowEventUtilities.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/RoRWindowEventUtilities.h
+++ b/source/main/utils/RoRWindowEventUtilities.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/Settings.h
+++ b/source/main/utils/Settings.h
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/Singleton.h
+++ b/source/main/utils/Singleton.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005,2006,2007,2008,2009 Pierre-Michel Ricordel
 Copyright 2007,2008,2009 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/Utils.h
+++ b/source/main/utils/Utils.h
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/WriteTextToTexture.cpp
+++ b/source/main/utils/WriteTextToTexture.cpp
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/WriteTextToTexture.h
+++ b/source/main/utils/WriteTextToTexture.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/ZeroedMemoryAllocator.h
+++ b/source/main/utils/ZeroedMemoryAllocator.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/main/utils/profiler/RigLoadingProfilerControl.h
+++ b/source/main/utils/profiler/RigLoadingProfilerControl.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/ReadMe.txt
+++ b/source/rig_file_input_output/ReadMe.txt
@@ -6,7 +6,7 @@ This is stand-aloner parser for rig-definition file format (called '.truck')
 used in Rigs of Rods game.
 
 Discussion on RoR forums:
-http://www.rigsofrods.com/threads/108818
+http://www.rigsofrods.org/threads/108818
 
 ________________________________________________________________________________
 TERMINOLOGY:

--- a/source/rig_file_input_output/RigDef_File.cpp
+++ b/source/rig_file_input_output/RigDef_File.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_File.h
+++ b/source/rig_file_input_output/RigDef_File.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Limits.h
+++ b/source/rig_file_input_output/RigDef_Limits.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Node.cpp
+++ b/source/rig_file_input_output/RigDef_Node.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Node.h
+++ b/source/rig_file_input_output/RigDef_Node.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Parser.cpp
+++ b/source/rig_file_input_output/RigDef_Parser.cpp
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Parser.h
+++ b/source/rig_file_input_output/RigDef_Parser.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Prerequisites.h
+++ b/source/rig_file_input_output/RigDef_Prerequisites.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Regexes.h
+++ b/source/rig_file_input_output/RigDef_Regexes.h
@@ -4,7 +4,7 @@
     Copyright 2007-2012 Thomas Fischer
     Copyright 2013-2016 Petr Ohlidal
 
-    For more information, see http://www.rigsofrods.com/
+    For more information, see http://www.rigsofrods.org/
 
     Rigs of Rods is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 3, as
@@ -83,7 +83,7 @@ namespace Regexes
 
 #define E_REAL_NUMBER_WITH_EXPONENT_NO_FRACTION "-?[[:digit:]]*[eE][-+]?[[:digit:]]+"
 
-// NOTE: Intentionally accepting format "1." for backwards compatibility, observed in http://www.rigsofrods.com/repository/view/2389
+// NOTE: Intentionally accepting format "1." for backwards compatibility, observed in http://www.rigsofrods.org/repository/view/2389
 #define E_REAL_NUMBER_SIMPLE "-?[[:digit:]]*\\.[[:digit:]]*"
 
 //NOTE: Uses |, MUST be enclosed in E_CAPTURE()
@@ -1437,9 +1437,9 @@ DEFINE_REGEX( FLEXBODIES_SUBSECTION_PROPLIKE_LINE,
 
 DEFINE_REGEX( FLEXBODIES_SUBSECTION_FORSET_LINE,
     // Compatibility rules:
-    // 1. Tolerate colon ":" as keyword/numbers separator, observed in http://www.rigsofrods.com/repository/view/2497
+    // 1. Tolerate colon ":" as keyword/numbers separator, observed in http://www.rigsofrods.org/repository/view/2497
     // 2. Tolerate missing keyword/numbers separator
-    //      (example: "forset12,34,56", observed in: http://www.rigsofrods.com/repository/view/5282)
+    //      (example: "forset12,34,56", observed in: http://www.rigsofrods.org/repository/view/5282)
     "forset"
     E_CAPTURE_OPTIONAL( E_DELIMITER E_OR E_DELIMITER_COLON ) // #1 Delimiter
     E_CAPTURE( ".*$" )                                       // #2 Entire line

--- a/source/rig_file_input_output/RigDef_SequentialImporter.cpp
+++ b/source/rig_file_input_output/RigDef_SequentialImporter.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_SequentialImporter.h
+++ b/source/rig_file_input_output/RigDef_SequentialImporter.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Serializer.cpp
+++ b/source/rig_file_input_output/RigDef_Serializer.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as
@@ -61,11 +61,11 @@ void Serializer::Serialize()
 	// Write banner
 	m_stream
 		<< "; ---------------------------------------------------------------------------- ;" << endl
-		<< "; Rigs of Rods project (www.rigsofrods.com)                                    ;" << endl
+		<< "; Rigs of Rods project (www.rigsofrods.org)                                    ;" << endl
 		<< "; =========================================                                    ;" << endl
 		<< ";                                                                              ;" << endl
 		<< "; This is a rig definition file.                                               ;" << endl
-		<< "; See http://www.rigsofrods.com/wiki/pages/Truck_Description_File for details. ;" << endl
+		<< "; See http://www.rigsofrods.org/wiki/pages/Truck_Description_File for details. ;" << endl
 		<< "; ---------------------------------------------------------------------------- ;" << endl
 		<< endl;
 

--- a/source/rig_file_input_output/RigDef_Serializer.h
+++ b/source/rig_file_input_output/RigDef_Serializer.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2015 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/rig_file_input_output/RigDef_Validator.cpp
+++ b/source/rig_file_input_output/RigDef_Validator.cpp
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as
@@ -291,7 +291,7 @@ bool Validator::CheckShock2(RigDef::Shock2 & shock2)
 {
 	std::list<Ogre::String> bad_fields;
 
-	/* Keep these in sync with wiki doc: http://www.rigsofrods.com/wiki/pages/Truck_Description_File#Shocks2 */
+	/* Keep these in sync with wiki doc: http://www.rigsofrods.org/wiki/pages/Truck_Description_File#Shocks2 */
 	/* We safely check for value -1.f */
 	if (shock2.spring_in < -0.8f)
 	{

--- a/source/rig_file_input_output/RigDef_Validator.h
+++ b/source/rig_file_input_output/RigDef_Validator.h
@@ -4,7 +4,7 @@
 	Copyright 2007-2012 Thomas Fischer
 	Copyright 2013-2014 Petr Ohlidal
 
-	For more information, see http://www.rigsofrods.com/
+	For more information, see http://www.rigsofrods.org/
 
 	Rigs of Rods is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License version 3, as

--- a/source/version_info/RoRVersion.h
+++ b/source/version_info/RoRVersion.h
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/source/version_info/RoRVersionDef.h.in
+++ b/source/version_info/RoRVersionDef.h.in
@@ -3,7 +3,7 @@ This source file is part of Rigs of Rods
 Copyright 2005-2012 Pierre-Michel Ricordel
 Copyright 2007-2012 Thomas Fischer
 
-For more information, see http://www.rigsofrods.com/
+For more information, see http://www.rigsofrods.org/
 
 Rigs of Rods is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/tools/MyGUI_LayoutEditor/BaseLayoutCPP.xml
+++ b/tools/MyGUI_LayoutEditor/BaseLayoutCPP.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 ================================================================================
-  Rigs of Rods project (www.rigsofrods.com)
+  Rigs of Rods project (www.rigsofrods.org)
   Code template for MyGUI's Layout Editor
 ================================================================================
 -->

--- a/tools/MyGUI_LayoutEditor/README.txt
+++ b/tools/MyGUI_LayoutEditor/README.txt
@@ -1,5 +1,5 @@
 ================================================================================
-  Rigs of Rods project (www.rigsofrods.com)
+  Rigs of Rods project (www.rigsofrods.org)
   Code template for MyGUI's Layout Editor
   
   Installation:

--- a/tools/linux/l10n/README.md
+++ b/tools/linux/l10n/README.md
@@ -10,7 +10,7 @@ Basically these steps are required to get up to date translations:
 - compile \<lang.mo\> for these translations (see below)
 - put \<lang\>.mo in ```bin/languages/<lang>/LC_MESSAGES/ ```
 
-Additional information: http://www.rigsofrods.com/wiki/pages/Language_Translation#How_it_works
+Additional information: http://www.rigsofrods.org/wiki/pages/Language_Translation#How_it_works
 
 ### Update source file on Transifex
 The source file (ror.pot) on Transifex serves as the base for all translations and


### PR DESCRIPTION
Mass replaced rigsofrods.com with rigsofrods.org 
Some links aren't working, needs manual checking and some wiki pages need to be converted to the new docs.