### PR TITLE
Improved Envmap (realtime reflections)

### DIFF
--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -108,9 +108,11 @@ namespace MOC
 
 namespace Ogre
 {
-    class MovableText;
-    class TerrainGroup;
+    class Camera;
     class ConfigFile;
+    class MovableText;
+    class RenderTarget;
+    class TerrainGroup;
 }
 
 class AeroEngine;

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -20,11 +20,12 @@
 
 #pragma once
 
-#include "RoRPrerequisites.h"
-#include "ForceFeedback.h"
-
-#include "CharacterFactory.h"
 #include "BeamFactory.h"
+#include "CharacterFactory.h"
+#include "EnvironmentMap.h"
+#include "ForceFeedback.h"
+#include "RoRPrerequisites.h"
+
 
 #include <Ogre.h>
 
@@ -81,6 +82,7 @@ protected:
 
     RoR::BeamFactory         m_beam_factory;
     RoR::CharacterFactory    m_character_factory;
+    RoR::GfxEnvmap           m_gfx_envmap;
     HeatHaze*                m_heathaze;
     RoR::SkidmarkConfig*     m_skidmark_conf;
     Ogre::Real               m_time_until_next_toggle; ///< just to stop toggles flipping too fast

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -20,29 +20,36 @@
 
 #pragma once
 
-#include "RoRPrerequisites.h"
+#include "ForwardDeclarations.h"
 
-class Envmap : public ZeroedMemoryAllocator
+#include <OgreVector3.h>
+#include <OgreTexture.h>
+
+namespace RoR {
+
+/// A dynamic environment probe; Creates a cubemap with realtime reflections around specified point.
+class GfxEnvmap
 {
 public:
 
-    Envmap();
-    ~Envmap();
+    GfxEnvmap();
+    ~GfxEnvmap();
 
-    void prepareShutdown()
-    {
-    };
-
-    void update(Ogre::Vector3 center, Beam* beam = 0);
+    void SetupEnvMap();
+    void UpdateEnvMap(Ogre::Vector3 center, Beam* beam = 0);
 
 private:
 
-    void init(Ogre::Vector3 center);
-
     static const unsigned int NUM_FACES = 6;
 
-    Ogre::Camera* mCameras[NUM_FACES];
-    Ogre::RenderTarget* mRenderTargets[NUM_FACES];
-    bool mInitiated;
-    int mRound;
+    void InitEnvMap(Ogre::Vector3 center);
+
+    Ogre::Camera*        m_cameras[NUM_FACES];
+    Ogre::RenderTarget*  m_render_targets[NUM_FACES];
+    Ogre::TexturePtr     m_rtt_texture;
+    bool                 m_is_initialized;
+    int                  m_update_round; /// Render targets are updated one-by-one; this is the index of next target to update.
+    bool                 m_is_enabled; // TODO: Use a GVar!! ~ only_a_ptr, 08/2017
 };
+
+} // namespace RoR

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -57,7 +57,6 @@ TerrainManager::TerrainManager(RoRFrameListener* sim_controller)
     , character(0)
     , collisions(0)
     , dashboard(0)
-    , envmap(0)
     , geometry_manager(0)
     , hdr_listener(0)
     , object_manager(0)
@@ -89,12 +88,6 @@ TerrainManager::~TerrainManager()
     {
         gEnv->sceneManager->destroyAllLights();
         main_light = nullptr;
-    }
-
-    if (envmap != nullptr)
-    {
-        delete(envmap);
-        envmap = nullptr;
     }
 
     if (dashboard != nullptr)
@@ -270,11 +263,6 @@ void TerrainManager::initSubSystems()
     {
         PROGRESS_WINDOW(41, _L("Initializing Sunburn Subsystem"));
         initSunburn();
-    }
-    if (!BSETTING("Envmapdisable", false))
-    {
-        PROGRESS_WINDOW(43, _L("Initializing Environment Map Subsystem"));
-        initEnvironmentMap();
     }
 
     PROGRESS_WINDOW(47, _L("Initializing Dashboards Subsystem"));
@@ -577,11 +565,6 @@ void TerrainManager::initWater()
 
         water->setHeight (m_def.water_height);
     }
-}
-
-void TerrainManager::initEnvironmentMap()
-{
-    envmap = new Envmap();
 }
 
 void TerrainManager::initDashboards()

--- a/source/main/terrain/TerrainManager.h
+++ b/source/main/terrain/TerrainManager.h
@@ -51,7 +51,6 @@ public:
 
     // some getters
     Collisions* getCollisions() { return collisions; };
-    Envmap* getEnvmap() { return envmap; };
     IHeightFinder* getHeightFinder();
     IWater* getWater() { return water; };
     Ogre::Light* getMainLight() { return main_light; };
@@ -80,7 +79,6 @@ protected:
     Character* character;
     Collisions* collisions;
     Dashboard* dashboard;
-    Envmap* envmap;
     HDRListener* hdr_listener;
     SurveyMapManager* m_survey_map;
     ShadowManager* shadow_manager;
@@ -104,7 +102,6 @@ protected:
     void initCamera();
     void initTerrainCollisions();
     void initDashboards();
-    void initEnvironmentMap();
     void initFog();
     void initGeometry();
     void initGlow();


### PR DESCRIPTION
Fixes the old bug where reflections of first terrain used would remain in all other terrains until game restart.

Additionally, removes weird old code I found - when player doesn't drive a vehicle, RoR would render the envmap at middle of the map in 50m height.  After this change, the rendering will simply stop, so when you exit a vehicle, it will retain it's reflections.