### PR TITLE
Terrn2: 2 new options

### DIFF
--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -188,6 +188,7 @@ set(SOURCE_FILES
         physics/water/ScrewProp.{h,cpp}
         resources/CacheSystem.{h,cpp}
         resources/ContentManager.{h,cpp}
+        resources/otc_fileformat/OTCFileformat.{h,cpp}
         resources/rig_def_fileformat/RigDef_File.{h,cpp}
         resources/rig_def_fileformat/RigDef_Node.{h,cpp}
         resources/rig_def_fileformat/RigDef_Parser.{h,cpp}
@@ -318,6 +319,7 @@ target_include_directories(${BINNAME} PRIVATE
         physics/utils
         physics/water
         resources
+        resources/otc_fileformat/
         resources/rig_def_fileformat
         resources/terrn2_fileformat
         rig_editor

--- a/source/main/gui/panels/GUI_TeleportWindow.cpp
+++ b/source/main/gui/panels/GUI_TeleportWindow.cpp
@@ -168,7 +168,10 @@ void TeleportWindow::SetupMap(RoRFrameListener* sim_controller, Terrn2Def* def, 
 {
     m_sim_controller = sim_controller;
     m_map_size = map_size;
-    m_minimap_image->setImageTexture(minimap_tex_name);
+    if (!def->teleport_map_image.empty())
+        m_minimap_image->setImageTexture(def->teleport_map_image);
+    else
+        m_minimap_image->setImageTexture(minimap_tex_name);
     m_info_textbox->setCaption(HELPTEXT_USAGE);
     m_info_textbox->setTextColour(HELPTEXT_COLOR_USAGE);
 

--- a/source/main/resources/otc_fileformat/OTCFileformat.cpp
+++ b/source/main/resources/otc_fileformat/OTCFileformat.cpp
@@ -1,0 +1,197 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2016-2017 Petr Ohlidal & contributors
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+/// @author Petr Ohlidal, 11/2016
+
+#include "OTCFileformat.h"
+#include "ConfigFile.h"
+#include "Utils.h"
+#include "BeamConstants.h"
+#include "RoRPrerequisites.h"
+
+#include <OgreException.h>
+
+#include <algorithm>
+
+bool RoR::OTCParser::LoadMasterConfig(Ogre::DataStreamPtr &ds, const char* filename)
+{
+    std::string file_basename, file_ext;
+    Ogre::StringUtil::splitBaseFilename(filename, file_basename, file_ext);
+    RoR::ConfigFile cfg;
+    try
+    {
+        cfg.load(ds, "\t:=", false);
+        m_def = std::make_shared<RoR::OTCFile>();
+
+        m_def->disable_cache           = cfg.GetBool  ("disableCaching",  false);
+        m_def->world_size_x            = cfg.GetInt   ("WorldSizeX",      1024);
+        m_def->world_size_y            = cfg.GetInt   ("WorldSizeY",      50);
+        m_def->world_size_z            = cfg.GetInt   ("WorldSizeZ",      1024);
+        m_def->page_size               = cfg.GetInt   ("PageSize",        1025);
+        m_def->pages_max_x             = cfg.GetInt   ("PagesX",          0);
+        m_def->pages_max_z             = cfg.GetInt   ("PagesZ",          0);
+        m_def->page_filename_format    = cfg.GetString("PageFileFormat",  file_basename + "-page-{X}-{Z}.otc");
+        m_def->is_flat                 = cfg.GetBool  ("Flat",            false);
+        m_def->max_pixel_error         = cfg.GetInt   ("MaxPixelError",   5);
+        m_def->batch_size_min          = cfg.GetInt   ("minBatchSize",    33);
+        m_def->batch_size_max          = cfg.GetInt   ("maxBatchSize",    65);
+        m_def->lightmap_enabled        = cfg.GetBool  ("LightmapEnabled",            false);
+        m_def->norm_map_enabled        = cfg.GetBool  ("NormalMappingEnabled",       false);
+        m_def->spec_map_enabled        = cfg.GetBool  ("SpecularMappingEnabled",     false);
+        m_def->parallax_enabled        = cfg.GetBool  ("ParallaxMappingEnabled",     false);
+        m_def->blendmap_dbg_enabled    = cfg.GetBool  ("DebugBlendMaps",             false);
+        m_def->global_colormap_enabled = cfg.GetBool  ("GlobalColourMapEnabled",     false);
+        m_def->recv_dyn_shadows_depth  = cfg.GetBool  ("ReceiveDynamicShadowsDepth", false);
+        m_def->composite_map_distance  = cfg.GetInt   ("CompositeMapDistance",       4000);
+        m_def->layer_blendmap_size     = cfg.GetInt   ("LayerBlendMapSize",          1024);
+        m_def->composite_map_size      = cfg.GetInt   ("CompositeMapSize",           1024);
+        m_def->lightmap_size           = cfg.GetInt   ("LightMapSize",               1024);
+        m_def->skirt_size              = cfg.GetInt   ("SkirtSize",                  30);
+
+        m_def->world_size = std::max(m_def->world_size_x, m_def->world_size_z);
+        m_def->origin_pos = Ogre::Vector3(m_def->world_size_x / 2.0f, 0.0f, m_def->world_size_z / 2.0f);
+        m_def->cache_filename_base = file_basename;
+
+        for (int x = 0; x <= m_def->pages_max_x; ++x)
+        {
+            for (int z = 0; z <= m_def->pages_max_z; ++z)
+            {
+                std::string filename = m_def->page_filename_format;
+                filename = Ogre::StringUtil::replaceAll(filename, "{X}", TOSTRING(x));
+                filename = Ogre::StringUtil::replaceAll(filename, "{Z}", TOSTRING(z));
+
+                char base[50], key[75];
+                snprintf(base, 50, "Heightmap.%d.%d", x, z);
+
+                snprintf(key, 75, "%s.raw.size", base);                int raw_size = cfg.GetInt(key, 1025);
+                snprintf(key, 75, "%s.raw.bpp",  base);                int raw_bpp  = cfg.GetInt(key, 2);
+                snprintf(key, 75, "%s.flipX",    base);                bool flip_x  = cfg.GetBool(key, false);
+                snprintf(key, 75, "%s.flipY",    base);                bool flip_y  = cfg.GetBool(key, false);
+
+                m_def->pages.emplace_back(x, z, filename, flip_x, flip_y, raw_size, raw_bpp);
+            }
+        }
+    }
+    catch (...)
+    {
+        this->HandleException(filename);
+        return false;
+    }
+    return true;
+}
+
+bool RoR::OTCParser::LoadPageConfig(Ogre::DataStreamPtr &ds, RoR::OTCPage& page, const char* filename)
+{
+    const int LINE_BUF_LEN = 4000;
+    char line_buf[LINE_BUF_LEN];
+    try
+    {
+        ds->readLine(line_buf, LINE_BUF_LEN);
+        page.heightmap_filename = RoR::Utils::SanitizeUtf8CString(line_buf);
+        RoR::Utils::TrimStr(page.heightmap_filename);
+
+        ds->readLine(line_buf, LINE_BUF_LEN);
+        page.num_layers = PARSEINT(line_buf);
+
+        while (!ds->eof())
+        {
+            size_t len = ds->readLine(line_buf, LINE_BUF_LEN);
+            if (len == 0 || line_buf[0] == ';' || line_buf[0] == '/') { continue; }
+
+            std::string line_sane = RoR::Utils::SanitizeUtf8String(std::string(line_buf));
+            Ogre::StringVector args = Ogre::StringUtil::split(line_sane, ",");
+            if (args.size() < 3)
+            {
+                LOG(std::string("[RoR|Terrain] Invalid OTC page config: [") + filename + "]");
+                return false;
+            }
+
+            OTCLayer layer;
+            layer.world_size               = PARSEREAL(args[0]);
+            layer.diffusespecular_filename = Utils::TrimStr(args[1]);
+            layer.normalheight_filename    = Utils::TrimStr(args[2]);
+            if (args.size() > 3)
+            {
+                layer.blendmap_filename = Utils::TrimStr(args[3]);
+            }
+            if (args.size() > 4)
+            {
+                layer.blend_mode = Utils::TrimStr(args[4])[0];
+            }
+            if (args.size() > 5)
+            {
+                layer.alpha = PARSEREAL(args[5]);
+            }
+
+            page.layers.push_back(layer);
+        }
+
+        if (page.heightmap_filename.find(".raw") != std::string::npos)
+        {
+            page.is_heightmap_raw = true;
+        }
+    }
+    catch (...)
+    {
+        this->HandleException(filename);
+        return false;
+    }
+    page.was_pageconf_parsed = true;
+    return true;
+}
+
+void RoR::OTCParser::HandleException(const char* filename)
+{
+    try { throw; } // Rethrow
+    catch (Ogre::Exception& e)
+    {
+        LOG(std::string("[RoR|Terrain] Error reading OTC file '") + filename + "', message: " + e.getFullDescription());
+    }
+    catch (std::exception& e)
+    {
+        LOG(std::string("[RoR|Terrain] Error reading OTC file '") + filename + "', Message: " + e.what());
+    }
+}
+
+RoR::OTCFile::OTCFile():
+    world_size_x(0), world_size_y(0), world_size_z(0), world_size(0),
+    page_size(0), pages_max_x(0), pages_max_z(0),
+    origin_pos(Ogre::Vector3::ZERO),
+    batch_size_min(0), batch_size_max(0),
+    layer_blendmap_size(0), max_pixel_error(0), composite_map_size(0), composite_map_distance(0),
+    skirt_size(0), lightmap_size(0),
+    lightmap_enabled(false), norm_map_enabled(false), spec_map_enabled(false), parallax_enabled(false),
+    global_colormap_enabled(false), recv_dyn_shadows_depth(false), disable_cache(false), is_flat(true)
+{
+}
+
+RoR::OTCPage::OTCPage(int x_pos, int z_pos, std::string const & conf_filename, bool flipX, bool flipY, int rawsize, int rawbpp):
+    pageconf_filename(conf_filename),
+    was_pageconf_parsed(false),
+    pos_x(x_pos), pos_z(z_pos),
+    is_heightmap_raw(false), raw_flip_x(flipX), raw_flip_y(flipY),
+    raw_size(rawsize), raw_bpp(rawbpp)
+{}
+
+RoR::OTCLayer::OTCLayer():
+    blend_mode('R'),
+    alpha(static_cast<float>('R')) // Backwards compatibility, probably old typo
+{
+}

--- a/source/main/resources/otc_fileformat/OTCFileformat.h
+++ b/source/main/resources/otc_fileformat/OTCFileformat.h
@@ -1,0 +1,107 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2016-2017 Petr Ohlidal & contributors
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/// @file
+/// @author Petr Ohlidal, 11/2016
+
+#include <OgreColourValue.h>
+#include <OgreDataStream.h>
+#include <OgreVector3.h>
+
+#include <string>
+#include <list>
+#include <memory>
+
+namespace RoR {
+
+struct OTCLayer
+{
+    OTCLayer();
+
+    std::string  blendmap_filename;
+    std::string  diffusespecular_filename;
+    std::string  normalheight_filename;
+    char         blend_mode;
+    float        alpha;
+    float        world_size;
+};
+
+struct OTCPage
+{
+    OTCPage(int pos_x, int pos_z, std::string const & conf_filename, bool flipX, bool flipY, int rawsize, int rawbpp);
+
+    std::string  pageconf_filename;
+    std::string  heightmap_filename;
+    bool         was_pageconf_parsed;
+    int          num_layers;
+    int          pos_x, pos_z;
+    bool         is_heightmap_raw, raw_flip_x, raw_flip_y;
+    int          raw_size, raw_bpp;
+
+    std::list<OTCLayer> layers;
+};
+
+/// Rembember OGRE coordinates are {X = right/left, Y = up/down, Z = front/back}
+struct OTCFile
+{
+    OTCFile();
+
+    std::string        page_filename_format;
+    std::string        cache_filename_base;
+    std::list<OTCPage> pages;
+    Ogre::Vector3      origin_pos;
+
+    int          world_size_x, world_size_y, world_size_z;
+    int          page_size;
+    int          world_size;
+    int          pages_max_x, pages_max_z; ///< Highest page index
+    int          max_pixel_error;
+    int          batch_size_min, batch_size_max;
+    int          layer_blendmap_size;
+    int          composite_map_size;
+    int          composite_map_distance;
+    int          skirt_size;
+    int          lightmap_size;
+    bool         lightmap_enabled;
+    bool         norm_map_enabled;
+    bool         spec_map_enabled;
+    bool         parallax_enabled;
+    bool         global_colormap_enabled;
+    bool         recv_dyn_shadows_depth;
+    bool         blendmap_dbg_enabled;
+    bool         disable_cache;
+    bool         is_flat;
+};
+
+class OTCParser
+{
+public:
+    bool                      LoadMasterConfig(Ogre::DataStreamPtr &ds, const char* filename);
+    bool                      LoadPageConfig(Ogre::DataStreamPtr &ds, OTCPage& page, const char* filename);
+    std::shared_ptr<OTCFile>  GetDefinition() { return m_def; };
+
+private:
+    void                      HandleException(const char* filename);
+
+    std::shared_ptr<OTCFile>  m_def;
+};
+
+} // namespace RoR

--- a/source/main/resources/terrn2_fileformat/Terrn2Fileformat.cpp
+++ b/source/main/resources/terrn2_fileformat/Terrn2Fileformat.cpp
@@ -125,9 +125,11 @@ bool Terrn2Parser::LoadTerrn2(Terrn2Def& def, Ogre::DataStreamPtr &ds)
 
 void Terrn2Parser::ProcessTeleport(Terrn2Def& def, RoR::ConfigFile* file)
 {
+    def.teleport_map_image = file->GetStringEx("NavigationMapImage", "Teleport");
+
     size_t telepoint_number = 1;
     for (;;)
-    {        
+    {
         char key_position [50];
         char key_name     [50];
 

--- a/source/main/resources/terrn2_fileformat/Terrn2Fileformat.cpp
+++ b/source/main/resources/terrn2_fileformat/Terrn2Fileformat.cpp
@@ -67,6 +67,7 @@ bool Terrn2Parser::LoadTerrn2(Terrn2Def& def, Ogre::DataStreamPtr &ds)
     def.traction_map_file    = file.GetStringEx   ("TractionMap",      "General");
     def.water_height         = file.GetFloat      ("WaterLine",        "General");
     def.water_bottom_height  = file.GetFloat      ("WaterBottomLine",  "General");
+    def.custom_material_name = file.GetStringEx   ("CustomMaterial",   "General");
 
     def.start_position       = StringConverter::parseVector3(file.GetStringEx("StartPosition", "General"), Vector3(512.0f, 0.0f, 512.0f));
 

--- a/source/main/resources/terrn2_fileformat/Terrn2Fileformat.h
+++ b/source/main/resources/terrn2_fileformat/Terrn2Fileformat.h
@@ -71,6 +71,7 @@ struct Terrn2Def
     std::string              hydrax_conf_file;
     std::string              traction_map_file;
     std::string              custom_material_name;
+    std::string              teleport_map_image;
 };
 
 class Terrn2Parser

--- a/source/main/resources/terrn2_fileformat/Terrn2Fileformat.h
+++ b/source/main/resources/terrn2_fileformat/Terrn2Fileformat.h
@@ -70,6 +70,7 @@ struct Terrn2Def
     bool                     has_water;
     std::string              hydrax_conf_file;
     std::string              traction_map_file;
+    std::string              custom_material_name;
 };
 
 class Terrn2Parser

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -28,19 +28,20 @@
 #include "TerrainManager.h"
 #include "ShadowManager.h"
 #include "OgreTerrainPSSMMaterialGenerator.h"
+#include "OTCFileformat.h"
 #include "Utils.h"
 
+#include <OgreLight.h>
 #include <OgreTerrainGroup.h>
 
 using namespace Ogre;
+using namespace RoR;
 
 #define XZSTR(X,Z)   String("[") + TOSTRING(X) + String(",") + TOSTRING(Z) + String("]")
 
-TerrainGeometryManager::TerrainGeometryManager(TerrainManager* terrainManager) :
-    m_terrn_disable_caching(false)
-    , mHeightData(nullptr)
+TerrainGeometryManager::TerrainGeometryManager(TerrainManager* terrainManager)
+    : mHeightData(nullptr)
     , m_was_new_geometry_generated(false)
-    , m_terrain_is_flat(true)
     , m_terrain_mgr(terrainManager)
 {
 }
@@ -165,7 +166,7 @@ float TerrainGeometryManager::getHeightAtWorldPosition(float x, float z)
 
 float TerrainGeometryManager::getHeightAt(float x, float z)
 {
-    if (m_terrain_is_flat)
+    if (m_spec->is_flat)
         return 0.0f;
     else
     //return m_ogre_terrain_group->getHeightAtWorldPosition(x, 1000, z);
@@ -181,126 +182,50 @@ Ogre::Vector3 TerrainGeometryManager::getNormalAt(float x, float y, float z, flo
     return down;
 }
 
-void TerrainGeometryManager::loadOgreTerrainConfig(String filename)
-{
-    String ext;
-    Ogre::StringUtil::splitBaseFilename(filename, m_terrn_base_name, ext);
-
-    loadTerrainConfig(filename);
-
-    m_terrn_disable_caching = m_terrain_config.GetBool("m_terrn_disable_caching", false);
-
-    initTerrain();
-}
-
-bool TerrainGeometryManager::loadTerrainConfig(String filename)
+void TerrainGeometryManager::InitTerrain(std::string otc_filename)
 {
     try
     {
-        DataStreamPtr ds_config = ResourceGroupManager::getSingleton().openResource(filename, Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
-        m_terrain_config.load(ds_config, "\t:=", false);
-        return true;
-    }
-    catch (...)
-    {
-        m_terrain_config.clear();
-    }
-    return false;
-}
+        OTCParser otc_parser;
+        DataStreamPtr ds_config = ResourceGroupManager::getSingleton().openResource(otc_filename);
+        otc_parser.LoadMasterConfig(ds_config, otc_filename.c_str());
 
-Ogre::String TerrainGeometryManager::getPageConfigFilename(int x, int z)
-{
-    String cfg = m_pageconf_filename_format;
-
-    cfg = StringUtil::replaceAll(cfg, "{X}", TOSTRING(x));
-    cfg = StringUtil::replaceAll(cfg, "{Z}", TOSTRING(z));
-
-    return cfg;
-}
-
-Ogre::DataStreamPtr TerrainGeometryManager::getPageConfig(int x, int z)
-{
-    String cfg = getPageConfigFilename(x, z);
-
-    try
-    {
-        LOG("loading page config for page " + XZSTR(x,z) + " : " + cfg);
-        DataStreamPtr ds = ResourceGroupManager::getSingleton().openResource(cfg, Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
-
-        if (!ds.isNull() && ds->isReadable())
+        for (OTCPage& page : otc_parser.GetDefinition()->pages)
         {
-            return ds;
+            if (page.pageconf_filename.empty())
+                continue;
+
+            DataStreamPtr ds_page = ResourceGroupManager::getSingleton().openResource(page.pageconf_filename);
+            if (ds_page.isNull() || !ds_page->isReadable())
+            {
+                LOG("[RoR|Terrain] Cannot read file [" + page.pageconf_filename + "].");
+                continue;
+            }
+
+            otc_parser.LoadPageConfig(ds_page, page, page.pageconf_filename.c_str());
         }
+
+        m_spec = otc_parser.GetDefinition();
     }
-    catch (...)
+    catch(...) // Error already reported
     {
+        return;
     }
 
-    LOG("error loading page config for page " + XZSTR(x,z) + " : " + cfg);
+    const std::string cache_filename_format = m_spec->cache_filename_base + "_OGRE_" + TOSTRING(OGRE_VERSION) + "_";
 
-    if (x != 0 || z != 0)
-    {
-        LOG("loading default page config: " + cfg + " instead");
-        return getPageConfig(0, 0);
-    }
-
-    return DataStreamPtr();
-}
-
-Ogre::String TerrainGeometryManager::getPageHeightmap(int x, int z)
-{
-    DataStreamPtr ds = getPageConfig(x, z);
-
-    if (ds.isNull())
-        return "";
-
-    char buf[4096];
-    ds->readLine(buf, 4096);
-    return RoR::Utils::SanitizeUtf8String(String(buf));
-}
-
-void TerrainGeometryManager::initTerrain()
-{
-    // X, Y and Z scale
-    m_map_size_x = m_terrain_config.GetInt("WorldSizeX", 1024);
-    m_map_size_y = m_terrain_config.GetInt("WorldSizeY", 50);
-    m_map_size_z = m_terrain_config.GetInt("WorldSizeZ", 1024);
-    m_terrain_page_size = m_terrain_config.GetInt("PageSize", 1025);
-
-    m_terrain_world_size = std::max(m_map_size_x, m_map_size_z);
-
-    int pageMinX = 0;
-    int pageMaxX = m_terrain_config.GetInt("PagesX", 0);
-    int pageMinZ = 0;
-    int pageMaxZ = m_terrain_config.GetInt("PagesZ", 0);
-
-    m_pageconf_filename_format = m_terrain_config.GetString("PageFileFormat", m_terrn_base_name + "-page-{X}-{Z}.otc");
-
-    m_terrain_is_flat = m_terrain_config.GetBool("Flat", false);
-
-    String Filename = m_terrn_base_name + "_OGRE_" + TOSTRING(OGRE_VERSION) + "_";
-
-    m_ogre_terrain_group 
-        = OGRE_NEW Ogre::TerrainGroup(gEnv->sceneManager,
-                                      Terrain::ALIGN_X_Z,
-                                      static_cast<Ogre::uint16>(m_terrain_page_size),
-                                      m_terrain_world_size);
-    m_ogre_terrain_group->setFilenameConvention(Filename, "mapbin");
-    m_ogre_terrain_group->setOrigin(Vector3(m_map_size_x / 2.0f, 0.0f, m_map_size_z / 2.0f));
+    m_ogre_terrain_group = OGRE_NEW TerrainGroup(gEnv->sceneManager, Terrain::ALIGN_X_Z, m_spec->page_size, m_spec->world_size);
+    m_ogre_terrain_group->setFilenameConvention(cache_filename_format, "mapbin");
+    m_ogre_terrain_group->setOrigin(m_spec->origin_pos);
     m_ogre_terrain_group->setResourceGroup("cache");
 
     configureTerrainDefaults();
 
     auto* loading_win = RoR::App::GetGuiManager()->GetLoadingWindow();
-
-    for (long x = pageMinX; x <= pageMaxX; ++x)
+    for (OTCPage& page : m_spec->pages)
     {
-        for (long z = pageMinZ; z <= pageMaxZ; ++z)
-        {
-            loading_win->setProgress(23, _L("preparing terrain page ") + XZSTR(x,z));
-            defineTerrain(x, z, m_terrain_is_flat);
-            loading_win->setProgress(23, _L("loading terrain page ") + XZSTR(x,z));
-        }
+        loading_win->setProgress(23, _L("preparing terrain page ") + XZSTR(page.pos_x, page.pos_z));
+        this->SetupGeometry(page, m_spec->is_flat);
     }
 
     // sync load since we want everything in place when we start
@@ -319,22 +244,20 @@ void TerrainGeometryManager::initTerrain()
     // update the blend maps
     if (m_was_new_geometry_generated)
     {
-        for (long x = pageMinX; x <= pageMaxX; ++x)
+        for (OTCPage& page : m_spec->pages)
         {
-            for (long z = pageMinZ; z <= pageMaxZ; ++z)
+            Terrain* terrain = m_ogre_terrain_group->getTerrain(page.pos_x, page.pos_z);
+            if (terrain != nullptr)
             {
-                Terrain* terrain = m_ogre_terrain_group->getTerrain(x, z);
-                if (!terrain)
-                    continue;
-                loading_win->setProgress(23, _L("loading terrain page layers ") + XZSTR(x,z));
-                loadLayers(x, z, terrain);
-                loading_win->setProgress(23, _L("loading terrain page blend maps ") + XZSTR(x,z));
-                initBlendMaps(x, z, terrain);
+                loading_win->setProgress(23, _L("loading terrain page layers ") + XZSTR(page.pos_x, page.pos_z));
+                this->SetupLayers(page, terrain);
+                loading_win->setProgress(23, _L("loading terrain page blend maps ") + XZSTR(page.pos_x, page.pos_z));
+                this->SetupBlendMaps(page, terrain);
             }
         }
 
         // always save the results when it was imported
-        if (!m_terrn_disable_caching)
+        if (!m_spec->disable_cache)
         {
             loading_win->setProgress(23, _L("saving all terrain pages ..."));
             m_ogre_terrain_group->saveAllTerrains(false);
@@ -393,7 +316,7 @@ void TerrainGeometryManager::configureTerrainDefaults()
 
     terrainOptions->setDefaultMaterialGenerator(ptr);
     // Configure global
-    terrainOptions->setMaxPixelError(m_terrain_config.GetInt("MaxPixelError", 5));
+    terrainOptions->setMaxPixelError(m_spec->max_pixel_error);
 
     // Important to set these so that the terrain knows what to use for derived (non-realtime) data
     if (light)
@@ -405,17 +328,17 @@ void TerrainGeometryManager::configureTerrainDefaults()
 
     // Configure default import settings for if we use imported image
     Ogre::Terrain::ImportData& defaultimp = m_ogre_terrain_group->getDefaultImportSettings();
-    defaultimp.terrainSize = static_cast<Ogre::uint16>(m_terrain_page_size); // the heightmap size
-    defaultimp.worldSize = m_terrain_world_size; // this is the scaled up size, like 12km
-    defaultimp.inputScale = m_map_size_y;
-    defaultimp.minBatchSize = m_terrain_config.GetInt("minBatchSize", 33);
-    defaultimp.maxBatchSize = m_terrain_config.GetInt("maxBatchSize", 65);
+    defaultimp.terrainSize  = m_spec->page_size; // the heightmap size
+    defaultimp.worldSize    = m_spec->world_size; // this is the scaled up size, like 12km
+    defaultimp.inputScale   = m_spec->world_size_y;
+    defaultimp.minBatchSize = m_spec->batch_size_min;
+    defaultimp.maxBatchSize = m_spec->batch_size_max;
 
     // optimizations
     TerrainPSSMMaterialGenerator::SM2Profile* matProfile = static_cast<TerrainPSSMMaterialGenerator::SM2Profile*>(terrainOptions->getDefaultMaterialGenerator()->getActiveProfile());
     if (matProfile)
     {
-        matProfile->setLightmapEnabled(m_terrain_config.GetBool("LightmapEnabled", false));
+        matProfile->setLightmapEnabled(m_spec->lightmap_enabled);
         // Fix for OpenGL, otherwise terrains are black
         if (Root::getSingleton().getRenderSystem()->getName() == "OpenGL Rendering Subsystem")
         {
@@ -424,21 +347,21 @@ void TerrainGeometryManager::configureTerrainDefaults()
         }
         else
         {
-            matProfile->setLayerNormalMappingEnabled(m_terrain_config.GetBool("NormalMappingEnabled", false));
-            matProfile->setLayerSpecularMappingEnabled(m_terrain_config.GetBool("SpecularMappingEnabled", false));
+            matProfile->setLayerNormalMappingEnabled(m_spec->norm_map_enabled);
+            matProfile->setLayerSpecularMappingEnabled(m_spec->spec_map_enabled);
         }
-        matProfile->setLayerParallaxMappingEnabled(m_terrain_config.GetBool("ParallaxMappingEnabled", false));
-        matProfile->setGlobalColourMapEnabled(m_terrain_config.GetBool("GlobalColourMapEnabled", false));
-        matProfile->setReceiveDynamicShadowsDepth(m_terrain_config.GetBool("ReceiveDynamicShadowsDepth", false));
+        matProfile->setLayerParallaxMappingEnabled(m_spec->parallax_enabled);
+        matProfile->setGlobalColourMapEnabled(m_spec->global_colormap_enabled);
+        matProfile->setReceiveDynamicShadowsDepth(m_spec->recv_dyn_shadows_depth);
 
         m_terrain_mgr->getShadowManager()->updateTerrainMaterial(matProfile);
     }
 
-    terrainOptions->setLayerBlendMapSize(m_terrain_config.GetInt("LayerBlendMapSize", 1024));
-    terrainOptions->setCompositeMapSize(m_terrain_config.GetInt("CompositeMapSize", 1024));
-    terrainOptions->setCompositeMapDistance(m_terrain_config.GetInt("CompositeMapDistance", 4000));
-    terrainOptions->setSkirtSize(m_terrain_config.GetInt("SkirtSize", 30));
-    terrainOptions->setLightMapSize(m_terrain_config.GetInt("LightMapSize", 1024));
+    terrainOptions->setLayerBlendMapSize   (m_spec->layer_blendmap_size);
+    terrainOptions->setCompositeMapSize    (m_spec->composite_map_size);
+    terrainOptions->setCompositeMapDistance(m_spec->composite_map_distance);
+    terrainOptions->setSkirtSize           (m_spec->skirt_size);
+    terrainOptions->setLightMapSize        (m_spec->lightmap_size);
 
     if (matProfile->getReceiveDynamicShadowsPSSM())
         terrainOptions->setCastsDynamicShadows(true);
@@ -448,123 +371,69 @@ void TerrainGeometryManager::configureTerrainDefaults()
     //TODO: Make this only when hydrax is enabled.
     terrainOptions->setUseVertexCompressionWhenAvailable(false);
 
-    // load layer basics now
-    loadLayers(0, 0, 0);
+    // HACK: Load the single page config now
+    // This is how it "worked before" ~ only_a_ptr, 04/2017
+    this->SetupLayers(*m_spec->pages.begin(), nullptr);
 }
 
 // if terrain is set, we operate on the already loaded terrain
-void TerrainGeometryManager::loadLayers(int x, int z, Terrain* terrain)
+void TerrainGeometryManager::SetupLayers(RoR::OTCPage& page, Ogre::Terrain *terrain)
 {
-    if (m_pageconf_filename_format.empty())
-        return;
-
-    DataStreamPtr ds = getPageConfig(x, z);
-
-    if (ds.isNull())
-        return;
-
-    char line_buf[4096];
-    ds->readLine(line_buf, 4096);
-    String heightmapImage = RoR::Utils::SanitizeUtf8String(String(line_buf));
-    ds->readLine(line_buf, 4096);
-    size_t num_layers = static_cast<size_t>(Ogre::StringConverter::parseUnsignedInt(RoR::Utils::SanitizeUtf8String(std::string(line_buf))));
-
-    if (num_layers == 0)
+    if (page.num_layers == 0)
         return;
 
     Ogre::Terrain::ImportData& defaultimp = m_ogre_terrain_group->getDefaultImportSettings();
 
     if (!terrain)
-        defaultimp.layerList.resize(num_layers);
+        defaultimp.layerList.resize(page.num_layers);
 
-    m_terrn_blend_layers.clear();
-    m_terrn_blend_layers.resize(num_layers);
+    int layer_idx = 0;
 
-    size_t layer = 0;
-
-    while (!ds->eof())
+    for (OTCLayer& layer : page.layers)
     {
-        size_t ll = ds->readLine(line_buf, 4096);
-        std::string line = RoR::Utils::SanitizeUtf8String(std::string(line_buf));
-        if (ll == 0 || line[0] == '/' || line[0] == ';')
-            continue;
-
-        StringVector args = StringUtil::split(String(line), ",");
-        if (args.size() < 3)
-        {
-            LOG("invalid page config line: '" + String(line) + "'");
-            continue;
-        }
-
-        StringUtil::trim(args[1]);
-        StringUtil::trim(args[2]);
-
-        float m_terrain_world_size = PARSEREAL(args[0]);
         if (!terrain)
         {
-            defaultimp.layerList[layer].worldSize = m_terrain_world_size;
-            defaultimp.layerList[layer].textureNames.push_back(args[1]);
-            defaultimp.layerList[layer].textureNames.push_back(args[2]);
+            defaultimp.layerList[layer_idx].worldSize = layer.world_size;
+            defaultimp.layerList[layer_idx].textureNames.push_back(layer.diffusespecular_filename);
+            defaultimp.layerList[layer_idx].textureNames.push_back(layer.normalheight_filename);
         }
         else
         {
-            Ogre::uint8 layer_u8 = static_cast<Ogre::uint8>(layer);
-            terrain->setLayerWorldSize(layer_u8, m_terrain_world_size);
-            terrain->setLayerTextureName(layer_u8, 0, args[1]);
-            terrain->setLayerTextureName(layer_u8, 1, args[2]);
+            terrain->setLayerWorldSize(layer_idx, layer.world_size);
+            terrain->setLayerTextureName(layer_idx, 0, layer.diffusespecular_filename);
+            terrain->setLayerTextureName(layer_idx, 1, layer.normalheight_filename);
         }
 
-        TerrnBlendLayerDef& bi = m_terrn_blend_layers[layer];
-        bi.blend_mode = 'R';
-        bi.alpha_value = 'R'; // WTF?? Kept around for bug-to-bug compatibility ~ only_a_ptr, 03/2017
-
-        if (args.size() > 3)
-        {
-            StringUtil::trim(args[3]);
-            bi.blendmap_tex_filename = args[3];
-        }
-        if (args.size() > 4)
-        {
-            StringUtil::trim(args[4]);
-            bi.blend_mode = args[4][0];
-        }
-        if (args.size() > 5)
-            bi.alpha_value = PARSEREAL(args[5]);
-
-        layer++;
-        if (layer >= num_layers)
-            break;
+        layer_idx++;
     }
-    LOG("done loading page: loaded " + TOSTRING(layer) + " layers");
+    LOG("done loading page: loaded " + TOSTRING(layer_idx) + " layers");
 }
 
-void TerrainGeometryManager::initBlendMaps(int x, int z, Ogre::Terrain* terrain)
+void TerrainGeometryManager::SetupBlendMaps(OTCPage& page, Ogre::Terrain* terrain )
 {
-    bool debugBlendMaps = m_terrain_config.GetBool("DebugBlendMaps", false);
-
-    int layerCount = terrain->getLayerCount();
+    const int layerCount = terrain->getLayerCount();
+    auto layer_def_itor = page.layers.begin();
+    ++layer_def_itor;
     for (int i = 1; i < layerCount; i++)
     {
-        TerrnBlendLayerDef& bi = m_terrn_blend_layers[i];
-
-        if (bi.blendmap_tex_filename.empty())
+        if (layer_def_itor->blendmap_filename.empty())
             continue;
 
         Ogre::Image img;
         try
         {
-            img.load(bi.blendmap_tex_filename, ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
+            img.load(layer_def_itor->blendmap_filename, ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
         }
         catch (Exception& e)
         {
-            LOG("Error loading blendmap: " + bi.blendmap_tex_filename + " : " + e.getFullDescription());
+            LOG("Error loading blendmap: " + layer_def_itor->blendmap_filename + " : " + e.getFullDescription());
             continue;
         }
 
         TerrainLayerBlendMap* blendmap = terrain->getLayerBlendMap(i);
 
         // resize that blending map so it will fit
-        Ogre::uint32 blendmapSize = terrain->getLayerBlendMapSize();
+        const Ogre::uint32 blendmapSize = terrain->getLayerBlendMapSize();
         if (img.getWidth() != blendmapSize)
             img.resize(blendmapSize, blendmapSize);
 
@@ -575,22 +444,23 @@ void TerrainGeometryManager::initBlendMaps(int x, int z, Ogre::Terrain* terrain)
             for (Ogre::uint32 x = 0; x != blendmapSize; x++)
             {
                 Ogre::ColourValue c = img.getColourAt(x, z, 0);
-                float alpha = bi.alpha_value;
-                if (bi.blend_mode == 'R')
+                const float alpha = layer_def_itor->alpha;
+                if (layer_def_itor->blend_mode == 'R')
                     *ptr++ = c.r * alpha;
-                else if (bi.blend_mode == 'G')
+                else if (layer_def_itor->blend_mode == 'G')
                     *ptr++ = c.g * alpha;
-                else if (bi.blend_mode == 'B')
+                else if (layer_def_itor->blend_mode == 'B')
                     *ptr++ = c.b * alpha;
-                else if (bi.blend_mode == 'A')
+                else if (layer_def_itor->blend_mode == 'A')
                     *ptr++ = c.a * alpha;
             }
         }
         blendmap->dirty();
         blendmap->update();
+        ++layer_def_itor;
     }
 
-    if (debugBlendMaps)
+    if (m_spec->blendmap_dbg_enabled)
     {
         for (int i = 1; i < layerCount; i++)
         {
@@ -610,78 +480,70 @@ void TerrainGeometryManager::initBlendMaps(int x, int z, Ogre::Terrain* terrain)
     }
 }
 
-bool TerrainGeometryManager::getTerrainImage(int x, int z, Image& img)
+// Internal helper
+bool LoadHeightmap(OTCPage& page, Image& img)
 {
-    String heightmapString = "Heightmap." + TOSTRING(x) + "." + TOSTRING(z);
-    String heightmapFilename = getPageHeightmap(x, z);
-    StringUtil::trim(heightmapFilename);
-
-    if (heightmapFilename.empty())
+    if (page.heightmap_filename.empty())
     {
-        LOG("empty Heightmap provided, please use 'Flat=1' instead");
+        LOG("[RoR|Terrain] Empty Heightmap provided in OTC, please use 'Flat=1' instead");
         return false;
     }
 
-    if (heightmapFilename.find(".raw") != String::npos)
+    if (page.heightmap_filename.find(".raw") != String::npos)
     {
-        int rawSize = m_terrain_config.GetInt(heightmapString + ".raw.size", 1025);
-        int bpp = m_terrain_config.GetInt(heightmapString + ".raw.bpp", 2);
-
         // load raw data
-        DataStreamPtr stream = ResourceGroupManager::getSingleton().openResource(heightmapFilename);
-        LOG(" loading RAW image: " + TOSTRING(stream->size()) + " / " + TOSTRING(rawSize*rawSize*bpp));
-        PixelFormat pformat = PF_L8;
-        if (bpp == 2)
-            pformat = PF_L16;
-        img.loadRawData(stream, rawSize, rawSize, 1, pformat);
+        DataStreamPtr stream = ResourceGroupManager::getSingleton().openResource(page.heightmap_filename);
+        LOG("[RoR|Terrain] loading RAW image: " + TOSTRING(stream->size()) + " / " + TOSTRING(page.raw_size*page.raw_size*page.raw_bpp));
+        PixelFormat pix_format = (page.raw_bpp == 2) ? PF_L16 : PF_L8;
+        img.loadRawData(stream, page.raw_size, page.raw_size, 1, pix_format);
     }
     else
     {
-        img.load(heightmapFilename, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        img.load(page.heightmap_filename, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     }
 
-    if (m_terrain_config.GetBool(heightmapString + ".flipX", false))
+    if (page.raw_flip_x)
         img.flipAroundX();
-    if (m_terrain_config.GetBool(heightmapString + ".flipY", false))
+    if (page.raw_flip_y)
         img.flipAroundY();
 
     return true;
 }
 
-void TerrainGeometryManager::defineTerrain(int x, int z, bool flat)
+void TerrainGeometryManager::SetupGeometry(RoR::OTCPage& page, bool flat)
 {
     if (flat)
     {
         // very simple, no height data to load at all
-        m_ogre_terrain_group->defineTerrain(x, z, 0.0f);
+        m_ogre_terrain_group->defineTerrain(page.pos_x, page.pos_z, 0.0f);
         return;
     }
 
-    String filename = m_ogre_terrain_group->generateFilename(x, z);
-
-    if (!m_terrn_disable_caching && ResourceGroupManager::getSingleton().resourceExists(m_ogre_terrain_group->getResourceGroup(), filename))
+    const std::string page_cache_filename = m_ogre_terrain_group->generateFilename(page.pos_x, page.pos_z);
+    const std::string res_group = m_ogre_terrain_group->getResourceGroup();
+    if (!m_spec->disable_cache && ResourceGroupManager::getSingleton().resourceExists(res_group, page_cache_filename))
     {
         // load from cache
-        m_ogre_terrain_group->defineTerrain(x, z);
+        m_ogre_terrain_group->defineTerrain(page.pos_x, page.pos_z);
     }
     else
     {
         Image img;
-        if (getTerrainImage(x, z, img))
+        if (LoadHeightmap(page, img))
         {
-            m_ogre_terrain_group->defineTerrain(x, z, &img);
+            m_ogre_terrain_group->defineTerrain(page.pos_x, page.pos_z, &img);
             m_was_new_geometry_generated = true;
         }
         else
         {
             // fall back to no heightmap
-            m_ogre_terrain_group->defineTerrain(x, z, 0.0f);
+            m_ogre_terrain_group->defineTerrain(page.pos_x, page.pos_z, 0.0f);
         }
     }
 }
 
 Ogre::Vector3 TerrainGeometryManager::getMaxTerrainSize()
 {
-    return Vector3(m_map_size_x, m_map_size_y, m_map_size_z);
+    return Vector3(m_spec->world_size_x, m_spec->world_size_y, m_spec->world_size_z);
 }
 

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -366,7 +366,7 @@ void TerrainGeometryManager::updateLightMap()
     }
 }
 
-bool TerrainGeometryManager::update(float dt)
+void TerrainGeometryManager::UpdateMainLightPosition()
 {
     Light* light = gEnv->terrainManager->getMainLight();
     TerrainGlobalOptions* terrainOptions = TerrainGlobalOptions::getSingletonPtr();
@@ -378,7 +378,6 @@ bool TerrainGeometryManager::update(float dt)
     terrainOptions->setCompositeMapAmbient(gEnv->sceneManager->getAmbientLight());
 
     m_ogre_terrain_group->update();
-    return true;
 }
 
 void TerrainGeometryManager::configureTerrainDefaults()

--- a/source/main/terrain/TerrainGeometryManager.h
+++ b/source/main/terrain/TerrainGeometryManager.h
@@ -24,9 +24,13 @@
 #include "RoRPrerequisites.h"
 #include "ConfigFile.h"
 #include "IHeightFinder.h"
+#include "OTCFileformat.h"
 
-#include <OgreTerrain.h>
 #include <OgreVector3.h>
+#include <OgreTerrain.h>
+
+// forward
+namespace Ogre { class Terrain; class TerrainGroup; class TerrainPaging; class PageManager; }
 
 /// this class handles all interactions with the Ogre Terrain system
 class TerrainGeometryManager : public ZeroedMemoryAllocator, public IHeightFinder
@@ -35,7 +39,7 @@ public:
     TerrainGeometryManager(TerrainManager* terrainManager);
     ~TerrainGeometryManager();
 
-    void loadOgreTerrainConfig(Ogre::String filename);
+    void InitTerrain(std::string otc_filename);
 
     Ogre::TerrainGroup* getTerrainGroup() { return m_ogre_terrain_group; };
 
@@ -54,38 +58,19 @@ public:
 
 private:
 
-    struct TerrnBlendLayerDef
-    {
-        std::string  blendmap_tex_filename;
-        char         blend_mode;
-        float        alpha_value;
-    };
-
     bool getTerrainImage(int x, int y, Ogre::Image& img);
     bool loadTerrainConfig(Ogre::String filename);
     void configureTerrainDefaults();
-    void defineTerrain(int x, int y, bool flat = false);
-    void initBlendMaps(int x, int y, Ogre::Terrain* t);
+    void SetupGeometry(RoR::OTCPage& page, bool flat=false);
+    void SetupBlendMaps(RoR::OTCPage& page, Ogre::Terrain* t );
     void initTerrain();
-    void loadLayers(int x, int y, Ogre::Terrain* terrain = 0);
-    Ogre::String getPageConfigFilename(int x, int z);
-    Ogre::String getPageHeightmap(int x, int z);
+    void SetupLayers(RoR::OTCPage& page, Ogre::Terrain *terrain);
     Ogre::DataStreamPtr getPageConfig(int x, int z);
 
-    RoR::ConfigFile   m_terrain_config;
-    std::string       m_terrn_base_name;               ///< Only for loading.
-    std::string       m_pageconf_filename_format;      ///< Only for loading.
-    bool              m_terrn_disable_caching;         ///< Only for loading.
-    bool              m_was_new_geometry_generated;    ///< Only for loading.
-    bool              m_terrain_is_flat;               ///< Only for loading.
-    TerrainManager*   m_terrain_mgr;
-    size_t            m_map_size_x;
-    size_t            m_map_size_y;
-    size_t            m_map_size_z;
-    size_t            m_terrain_page_size;
-    size_t            m_terrain_world_size;
+    std::shared_ptr<RoR::OTCFile> m_spec;
+    TerrainManager*      m_terrain_mgr;
     Ogre::TerrainGroup*  m_ogre_terrain_group;
-    std::vector<TerrnBlendLayerDef>  m_terrn_blend_layers;
+    bool                 m_was_new_geometry_generated;
 
     // Terrn position lookup - ported from OGRE engine.
     Ogre::Terrain::Alignment mAlign;

--- a/source/main/terrain/TerrainGeometryManager.h
+++ b/source/main/terrain/TerrainGeometryManager.h
@@ -49,7 +49,7 @@ public:
 
     Ogre::Vector3 getMaxTerrainSize();
 
-    bool update(float dt);
+    void UpdateMainLightPosition();
     void updateLightMap();
 
 private:

--- a/source/main/terrain/TerrainGeometryManager.h
+++ b/source/main/terrain/TerrainGeometryManager.h
@@ -62,7 +62,7 @@ private:
     bool loadTerrainConfig(Ogre::String filename);
     void configureTerrainDefaults();
     void SetupGeometry(RoR::OTCPage& page, bool flat=false);
-    void SetupBlendMaps(RoR::OTCPage& page, Ogre::Terrain* t );
+    void SetupBlendMaps(RoR::OTCPage& page, Ogre::Terrain* t);
     void initTerrain();
     void SetupLayers(RoR::OTCPage& page, Ogre::Terrain *terrain);
     Ogre::DataStreamPtr getPageConfig(int x, int z);

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -47,7 +47,7 @@
 #include "Water.h"
 
 #include <Terrain/OgreTerrainPaging.h>
-#include <OgreTerrainGroup.h>
+#include <Terrain/OgreTerrainGroup.h>
 
 using namespace RoR;
 using namespace Ogre;
@@ -170,7 +170,7 @@ void TerrainManager::loadTerrain(String filename)
 
     // load the terrain geometry
     PROGRESS_WINDOW(80, _L("Loading Terrain Geometry"));
-    geometry_manager->loadOgreTerrainConfig(m_def.ogre_ter_conf_filename);
+    geometry_manager->InitTerrain(m_def.ogre_ter_conf_filename);
 
     LOG(" ===== LOADING TERRAIN WATER " + filename);
     // must happen here
@@ -617,7 +617,7 @@ void TerrainManager::initScripting()
     {
         for (std::string as_filename : m_def.as_files)
         {
-            if(ScriptEngine::getSingleton().loadScript(as_filename) == 0)
+            if (ScriptEngine::getSingleton().loadScript(as_filename) == 0)
                 loaded = true;
         }
     }

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -194,6 +194,8 @@ void TerrainManager::loadTerrain(String filename)
         m_survey_map = new SurveyMapManager();
     }
 
+    PROGRESS_WINDOW(95, _L("Initializing terrain light properties"));
+    geometry_manager->UpdateMainLightPosition(); // Initial update takes a while
     collisions->finishLoadingTerrain();
     LOG(" ===== TERRAIN LOADING DONE " + filename);
 }
@@ -600,7 +602,7 @@ bool TerrainManager::update(float dt)
         object_manager->update(dt);
 
     if (geometry_manager)
-        geometry_manager->update(dt);
+        geometry_manager->UpdateMainLightPosition(); // TODO: Is this necessary? I'm leaving it here just in case ~ only_a_ptr, 04/2017
 
     return true;
 }

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -107,37 +107,6 @@ TerrainObjectManager::~TerrainObjectManager()
     gEnv->sceneManager->destroyAllEntities();
 }
 
-void TerrainObjectManager::proceduralTests()
-{
-#if 0
-    // TODO: it crashes, get this working!
-	try
-	{
-		Procedural::MultiShape out;
-		Procedural::SvgLoader svg;
-		svg.parseSvgFile(out, "test.svg");
-		Procedural::Path p = out.getShape(0).convertToPath();
-		Procedural::Shape s = out.getShape(1);
-		
-		Procedural::Track textureTrack = Procedural::Track(Procedural::Track::AM_POINT).addKeyFrame(0,0).addKeyFrame(2,.2f).addKeyFrame(3,.8f).addKeyFrame(5,1);
-    // The extruder actually creates the road mesh from all parameters
-		Procedural::Extruder().setExtrusionPath(&p).setShapeToExtrude(&s).setShapeTextureTrack(&textureTrack).setUTile(20.f).realizeMesh("extrudedMesh");
-
-		Entity* ent2 = gEnv->sceneManager->createEntity("svg");
-		SceneNode* sn = gEnv->sceneManager->getRootSceneNode()->createChildSceneNode();
-		sn->attachObject(ent2);
-		sn->setPosition(Vector3(0,0,0));
-		ent2->setMaterialName("Examples/Road");
-		ent2->setCastShadows(true);
-
-	}
-    catch (Exception &e)
-	{
-		ErrorUtils::ShowError("Error within procedural tests", e.what());
-	}
-#endif //0
-}
-
 void TerrainObjectManager::loadObjectConfigFile(Ogre::String odefname)
 {
     if (proceduralManager == nullptr)

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -138,7 +138,5 @@ protected:
     std::map<std::string, loadedObject_t> loadedObjects;
 
     std::vector<object_t> objects;
-
-    void proceduralTests();
 };
 

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -349,5 +349,18 @@ std::string SanitizeUtf8String(std::string const& str_in)
     return str_out;
 }
 
+std::string SanitizeUtf8CString(const char* start, const char* end /* = nullptr */)
+{
+    if (end == nullptr)
+    {
+        end = (start + strlen(start));
+    }
+
+    // Cloned from UTFCPP tutorial: http://utfcpp.sourceforge.net/#fixinvalid
+    std::string str_out;
+    utf8::replace_invalid(start, end, std::back_inserter(str_out));
+    return str_out;
+}
+
 } // namespace Utils
 } // namespace RoR

--- a/source/main/utils/Utils.h
+++ b/source/main/utils/Utils.h
@@ -105,6 +105,9 @@ namespace Utils {
 std::string TrimBlanksAndLinebreaks(std::string const& input);
 
 std::string SanitizeUtf8String(std::string const& str_in);
+std::string SanitizeUtf8CString(const char* start, const char* end = nullptr);
+
+    inline std::string& TrimStr(std::string& s) { Ogre::StringUtil::trim(s); return s; }
 }
 
 namespace Color {
@@ -113,4 +116,4 @@ const Ogre::UTFString NormalColour = Ogre::UTFString("#FFFFFF");
 const Ogre::UTFString WhisperColour = Ogre::UTFString("#FFCC00");
 const Ogre::UTFString ScriptCommandColour = Ogre::UTFString("#0099FF");
 }
-}
+} // namespace RoR


### PR DESCRIPTION
New features:

## Support for custom terrain material in "Terrn2" format.

This will enable porting the remaining 0.38 maps (such as ashes48's "around the mountain") that were blocked by lack of custom material support.

This is Auriga-0.4 map hacked to use it's heightmap for ground texture:
```
[General]
CustomMaterial=TEST_MAT_heightmap_for_texture
```

![screenshot_2017-04-10_00-14-31_1](https://cloud.githubusercontent.com/assets/491088/24841345/c4186ed6-1d82-11e7-9e21-b4ff8b691b52.jpg)

## Custom minimap image for Teleport.

Until now, the minimap relied on "Survey map" feature which can be disabled in config, thus making Teleport minimap blank.

Again, Auriga-0.4 with it's heightmap used for Teleport minimap:
```
[Teleport]
NavigationMapImage=31-heightmap.png
```
![screenshot_2017-04-09_23-57-56_1](https://cloud.githubusercontent.com/assets/491088/24841329/87bf7060-1d82-11e7-96e7-ac08e70305c1.jpg)