### PR TITLE
[Fix] Fixed text being small on Dynamic Signs

### DIFF
--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -1068,7 +1068,7 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 					AnimationStateSet *s = mo->getEntity()->getAllAnimationStates();
 					if (!s->hasAnimationState(String(animname)))
 					{
-						LOG("ODEF: animation '" + String(animname) + "' for mesh: '" + String(mesh) + "' in odef file '" + name + ".odef' not found!");
+						LOG("[ODEF] animation '" + String(animname) + "' for mesh: '" + String(mesh) + "' in odef file '" + name + ".odef' not found!");
 						continue;
 					}
 					animated_object_t ao;
@@ -1087,7 +1087,7 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 					}
 					if (!ao.anim)
 					{
-						LOG("ODEF: animation '" + String(animname) + "' for mesh: '" + String(mesh) + "' in odef file '" + name + ".odef' not found!");
+						LOG("[ODEF] animation '" + String(animname) + "' for mesh: '" + String(mesh) + "' in odef file '" + name + ".odef' not found!");
 						continue;
 					}
 					ao.anim->setEnabled(true);
@@ -1103,14 +1103,14 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 				MaterialPtr m = MaterialManager::getSingleton().getByName(matName);
 				if (m.getPointer() == 0)
 				{
-					LOG("ODEF: problem with drawTextOnMeshTexture command: mesh material not found: "+odefname+" : "+String(ptline));
+					LOG("[ODEF] problem with drawTextOnMeshTexture command: mesh material not found: "+odefname+" : "+String(ptline));
 					continue;
 				}
 				String texName = m->getTechnique(0)->getPass(0)->getTextureUnitState(0)->getTextureName();
 				Texture* background = (Texture *)TextureManager::getSingleton().getByName(texName).getPointer();
 				if (!background)
 				{
-					LOG("ODEF: problem with drawTextOnMeshTexture command: mesh texture not found: "+odefname+" : "+String(ptline));
+					LOG("[ODEF] problem with drawTextOnMeshTexture command: mesh texture not found: "+odefname+" : "+String(ptline));
 					continue;
 				}
 
@@ -1122,19 +1122,20 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 				TexturePtr texture = TextureManager::getSingleton().createManual(tmpTextName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, TEX_TYPE_2D, (Ogre::uint)background->getWidth(), (Ogre::uint)background->getHeight(), MIP_UNLIMITED , PF_X8R8G8B8, Ogre::TU_STATIC|Ogre::TU_AUTOMIPMAP);
 				if (texture.getPointer() == 0)
 				{
-					LOG("ODEF: problem with drawTextOnMeshTexture command: could not create texture: "+odefname+" : "+String(ptline));
+					LOG("[ODEF] problem with drawTextOnMeshTexture command: could not create texture: "+odefname+" : "+String(ptline));
 					continue;
 				}
 
-				float x=0, y=0, w=0, h=0;
-				float a=0, r=0, g=0, b=0;
+				float x = 0, y = 0, w = 0, h = 0;
+				float a = 0, r = 0, g = 0, b = 0;
+				int fs = 40, fdpi = 144;
 				char fontname[256]="";
 				char text[256]="";
 				char option='l';
-				int res = sscanf(ptline, "drawTextOnMeshTexture %f, %f, %f, %f, %f, %f, %f, %f, %c, %s %s", &x, &y, &w, &h, &r, &g, &b, &a, &option, fontname, text);
-				if (res < 11)
+				int res = sscanf(ptline, "drawTextOnMeshTexture %f, %f, %f, %f, %f, %f, %f, %f, %c, %i, %i, %s %s", &x, &y, &w, &h, &r, &g, &b, &a, &option, &fs, &fdpi, fontname, text);
+				if (res < 13)
 				{
-					LOG("ODEF: problem with drawTextOnMeshTexture command: "+odefname+" : "+String(ptline));
+					LOG("[ODEF] problem with drawTextOnMeshTexture command: "+odefname+" : "+String(ptline));
 					continue;
 				}
 
@@ -1149,7 +1150,7 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 				Font* font = (Font *)FontManager::getSingleton().getByName(String(fontname)).getPointer();
 				if (!font)
 				{
-					LOG("ODEF: problem with drawTextOnMeshTexture command: font not found: "+odefname+" : "+String(ptline));
+					LOG("[ODEF] problem with drawTextOnMeshTexture command: font not found: "+odefname+" : "+String(ptline));
 					continue;
 				}
 
@@ -1163,7 +1164,7 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 				h = background->getHeight() * h;
 
 				Image::Box box = Image::Box((size_t)x, (size_t)y, (size_t)(x+w), (size_t)(y+h));
-				WriteToTexture(String(text), texture, box, font, ColourValue(r, g, b, a), option);
+				WriteToTexture(String(text), texture, box, font, ColourValue(r, g, b, a), fs, fdpi, option);
 
 				// we can save it to disc for debug purposes:
 				//SaveImage(texture, "test.png");
@@ -1176,7 +1177,7 @@ void TerrainObjectManager::loadObject(const Ogre::String &name, const Ogre::Vect
 				continue;
 			}
 
-			LOG("ODEF: unknown command in "+odefname+" : "+String(ptline));
+			LOG("[ODEF] unknown command in "+odefname+" : "+String(ptline));
 		}
 
 		//add icons if type is set

--- a/source/main/utils/WriteTextToTexture.cpp
+++ b/source/main/utils/WriteTextToTexture.cpp
@@ -26,26 +26,26 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 #include <OgreTexture.h>
 #include <OgreTextureManager.h>
 
-// source: ogre wiki: http://www.ogre3d.org/wiki/index.php/HowTo:_Write_text_on_texture
+// source: ogre wiki: http://www.ogre3d.org/tikiwiki/tiki-index.php?page=HowTo%3A+Write+text+on+texture
 using namespace Ogre;
 
 void SaveImage(TexturePtr TextureToSave, String filename)
 {
-    HardwarePixelBufferSharedPtr readbuffer;
-    readbuffer = TextureToSave->getBuffer(0, 0);
-    readbuffer->lock(HardwareBuffer::HBL_NORMAL );
-    const PixelBox &readrefpb = readbuffer->getCurrentLock();
-    uchar *readrefdata = static_cast<uchar*>(readrefpb.data);
+	HardwarePixelBufferSharedPtr readbuffer;
+	readbuffer = TextureToSave->getBuffer(0, 0);
+	readbuffer->lock(HardwareBuffer::HBL_NORMAL);
+	const PixelBox& readrefpb = readbuffer->getCurrentLock();
+	uchar* readrefdata = static_cast<uchar*>(readrefpb.data);
 
-    Image img;
-    img = img.loadDynamicImage (readrefdata, TextureToSave->getWidth(),
-        TextureToSave->getHeight(), TextureToSave->getFormat());
-    img.save(filename);
+	Image img;
+	img = img.loadDynamicImage(readrefdata, TextureToSave->getWidth(),
+	                           TextureToSave->getHeight(), TextureToSave->getFormat());
+	img.save(filename);
 
-    readbuffer->unlock();
+	readbuffer->unlock();
 }
 
-void WriteToTexture(const String &str, TexturePtr destTexture, Image::Box destRectangle, Font* font, const ColourValue &color, char justify,  bool wordwrap)
+void WriteToTexture(const String& str, TexturePtr destTexture, Image::Box destRectangle, Font* Reffont, const ColourValue& color, int fontSize, int fontDPI, char justify, bool wordwrap)
 {
 	using namespace Ogre;
 
@@ -54,28 +54,43 @@ void WriteToTexture(const String &str, TexturePtr destTexture, Image::Box destRe
 	if (destTexture->getWidth() < destRectangle.right)
 		destRectangle.right = destTexture->getWidth();
 
-	if (!font->isLoaded())
-		font->load();
+	// Find our scaled up (or down) font.
+	std::string fontname = "WTTFont_" + TOSTRING(fontSize + fontDPI) + "_" + Reffont->getSource();
+	FontPtr font = FontManager::getSingleton().getByName(fontname);
 
-	TexturePtr fontTexture = (TexturePtr) TextureManager::getSingleton().getByName(font->getMaterial()->getTechnique(0)->getPass(0)->getTextureUnitState(0)->getTextureName());
-	
+	// Font not found, let's created it :)
+	if (font.isNull())
+	{
+		font = FontManager::getSingleton().create(fontname, "General");
+		font->setType(FT_TRUETYPE);
+		font->setSource(Reffont->getSource());
+
+		font->setTrueTypeSize(fontSize);
+		font->setTrueTypeResolution(fontDPI);
+		font->load();
+		LOG("[WriteToTexture] Created font: " + fontname);
+	}
+
+	TexturePtr fontTexture = (TexturePtr)TextureManager::getSingleton().getByName(font->getMaterial()->getTechnique(0)->getPass(0)->getTextureUnitState(0)->getTextureName());
+
 	HardwarePixelBufferSharedPtr fontBuffer = fontTexture->getBuffer();
 	HardwarePixelBufferSharedPtr destBuffer = destTexture->getBuffer();
 
-	PixelBox destPb = destBuffer->lock(destRectangle,HardwareBuffer::HBL_NORMAL);
-	
-		// The font texture buffer was created write only...so we cannot read it back :o). One solution is to copy the buffer  instead of locking it. (Maybe there is a way to create a font texture which is not write_only ?)
+	PixelBox destPb = destBuffer->lock(destRectangle, HardwareBuffer::HBL_NORMAL);
 
-		// create a buffer
-		size_t nBuffSize = fontBuffer->getSizeInBytes();
-		unsigned char* buffer = (unsigned char*)calloc(nBuffSize, sizeof(unsigned char));
+	// The font texture buffer was created write only...so we cannot read it back :o). One solution is to copy the buffer  instead of locking it. (Maybe there is a way to create a font texture which is not write_only ?)
 
-		// create pixel box using the copy of the buffer
-		PixelBox fontPb(fontBuffer->getWidth(), fontBuffer->getHeight(),fontBuffer->getDepth(), fontBuffer->getFormat(), buffer);
-		fontBuffer->blitToMemory(fontPb);
+	// create a buffer
+	size_t nBuffSize = fontBuffer->getSizeInBytes();
+	uint8* buffer = (uint8*)calloc(nBuffSize, sizeof(uint8));
 
-	unsigned char* fontData = static_cast<unsigned char*>( fontPb.data );
-	unsigned char* destData = static_cast<unsigned char*>( destPb.data );
+	// create pixel box using the copy of the buffer
+	PixelBox fontPb(fontBuffer->getWidth(), fontBuffer->getHeight(), fontBuffer->getDepth(), fontBuffer->getFormat(), buffer);
+	fontBuffer->blitToMemory(fontPb);
+
+
+	uint8* fontData = static_cast<uint8*>(fontPb.data);
+	uint8* destData = static_cast<uint8*>(destPb.data);
 
 	const size_t fontPixelSize = PixelUtil::getNumElemBytes(fontPb.format);
 	const size_t destPixelSize = PixelUtil::getNumElemBytes(destPb.format);
@@ -83,7 +98,7 @@ void WriteToTexture(const String &str, TexturePtr destTexture, Image::Box destRe
 	const size_t fontRowPitchBytes = fontPb.rowPitch * fontPixelSize;
 	const size_t destRowPitchBytes = destPb.rowPitch * destPixelSize;
 
-	Box *GlyphTexCoords;
+	Box* GlyphTexCoords;
 	GlyphTexCoords = new Box[str.size()];
 
 	Font::UVRect glypheTexRect;
@@ -105,8 +120,7 @@ void WriteToTexture(const String &str, TexturePtr destTexture, Image::Box destRe
 			if (GlyphTexCoords[i].getWidth() > charwidth)
 				charwidth = GlyphTexCoords[i].getWidth();
 		}
-
-	}	
+	}
 
 	size_t cursorX = 0;
 	size_t cursorY = 0;
@@ -114,50 +128,58 @@ void WriteToTexture(const String &str, TexturePtr destTexture, Image::Box destRe
 	bool carriagreturn = true;
 	for (unsigned int strindex = 0; strindex < str.size(); strindex++)
 	{
-		switch(str[strindex])
+		switch (str[strindex])
 		{
-		case ' ': cursorX += charwidth;  break;
-		case '\t':cursorX += charwidth * 3; break;
-		case '\n':cursorY += charheight; carriagreturn = true; break;
+		case ' ': cursorX += charwidth;
+			break;
+		case '\t': cursorX += charwidth * 3;
+			break;
+		case '\n': cursorY += charheight;
+			carriagreturn = true;
+			break;
 		default:
 			{
 				//wrapping
-				if ((cursorX + GlyphTexCoords[strindex].getWidth()> lineend) && !carriagreturn )
+				if ((cursorX + GlyphTexCoords[strindex].getWidth() > lineend) && !carriagreturn)
 				{
 					cursorY += charheight;
 					carriagreturn = true;
 				}
-				
+
 				//justify
 				if (carriagreturn)
 				{
 					size_t l = strindex;
-					size_t textwidth = 0;	
+					size_t textwidth = 0;
 					size_t wordwidth = 0;
 
-					while( (l < str.size() ) && (str[l] != '\n'))
-					{		
+					while (l < str.size() && str[l] != '\n)')
+					{
 						wordwidth = 0;
 
 						switch (str[l])
 						{
-						case ' ': wordwidth = charwidth; ++l; break;
-						case '\t': wordwidth = charwidth *3; ++l; break;
+						case ' ': wordwidth = charwidth;
+							++l;
+							break;
+						case '\t': wordwidth = charwidth * 3;
+							++l;
+							break;
 						case '\n': l = str.size();
 						}
-						
+
 						if (wordwrap)
-							while((l < str.size()) && (str[l] != ' ') && (str[l] != '\t') && (str[l] != '\n'))
+							while (l < str.size() && str[l] != ' ' && str[l] != '\t' && str[l] != '\n')
 							{
 								wordwidth += GlyphTexCoords[l].getWidth();
 								++l;
 							}
 						else
-							{
-								wordwidth += GlyphTexCoords[l].getWidth();
-								l++;
-							}
-	
+						{
+							wordwidth += GlyphTexCoords[l].getWidth();
+							l++;
+						}
+
 						if ((textwidth + wordwidth) <= destRectangle.getWidth())
 							textwidth += (wordwidth);
 						else
@@ -169,17 +191,17 @@ void WriteToTexture(const String &str, TexturePtr destTexture, Image::Box destRe
 
 					switch (justify)
 					{
-					case 'c':	cursorX = (destRectangle.getWidth() - textwidth)/2;
-							lineend = destRectangle.getWidth() - cursorX;
-							break;
+					case 'c': cursorX = (destRectangle.getWidth() - textwidth) / 2;
+						lineend = destRectangle.getWidth() - cursorX;
+						break;
 
-					case 'r':	cursorX = (destRectangle.getWidth() - textwidth);
-							lineend = destRectangle.getWidth();
-							break;
+					case 'r': cursorX = (destRectangle.getWidth() - textwidth);
+						lineend = destRectangle.getWidth();
+						break;
 
-					default:	cursorX = 0;
-							lineend = textwidth;
-							break;
+					default: cursorX = 0;
+						lineend = textwidth;
+						break;
 					}
 
 					carriagreturn = false;
@@ -190,16 +212,16 @@ void WriteToTexture(const String &str, TexturePtr destTexture, Image::Box destRe
 					goto stop;
 
 				//draw pixel by pixel
-				for (size_t i = 0; i < GlyphTexCoords[strindex].getHeight(); i++ )
+				for (size_t i = 0; i < GlyphTexCoords[strindex].getHeight(); i++)
 					for (size_t j = 0; j < GlyphTexCoords[strindex].getWidth(); j++)
 					{
-						float alpha =  color.a * (fontData[(i + GlyphTexCoords[strindex].top) * fontRowPitchBytes + (j + GlyphTexCoords[strindex].left) * fontPixelSize +1 ] / 255.0);
+						float alpha = color.a * (fontData[(i + GlyphTexCoords[strindex].top) * fontRowPitchBytes + (j + GlyphTexCoords[strindex].left) * fontPixelSize + 1] / 255.0);
 						float invalpha = 1.0 - alpha;
 						size_t offset = (i + cursorY) * destRowPitchBytes + (j + cursorX) * destPixelSize;
 						ColourValue pix;
-						PixelUtil::unpackColour(&pix,destPb.format,&destData[offset]);
+						PixelUtil::unpackColour(&pix, destPb.format, &destData[offset]);
 						pix = (pix * invalpha) + (color * alpha);
-						PixelUtil::packColour(pix,destPb.format,&destData[offset]);
+						PixelUtil::packColour(pix, destPb.format, &destData[offset]);
 					}
 
 				cursorX += GlyphTexCoords[strindex].getWidth();
@@ -211,7 +233,8 @@ stop:
 	delete[] GlyphTexCoords;
 
 	destBuffer->unlock();
-	
-		// Free the memory allocated for the buffer
-		free(buffer); buffer = 0;
+
+	// Free the memory allocated for the buffer
+	free(buffer);
+	buffer = 0;
 }

--- a/source/main/utils/WriteTextToTexture.h
+++ b/source/main/utils/WriteTextToTexture.h
@@ -18,7 +18,10 @@ You should have received a copy of the GNU General Public License
 along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// source: ogre wiki: http://www.ogre3d.org/wiki/index.php/HowTo:_Write_text_on_texture
+/**
+ *  @file WriteTextToTexture.h
+ *  @brief Copied from the ogre wiki: http://www.ogre3d.org/tikiwiki/tiki-index.php?page=HowTo%3A+Write+text+on+texture
+ */
 
 #pragma once
 
@@ -27,5 +30,25 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "RoRPrerequisites.h"
 
+/**
+ *  @brief Saves a texture to the disk.
+ *  
+ *  @param TextureToSave The texture to save.
+ *  @param filename The file-name.
+ */
 void SaveImage(Ogre::TexturePtr TextureToSave, Ogre::String filename);
-void WriteToTexture(const Ogre::String &str, Ogre::TexturePtr destTexture, Ogre::Image::Box destRectangle, Ogre::Font* font, const Ogre::ColourValue &color, char justify = 'l',  bool wordwrap = true);
+
+/**
+ *  @brief Writes a string onto a texture.
+ *  
+ *  @param str The string to write onto the texture.
+ *  @param destTexture The texture to write the string on.
+ *  @param destRectangle The Area to write in.
+ *  @param font A pointer to the font to use.
+ *  @param color The color of the text.
+ *  @param fontSize The size of the font in points.
+ *  @param fontDPI  The resolution of the font in dpi.
+ *  @param justify 'l' = left aligned, 'c' = centered, 'r' = right aligned.
+ *  @param wordwrap if true the line will only be wrapped after a word.
+ */
+void WriteToTexture(const Ogre::String& str, Ogre::TexturePtr destTexture, Ogre::Image::Box destRectangle, Ogre::Font* font, const Ogre::ColourValue& color, int fontSize = 15, int fontDPI = 400, char justify = 'l', bool wordwrap = true);


### PR DESCRIPTION
Things done:

- Updated the code copied from the ogre wiki (http://www.ogre3d.org/tikiwiki/tiki-index.php?page=HowTo%3A+Write+text+on+texture)
- Added 2 more variables to ```drawTextOnMeshTexture```
- Documented WriteTextToTexture.h

Variables added:
_drawTextOnMeshTexture x, y, w, h, r, g, b, a, option,_ **font size, font dpi,** _fontname, text_
_drawTextOnMeshTexture 0.1, 0.1, 0.9, 0.9, 1, 1, 1, 1, c,_ **20, 400,**  _CyberbitEnglish {{argument1}}_

Screenshot:

![screenshot_2016-09-01_16-13-43_1](https://cloud.githubusercontent.com/assets/9480940/18173447/e405e406-7069-11e6-923c-890aeea4d6da.png)

Fixes #1088
