### PR TITLE
[Codechange] Recreate old parser behavior

### DIFF
--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -2567,6 +2567,7 @@ void RigSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
 		std::stringstream msg;
 		msg << "Managed material '" << def.name << "' already exists (probably because the vehicle was already spawned before)";
 		AddMessage(Message::TYPE_WARNING, msg.str());
+		return;
 	}
 
 	Ogre::MaterialPtr material;


### PR DESCRIPTION
Skip existing managed materials

Reference: https://github.com/only-a-ptr/ror-legacy-svn-trunk/blob/master/source/main/physics/input_output/SerializedRig.cpp#L4615