### PR TITLE
[Bugfix] Proper destruction of inter-truck-beams

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4008,7 +4008,13 @@ void Beam::tieToggle(int group)
 			it->beam->p2 = &nodes[0];
 			it->beam->p2truck = false;
 			it->beam->disabled = true;
-			removeInterTruckBeam(it->beam);
+			if (it->locked_truck != this)
+			{
+				removeInterTruckBeam(it->beam);
+				// update skeletonview on the untied truck
+				it->locked_truck->m_request_skeletonview_change = -1;
+			}
+			it->locked_truck = nullptr;
 		}
 	}
 
@@ -4061,6 +4067,7 @@ void Beam::tieToggle(int group)
 					// enable the beam and visually display the beam
 					it->beam->disabled = false;
 					// now trigger the tying action
+					it->locked_truck = shtruck;
 					it->beam->p2 = shorter;
 					it->beam->p2truck = shtruck != 0;
 					it->beam->stress = 0;
@@ -4069,7 +4076,12 @@ void Beam::tieToggle(int group)
 					it->tying = true;
 					it->lockedto = locktedto;
 					it->lockedto->in_use = true;
-					addInterTruckBeam(it->beam, this, shtruck);
+					if (shtruck != this)
+					{
+						addInterTruckBeam(it->beam, this, shtruck);
+						// update skeletonview on the tied truck
+						shtruck->m_request_skeletonview_change = m_skeletonview_is_active ? 1 : -1;
+					}
 				}
 			}
 		}

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1583,10 +1583,6 @@ void Beam::SyncReset()
 
 	for (std::vector <hook_t>::iterator it = hooks.begin(); it != hooks.end(); it++)
 	{
-		if (it->lockTruck)
-		{
-			it->lockTruck->hideSkeleton(true);
-		}
 		it->beam->disabled = true;
 		it->locked        = UNLOCKED;
 		it->lockNode      = 0;
@@ -3836,7 +3832,7 @@ void Beam::setMeshWireframe(SceneNode *node, bool value)
 	}
 }
 
-void Beam::setBeamVisibility(bool visible, bool linked)
+void Beam::setBeamVisibility(bool visible)
 {
 	for (int i=0; i < free_beam; i++)
 	{
@@ -3847,18 +3843,9 @@ void Beam::setBeamVisibility(bool visible, bool linked)
 	}
 
 	beamsVisible = visible;
-
-	if (linked)
-	{
-		// apply to the locked truck
-		for (std::list<Beam*>::iterator it = linkedBeams.begin(); it != linkedBeams.end(); ++it)
-		{
-			(*it)->setBeamVisibility(visible, false);
-		}
-	}
 }
 
-void Beam::setMeshVisibility(bool visible, bool linked)
+void Beam::setMeshVisibility(bool visible)
 {
 	for (int i=0; i < free_prop; i++)
 	{
@@ -3890,15 +3877,6 @@ void Beam::setMeshVisibility(bool visible, bool linked)
 	}
 
 	meshesVisible = visible;
-
-	if (linked)
-	{
-		// apply to the locked truck
-		for (std::list<Beam*>::iterator it = linkedBeams.begin(); it != linkedBeams.end(); ++it)
-		{
-			(*it)->setMeshVisibility(visible, false);
-		}
-	}
 }
 
 void Beam::cabFade(float amount)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -646,8 +646,12 @@ protected:
 
 	bool high_res_wheelnode_collisions;
 
-	void addInterTruckBeam(beam_t* beam);
+	void addInterTruckBeam(beam_t* beam, Beam* a, Beam* b);
 	void removeInterTruckBeam(beam_t* beam);
+	/**
+	* Destroys all inter truck beams which are connected with this truck
+	*/
+	void disjoinInterTruckBeams();
 
 	// this is for managing the blinkers on the truck:
 	blinktype blinkingtype;

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -506,19 +506,17 @@ public:
 
 	/**
 	* Sets visibility of all beams on this vehicle
-	* @param visible Toggle
-	* @param linked Apply to linked vehicles also?
+	* @param visibility
 	*/
-	void setBeamVisibility(bool visible, bool linked=true);
+	void setBeamVisibility(bool visible);
 
 	bool beamsVisible; //!< Are beams visible? @see setBeamVisibility
 
 	/**
 	* Sets visibility of all meshes on this vehicle
-	* @param visible Toggle
-	* @param linked Apply to linked vehicles also?
+	* @param visibility
 	*/
-	void setMeshVisibility(bool visible, bool linked=true);
+	void setMeshVisibility(bool visible);
 
 	bool meshesVisible; //!< Are meshes visible? @see setMeshVisibility
 

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -339,7 +339,7 @@ struct ropable_t
 	node_t *node;
 	int group;
 	bool multilock;
-	int used;
+	bool in_use;
 };
 
 struct rope_t

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -355,6 +355,7 @@ struct rope_t
 
 struct tie_t
 {
+	Beam* locked_truck;
 	beam_t *beam;
 	ropable_t *lockedto;
 	int group;

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -155,6 +155,9 @@ public:
 
 	void SyncWithSimThread();
 
+	// A list of all beams interconnecting two trucks
+	std::map<beam_t*, std::pair<Beam*, Beam*>> interTruckLinks;
+
 protected:
 
 	int CreateRemoteInstance(stream_register_trucks_t *reg);

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1800,7 +1800,7 @@ void Beam::calcHooks()
 				it->beam->p2truck  = it->lockTruck != 0;
 				it->beam->L = (it->hookNode->AbsPosition - it->lockNode->AbsPosition).length();
 				it->beam->disabled = false;
-				addInterTruckBeam(it->beam);
+				addInterTruckBeam(it->beam, this, it->lockTruck);
 			} else
 			{
 				if (it->beam->L < it->beam->commandShort)

--- a/source/main/physics/input_output/RigSpawner.cpp
+++ b/source/main/physics/input_output/RigSpawner.cpp
@@ -2921,7 +2921,7 @@ void RigSpawner::ProcessRopable(RigDef::Ropable & def)
     ropable_t ropable;
 	ropable.node = GetNodePointerOrThrow(def.node);
 	ropable.group = def.group;
-	ropable.used = 0; // Hardcoded in BTS_ROPABLES
+	ropable.in_use = false;
 	ropable.multilock = def.multilock;
 	m_rig->ropables.push_back(ropable);
 }

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -331,7 +331,7 @@ void ScriptEngine::init()
 	result = engine->RegisterObjectMethod("BeamClass", "int getBlinkType()", AngelScript::asMETHOD(Beam,getBlinkType), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 	result = engine->RegisterObjectMethod("BeamClass", "bool getCustomParticleMode()", AngelScript::asMETHOD(Beam,getCustomParticleMode), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 	result = engine->RegisterObjectMethod("BeamClass", "int getLowestNode()", AngelScript::asMETHOD(Beam,getLowestNode), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
-	result = engine->RegisterObjectMethod("BeamClass", "bool setMeshVisibility(bool)", AngelScript::asMETHOD(Beam,setMeshVisibility), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
+	result = engine->RegisterObjectMethod("BeamClass", "bool setMeshVisibility()", AngelScript::asMETHOD(Beam,setMeshVisibility), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 	result = engine->RegisterObjectMethod("BeamClass", "bool getReverseLightVisible()", AngelScript::asMETHOD(Beam,getCustomParticleMode), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 	result = engine->RegisterObjectMethod("BeamClass", "float getHeadingDirectionAngle()", AngelScript::asMETHOD(Beam,getHeadingDirectionAngle), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 	result = engine->RegisterObjectMethod("BeamClass", "bool isLocked()", AngelScript::asMETHOD(Beam,isLocked), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);


### PR DESCRIPTION
* Fixes the handling of inter-truck-beams (hooks and ties) on truck deletion.
* Fixes segfaults and state inconsistencies when trucks are removed or reset while they are hooked or tied to other trucks
* Fixes: #498

Side-effect: Skeleton view changes are now properly propagated through all interconnected trucks.