### PR TITLE
Fixed crash when loading "miniredmars" map.

### DIFF
--- a/source/main/physics/flex/FlexObj.h
+++ b/source/main/physics/flex/FlexObj.h
@@ -81,7 +81,7 @@ private:
         Ogre::Vector2 texcoord;
     };
 
-    /// Compute vertex position (0-based offset) for node `v` in triangle `tidx`
+    /// Compute vertex position in the vertexbuffer (0-based offset) for node `v` of triangle `tidx`
     int             ComputeVertexPos(int tidx, int v, std::vector<CabSubmesh>& submeshes);
     Ogre::Vector3   UpdateMesh();
 


### PR DESCRIPTION
Crash occured when spawning an actor (=truck, load, boat, whatever) with exactly 1 "submesh" in truckfile.

Fixes
* #1256 - Crash on loading map "miniredmars" - a contained truckfile 'boobytrap.load' triggered it.
* #540 - Loading problems of Manitou_731.zip

## Status

Works OK for me, but @tritonas00 reports crash from 'bombinette.load' in "miniredmars" map.