### PR TITLE
HOTFIX: Crash with flexbodywheels and skidmarks enabled

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2842,9 +2842,14 @@ void Beam::updateSkidmarks()
         if (wheels[i].lastContactInner == Vector3::ZERO && wheels[i].lastContactOuter == Vector3::ZERO)
             continue;
 
-        skidtrails[i]->updatePoint();
-        if (skidtrails[i] && wheels[i].isSkiding)
-            skidtrails[i]->update();
+        if (skidtrails[i])
+        {
+            skidtrails[i]->updatePoint();
+            if (wheels[i].isSkiding)
+            {
+                skidtrails[i]->update();
+            }
+        }
     }
 
     BES_STOP(BES_CORE_Skidmarks);


### PR DESCRIPTION
For some reason, skidmark-handler is never created for flexbodywheels. This causes crash when simulation logic attempts to update them.

I'm quickly patching it around by adding "was skidmark handler created?" check in simulation logic. Skidmarks are currently broken in several ways and fixing is in progress, see https://github.com/RigsOfRods/rigs-of-rods/pull/1404