### PR TITLE
Made node debug size smaller

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4718,7 +4718,7 @@ void Beam::setDebugOverlayState(int mode)
             deletion_sceneNodes.emplace_back(t.node);
             t.node->attachObject(t.txt);
             t.node->setPosition(nodes[i].AbsPosition);
-            t.node->setScale(Vector3(0.5, 0.5, 0.5));
+            t.node->setScale(Vector3(0.05, 0.05, 0.05));
 
             // collision nodes debug, also mimics as node visual
             SceneNode* s = t.node->createChildSceneNode();


### PR DESCRIPTION
This makes the visual node debug readable on complex n/b's, using the same size values found in 0.36's source (https://github.com/only-a-ptr/ror-legacy-svn-trunk/blob/dcb83de66935cb6b82d153fea2838e166419a7ac/build/main/source/Beam.cpp#L9633)
![image](https://user-images.githubusercontent.com/11002490/34077227-8d7268cc-e2cc-11e7-92d6-329700887bb8.png)