### PR TITLE
Buildsystem allow reproducible builds

### DIFF
--- a/cmake/GenerateVersionInfo.cmake
+++ b/cmake/GenerateVersionInfo.cmake
@@ -90,6 +90,25 @@ if( BUILD_DEV_VERSION )
 
 endif()
 
+# This whole if and else can replaced, when using cmake >= 3.8 (as it then uses environment variable SOURCE_DATE_EPOCH), with this:
+# STRING(TIMESTAMP BUILD_DATE "%b %d %Y" UTC)
+# STRING(TIMESTAMP BUILD_TIME "%H:%M" UTC)
+if (DEFINED ENV{SOURCE_DATE_EPOCH})
+  execute_process(
+    COMMAND "date" "-u" "-d" "@$ENV{SOURCE_DATE_EPOCH}" "+%b %e %Y"
+    OUTPUT_VARIABLE BUILD_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  execute_process(
+    COMMAND "date" "-u" "-d" "@$ENV{SOURCE_DATE_EPOCH}" "+%R"
+    OUTPUT_VARIABLE BUILD_TIME
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+else ()
+  string(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC) # more correct would be "%b %d %Y" but this is only supported from cmake >= 3.7
+  string(TIMESTAMP BUILD_TIME "%H:%M" UTC)
+endif ()
+
 # Fill in the actual version information in the provided template
 configure_file( ${VERSION_FILE_INPUT} ${VERSION_FILE_OUTPUT} @ONLY )
 

--- a/source/configurator/Configurator.cpp
+++ b/source/configurator/Configurator.cpp
@@ -791,7 +791,7 @@ MyDialog::MyDialog(const wxString& title) : wxDialog(NULL, wxID_ANY, title,  wxP
     dText = new wxStaticText(aboutPanel, -1, wxString::Format(_("Network Protocol version: %s"), wxString(RORNET_VERSION, wxConvUTF8).c_str()), wxPoint(x_row1 + 15, y));
     y += dText->GetSize().GetHeight() + 2;
 
-    dText = new wxStaticText(aboutPanel, -1, wxString::Format(_("Build time: %s, %s"), wxT(__DATE__), wxT(__TIME__)), wxPoint(x_row1 + 15, y));
+    dText = new wxStaticText(aboutPanel, -1, wxString::Format(_("Build time: %s, %s"), ROR_BUILD_DATE, ROR_BUILD_TIME), wxPoint(x_row1 + 15, y));
     y += dText->GetSize().GetHeight() + 2;
 
 

--- a/source/main/gui/panels/GUI_GameAbout.cpp
+++ b/source/main/gui/panels/GUI_GameAbout.cpp
@@ -50,7 +50,7 @@ CLASS::CLASS()
     m_backbtn->eventMouseButtonClick += MyGUI::newDelegate(this, &CLASS::eventMouseButtonClickBackButton);
     m_ror_version->setCaption(Ogre::String(ROR_VERSION_STRING));
     m_net_version->setCaption(Ogre::String(RORNET_VERSION));
-    m_build_time->setCaption(Ogre::String(__DATE__) + ", " + Ogre::String(__TIME__));
+    m_build_time->setCaption(Ogre::String(ROR_BUILD_DATE) + ", " + Ogre::String(ROR_BUILD_TIME));
 
     initMisc();
     CenterToScreen();

--- a/source/main/gui/panels/GUI_GameConsole.cpp
+++ b/source/main/gui/panels/GUI_GameConsole.cpp
@@ -379,7 +379,7 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, "Rigs of Rods:", "information.png");
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " Version: " + String(ROR_VERSION_STRING), "information.png");
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " Protocol version: " + String(RORNET_VERSION), "information.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " build time: " + String(__DATE__) + ", " + String(__TIME__), "information.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " build time: " + String(ROR_BUILD_DATE) + ", " + String(ROR_BUILD_TIME), "information.png");
             return;
         }
         else if (args[0] == "/quit")

--- a/source/main/utils/PlatformUtils.cpp
+++ b/source/main/utils/PlatformUtils.cpp
@@ -151,8 +151,8 @@ void InstallCrashRpt()
 
     crAddProperty("Version", ROR_VERSION_STRING);
     crAddProperty("protocol_version", RORNET_VERSION);
-    crAddProperty("build_date", __DATE__);
-    crAddProperty("build_time", __TIME__);
+    crAddProperty("build_date", ROR_BUILD_DATE);
+    crAddProperty("build_time", ROR_BUILD_TIME);
 
     crAddProperty("System_GUID", SSETTING("GUID", "None").c_str());
     crAddProperty("Multiplayer", RoR::App::GetActiveMpState() ? "1" : "0");

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -133,11 +133,11 @@ String getVersionString(bool multiline)
             " version: %s\n"
             " protocol version: %s\n"
             " build time: %s, %s\n"
-            , ROR_VERSION_STRING, RORNET_VERSION, __DATE__, __TIME__);
+            , ROR_VERSION_STRING, RORNET_VERSION, ROR_BUILD_DATE, ROR_BUILD_TIME);
     }
     else
     {
-        sprintf(tmp, "Rigs of Rods version %s, protocol version: %s, build time: %s, %s", ROR_VERSION_STRING, RORNET_VERSION, __DATE__, __TIME__);
+        sprintf(tmp, "Rigs of Rods version %s, protocol version: %s, build time: %s, %s", ROR_VERSION_STRING, RORNET_VERSION, ROR_BUILD_DATE, ROR_BUILD_TIME);
     }
 
     return String(tmp);

--- a/source/version_info/RoRVersion.cpp.in
+++ b/source/version_info/RoRVersion.cpp.in
@@ -5,4 +5,5 @@
 
 const char* const ROR_VERSION_STRING_SHORT = "@VERSION_MAJOR@.@VERSION_MINOR@";
 const char* const ROR_VERSION_STRING       = "@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@.@VERSION_TWEAK@@VERSION_SUFFIX@";
-
+const char* const ROR_BUILD_DATE           = "@BUILD_DATE@";
+const char* const ROR_BUILD_TIME           = "@BUILD_TIME@";

--- a/source/version_info/RoRVersion.h
+++ b/source/version_info/RoRVersion.h
@@ -22,3 +22,5 @@ along with Rigs of Rods.  If not, see <http://www.gnu.org/licenses/>.
 
 extern const char* const ROR_VERSION_STRING_SHORT;
 extern const char* const ROR_VERSION_STRING;
+extern const char* const ROR_BUILD_DATE;
+extern const char* const ROR_BUILD_TIME;


### PR DESCRIPTION
Use [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/) environment variable if available to force build date and time.

This allows packagers to override `__DATE__` and `__TIME__` to make the build deterministic (build of same source will result in same binary), for more information please have look at:
https://reproducible-builds.org/