### PR TITLE
BUGFIX: Crashes when changing sky type in Settings

### DIFF
--- a/source/main/GlobalEnvironment.h
+++ b/source/main/GlobalEnvironment.h
@@ -33,7 +33,6 @@ public:
         , mainCamera(0)
         , player(0)
         , sceneManager(0)
-        , sky(0)
         , surveyMap(0)
         , terrainManager(0)
         , threadPool(0)
@@ -47,7 +46,6 @@ public:
     Character*          player;
     Collisions*         collisions;
     SurveyMapManager*   surveyMap;
-    SkyManager*         sky;
     TerrainManager*     terrainManager;
     ThreadPool*         threadPool;
     float               mrTime;

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -2240,48 +2240,10 @@ bool RoRFrameListener::SetupGameplayLoop()
 
     auto* loading_window = App::GetGuiManager()->GetLoadingWindow();
 
-    LOG("Loading base resources");
+    RoR::Log("[RoR] Loading resources...");
 
-    loading_window->setProgress(0, _L("Loading base resources"));
-    App::GetContentManager()->CheckAndLoadBaseResources();
-
-
-    // ============================================================================
-    // Loading settings resources
-    // ============================================================================
-
-    if (App::gfx_water_mode.GetActive() == GfxWaterMode::HYDRAX && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::HYDRAX.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::HYDRAX);
-
-    if (App::gfx_sky_mode.GetActive() == GfxSkyMode::CAELUM && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::CAELUM.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::CAELUM);
-
-    if (App::gfx_vegetation_mode.GetActive() != RoR::GfxVegetation::NONE && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::PAGED.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::PAGED);
-
-    if (App::gfx_enable_hdr.GetActive() && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::HDR.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::HDR);
-
-    if (App::gfx_enable_dof.GetActive() && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::DEPTH_OF_FIELD.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::DEPTH_OF_FIELD);
-
-    if (App::gfx_enable_glow.GetActive() && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::GLOW.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::GLOW);
-
-    if (App::gfx_motion_blur.GetActive() && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::BLUR.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::BLUR);
-
-    if (App::gfx_enable_heathaze.GetActive() && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::HEATHAZE.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::HEATHAZE);
-
-    if (App::gfx_enable_sunburn.GetActive() && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::SUNBURN.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::SUNBURN);
-
-    /*if (SSETTING("Shadow technique", "") == "Parallel-split Shadow Maps" && !RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::PSSM.mask))
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::PSSM);
-        */
-
-    Ogre::ResourceGroupManager::getSingleton().initialiseResourceGroup("LoadBeforeMap");
+    loading_window->setProgress(0, _L("Loading resources"));
+    App::GetContentManager()->LoadGameplayResources();
 
     // ============================================================================
     // Setup
@@ -2307,7 +2269,7 @@ bool RoRFrameListener::SetupGameplayLoop()
     gEnv->player = m_character_factory.createLocal(colourNum);
 
     // heathaze effect
-    if (App::gfx_enable_heathaze.GetActive() && RoR::App::GetContentManager()->isLoaded(ContentManager::ResourcePack::HEATHAZE.mask))
+    if (App::gfx_enable_heathaze.GetActive())
     {
         m_heathaze = new HeatHaze();
         m_heathaze->setEnable(true);

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1212,7 +1212,7 @@ bool RoRFrameListener::UpdateInputEvents(float dt)
 
 #ifdef USE_CAELUM
 
-        static const bool caelum_enabled = App::gfx_sky_mode.GetActive() == GfxSkyMode::CAELUM;
+        const bool caelum_enabled = App::gfx_sky_mode.GetActive() == GfxSkyMode::CAELUM;
         if (caelum_enabled && (simRUNNING(s) || simPAUSED(s) || simEDITOR(s)))
         {
             Real time_factor = 1000.0f;

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1241,14 +1241,14 @@ bool RoRFrameListener::UpdateInputEvents(float dt)
             else
             {
                 time_factor = 1.0f;
-                update_time = gEnv->terrainManager->getSkyManager()->getTimeFactor() != 1.0f;
+                update_time = gEnv->terrainManager->getSkyManager()->GetSkyTimeFactor() != 1.0f;
             }
 
             if (update_time)
             {
-                gEnv->terrainManager->getSkyManager()->setTimeFactor(time_factor);
-                RoR::App::GetGuiManager()->PushNotification("Notice:", _L("Time set to ") + gEnv->terrainManager->getSkyManager()->getPrettyTime());
-                RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Time set to ") + gEnv->terrainManager->getSkyManager()->getPrettyTime(), "weather_sun.png", 1000);
+                gEnv->terrainManager->getSkyManager()->SetSkyTimeFactor(time_factor);
+                RoR::App::GetGuiManager()->PushNotification("Notice:", _L("Time set to ") + gEnv->terrainManager->getSkyManager()->GetPrettyTime());
+                RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Time set to ") + gEnv->terrainManager->getSkyManager()->GetPrettyTime(), "weather_sun.png", 1000);
             }
         }
 
@@ -1676,7 +1676,7 @@ bool RoRFrameListener::frameStarted(const FrameEvent& evt)
     SkyManager* sky = gEnv->terrainManager->getSkyManager();
     if ((sky != nullptr) && (simRUNNING(s) || simPAUSED(s) || simEDITOR(s)))
     {
-        sky->detectUpdate();
+        sky->DetectSkyUpdate();
     }
 #endif
 

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -264,9 +264,10 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, Beam* beam /* = 0 */)
         // caelum needs to know that we changed the cameras
 #ifdef USE_CAELUM
 
-        if (gEnv->terrainManager->getSkyManager())
+        SkyManager* sky = gEnv->terrainManager->getSkyManager();
+        if (sky != nullptr)
         {
-            gEnv->terrainManager->getSkyManager()->notifyCameraChanged(m_cameras[m_update_round]);
+            sky->NotifySkyCameraChanged(m_cameras[m_update_round]);
         }
 #endif // USE_CAELUM
         m_render_targets[m_update_round]->update();
@@ -276,7 +277,7 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, Beam* beam /* = 0 */)
 
     if (gEnv->terrainManager->getSkyManager())
     {
-        gEnv->terrainManager->getSkyManager()->notifyCameraChanged(gEnv->mainCamera);
+        gEnv->terrainManager->getSkyManager()->NotifySkyCameraChanged(gEnv->mainCamera);
     }
 #endif // USE_CAELUM
 

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -24,6 +24,7 @@
 #include "Beam.h"
 #include "GlobalEnvironment.h" // TODO: Eliminate!
 #include "SkyManager.h"
+#include "TerrainManager.h"
 
 #include <OgrePass.h>
 #include <OgreRenderWindow.h>
@@ -229,9 +230,10 @@ void RoR::GfxActor::UpdateVideoCameras(float dt_sec)
     {
 #ifdef USE_CAELUM
         // caelum needs to know that we changed the cameras
-        if (gEnv->sky && RoR::App::app_state.GetActive() == RoR::AppState::SIMULATION)
+        SkyManager* sky = gEnv->terrainManager->getSkyManager();
+        if ((sky != nullptr) && (RoR::App::app_state.GetActive() == RoR::AppState::SIMULATION))
         {
-            gEnv->sky->notifyCameraChanged(vidcam.vcam_ogre_camera);
+            sky->NotifySkyCameraChanged(vidcam.vcam_ogre_camera);
         }
 #endif // USE_CAELUM
 

--- a/source/main/gfx/HydraxWater.cpp
+++ b/source/main/gfx/HydraxWater.cpp
@@ -23,6 +23,7 @@
 #include "Application.h"
 #include "OgreSubsystem.h"
 #include "SkyManager.h"
+#include "TerrainManager.h"
 
 #ifdef USE_CAELUM
 #include <Caelum.h>
@@ -108,12 +109,13 @@ void HydraxWater::update()
 {
     //This has to change in the next versions when SkyX will be added.
 #ifdef USE_CAELUM
-    if (gEnv->sky) //Caelum way of doing things
+    SkyManager* sky = gEnv->terrainManager->getSkyManager();
+    if (sky != nullptr) //Caelum way of doing things
     {
         Ogre::Vector3 sunPosition = gEnv->mainCamera->getDerivedPosition();
-        sunPosition -= gEnv->sky->getCaelumSys()->getSun()->getLightDirection() * 80000;
+        sunPosition -= sky->GetCaelumSys()->getSun()->getLightDirection() * 80000;
         mHydrax->setSunPosition(sunPosition);
-        mHydrax->setSunColor(Ogre::Vector3(gEnv->sky->getCaelumSys()->getSun()->getBodyColour().r, gEnv->sky->getCaelumSys()->getSun()->getBodyColour().g, gEnv->sky->getCaelumSys()->getSun()->getBodyColour().b));
+        mHydrax->setSunColor(Ogre::Vector3(sky->GetCaelumSys()->getSun()->getBodyColour().r, sky->GetCaelumSys()->getSun()->getBodyColour().g, sky->GetCaelumSys()->getSun()->getBodyColour().b));
     }
     else
 #endif // USE_CAELUM

--- a/source/main/gfx/SkyManager.cpp
+++ b/source/main/gfx/SkyManager.cpp
@@ -2,7 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
-    Copyright 2013-2014 Petr Ohlidal
+    Copyright 2013-2018 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -31,72 +31,57 @@
 
 #include <Caelum.h>
 
-using namespace Ogre;
-
-//---------------------------------------------------------------------
-SkyManager::SkyManager() : mCaelumSystem(0), lc(0)
+SkyManager::SkyManager() : m_caelum_system(nullptr), m_last_clock(0.0)
 {
     // Initialise CaelumSystem.
-    mCaelumSystem = new Caelum::CaelumSystem(
+    m_caelum_system = new Caelum::CaelumSystem(
         RoR::App::GetOgreSubsystem()->GetOgreRoot(),
         gEnv->sceneManager,
         Caelum::CaelumSystem::CAELUM_COMPONENTS_DEFAULT
     );
-    mCaelumSystem->attachViewport(RoR::App::GetOgreSubsystem()->GetViewport());
-    /*
-    // TODO: set real time, and let the user select his true location
-    mCaelumSystem->getUniversalClock()->setGregorianDateTime(2008, 4, 9, 6, 33, 0);
-    mCaelumSystem->setObserverLongitude(Degree(0));
-    mCaelumSystem->setObserverLatitude(Degree(0));
-    mCaelumSystem->getUniversalClock()->setTimeScale(100);
-    */
+
+    m_caelum_system->attachViewport(RoR::App::GetOgreSubsystem()->GetViewport());
 
     // Register caelum as a listener.
-    RoR::App::GetOgreSubsystem()->GetRenderWindow()->addListener(mCaelumSystem);
-    RoR::App::GetOgreSubsystem()->GetOgreRoot()->addFrameListener(mCaelumSystem);
+    RoR::App::GetOgreSubsystem()->GetRenderWindow()->addListener(m_caelum_system);
+    RoR::App::GetOgreSubsystem()->GetOgreRoot()->addFrameListener(m_caelum_system);
 }
 
 SkyManager::~SkyManager()
 {
-    RoR::App::GetOgreSubsystem()->GetRenderWindow()->removeListener(mCaelumSystem);
-    mCaelumSystem->shutdown(false);
-    mCaelumSystem = nullptr;
+    RoR::App::GetOgreSubsystem()->GetRenderWindow()->removeListener(m_caelum_system);
+    m_caelum_system->shutdown(false);
+    m_caelum_system = nullptr;
 }
 
-void SkyManager::notifyCameraChanged(Camera* cam)
+void SkyManager::NotifySkyCameraChanged(Ogre::Camera* cam)
 {
-    if (mCaelumSystem)
-        mCaelumSystem->notifyCameraChanged(cam);
+    if (m_caelum_system)
+        m_caelum_system->notifyCameraChanged(cam);
 }
 
-void SkyManager::forceUpdate(float dt)
+void SkyManager::DetectSkyUpdate()
 {
-    if (mCaelumSystem)
-        mCaelumSystem->updateSubcomponents(dt);
-}
-
-void SkyManager::detectUpdate()
-{
-    if (!mCaelumSystem || !gEnv->terrainManager)
+    if (!m_caelum_system || !gEnv->terrainManager)
         return;
-    Caelum::LongReal c = mCaelumSystem->getUniversalClock()->getJulianDay();
+    Caelum::LongReal c = m_caelum_system->getUniversalClock()->getJulianDay();
 
-    if (c - lc > 0.001f)
+    if (c - m_last_clock > 0.001f)
     {
         TerrainGeometryManager* gm = gEnv->terrainManager->getGeometryManager();
         if (gm)
             gm->updateLightMap();
     }
 
-    lc = c;
+    m_last_clock = c;
 }
 
-void SkyManager::loadScript(String script, int fogStart, int fogEnd)
+void SkyManager::LoadCaelumScript(std::string script, int fogStart, int fogEnd)
 {
     // load the caelum config
     try
     {
-        Caelum::CaelumPlugin::getSingleton().loadCaelumSystemFromScript(mCaelumSystem, script);
+        Caelum::CaelumPlugin::getSingleton().loadCaelumSystemFromScript(m_caelum_system, script);
 
         // overwrite some settings
 #ifdef CAELUM_VERSION_SEC
@@ -106,9 +91,9 @@ void SkyManager::loadScript(String script, int fogStart, int fogEnd)
             // setting farclip (hacky)
             gEnv->mainCamera->setFarClipDistance(fogEnd / 0.8);
             // custom boundaries
-            mCaelumSystem->setManageSceneFog(FOG_LINEAR);
-            mCaelumSystem->setManageSceneFogStart(fogStart);
-            mCaelumSystem->setManageSceneFogEnd(fogEnd);
+            m_caelum_system->setManageSceneFog(Ogre::FOG_LINEAR);
+            m_caelum_system->setManageSceneFogStart(fogStart);
+            m_caelum_system->setManageSceneFogEnd(fogEnd);
         }
         else if (gEnv->mainCamera->getFarClipDistance() > 0)
         {
@@ -121,71 +106,73 @@ void SkyManager::loadScript(String script, int fogStart, int fogEnd)
                 LOG("You always need to define both boundaries (CaelumFogStart AND CaelumFogEnd). Ignoring boundaries.");
             }
             // non infinite farclip
-            Real farclip = gEnv->mainCamera->getFarClipDistance();
-            mCaelumSystem->setManageSceneFog(FOG_LINEAR);
-            mCaelumSystem->setManageSceneFogStart(farclip * 0.7);
-            mCaelumSystem->setManageSceneFogEnd(farclip * 0.9);
+            float farclip = gEnv->mainCamera->getFarClipDistance();
+            m_caelum_system->setManageSceneFog(Ogre::FOG_LINEAR);
+            m_caelum_system->setManageSceneFogStart(farclip * 0.7);
+            m_caelum_system->setManageSceneFogEnd(farclip * 0.9);
         }
         else
         {
             // no fog in infinite farclip
-            mCaelumSystem->setManageSceneFog(FOG_NONE);
+            m_caelum_system->setManageSceneFog(Ogre::FOG_NONE);
         }
 #else
 #error please use a recent Caelum version, see http://www.rigsofrods.org/wiki/pages/Compiling_3rd_party_libraries#Caelum
 #endif // CAELUM_VERSION
         // now optimize the moon a bit
-        if (mCaelumSystem->getMoon())
+        if (m_caelum_system->getMoon())
         {
-            mCaelumSystem->getMoon()->setAutoDisable(true);
-            //mCaelumSystem->getMoon()->setAutoDisableThreshold(1);
-            mCaelumSystem->getMoon()->setForceDisable(true);
-            mCaelumSystem->getMoon()->getMainLight()->setCastShadows(false);
+            m_caelum_system->getMoon()->setAutoDisable(true);
+            //m_caelum_system->getMoon()->setAutoDisableThreshold(1);
+            m_caelum_system->getMoon()->setForceDisable(true);
+            m_caelum_system->getMoon()->getMainLight()->setCastShadows(false);
         }
 
-        mCaelumSystem->setEnsureSingleShadowSource(true);
-        mCaelumSystem->setEnsureSingleLightSource(true);
+        m_caelum_system->setEnsureSingleShadowSource(true);
+        m_caelum_system->setEnsureSingleLightSource(true);
 
         // enforcing update, so shadows are set correctly before creating the terrain
-        forceUpdate(0.1);
+        m_caelum_system->updateSubcomponents(0.1);
     }
-    catch (Exception& e)
+    catch (Ogre::Exception& e)
     {
-        LOG("exception upon loading sky script: " + e.getFullDescription());
+        RoR::LogFormat("[RoR] Exception while loading sky script: %s", e.getFullDescription().c_str());
     }
-    Ogre::Vector3 lightsrc = mCaelumSystem->getSun()->getMainLight()->getDirection();
-    mCaelumSystem->getSun()->getMainLight()->setDirection(lightsrc.normalisedCopy());
+    Ogre::Vector3 lightsrc = m_caelum_system->getSun()->getMainLight()->getDirection();
+    m_caelum_system->getSun()->getMainLight()->setDirection(lightsrc.normalisedCopy());
 }
 
-void SkyManager::setTimeFactor(Real factor)
+void SkyManager::SetSkyTimeFactor(float factor)
 {
-    mCaelumSystem->getUniversalClock()->setTimeScale(factor);
+    m_caelum_system->getUniversalClock()->setTimeScale(factor);
 }
 
-Light* SkyManager::getMainLight()
+Ogre::Light* SkyManager::GetSkyMainLight()
 {
-    if (mCaelumSystem && mCaelumSystem->getSun())
-        return mCaelumSystem->getSun()->getMainLight();
-    return 0;
+    if (m_caelum_system && m_caelum_system->getSun())
+    {
+        return m_caelum_system->getSun()->getMainLight();
+    }
+    return nullptr;
 }
 
-Real SkyManager::getTimeFactor()
+float SkyManager::GetSkyTimeFactor()
 {
-    return mCaelumSystem->getUniversalClock()->getTimeScale();
+    return m_caelum_system->getUniversalClock()->getTimeScale();
 }
 
-String SkyManager::getPrettyTime()
+std::string SkyManager::GetPrettyTime()
 {
     int ignore;
     int hour;
     int minute;
     Caelum::LongReal second;
-    Caelum::Astronomy::getGregorianDateTimeFromJulianDay(mCaelumSystem->getJulianDay()
+    Caelum::Astronomy::getGregorianDateTimeFromJulianDay(m_caelum_system->getJulianDay()
         , ignore, ignore, ignore, hour, minute, second);
 
-    return StringConverter::toString(hour, 2, '0')
-        + ":" + StringConverter::toString(minute, 2, '0')
-        + ":" + StringConverter::toString((int)second, 2, '0');
+    char buf[100];
+    snprintf(buf, 100, "%02d:%02d:%02d", hour, minute, static_cast<size_t>(second));
+    return buf;
 }
 
 #endif //USE_CAELUM

--- a/source/main/gfx/SkyManager.h
+++ b/source/main/gfx/SkyManager.h
@@ -2,6 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
+    Copyright 2017-2018 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -22,45 +23,30 @@
 
 #pragma once
 
-#include "RoRPrerequisites.h"
+#include "ForwardDeclarations.h"
 
 #include "CaelumPrerequisites.h"
 
-class SkyManager : public ZeroedMemoryAllocator
+class SkyManager
 {
 public:
 
     SkyManager();
     ~SkyManager();
 
-    void loadScript(Ogre::String script, int fogStart = -1, int fogEnd = -1);
+    void           LoadCaelumScript(Ogre::String script, int fogStart = -1, int fogEnd = -1);
+    void           SetSkyTimeFactor(Ogre::Real f);  //!< change the time scale
+    Ogre::Light*   GetSkyMainLight();
+    float          GetSkyTimeFactor();              //!< gets the current time scale
+    std::string    GetPrettyTime();                 //!< prints the current time of the simulation in the format of HH:MM:SS
+    bool           UpdateSky(float dt);
+    void           NotifySkyCameraChanged(Ogre::Camera* cam);
+    void           DetectSkyUpdate();
+    Caelum::CaelumSystem* GetCaelumSys()        { return m_caelum_system; }
 
-    /// change the time scale
-    void setTimeFactor(Ogre::Real f);
-    Ogre::Light* getMainLight();
-    /// gets the current time scale
-    Ogre::Real getTimeFactor();
-
-    /// prints the current time of the simulation in the format of HH:MM:SS
-    Ogre::String getPrettyTime();
-
-    bool update(float dt);
-
-    void forceUpdate(float dt);
-
-    void notifyCameraChanged(Ogre::Camera* cam);
-
-    void detectUpdate();
-
-    Caelum::CaelumSystem* getCaelumSys()
-    {
-        return mCaelumSystem;
-    }
-
-protected:
-    Caelum::LongReal lc;
-    Caelum::CaelumSystem* mCaelumSystem;
-    Caelum::CaelumSystem* getCaelumSystem() { return mCaelumSystem; };
+private:
+    Caelum::LongReal      m_last_clock;
+    Caelum::CaelumSystem* m_caelum_system;
 };
 
 #endif // USE_CAELUM

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -168,8 +168,6 @@ int main(int argc, char *argv[])
         // Add startup resources
         App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::OGRE_CORE);
         App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::WALLPAPERS);
-        Ogre::ResourceGroupManager::getSingleton().initialiseResourceGroup("Bootstrap");
-        Ogre::ResourceGroupManager::getSingleton().initialiseResourceGroup("Wallpapers");
 
         // Setup rendering (menu + simulation)
         Ogre::SceneManager* scene_manager = App::GetOgreSubsystem()->GetOgreRoot()->createSceneManager(Ogre::ST_EXTERIOR_CLOSE, "main_scene_manager");
@@ -195,7 +193,7 @@ int main(int argc, char *argv[])
 
         App::CreateCacheSystem(); // Reads GVars
 
-        App::GetContentManager()->init();
+        App::GetContentManager()->OnApplicationStartup();
 
         App::CreateGuiManagerIfNotExists();
 

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -63,46 +63,44 @@ using namespace RoR;
 // Static variables
 // ================================================================================
 
-#define DECLARE_RESOURCE_PACK(_NUMBER_, _FIELD_, _NAME_, _RESOURCE_GROUP_) \
-    const ContentManager::ResourcePack ContentManager::ResourcePack::_FIELD_(BITMASK_64(_NUMBER_), _NAME_, _RESOURCE_GROUP_);
+#define DECLARE_RESOURCE_PACK(_FIELD_, _NAME_, _RESOURCE_GROUP_) \
+    const ContentManager::ResourcePack ContentManager::ResourcePack::_FIELD_(_NAME_, _RESOURCE_GROUP_);
 
-DECLARE_RESOURCE_PACK(  1, OGRE_CORE,             "OgreCore",             "Bootstrap");
-DECLARE_RESOURCE_PACK(  2, WALLPAPERS,            "wallpapers",           "Wallpapers");
-// UNUSED               3
-DECLARE_RESOURCE_PACK(  4, AIRFOILS,              "airfoils",             "LoadBeforeMap");
-DECLARE_RESOURCE_PACK(  5, BEAM_OBJECTS,          "beamobjects",          "LoadBeforeMap");
-DECLARE_RESOURCE_PACK(  6, BLUR,                  "blur",                 "LoadBeforeMap");
-DECLARE_RESOURCE_PACK(  7, CAELUM,                "caelum",               "LoadBeforeMap");
-DECLARE_RESOURCE_PACK(  8, CUBEMAPS,              "cubemaps",             "General");
-DECLARE_RESOURCE_PACK(  9, DASHBOARDS,            "dashboards",           "General");
-DECLARE_RESOURCE_PACK( 10, DEPTH_OF_FIELD,        "dof",                  "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 11, FAMICONS,              "famicons",             "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 12, FLAGS,                 "flags",                "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 13, GLOW,                  "glow",                 "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 14, HDR,                   "hdr",                  "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 15, HEATHAZE,              "heathaze",             "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 16, HYDRAX,                "hydrax",               "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 17, ICONS,                 "icons",                "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 18, MATERIALS,             "materials",            "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 19, MESHES,                "meshes",               "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 20, MYGUI,                 "mygui",                "General");
-DECLARE_RESOURCE_PACK( 21, OVERLAYS,              "overlays",             "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 22, PAGED,                 "paged",                "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 23, PARTICLES,             "particles",            "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 24, PSSM,                  "pssm",                 "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 25, RTSHADER,              "rtshader",             "General");
-DECLARE_RESOURCE_PACK( 26, SCRIPTS,               "scripts",              "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 27, SOUNDS,                "sounds",               "General");
-DECLARE_RESOURCE_PACK( 28, SUNBURN,               "sunburn",              "LoadBeforeMap");
-DECLARE_RESOURCE_PACK( 29, TEXTURES,              "textures",             "LoadBeforeMap");
+DECLARE_RESOURCE_PACK( OGRE_CORE,             "OgreCore",             "OgreCoreRG");
+DECLARE_RESOURCE_PACK( WALLPAPERS,            "wallpapers",           "Wallpapers");
+DECLARE_RESOURCE_PACK( AIRFOILS,              "airfoils",             "AirfoilsRG");
+DECLARE_RESOURCE_PACK( BEAM_OBJECTS,          "beamobjects",          "BeamObjectsRG");
+DECLARE_RESOURCE_PACK( BLUR,                  "blur",                 "BlurRG");
+DECLARE_RESOURCE_PACK( CAELUM,                "caelum",               "CaelumRG");
+DECLARE_RESOURCE_PACK( CUBEMAPS,              "cubemaps",             "CubemapsRG");
+DECLARE_RESOURCE_PACK( DASHBOARDS,            "dashboards",           "DashboardsRG");
+DECLARE_RESOURCE_PACK( DEPTH_OF_FIELD,        "dof",                  "DepthOfFieldRG");
+DECLARE_RESOURCE_PACK( FAMICONS,              "famicons",             "FamiconsRG");
+DECLARE_RESOURCE_PACK( FLAGS,                 "flags",                "FlagsRG");
+DECLARE_RESOURCE_PACK( GLOW,                  "glow",                 "GlowRG");
+DECLARE_RESOURCE_PACK( HDR,                   "hdr",                  "HdrRG");
+DECLARE_RESOURCE_PACK( HEATHAZE,              "heathaze",             "HeatHazeRG");
+DECLARE_RESOURCE_PACK( HYDRAX,                "hydrax",               "HydraxRG");
+DECLARE_RESOURCE_PACK( ICONS,                 "icons",                "IconsRG");
+DECLARE_RESOURCE_PACK( MATERIALS,             "materials",            "MaterialsRG");
+DECLARE_RESOURCE_PACK( MESHES,                "meshes",               "MeshesRG");
+DECLARE_RESOURCE_PACK( MYGUI,                 "mygui",                "MyGuiRG");
+DECLARE_RESOURCE_PACK( OVERLAYS,              "overlays",             "OverlaysRG");
+DECLARE_RESOURCE_PACK( PAGED,                 "paged",                "PagedRG");
+DECLARE_RESOURCE_PACK( PARTICLES,             "particles",            "ParticlesRG");
+DECLARE_RESOURCE_PACK( PSSM,                  "pssm",                 "PssmRG");
+DECLARE_RESOURCE_PACK( RTSHADER,              "rtshader",             "RtShaderRG");
+DECLARE_RESOURCE_PACK( SCRIPTS,               "scripts",              "ScriptsRG");
+DECLARE_RESOURCE_PACK( SOUNDS,                "sounds",               "SoundsRG");
+DECLARE_RESOURCE_PACK( SUNBURN,               "sunburn",              "SunburnRG");
+DECLARE_RESOURCE_PACK( TEXTURES,              "textures",             "TexturesRG");
 
 // ================================================================================
 // Functions
 // ================================================================================
 
 ContentManager::ContentManager():
-    m_skin_manager(nullptr),
-    m_loaded_resource_packs(0)
+    m_skin_manager(nullptr)
 {
 }
 
@@ -110,24 +108,16 @@ ContentManager::~ContentManager()
 {
 }
 
-bool ContentManager::isLoaded(Ogre::uint64 res_pack_id)
-{
-    if (BITMASK_64_IS_1(m_loaded_resource_packs, res_pack_id)) // Already loaded?
-    {
-        return true;
-    }
-    return false;
-}
-
 void ContentManager::AddResourcePack(ResourcePack const& resource_pack)
 {
-    std::stringstream log_msg;
-    if (BITMASK_64_IS_1(m_loaded_resource_packs, resource_pack.mask)) // Already loaded?
+    Ogre::ResourceGroupManager& rgm = Ogre::ResourceGroupManager::getSingleton();
+
+    if (rgm.resourceGroupExists(resource_pack.resource_group_name)) // Already loaded?
     {
-        log_msg << "[RoR|ContentManager] Resource pack \"" << resource_pack.name << "\" already loaded.";
-        LOG(log_msg.str());
-        return;
+        return; // Nothing to do, nothing to report
     }
+
+    std::stringstream log_msg;
     log_msg << "[RoR|ContentManager] Loading resource pack \"" << resource_pack.name << "\" from group \"" << resource_pack.resource_group_name << "\"";
     Ogre::String resources_dir = Ogre::String(App::sys_resources_dir.GetActive()) + PATH_SLASH;
     Ogre::String zip_path = resources_dir + resource_pack.name + Ogre::String(".zip");
@@ -135,8 +125,8 @@ void ContentManager::AddResourcePack(ResourcePack const& resource_pack)
     {
         log_msg << " (ZIP archive)";
         LOG(log_msg.str());
-        ResourceGroupManager::getSingleton().addResourceLocation(zip_path, "Zip", resource_pack.resource_group_name);
-        BITMASK_64_SET_1(m_loaded_resource_packs, resource_pack.mask);
+        rgm.addResourceLocation(zip_path, "Zip", resource_pack.resource_group_name);
+        rgm.initialiseResourceGroup(resource_pack.resource_group_name);
     }
     else
     {
@@ -146,7 +136,7 @@ void ContentManager::AddResourcePack(ResourcePack const& resource_pack)
             log_msg << " (directory)";
             LOG(log_msg.str());
             ResourceGroupManager::getSingleton().addResourceLocation(dir_path, "FileSystem", resource_pack.resource_group_name);
-            BITMASK_64_SET_1(m_loaded_resource_packs, resource_pack.mask);
+            rgm.initialiseResourceGroup(resource_pack.resource_group_name);
         }
         else
         {
@@ -156,25 +146,18 @@ void ContentManager::AddResourcePack(ResourcePack const& resource_pack)
     }
 }
 
-bool ContentManager::init(void)
+bool ContentManager::OnApplicationStartup(void)
 {
     // set listener if none has already been set
     if (!Ogre::ResourceGroupManager::getSingleton().getLoadingListener())
         Ogre::ResourceGroupManager::getSingleton().setLoadingListener(this);
 
-    // try to get correct paths
-    // note: we don't have LogManager available yet!
-    // FIRST: Get the "program path" and the user space path
-
-    // note: this is now done in the settings class, so set it up
-    // note: you need to set the build mode correctly before you build the paths!
-
     // by default, display everything in the depth map
     Ogre::MovableObject::setDefaultVisibilityFlags(DEPTHMAP_ENABLED);
 
 
-    AddResourcePack(ResourcePack::MYGUI);
-    AddResourcePack(ResourcePack::DASHBOARDS);
+    this->AddResourcePack(ResourcePack::MYGUI);
+    this->AddResourcePack(ResourcePack::DASHBOARDS);
 
 
 #ifdef _WIN32
@@ -392,25 +375,52 @@ void ContentManager::InitManagedMaterials()
     ResourceGroupManager::getSingleton().initialiseResourceGroup("ManagedMats");
 }
 
-void ContentManager::CheckAndLoadBaseResources()
+void ContentManager::LoadGameplayResources()
 {
     if (!m_base_resource_loaded)
     {
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::AIRFOILS);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::BEAM_OBJECTS);
+        this->AddResourcePack(ContentManager::ResourcePack::AIRFOILS);
+        this->AddResourcePack(ContentManager::ResourcePack::BEAM_OBJECTS);
 
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::MATERIALS);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::MESHES);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::OVERLAYS);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::PARTICLES);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::SCRIPTS);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::TEXTURES);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::FLAGS);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::ICONS);
-        RoR::App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::FAMICONS);
+        this->AddResourcePack(ContentManager::ResourcePack::MATERIALS);
+        this->AddResourcePack(ContentManager::ResourcePack::MESHES);
+        this->AddResourcePack(ContentManager::ResourcePack::OVERLAYS);
+        this->AddResourcePack(ContentManager::ResourcePack::PARTICLES);
+        this->AddResourcePack(ContentManager::ResourcePack::SCRIPTS);
+        this->AddResourcePack(ContentManager::ResourcePack::TEXTURES);
+        this->AddResourcePack(ContentManager::ResourcePack::FLAGS);
+        this->AddResourcePack(ContentManager::ResourcePack::ICONS);
+        this->AddResourcePack(ContentManager::ResourcePack::FAMICONS);
 
         m_base_resource_loaded = true;
     }
+
+    if (App::gfx_water_mode.GetActive() == GfxWaterMode::HYDRAX)
+        this->AddResourcePack(ContentManager::ResourcePack::HYDRAX);
+
+    if (App::gfx_sky_mode.GetActive() == GfxSkyMode::CAELUM)
+        this->AddResourcePack(ContentManager::ResourcePack::CAELUM);
+
+    if (App::gfx_vegetation_mode.GetActive() != RoR::GfxVegetation::NONE)
+        this->AddResourcePack(ContentManager::ResourcePack::PAGED);
+
+    if (App::gfx_enable_hdr.GetActive())
+        this->AddResourcePack(ContentManager::ResourcePack::HDR);
+
+    if (App::gfx_enable_dof.GetActive())
+        this->AddResourcePack(ContentManager::ResourcePack::DEPTH_OF_FIELD);
+
+    if (App::gfx_enable_glow.GetActive())
+        this->AddResourcePack(ContentManager::ResourcePack::GLOW);
+
+    if (App::gfx_motion_blur.GetActive())
+        this->AddResourcePack(ContentManager::ResourcePack::BLUR);
+
+    if (App::gfx_enable_heathaze.GetActive())
+        this->AddResourcePack(ContentManager::ResourcePack::HEATHAZE);
+
+    if (App::gfx_enable_sunburn.GetActive())
+        this->AddResourcePack(ContentManager::ResourcePack::SUNBURN);
 }
 
 void ContentManager::RegenCache()

--- a/source/main/resources/ContentManager.h
+++ b/source/main/resources/ContentManager.h
@@ -40,12 +40,9 @@ public:
 
     struct ResourcePack
     {
-        ResourcePack(Ogre::uint64 mask, const char* name, const char* resource_group_name):
-            mask(mask),
-            name(name),
-            resource_group_name(resource_group_name)
-        {
-        }
+        ResourcePack(const char* name, const char* resource_group_name):
+            name(name), resource_group_name(resource_group_name)
+        {}
 
         static const ResourcePack OGRE_CORE;
         static const ResourcePack WALLPAPERS;
@@ -76,22 +73,16 @@ public:
         static const ResourcePack SUNBURN;
         static const ResourcePack TEXTURES;
 
-        Ogre::uint64 mask;
         const char* name;
         const char* resource_group_name;
     };
 
-    void AddResourcePack(ResourcePack const& resource_pack);
-
-    bool isLoaded(Ogre::uint64 res_pack_id);
-
-    bool init(void);
-
-    inline RoR::SkinManager* GetSkinManager() const { return m_skin_manager; }
-
-    void InitManagedMaterials();
-    void CheckAndLoadBaseResources();
-    void RegenCache();
+    void               AddResourcePack(ResourcePack const& resource_pack); //!< Loads resources if not already loaded (currently resources never unload until shutdown)
+    bool               OnApplicationStartup(void);
+    void               InitManagedMaterials();
+    void               LoadGameplayResources();  //!< Checks GVar settings and loads required resources.
+    void               RegenCache();
+    RoR::SkinManager*  GetSkinManager()  { return m_skin_manager; }
 
 protected:
 
@@ -103,7 +94,6 @@ protected:
     void resourceStreamOpened(const Ogre::String& name, const Ogre::String& group, Ogre::Resource* resource, Ogre::DataStreamPtr& dataStream);
     bool resourceCollision(Ogre::Resource* resource, Ogre::ResourceManager* resourceManager);
 
-    Ogre::uint64 m_loaded_resource_packs;
     RoR::SkinManager* m_skin_manager;
     bool              m_base_resource_loaded;
 };

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -156,7 +156,7 @@ String GameScript::getCaelumTime()
     String result = "";
 #ifdef USE_CAELUM
     if (gEnv->terrainManager)
-        result = gEnv->terrainManager->getSkyManager()->getPrettyTime();
+        result = gEnv->terrainManager->getSkyManager()->GetPrettyTime();
 #endif // USE_CAELUM
     return result;
 }
@@ -165,7 +165,7 @@ void GameScript::setCaelumTime(float value)
 {
 #ifdef USE_CAELUM
     if (gEnv->terrainManager)
-        gEnv->terrainManager->getSkyManager()->setTimeFactor(value);
+        gEnv->terrainManager->getSkyManager()->SetSkyTimeFactor(value);
 #endif // USE_CAELUM
 }
 

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -80,7 +80,6 @@ TerrainManager::~TerrainManager()
     if (sky_manager != nullptr)
     {
         delete(sky_manager);
-        gEnv->sky = nullptr;
         sky_manager = nullptr;
     }
 
@@ -295,18 +294,17 @@ void TerrainManager::initSkySubSystem()
     if (App::gfx_sky_mode.GetActive() == GfxSkyMode::CAELUM)
     {
         sky_manager = new SkyManager();
-        gEnv->sky = sky_manager;
 
         // try to load caelum config
         if (!m_def.caelum_config.empty() && ResourceGroupManager::getSingleton().resourceExistsInAnyGroup(m_def.caelum_config))
         {
             // config provided and existing, use it :)
-            sky_manager->loadScript(m_def.caelum_config, m_def.caelum_fog_start, m_def.caelum_fog_end);
+            sky_manager->LoadCaelumScript(m_def.caelum_config, m_def.caelum_fog_start, m_def.caelum_fog_end);
         }
         else
         {
             // no config provided, fall back to the default one
-            sky_manager->loadScript("ror_default_sky");
+            sky_manager->LoadCaelumScript("ror_default_sky");
         }
     }
     else
@@ -331,7 +329,7 @@ void TerrainManager::initLight()
     if (App::gfx_sky_mode.GetActive() == GfxSkyMode::CAELUM)
     {
 #ifdef USE_CAELUM
-        main_light = sky_manager->getMainLight();
+        main_light = sky_manager->GetSkyMainLight();
 #endif
     }
     else


### PR DESCRIPTION
It turned out there was a bug in loading resources based on configuration, so this crash could also happen if you toggled other effects. Kudos to @Speciesx for discovering and reporting.