### PR TITLE
Replaced JsonCPP with RapidJSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
       - libcurl4-openssl-dev
       - libgtk2.0-dev
       - libwxgtk2.8-dev
-      - libjsoncpp-dev
+      - rapidjson-dev
 
 before_install:
   # show some information about the build host

--- a/source/main/gui/panels/GUI_MultiplayerSelector.h
+++ b/source/main/gui/panels/GUI_MultiplayerSelector.h
@@ -28,19 +28,21 @@
 #include "ForwardDeclarations.h"
 #include "GUI_MultiplayerSelectorLayout.h"
 
-namespace RoR
-{
+#include <memory>
+#include <thread>
+#include <future>
 
-namespace GUI
-{
+namespace RoR {
+namespace GUI {
 
-struct ServerlistData; // Forward decl
+struct MpServerlistData; // Forward declaration, private implementation.
 
 class MultiplayerSelector : public MultiplayerSelectorLayout
 {
 
 public:
     MultiplayerSelector();
+    ~MultiplayerSelector();
 
     void SetVisible(bool v);
     bool IsVisible();
@@ -60,10 +62,10 @@ private:
     void CenterToScreen();
     void ServerlistJoin(size_t sel_index);
 
-    ServerlistData*            m_serverlist_data;
-    bool                       m_is_refreshing;
+    std::future<MpServerlistData*>     m_serverlist_future;
+    std::unique_ptr<MpServerlistData>  m_serverlist_data;
+    bool                               m_is_refreshing;
 };
 
 } // namespace GUI
-
 } // namespace RoR


### PR DESCRIPTION
I want to use RapidJSON only in the remade multiplayer lobby: https://github.com/RigsOfRods/rigs-of-rods/pull/1333#issuecomment-331213832 To make the transition smoother, I want to make the switch in upstream first.

Fixes #1331