### PR TITLE
Added console command spawnobject

### DIFF
--- a/source/main/gui/panels/GUI_GameConsole.cpp
+++ b/source/main/gui/panels/GUI_GameConsole.cpp
@@ -38,6 +38,7 @@
 #include "Scripting.h"
 #include "Settings.h"
 #include "TerrainManager.h"
+#include "TerrainObjectManager.h"
 #include "Utils.h"
 
 #if MYGUI_PLATFORM == MYGUI_PLATFORM_LINUX
@@ -235,190 +236,219 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
         // discard the empty message
         return;
     }
-        Ogre::StringVector args = StringUtil::split(msg, " ");
-        sTextHistory[iText] = msg;
-        iText++; //Used for text history
-        if (args[0] == "help")
-        {
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, _L("Available commands:"), "help.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("help - information on commands (this)"), "help.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("ver - shows the Rigs of Rods version"), "information.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("pos - outputs the current position"), "world.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("goto <x> <y> <z> - jumps to the mentioned position"), "world.png");
+    Ogre::StringVector args = StringUtil::split(msg, " ");
+    sTextHistory[iText] = msg;
+    iText++; //Used for text history
+    if (args[0] == "help")
+    {
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, _L("Available commands:"), "help.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("help - information on commands (this)"), "help.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("ver - shows the Rigs of Rods version"), "information.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("pos - outputs the current position"), "world.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("goto <x> <y> <z> - jumps to the mentioned position"), "world.png");
 
-            //if (gEnv->terrainManager->getHeightFinder()) //Not needed imo -max98
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("terrainheight - get height of terrain at current position"), "world.png");
+        //if (gEnv->terrainManager->getHeightFinder()) //Not needed imo -max98
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("terrainheight - get height of terrain at current position"), "world.png");
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("log - toggles log output on the console"), "table_save.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("log - toggles log output on the console"), "table_save.png");
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("quit - exit Rigs of Rods"), "table_save.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("quit - exit Rigs of Rods"), "table_save.png");
 
 #ifdef USE_ANGELSCRIPT
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("as <code here> - interpret angel code using console"), "script_go.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("as <code here> - interpret angel code using console"), "script_go.png");
 #endif // USE_ANGELSCRIPT
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("gravity <real> or <text string> - changes gravity constant. Outputs current value if no argument is given"), "script_go.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("Possible values: \n earth \n moon \n jupiter \n A random number (use negative)"), "script_go.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("gravity <real> or <text string> - changes gravity constant. Outputs current value if no argument is given"), "script_go.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("Possible values: \n earth \n moon \n jupiter \n A random number (use negative)"), "script_go.png");
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("setwaterlevel <real> - changes water's level"), "script_go.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("setwaterlevel <real> - changes water's level"), "script_go.png");
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, _L("Tips:"), "help.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("- use Arrow Up/Down Keys in the InputBox to reuse old messages"), "information.png");
-            return;
-        }
-        else if (args[0] == "gravity")
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("spawnobject <odef name> - spawn a object at the player position"), "script_go.png");
+
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, _L("Tips:"), "help.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("- use Arrow Up/Down Keys in the InputBox to reuse old messages"), "information.png");
+        return;
+    }
+    else if (args[0] == "gravity")
+    {
+        float gValue;
+
+        if (args.size() > 1)
         {
-            float gValue;
-
-            if (args.size() > 1)
-            {
-                if (args[1] == "earth")
-                    gValue = -9.81;
-                else if (args[1] == "moon")
-                    gValue = -1.6;
-                else if (args[1] == "jupiter")
-                    gValue = -50;
-                else
-                    gValue = std::stof(args[1]);
-            }
+            if (args[1] == "earth")
+                gValue = -9.81;
+            else if (args[1] == "moon")
+                gValue = -1.6;
+            else if (args[1] == "jupiter")
+                gValue = -50;
             else
-            {
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Current gravity is: ") + StringConverter::toString(gEnv->terrainManager->getGravity()), "information.png");
-                return;
-            }
-
-            gEnv->terrainManager->setGravity(gValue);
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Gravity set to: ") + StringConverter::toString(gValue), "information.png");
-            return;
-        }
-        else if (args[0] == "setwaterlevel")
-        {
-            if (gEnv->terrainManager && gEnv->terrainManager->getWater() && args.size() > 1)
-            {
-                IWater* water = gEnv->terrainManager->getWater();
-                water->setCamera(gEnv->mainCamera);
-                water->setHeight(std::stof(args[1]));
-                water->update();
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Water level set to: ") + StringConverter::toString(water->getHeight()), "information.png");
-            }
-            else
-            {
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_ERROR, _L("Please enter a correct value. "), "information.png");
-            }
-            return;
-        }
-        else if (args[0] == "pos" && (is_appstate_sim && !is_sim_select))
-        {
-            Beam* b = m_sim_controller->GetBeamFactory()->getCurrentTruck();
-            if (!b && gEnv->player)
-            {
-                Vector3 pos = gEnv->player->getPosition();
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Character position: ") + String("x: ") + TOSTRING(pos.x) + String(" y: ") + TOSTRING(pos.y) + String(" z: ") + TOSTRING(pos.z), "world.png");
-            }
-            else if (b)
-            {
-                Vector3 pos = b->getPosition();
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Vehicle position: ") + String("x: ") + TOSTRING(pos.x) + String(" y: ") + TOSTRING(pos.y) + String(" z: ") + TOSTRING(pos.z), "world.png");
-            }
-
-            return;
-        }
-        else if (args[0] == "goto" && (is_appstate_sim && !is_sim_select))
-        {
-            if (args.size() != 4)
-            {
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, RoR::Color::CommandColour + _L("usage: goto x y z"), "information.png");
-                return;
-            }
-
-            Vector3 pos = Vector3(PARSEREAL(args[1]), PARSEREAL(args[2]), PARSEREAL(args[3]));
-
-            Beam* b = m_sim_controller->GetBeamFactory()->getCurrentTruck();
-            if (!b && gEnv->player)
-            {
-                gEnv->player->setPosition(pos);
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Character position set to: ") + String("x: ") + TOSTRING(pos.x) + String(" y: ") + TOSTRING(pos.y) + String(" z: ") + TOSTRING(pos.z), "world.png");
-            }
-            else if (b)
-            {
-                b->resetPosition(pos, false);
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Vehicle position set to: ") + String("x: ") + TOSTRING(pos.x) + String(" y: ") + TOSTRING(pos.y) + String(" z: ") + TOSTRING(pos.z), "world.png");
-            }
-
-            return;
-        }
-        else if (args[0] == "terrainheight" && (is_appstate_sim && !is_sim_select))
-        {
-            if (!gEnv->terrainManager->getHeightFinder())
-                return;
-            Vector3 pos = Vector3::ZERO;
-
-            Beam* b = m_sim_controller->GetBeamFactory()->getCurrentTruck();
-            if (!b && gEnv->player)
-            {
-                pos = gEnv->player->getPosition();
-            }
-            else if (b)
-            {
-                pos = b->getPosition();
-            }
-
-            Real h = gEnv->terrainManager->getHeightFinder()->getHeightAt(pos.x, pos.z);
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Terrain height at position: ") + String("x: ") + TOSTRING(pos.x) + String("z: ") + TOSTRING(pos.z) + _L(" = ") + TOSTRING(h), "world.png");
-
-            return;
-        }
-        else if (args[0] == "ver")
-        {
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, "Rigs of Rods:", "information.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " Version: " + String(ROR_VERSION_STRING), "information.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " Protocol version: " + String(RORNET_VERSION), "information.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " build time: " + String(ROR_BUILD_DATE) + ", " + String(ROR_BUILD_TIME), "information.png");
-            return;
-        }
-        else if (args[0] == "quit")
-        {
-            RoR::App::SetPendingAppState(RoR::App::APP_STATE_SHUTDOWN);
-            return;
-        }
-#ifdef USE_ANGELSCRIPT
-        else if (args[0] == "as" && (is_appstate_sim && !is_sim_select))
-        {
-            // we want to notify any running scripts that we might change something (prevent cheating)
-            ScriptEngine::getSingleton().triggerEvent(SE_ANGELSCRIPT_MANIPULATIONS);
-
-            String command = msg.substr(args[0].length());
-
-            StringUtil::trim(command);
-            if (command.empty())
-                return;
-
-            String nmsg = RoR::Color::ScriptCommandColour + ">>> " + RoR::Color::NormalColour + command;
-            putMessage(CONSOLE_MSGTYPE_SCRIPT, CONSOLE_LOCAL_SCRIPT, nmsg, "script_go.png");
-            int res = ScriptEngine::getSingleton().executeString(command);
-            return;
-        }
-#endif //ANGELSCRIPT
-        else if (args[0] == "log")
-        {
-            // switch to console logging
-            bool logging = BSETTING("Enable Ingame Console", false);
-            if (!logging)
-            {
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_NOTICE, _L(" logging to console enabled"), "information.png");
-                SETTINGS.setSetting("Enable Ingame Console", "Yes");
-            }
-            else
-            {
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_NOTICE, _L(" logging to console disabled"), "information.png");
-                SETTINGS.setSetting("Enable Ingame Console", "No");
-            }
-            return;
+                gValue = std::stof(args[1]);
         }
         else
         {
-            //TODO: Angelscript here
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_ERROR, _L("unknown command: ") + msg, "error.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Current gravity is: ") + StringConverter::toString(gEnv->terrainManager->getGravity()), "information.png");
+            return;
         }
-    
+
+        gEnv->terrainManager->setGravity(gValue);
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Gravity set to: ") + StringConverter::toString(gValue), "information.png");
+        return;
+    }
+    else if (args[0] == "setwaterlevel")
+    {
+        if (gEnv->terrainManager && gEnv->terrainManager->getWater() && args.size() > 1)
+        {
+            IWater* water = gEnv->terrainManager->getWater();
+            water->setCamera(gEnv->mainCamera);
+            water->setHeight(std::stof(args[1]));
+            water->update();
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Water level set to: ") + StringConverter::toString(water->getHeight()), "information.png");
+        }
+        else
+        {
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_ERROR, _L("Please enter a correct value. "), "information.png");
+        }
+        return;
+    }
+    else if (args[0] == "pos" && (is_appstate_sim && !is_sim_select))
+    {
+        Beam* b = m_sim_controller->GetBeamFactory()->getCurrentTruck();
+        if (!b && gEnv->player)
+        {
+            Vector3 pos = gEnv->player->getPosition();
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Character position: ") + String("x: ") + TOSTRING(pos.x) + String(" y: ") + TOSTRING(pos.y) + String(" z: ") + TOSTRING(pos.z), "world.png");
+        }
+        else if (b)
+        {
+            Vector3 pos = b->getPosition();
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Vehicle position: ") + String("x: ") + TOSTRING(pos.x) + String(" y: ") + TOSTRING(pos.y) + String(" z: ") + TOSTRING(pos.z), "world.png");
+        }
+
+        return;
+    }
+    else if (args[0] == "goto" && (is_appstate_sim && !is_sim_select))
+    {
+        if (args.size() != 4)
+        {
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, RoR::Color::CommandColour + _L("usage: goto x y z"), "information.png");
+            return;
+        }
+
+        Vector3 pos = Vector3(PARSEREAL(args[1]), PARSEREAL(args[2]), PARSEREAL(args[3]));
+
+        Beam* b = m_sim_controller->GetBeamFactory()->getCurrentTruck();
+        if (!b && gEnv->player)
+        {
+            gEnv->player->setPosition(pos);
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Character position set to: ") + String("x: ") + TOSTRING(pos.x) + String(" y: ") + TOSTRING(pos.y) + String(" z: ") + TOSTRING(pos.z), "world.png");
+        }
+        else if (b)
+        {
+            b->resetPosition(pos, false);
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Vehicle position set to: ") + String("x: ") + TOSTRING(pos.x) + String(" y: ") + TOSTRING(pos.y) + String(" z: ") + TOSTRING(pos.z), "world.png");
+        }
+
+        return;
+    }
+    else if (args[0] == "terrainheight" && (is_appstate_sim && !is_sim_select))
+    {
+        if (!gEnv->terrainManager->getHeightFinder())
+            return;
+        Vector3 pos = Vector3::ZERO;
+
+        Beam* b = m_sim_controller->GetBeamFactory()->getCurrentTruck();
+        if (!b && gEnv->player)
+        {
+            pos = gEnv->player->getPosition();
+        }
+        else if (b)
+        {
+            pos = b->getPosition();
+        }
+
+        Real h = gEnv->terrainManager->getHeightFinder()->getHeightAt(pos.x, pos.z);
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Terrain height at position: ") + String("x: ") + TOSTRING(pos.x) + String("z: ") + TOSTRING(pos.z) + _L(" = ") + TOSTRING(h), "world.png");
+
+        return;
+    }
+    else if (args[0] == "ver")
+    {
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, "Rigs of Rods:", "information.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " Version: " + String(ROR_VERSION_STRING), "information.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " Protocol version: " + String(RORNET_VERSION), "information.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " build time: " + String(ROR_BUILD_DATE) + ", " + String(ROR_BUILD_TIME), "information.png");
+        return;
+    }
+    else if (args[0] == "quit")
+    {
+        RoR::App::SetPendingAppState(RoR::App::APP_STATE_SHUTDOWN);
+        return;
+    }
+#ifdef USE_ANGELSCRIPT
+    else if (args[0] == "as" && (is_appstate_sim && !is_sim_select))
+    {
+        // we want to notify any running scripts that we might change something (prevent cheating)
+        ScriptEngine::getSingleton().triggerEvent(SE_ANGELSCRIPT_MANIPULATIONS);
+
+        String command = msg.substr(args[0].length());
+
+        StringUtil::trim(command);
+        if (command.empty())
+            return;
+
+        String nmsg = RoR::Color::ScriptCommandColour + ">>> " + RoR::Color::NormalColour + command;
+        putMessage(CONSOLE_MSGTYPE_SCRIPT, CONSOLE_LOCAL_SCRIPT, nmsg, "script_go.png");
+        int res = ScriptEngine::getSingleton().executeString(command);
+        return;
+    }
+#endif //ANGELSCRIPT
+    else if (args[0] == "log")
+    {
+        // switch to console logging
+        bool logging = BSETTING("Enable Ingame Console", false);
+        if (!logging)
+        {
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_NOTICE, _L(" logging to console enabled"), "information.png");
+            SETTINGS.setSetting("Enable Ingame Console", "Yes");
+        }
+        else
+        {
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_NOTICE, _L(" logging to console disabled"), "information.png");
+            SETTINGS.setSetting("Enable Ingame Console", "No");
+        }
+        return;
+    }
+    else if (args[0] == "spawnobject" && (is_appstate_sim && !is_sim_select))
+    {
+        Vector3 pos = Vector3::ZERO;
+
+        if (gEnv->player)
+        {
+            pos = gEnv->player->getPosition();
+        }
+
+        try
+        {
+            SceneNode* bakeNode = gEnv->sceneManager->getRootSceneNode()->createChildSceneNode();
+            gEnv->terrainManager->getObjectManager()->loadObject(args[1], pos, Vector3::ZERO, bakeNode, "Console", "");
+
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Spawned object at position: ") + String("x: ") + TOSTRING(pos.x) + String("z: ") + TOSTRING(pos.z), "world.png");
+        }
+        catch (std::exception e)
+        {
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_ERROR, e.what(), "error.png");
+        }
+
+        return;
+    }
+    else
+    {
+#ifdef USE_ANGELSCRIPT
+        // Just send the complete message to the ScriptEngine
+        ScriptEngine::getSingleton().executeString(msg);
+#else
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_ERROR, _L("unknown command: ") + msg, "error.png");
+#endif //ANGELSCRIPT
+    }
+
 }

--- a/source/main/gui/panels/GUI_GameConsole.cpp
+++ b/source/main/gui/panels/GUI_GameConsole.cpp
@@ -235,40 +235,38 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
         // discard the empty message
         return;
     }
-    if (msg[0] == '/' || msg[0] == '\\')
-    {
         Ogre::StringVector args = StringUtil::split(msg, " ");
         sTextHistory[iText] = msg;
         iText++; //Used for text history
-        if (args[0] == "/help")
+        if (args[0] == "help")
         {
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, _L("Available commands:"), "help.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/help - information on commands (this)"), "help.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/ver - shows the Rigs of Rods version"), "information.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/pos - outputs the current position"), "world.png");
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/goto <x> <y> <z> - jumps to the mentioned position"), "world.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("help - information on commands (this)"), "help.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("ver - shows the Rigs of Rods version"), "information.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("pos - outputs the current position"), "world.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("goto <x> <y> <z> - jumps to the mentioned position"), "world.png");
 
             //if (gEnv->terrainManager->getHeightFinder()) //Not needed imo -max98
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/terrainheight - get height of terrain at current position"), "world.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("terrainheight - get height of terrain at current position"), "world.png");
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/log - toggles log output on the console"), "table_save.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("log - toggles log output on the console"), "table_save.png");
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/quit - exit Rigs of Rods"), "table_save.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("quit - exit Rigs of Rods"), "table_save.png");
 
 #ifdef USE_ANGELSCRIPT
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/as <code here> - interpret angel code using console"), "script_go.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("as <code here> - interpret angel code using console"), "script_go.png");
 #endif // USE_ANGELSCRIPT
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/gravity <real> or <text string> - changes gravity constant. Outputs current value if no argument is given"), "script_go.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("gravity <real> or <text string> - changes gravity constant. Outputs current value if no argument is given"), "script_go.png");
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("Possible values: \n earth \n moon \n jupiter \n A random number (use negative)"), "script_go.png");
 
-            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("/setwaterlevel <real> - changes water's level"), "script_go.png");
+            putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("setwaterlevel <real> - changes water's level"), "script_go.png");
 
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, _L("Tips:"), "help.png");
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("- use Arrow Up/Down Keys in the InputBox to reuse old messages"), "information.png");
             return;
         }
-        else if (args[0] == "/gravity")
+        else if (args[0] == "gravity")
         {
             float gValue;
 
@@ -293,7 +291,7 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L("Gravity set to: ") + StringConverter::toString(gValue), "information.png");
             return;
         }
-        else if (args[0] == "/setwaterlevel")
+        else if (args[0] == "setwaterlevel")
         {
             if (gEnv->terrainManager && gEnv->terrainManager->getWater() && args.size() > 1)
             {
@@ -309,7 +307,7 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
             }
             return;
         }
-        else if (args[0] == "/pos" && (is_appstate_sim && !is_sim_select))
+        else if (args[0] == "pos" && (is_appstate_sim && !is_sim_select))
         {
             Beam* b = m_sim_controller->GetBeamFactory()->getCurrentTruck();
             if (!b && gEnv->player)
@@ -325,11 +323,11 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
 
             return;
         }
-        else if (args[0] == "/goto" && (is_appstate_sim && !is_sim_select))
+        else if (args[0] == "goto" && (is_appstate_sim && !is_sim_select))
         {
             if (args.size() != 4)
             {
-                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, RoR::Color::CommandColour + _L("usage: /goto x y z"), "information.png");
+                putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, RoR::Color::CommandColour + _L("usage: goto x y z"), "information.png");
                 return;
             }
 
@@ -349,7 +347,7 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
 
             return;
         }
-        else if (args[0] == "/terrainheight" && (is_appstate_sim && !is_sim_select))
+        else if (args[0] == "terrainheight" && (is_appstate_sim && !is_sim_select))
         {
             if (!gEnv->terrainManager->getHeightFinder())
                 return;
@@ -370,7 +368,7 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
 
             return;
         }
-        else if (args[0] == "/ver")
+        else if (args[0] == "ver")
         {
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_TITLE, "Rigs of Rods:", "information.png");
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " Version: " + String(ROR_VERSION_STRING), "information.png");
@@ -378,13 +376,13 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, " build time: " + String(ROR_BUILD_DATE) + ", " + String(ROR_BUILD_TIME), "information.png");
             return;
         }
-        else if (args[0] == "/quit")
+        else if (args[0] == "quit")
         {
             RoR::App::SetPendingAppState(RoR::App::APP_STATE_SHUTDOWN);
             return;
         }
 #ifdef USE_ANGELSCRIPT
-        else if (args[0] == "/as" && (is_appstate_sim && !is_sim_select))
+        else if (args[0] == "as" && (is_appstate_sim && !is_sim_select))
         {
             // we want to notify any running scripts that we might change something (prevent cheating)
             ScriptEngine::getSingleton().triggerEvent(SE_ANGELSCRIPT_MANIPULATIONS);
@@ -401,7 +399,7 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
             return;
         }
 #endif //ANGELSCRIPT
-        else if (args[0] == "/log")
+        else if (args[0] == "log")
         {
             // switch to console logging
             bool logging = BSETTING("Enable Ingame Console", false);
@@ -422,5 +420,5 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
             //TODO: Angelscript here
             putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_ERROR, _L("unknown command: ") + msg, "error.png");
         }
-    }
+    
 }


### PR DESCRIPTION
This command spawns an odef object at the player's position 
For instance ```spawnobject opentruckshop``` spawns a opentruckshop at the player's position

This can be useful for quickly adding new objects and moving them with the [terrain editor](http://docs.rigsofrods.org/terrain-creation/editing-terrain-objects/)
