### PR TITLE
[Bugfix] Fixes broken 'skinzip' selection

### DIFF
--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -707,7 +707,6 @@ void CLASS::OnSelectionDone()
 		m_skin_manager->GetUsableSkins(m_selected_entry->guid, this->m_current_skins);
 		if (!m_current_skins.empty())
 		{
-			Hide();
 			Show(LT_SKIN);
 		}
 		else


### PR DESCRIPTION
The 'skinzip' selector did not show up when closing the selector window by pressing 'Enter'