### PR TITLE
Removed collision object count limits on maps

### DIFF
--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -113,7 +113,6 @@ using namespace Ogre;
 
 Collisions::Collisions(RoRFrameListener* sim_controller)
     : m_sim_controller(sim_controller)
-    , collision_count(0)
     , debugMode(false)
     , forcecam(false)
     , free_eventsource(0)
@@ -775,13 +774,6 @@ int Collisions::addCollisionTri(Vector3 p1, Vector3 p2, Vector3 p3, ground_model
 
     m_collision_tris.push_back(new_tri);
     return new_tri_index;
-}
-
-void Collisions::printStats()
-{
-    LOG("COLL: Collision system statistics:");
-    LOG("COLL: Cell size: "+TOSTRING((float)CELL_SIZE)+" m");
-    LOG("COLL: Hashtable collisions: "+TOSTRING(collision_count));
 }
 
 bool Collisions::envokeScriptCallback(collision_box_t *cbox, node_t *node)

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -446,11 +446,10 @@ void Collisions::hash_add(int cell_x, int cell_z, int value)
     {
         // create a new cell
         cell_t* newcell = new cell_t;
-        
+
         hashtable[pos].cellid = cellid;
         hashtable[pos].cell = newcell;
         newcell->push_back(value);
-        cells.push_back(newcell);
         if (pos != hashfunc(cellid))
         {
             collision_count++;
@@ -837,7 +836,6 @@ void Collisions::printStats()
 {
     LOG("COLL: Collision system statistics:");
     LOG("COLL: Cell size: "+TOSTRING((float)CELL_SIZE)+" m");
-    LOG("COLL: Hashtable occupation: "+TOSTRING(cells.size()));
     LOG("COLL: Hashtable collisions: "+TOSTRING(collision_count));
     LOG("COLL: Largest cell: "+TOSTRING(largest_cellcount));
 }

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -134,7 +134,6 @@ private:
     Landusemap* landuse;
     Ogre::ManualObject* debugmo;
     bool debugMode;
-    int collision_count;
     int collision_version;
     inline int GetNumCollisionTris() const { return static_cast<int>(m_collision_tris.size()); }
     inline int GetNumCollisionBoxes() const { return static_cast<int>(m_collision_boxes.size()); }
@@ -177,7 +176,6 @@ public:
 
     void clearEventCache();
     void finishLoadingTerrain();
-    void printStats();
 
     int addCollisionBox(Ogre::SceneNode* tenode, bool rotating, bool virt, Ogre::Vector3 pos, Ogre::Vector3 rot, Ogre::Vector3 l, Ogre::Vector3 h, Ogre::Vector3 sr, const Ogre::String& eventname, const Ogre::String& instancename, bool forcecam, Ogre::Vector3 campos, Ogre::Vector3 sc = Ogre::Vector3::UNIT_SCALE, Ogre::Vector3 dr = Ogre::Vector3::ZERO, int event_filter = EVENT_ALL, int scripthandler = -1);
     int addCollisionMesh(Ogre::String meshname, Ogre::Vector3 pos, Ogre::Quaternion q, Ogre::Vector3 scale, ground_model_t* gm = 0, std::vector<int>* collTris = 0);

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -117,9 +117,6 @@ private:
     // collision hashtable
     hash_t hashtable[HASH_SIZE];
 
-    // cell pool
-    std::vector<cell_t*> cells;
-
     // ground models
     std::map<Ogre::String, ground_model_t> ground_models;
 

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -3,7 +3,7 @@
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
     Copyright 2009      Lefteris Stamatogiannakis
-    Copyright 2013-2015 Petr Ohlidal
+    Copyright 2013-2017 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -46,6 +46,8 @@ struct eventsource_t
     bool enabled;
 };
 
+/// Values below CELL_COLLISION_TRI_BASE are collision box indices (Collisions::m_collision_boxes),
+///    values above are collision tri indices (Collisions::m_collision_tris).
 typedef std::vector<int> cell_t;
 
 class Landusemap;
@@ -63,9 +65,7 @@ public:
         FX_PARTICLE
     };
 
-    // these are absolute maximums per terrain
-    static const int MAX_COLLISION_BOXES = 5000;
-    static const int MAX_COLLISION_TRIS = 100000;
+    static const int CELL_COLLISION_TRI_BASE = 1000000; // Effectively a maximum number of collision boxes
 
 private:
 
@@ -108,13 +108,11 @@ private:
     RoRFrameListener* m_sim_controller;
 
     // collision boxes pool
-    collision_box_t collision_boxes[MAX_COLLISION_BOXES];
-    collision_box_t* last_called_cbox;
-    int free_collision_box;
+    std::vector<collision_box_t> m_collision_boxes; // Formerly MAX_COLLISION_BOXES = 5000
+    collision_box_t* m_last_called_cbox;
 
     // collision tris pool;
-    collision_tri_t* collision_tris;
-    int free_collision_tri;
+    std::vector<collision_tri_t> m_collision_tris; // Formerly MAX_COLLISION_TRIS = 100000
 
     // collision hashtable
     hash_t hashtable[HASH_SIZE];
@@ -139,7 +137,8 @@ private:
     int collision_count;
     int collision_version;
     int largest_cellcount;
-    long max_col_tris;
+    inline int GetNumCollisionTris() const { return static_cast<int>(m_collision_tris.size()); }
+    inline int GetNumCollisionBoxes() const { return static_cast<int>(m_collision_boxes.size()); }
     unsigned int hashmask;
 
     void hash_add(int cell_x, int cell_z, int value);
@@ -201,7 +200,6 @@ public:
         size_t& index_count, unsigned* & indices,
         const Ogre::Vector3& position = Ogre::Vector3::ZERO,
         const Ogre::Quaternion& orient = Ogre::Quaternion::IDENTITY, const Ogre::Vector3& scale = Ogre::Vector3::UNIT_SCALE);
-    void resizeMemory(long newSize);
 };
 
 void primitiveCollision(node_t* node, Ogre::Vector3& force, const Ogre::Vector3& velocity, const Ogre::Vector3& normal, float dt, ground_model_t* gm, float* nso, float penetration = 0, float reaction = -1.0f);

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -181,8 +181,6 @@ void TerrainManager::loadTerrain(String filename)
     PROGRESS_WINDOW(90, _L("Loading Terrain Objects"));
     loadTerrainObjects();
 
-    collisions->printStats();
-
     // bake the decals
     //finishTerrainDecal();
 

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -1235,7 +1235,6 @@ void TerrainObjectManager::loadObject(const Ogre::String& name, const Ogre::Vect
             Vector3 lpos, ldir;
             float lrange = 10, innerAngle = 45, outerAngle = 45;
             ColourValue lcol;
-            String lname = "spotlight_" + TOSTRING(Math::RangeRandom(1000, 9999));
 
             int res = sscanf(ptline, "spotlight %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f, %f",
                 &lpos.x, &lpos.y, &lpos.z, &ldir.x, &ldir.y, &ldir.z, &lcol.r, &lcol.g, &lcol.b, &lrange, &innerAngle, &outerAngle);
@@ -1245,7 +1244,11 @@ void TerrainObjectManager::loadObject(const Ogre::String& name, const Ogre::Vect
                 continue;
             }
 
-            Light* spotLight = gEnv->sceneManager->createLight(lname);
+            static size_t counter = 0;
+            char name[50];
+            snprintf(name, 50, "terrn2/spotlight-%x", counter);
+            ++counter;
+            Light* spotLight = gEnv->sceneManager->createLight(name);
 
             spotLight->setType(Light::LT_SPOTLIGHT);
             spotLight->setPosition(lpos);

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -1281,7 +1281,6 @@ void TerrainObjectManager::loadObject(const Ogre::String& name, const Ogre::Vect
             Vector3 lpos, ldir;
             float lrange = 10;
             ColourValue lcol;
-            String lname = "pointlight_" + TOSTRING(Math::RangeRandom(1000, 9999));
 
             int res = sscanf(ptline, "pointlight %f, %f, %f, %f, %f, %f, %f, %f, %f, %f",
                 &lpos.x, &lpos.y, &lpos.z, &ldir.x, &ldir.y, &ldir.z, &lcol.r, &lcol.g, &lcol.b, &lrange);
@@ -1291,7 +1290,11 @@ void TerrainObjectManager::loadObject(const Ogre::String& name, const Ogre::Vect
                 continue;
             }
 
-            Light* pointlight = gEnv->sceneManager->createLight(lname);
+            static size_t counter = 0;
+            char name[50];
+            snprintf(name, 50, "terrn2/pointlight-%x", counter);
+            ++counter;
+            Light* pointlight = gEnv->sceneManager->createLight(name);
 
             pointlight->setType(Light::LT_POINT);
             pointlight->setPosition(lpos);

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -2,7 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
-    Copyright 2013+     Petr Ohlidal & contributors
+    Copyright 2013-2017 Petr Ohlidal & contributors
 
     For more information, see http://www.rigsofrods.org/
 
@@ -197,13 +197,6 @@ void TerrainObjectManager::loadObjectConfigFile(Ogre::String odefname)
             continue; //comments
         if (!strcmp("end", line))
             break;
-
-        if (!strncmp(line, "collision-tris", 14))
-        {
-            long amount = Collisions::MAX_COLLISION_TRIS;
-            sscanf(line, "collision-tris %ld", &amount);
-            gEnv->collisions->resizeMemory(amount);
-        }
 
         if (!strncmp(line, "grid", 4))
         {


### PR DESCRIPTION
I think I nailed it. The messy code in 'Collisions.h/cpp' made it hard to see what's going on (I'm looking at you, estama!), but I figured it out. I quickly tested by driving Desperado buggy on Auriga - everything seemed to work just fine.

## Changes
* The collision box limit is now 1 million
* The collision triangle limit is now 4 billion
* The memory is dynamically sized - you can forget the 'collision-tris' entry from .terrn2
* The `COLL: The hashtable is full` error is history.

Fixes #1395