### PR TITLE
[Bugfix] Fix buffer overflow crash

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -5102,7 +5102,7 @@ void Beam::updateDashBoards(float dt)
 			float alt = nodes[0].AbsPosition.y * 1.1811f; // MAGIC
 			dash->setFloat(DD_ALTITUDE, alt);
 
-			char altc[10];
+			char altc[11];
 			sprintf(altc, "%03u", (int)(nodes[0].AbsPosition.y / 30.48f)); // MAGIC
 			dash->setChar(DD_ALTITUDE_STRING, altc);
 		}


### PR DESCRIPTION
The game was often crashing with:

*** buffer overflow detected ***: /home/pp/rigs-of-rods/install/bin/RoR terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x790cb)[0x7f971d3a30cb]
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x54)[0x7f971d4442c4]
/lib/x86_64-linux-gnu/libc.so.6(+0x118240)[0x7f971d442240]
/lib/x86_64-linux-gnu/libc.so.6(+0x1177f9)[0x7f971d4417f9]
/lib/x86_64-linux-gnu/libc.so.6(_IO_default_xsputn+0xa9)[0x7f971d3a7a09]
/lib/x86_64-linux-gnu/libc.so.6(_IO_vfprintf+0xcda)[0x7f971d3785aa]
/lib/x86_64-linux-gnu/libc.so.6(__vsprintf_chk+0x84)[0x7f971d441884]
/lib/x86_64-linux-gnu/libc.so.6(__sprintf_chk+0x7d)[0x7f971d4417dd]
/home/pp/rigs-of-rods/install/bin/RoR(_ZN4Beam16updateDashBoardsEf+0x11f1)[0x558165626261]
/home/pp/rigs-of-rods/install/bin/RoR(_ZN4Beam11calcNetworkEv+0xbe7)[0x558165628ed7]
/home/pp/rigs-of-rods/install/bin/RoR(_ZN11BeamFactory6updateEf+0x22c)[0x558165643c6c]
/home/pp/rigs-of-rods/install/bin/RoR(_ZN16RoRFrameListener12frameStartedERKN4Ogre10FrameEventE+0x470)[0x5581654a4170]
/home/pp/rigs-of-rods/install/lib/libOgreMain.so.1.9.0(_ZN4Ogre4Root17_fireFrameStartedERNS_10FrameEventE+0x5c)[0x7f97204158cc]
/home/pp/rigs-of-rods/install/lib/libOgreMain.so.1.9.0(_ZN4Ogre4Root17_fireFrameStartedEv+0x31)[0x7f9720415ea1]
/home/pp/rigs-of-rods/install/lib/libOgreMain.so.1.9.0(_ZN4Ogre4Root14renderOneFrameEv+0x9)[0x7f9720416009]
/home/pp/rigs-of-rods/install/bin/RoR(_ZN3RoR10MainThread17EnterGameplayLoopEv+0x19e)[0x55816546941e]
/home/pp/rigs-of-rods/install/bin/RoR(_ZN3RoR10MainThread2GoEv+0xa82)[0x55816546ee72]
/home/pp/rigs-of-rods/install/bin/RoR(main+0x25d)[0x5581654529dd]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1)[0x7f971d34a3f1]
/home/pp/rigs-of-rods/install/bin/RoR(_start+0x2a)[0x55816546609a]

_ZN4Beam16updateDashBoardsEf+0x11f1 is in source/main/physics/Beam.cpp:

5105: char altc[10];
5106: sprintf(altc, "%03u", (int)(nodes[0].AbsPosition.y / 30.48f)); // MAGIC

The largest int has 10 digits, so the terminating NULL overflows the buffer.