### PR TITLE
pssm material allowance

### DIFF
--- a/source/main/terrain/OgreTerrainPSSMMaterialGenerator.cpp
+++ b/source/main/terrain/OgreTerrainPSSMMaterialGenerator.cpp
@@ -229,7 +229,7 @@ uint8 TerrainPSSMMaterialGenerator::SM2Profile::getMaxLayers(const Terrain* terr
     }
 
     // each layer needs 2.25 units (1xdiffusespec, 1xnormalheight, 0.25xblend)
-    return static_cast<uint8>(freeTextureUnits / 2.25f);
+    return static_cast<uint8>(freeTextureUnits / 2.16f);
 }
 
 //---------------------------------------------------------------------


### PR DESCRIPTION
this allows pssm to work on terrains with 6 materials. for backwards compatibility.
![screenshot_2017-06-29_05-21-39_1](https://user-images.githubusercontent.com/12094306/27660908-dad3cc82-5c8a-11e7-802c-b9715f089fdd.jpg)
the problems stem with limiting the blend maps, this can cause some uneven material edges.
this needs to be discussed and balanced.