### PR TITLE
[Bugfix] Dashboard frozen after map switch

### DIFF
--- a/source/main/gui/Dashboard.cpp
+++ b/source/main/gui/Dashboard.cpp
@@ -72,6 +72,7 @@ Dashboard::Dashboard() :
 Dashboard::~Dashboard()
 {
 	gEnv->sceneManager->destroyCamera("DashCam");
+    Ogre::TextureManager::getSingleton().remove("dashtexture");
 }
 
 void Dashboard::setEnable(bool en)


### PR DESCRIPTION
Problem: duplicate RTT texture "dashtexture". It's strange that OGRE didn't complain when re-creating texture with the same name.

Fixes #1148