### PR TITLE
[Bugfix] Hotfix for the sound loop issue

### DIFF
--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -156,6 +156,8 @@ bool compareByAudibility(std::pair<int, float> a, std::pair<int, float> b)
 // called when the camera moves
 void SoundManager::recomputeAllSources()
 {
+	// Creates this issue: https://github.com/RigsOfRods/rigs-of-rods/issues/1054
+#if 0
 	if (!audio_device) return;
 
 	for (int i=0; i < audio_buffers_in_use_count; i++)
@@ -191,6 +193,7 @@ void SoundManager::recomputeAllSources()
 			}
 		}
 	}
+#endif
 }
 
 void SoundManager::recomputeSource(int source_index, int reason, float vfl, Vector3 *vvec)


### PR DESCRIPTION
Fixes: #1054

Trivia: `recomputeAllSources()` used to be dead code until it was fixed in this commit: https://github.com/RigsOfRods/rigs-of-rods/commit/491c3ddbc35922f1729b4dbc830c9b35218eeafc Hence, it should not be a problem to disable it until we overwork the audio system.