### PR TITLE
[Bugfix] Fixes 'set_node_defaults' options parsing

### DIFF
--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -1396,16 +1396,16 @@ void Parser::ParseDirectiveSetNodeDefaults()
     m_user_node_defaults->volume      = (volume      < 0) ? m_ror_node_defaults->volume      : volume;
     m_user_node_defaults->surface     = (surface     < 0) ? m_ror_node_defaults->surface     : surface;
 
-    if (!opt_str.empty())
-    {
-        this->_ParseNodeOptions(m_user_node_defaults->options, opt_str);
-    }
+    this->_ParseNodeOptions(m_user_node_defaults->options, opt_str);
+
     this->LogParsedDirectiveSetNodeDefaultsData(
         load_weight, friction, volume, surface, m_user_node_defaults->options);
 }
 
 void Parser::_ParseNodeOptions(unsigned int & options, const std::string & options_str)
 {
+	options = 0;
+
     for (unsigned int i = 0; i < options_str.length(); i++)
     {
         const char c = options_str.at(i);


### PR DESCRIPTION
Reference: https://github.com/only-a-ptr/ror-legacy-svn-trunk/blob/master/source/main/physics/input_output/SerializedRig.cpp#L1290