### PR TITLE
[Bugfix] Fixes conflict between animators and hydros

### DIFF
--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -814,7 +814,7 @@ void Beam::calcForcesEulerCompute(int doUpdate, Real dt, int step, int maxsteps)
 			if (hydroInertia)
 				cstate=hydroInertia->calcCmdKeyDelay(cstate,i,dt);
 
-			if (!(beams[hydro[i]].hydroFlags & HYDRO_FLAG_SPEED))
+			if (!(beams[hydro[i]].hydroFlags & HYDRO_FLAG_SPEED) && !flagstate)
 				hydrodirwheeldisplay=cstate;
 
 			float factor = 1.0-cstate*beams[hydro[i]].hydroRatio;


### PR DESCRIPTION
The steering wheel rotation angle (`hydrodirwheeldisplay`) must not be affected by animators.

Fixes: #1100