### PR TITLE
[Work in Progress] Fixes 'Globals' parsing in some cases

### DIFF
--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -159,6 +159,7 @@ void Parser::ProcessCurrentLine()
 
             case (File::KEYWORD_AUTHOR):
                 ParseAuthor();
+                new_section = File::SECTION_NONE;
                 line_finished = true;
                 break;
 
@@ -309,11 +310,13 @@ void Parser::ProcessCurrentLine()
                     AddMessage(line, Message::TYPE_WARNING, "Inline section 'fileformatversion' has global effect and should not appear in a module");
                 }
                 ParseFileFormatVersion();
+                new_section = File::SECTION_NONE;
                 line_finished = true;
                 break;
 
             case (File::KEYWORD_FILEINFO):
                 ParseFileinfo();
+                new_section = File::SECTION_NONE;
                 line_finished = true;
                 break;
 


### PR DESCRIPTION
Fixes parsing of [`WTJ REALdmg COMP no FT.truck`](https://www.dropbox.com/s/0kazidh61bzyd5u/TJ_s_WTJ__V5.zip?dl=1).

Truck file contents:
```
globals
150, 10000.0, invis

fileinfo -1, 162, 2

fileformatversion 3

ddescription
wrangler TJ
```

Error message:
```
ERROR (Section globals)
Line (15): wrangler TJ
Message: Argument [1] ("wrangler") is not valid float
```

**I think we need a different solution**