### PR TITLE
[Bugfix] Fixes 'ManagedMaterial' string comparison

### DIFF
--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -1433,12 +1433,12 @@ struct ManagedMaterial
 
 	bool HasDamagedDiffuseMap()
 	{
-		return damaged_diffuse_map.length() != 0;
+		return (damaged_diffuse_map.length() != 0 && damaged_diffuse_map[0] != '-');
 	}
 
 	bool HasSpecularMap()
 	{
-		return specular_map.length() != 0;
+		return (specular_map.length() != 0 && specular_map[0] != '-');
 	}
 };
 


### PR DESCRIPTION
Reference: https://github.com/only-a-ptr/ror-legacy-svn-trunk/blob/master/source/main/physics/input_output/SerializedRig.cpp#L4635