### PR TITLE
[Bugfix] Fixes SelectorWindow loop on some maps

### DIFF
--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -53,6 +53,8 @@ public:
 
 	void move(Ogre::Vector3 offset);
 
+	void unwindMovement(float distance);
+
 	void update(float dt);
 	void updateCharacterColour();
 	void updateCharacterRotation();
@@ -91,7 +93,7 @@ protected:
 	Ogre::String mLastAnimMode;
 	Ogre::String myName;
 	Ogre::UTFString networkUsername;
-	Ogre::Vector3 mLastPosition;
+	std::deque<Ogre::Vector3> mLastPosition;
 
 	void setAnimationMode(Ogre::String mode, float time=0);
 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1317,6 +1317,9 @@ bool RoRFrameListener::updateEvents(float dt)
 					Beam *local_truck = BeamFactory::getSingleton().CreateLocalRigInstance(m_reload_pos, m_reload_dir, selection->fname, selection->number, m_reload_box, false, config_ptr, skin);
 
 					finalizeTruckSpawning(local_truck, current_truck);
+				} else if (gEnv->player)
+				{
+					gEnv->player->unwindMovement(0.1f);
 				}
 
 				m_reload_box = 0;


### PR DESCRIPTION
* Avoids getting stuck in the vehicle selector window when you cancel it

This moves the character back to where he was before he entered the collision box that triggers the vehicle selection.