### PR TITLE
Fixed `EnvmapUpdateRate` default value

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -148,7 +148,7 @@ static RoRFrameListener* g_sim_controller;
  GVarPod_A<bool>          gfx_enable_heathaze     ("gfx_enable_heathaze",     "HeatHaze",                  false);
  GVarPod_A<bool>          gfx_enable_videocams    ("gfx_enable_videocams",    "gfx_enable_videocams",      false);
  GVarPod_A<bool>          gfx_envmap_enabled      ("gfx_envmap_enabled",      "Envmap",                    false);
- GVarPod_A<int>           gfx_envmap_rate         ("gfx_envmap_rate",         "EnvmapUpdateRate",          0);
+ GVarPod_A<int>           gfx_envmap_rate         ("gfx_envmap_rate",         "EnvmapUpdateRate",          2);
  GVarPod_A<int>           gfx_skidmarks_mode      ("gfx_skidmarks_mode",      "Skidmarks",                 0);
  GVarPod_A<float>         gfx_sight_range         ("gfx_sight_range",         "SightRange",                3000.f); // Previously either 2000 or 4500 (inconsistent)
  GVarPod_APS<float>       gfx_fov_external        ("gfx_fov_external",        "FOV External",              60.f,                      60.f,     60.f);


### PR DESCRIPTION
If `RoR.cfg` does not contain the `EnvmapUpdateRate` line (the Configurator does not write this value, so RoR writes it once you exit) the default value would be set to 0, thus causing vehicles to not have any reflections:
![screenshot_2017-12-15_16-53-53_1](https://user-images.githubusercontent.com/11002490/34063434-11e3e2e2-e1c0-11e7-8f9f-bdd61cc83682.png)
This sets the default value to `2` (from here: https://github.com/RigsOfRods/rigs-of-rods/wiki/GVars:-global-(console)-variables)