### PR TITLE
Build fix for OGRE 1.8

### DIFF
--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -67,7 +67,7 @@ public:
         ~Profile() override {};
 
         bool               isVertexCompressionSupported () const { return false; }
-        void               setLightmapEnabled           (bool set) override {}
+        void               setLightmapEnabled           (bool set) /*override*/ {} // OGRE 1.8 doesn't have this method
         Ogre::MaterialPtr  generate                     (const Ogre::Terrain* terrain) override;
         Ogre::uint8        getMaxLayers                 (const Ogre::Terrain* terrain) const override { return 0; };
         void               updateParams                 (const Ogre::MaterialPtr& mat, const Ogre::Terrain* terrain) override {};


### PR DESCRIPTION
Apparently function `Ogre::TerrainMaterialGenerator::Profile::setLightmapEnabled()` is only present in v1.9

1.9 docs: https://www.ogre3d.org/docs/api/1.9/class_ogre_1_1_terrain_material_generator_1_1_profile.html
1.8 docs: https://www.ogre3d.org/docs/api/1.8/class_ogre_1_1_terrain_material_generator_1_1_profile.html