### PR TITLE
Fixed compiler warnings and undefined operation

### DIFF
--- a/source/main/gui/TruckHUD.cpp
+++ b/source/main/gui/TruckHUD.cpp
@@ -408,7 +408,7 @@ bool TruckHUD::update(float dt, Beam* truck, bool visible)
         }
 
         // hide command section title if no commands
-        overlayElement = overlayElement = OverlayManager::getSingleton().getOverlayElement("tracks/TruckInfoBox/CommandsTitleLabel");
+        overlayElement = OverlayManager::getSingleton().getOverlayElement("tracks/TruckInfoBox/CommandsTitleLabel");
         overlayElement->setCaption("");
         if (filledCommands > 0)
         {

--- a/source/main/gui/panels/GUI_DebugOptions.cpp
+++ b/source/main/gui/panels/GUI_DebugOptions.cpp
@@ -228,7 +228,7 @@ void CLASS::SaveConfig()
     // now save the GameSettingsMap
     for (it = DebugOptionsMap.begin(); it != DebugOptionsMap.end(); it++)
     {
-        if (it->first.c_str() == "User Token" || it->first.c_str() == "User Token Hash")
+        if (it->first == "User Token" || it->first == "User Token Hash")
             return;
 
         Settings::getSingleton().setSetting(it->first.c_str(), it->second.c_str()); //Avoid restarting the game in few cases.

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -62,6 +62,7 @@
 #endif // USE_MYGUI
 
 #include <algorithm>
+#include <cstring>
 
 using namespace Ogre;
 
@@ -100,9 +101,9 @@ unsigned int getNumberOfCPUCores()
     // Get CPU vendor
     char vendor[12];
     cpuID(0, regs);
-    ((unsigned *)vendor)[0] = regs[1]; // EBX
-    ((unsigned *)vendor)[1] = regs[3]; // EDX
-    ((unsigned *)vendor)[2] = regs[2]; // ECX
+    memcpy((void *)vendor,     (void *)&regs[1], 4); // EBX
+    memcpy((void *)&vendor[4], (void *)&regs[3], 4); // EDX
+    memcpy((void *)&vendor[8], (void *)&regs[2], 4); // ECX
     std::string cpuVendor = std::string(vendor, 12);
 
     // Get CPU features

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1717,9 +1717,9 @@ void Beam::calcNodes(int doUpdate, Ogre::Real dt, int step, int maxsteps)
             {
                 float ns = 0;
                 ground_model_t* gm = 0; // this is used as result storage, so we can use it later on
-                bool contacted = false;
+                bool contacted = gEnv->collisions->groundCollision(&nodes[i], nodes[i].collTestTimer, &gm, &ns);
                 // reverted this construct to the old form, don't mess with it, the binary operator is intentionally!
-                if ((contacted = gEnv->collisions->groundCollision(&nodes[i], nodes[i].collTestTimer, &gm, &ns)) | gEnv->collisions->nodeCollision(&nodes[i], contacted, nodes[i].collTestTimer, &ns, &gm))
+                if (contacted | gEnv->collisions->nodeCollision(&nodes[i], contacted, nodes[i].collTestTimer, &ns, &gm))
                 {
                     // FX
                     if (gm && doUpdate && !nodes[i].disable_particles)


### PR DESCRIPTION
When building for openSUSE I discovered some warnings (one of them is considered an error by RPMLint).

**First kind of warning:**
> I: Program causes undefined operation
>    (likely same variable used twice and post/pre incremented in the same expression).
>    e.g. x = x++; Split it in two operations.
> W: rigsofrods sequence-point

Triggered by:

1. `TruckHUD.cpp`: It is not defined which value `overlayElement` should have after the `=`.
(Because it is not defined which `=` should be done first).
2. `BeamForcesEuler.cpp`, same kind of issue: It is not defined which should be executed first so `contacted` might be set by `(contacted = ... )` before the  code at the right side of the `|` operator is executed, or it might be executed after that part so the right side can result in two different solutions.

**Second kind of warning (considered an error by RPMLint):**
> I: Expression compares a char* pointer with a string literal.
>    Usually a strcmp() was intended by the programmer
> E: rigsofrods stringcompare

Triggered by `GUI_DebugOptions.cpp`: I think this is clear, here are two pointers be compared which will in this case be always false, I think it was meant to compare the content of the strings so simply remove the c_str() call.

**Third kind of warning:**
> I: Program is likely to break with new gcc. Try -fno-strict-aliasing.
> W: rigsofrods strict-aliasing-punning

Triggered by `BeamFactory.cpp`: [If strict aliasing punning is not clear ](https://blog.qt.io/blog/2011/06/10/type-punning-and-strict-aliasing/). Not sure if this is the best fix, but I think the code readability should not be affected by this fix.