### PR TITLE
BUGFIX: Fixed HQ water glitch when re-entering simulation

### DIFF
--- a/source/main/gfx/HydraxWater.cpp
+++ b/source/main/gfx/HydraxWater.cpp
@@ -166,12 +166,6 @@ void HydraxWater::updateReflectionPlane(float h)
 {
 }
 
-void HydraxWater::setFadeColour(ColourValue ambient)
-{
-    if (mHydrax)
-        mHydrax->setSunColor(Vector3(ambient.r, ambient.g, ambient.b));
-}
-
 void HydraxWater::setSunPosition(Ogre::Vector3 pos)
 {
     if (mHydrax)

--- a/source/main/gfx/HydraxWater.h
+++ b/source/main/gfx/HydraxWater.h
@@ -38,7 +38,6 @@ public:
     Ogre::Vector3 getVelocity(Ogre::Vector3 pos);
 
     void setCamera(Ogre::Camera* cam);
-    void setFadeColour(Ogre::ColourValue ambient);
     void setHeight(float value);
     void setSunPosition(Ogre::Vector3);
     void setVisible(bool value);

--- a/source/main/gfx/IWater.h
+++ b/source/main/gfx/IWater.h
@@ -39,7 +39,6 @@ public:
     virtual Ogre::Vector3 getVelocity(Ogre::Vector3 pos) = 0;
 
     virtual void setCamera(Ogre::Camera* cam) = 0;
-    virtual void setFadeColour(Ogre::ColourValue ambient) = 0;
     virtual void setHeight(float value) = 0;
     virtual void setSunPosition(Ogre::Vector3) = 0;
     virtual void setVisible(bool value) = 0;

--- a/source/main/gfx/Water.cpp
+++ b/source/main/gfx/Water.cpp
@@ -108,7 +108,6 @@ Water::Water() :
 {
     //Ugh.. Why so ugly and hard to read
     mapSize = gEnv->terrainManager->getMaxTerrainSize();
-    fade = gEnv->sceneManager->getFogColour();
     waterSceneMgr = gEnv->sceneManager;
 
     if (mapSize.x < 1500 && mapSize.z < 1500)
@@ -274,7 +273,7 @@ void Water::processWater()
 
                 vRtt1 = rttTex1->addViewport(mRefractCam);
                 vRtt1->setClearEveryFrame(true);
-                vRtt1->setBackgroundColour(fade);
+                vRtt1->setBackgroundColour(gEnv->sceneManager->getFogColour());
                 //            v->setBackgroundColour( ColourValue::Black );
 
                 MaterialPtr mat = MaterialManager::getSingleton().getByName("Examples/FresnelReflectionRefraction");
@@ -308,7 +307,7 @@ void Water::processWater()
 
             vRtt2 = rttTex2->addViewport(mReflectCam);
             vRtt2->setClearEveryFrame(true);
-            vRtt2->setBackgroundColour(fade);
+            vRtt2->setBackgroundColour(gEnv->sceneManager->getFogColour());
 
             MaterialPtr mat;
             if (full_gfx)
@@ -407,15 +406,6 @@ void Water::setVisible(bool value)
         pWaterNode->setVisible(value);
     if (pBottomNode)
         pBottomNode->setVisible(value);
-}
-
-void Water::setFadeColour(ColourValue ambient)
-{
-    // update the viewports background colour!
-    if (vRtt1)
-        vRtt1->setBackgroundColour(ambient);
-    if (vRtt2)
-        vRtt2->setBackgroundColour(ambient);
 }
 
 void Water::moveTo(float centerheight)

--- a/source/main/gfx/Water.cpp
+++ b/source/main/gfx/Water.cpp
@@ -191,11 +191,25 @@ Water::~Water()
         rttTex1 = nullptr;
     }
 
+    if (!m_refraction_rtt_texture.isNull())
+    {
+        m_refraction_rtt_texture->unload();
+        Ogre::TextureManager::getSingleton().remove(m_refraction_rtt_texture->getHandle());
+        m_refraction_rtt_texture.setNull();
+    }
+
     if (rttTex2)
     {
         //vRtt2->clear();
         rttTex2->removeAllListeners();
         rttTex2 = nullptr;
+    }
+
+    if (!m_reflection_rtt_texture.isNull())
+    {
+        m_reflection_rtt_texture->unload();
+        Ogre::TextureManager::getSingleton().remove(m_reflection_rtt_texture->getHandle());
+        m_reflection_rtt_texture.setNull();
     }
 
     if (wbuffer)
@@ -245,6 +259,7 @@ void Water::processWater()
         if (full_gfx)
         {
             TexturePtr rttTex1Ptr = TextureManager::getSingleton().createManual("Refraction", ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, TEX_TYPE_2D, 512, 512, 0, PF_R8G8B8, TU_RENDERTARGET);
+            m_refraction_rtt_texture = rttTex1Ptr;
             rttTex1 = rttTex1Ptr->getBuffer()->getRenderTarget();
             {
                 mRefractCam = gEnv->sceneManager->createCamera("RefractCam");
@@ -278,6 +293,7 @@ void Water::processWater()
         }
 
         TexturePtr rttTex2Ptr = TextureManager::getSingleton().createManual("Reflection", ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, TEX_TYPE_2D, 512, 512, 0, PF_R8G8B8, TU_RENDERTARGET);
+        m_reflection_rtt_texture = rttTex2Ptr;
         rttTex2 = rttTex2Ptr->getBuffer()->getRenderTarget();
         {
             mReflectCam = gEnv->sceneManager->createCamera("ReflectCam");

--- a/source/main/gfx/Water.h
+++ b/source/main/gfx/Water.h
@@ -24,7 +24,6 @@
 #include "IWater.h"
 #include "RoRPrerequisites.h"
 
-#include <OgreColourValue.h>
 #include <OgreMesh.h>
 #include <OgreVector3.h>
 #include <vector>
@@ -41,7 +40,6 @@ public:
     Ogre::Vector3 getVelocity(Ogre::Vector3 pos);
 
     void setCamera(Ogre::Camera* cam);
-    void setFadeColour(Ogre::ColourValue ambient);
     void setHeight(float value);
     void setSunPosition(Ogre::Vector3);
     void setVisible(bool value);
@@ -96,6 +94,5 @@ private:
     Ogre::SceneNode* pBottomNode;
     Ogre::SceneNode* pWaterNode;
     Ogre::Viewport *vRtt1, *vRtt2;
-    Ogre::ColourValue fade;
     std::vector<WaveTrain> m_wavetrain_defs;
 };

--- a/source/main/gfx/Water.h
+++ b/source/main/gfx/Water.h
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <Ogre.h>
-
+#include "IWater.h"
 #include "RoRPrerequisites.h"
 
-#include "IWater.h"
+#include <OgreColourValue.h>
+#include <OgreMesh.h>
+#include <OgreVector3.h>
+#include <vector>
 
 class Water : public IWater, public ZeroedMemoryAllocator
 {
@@ -60,7 +62,7 @@ private:
 
     float getWaveHeight(Ogre::Vector3 pos);
 
-    struct wavetrain_t
+    struct WaveTrain
     {
         float amplitude;
         float maxheight;
@@ -72,7 +74,6 @@ private:
     };
 
     static const int WAVEREZ = 100;
-    static const int MAX_WAVETRAINS = 10;
 
     bool visible;
     float* wbuffer;
@@ -80,7 +81,6 @@ private:
     float maxampl;
     float mScale;
     int framecounter;
-    int free_wavetrain;
     bool ForceUpdate;
 
     Ogre::MeshPtr mprt;
@@ -97,5 +97,5 @@ private:
     Ogre::SceneNode* pWaterNode;
     Ogre::Viewport *vRtt1, *vRtt2;
     Ogre::ColourValue fade;
-    wavetrain_t wavetrains[MAX_WAVETRAINS];
+    std::vector<WaveTrain> m_wavetrain_defs;
 };

--- a/source/main/gfx/Water.h
+++ b/source/main/gfx/Water.h
@@ -91,6 +91,8 @@ private:
     Ogre::HardwareVertexBufferSharedPtr wbuf;
     Ogre::RenderTexture* rttTex1;
     Ogre::RenderTexture* rttTex2;
+    Ogre::TexturePtr     m_refraction_rtt_texture;
+    Ogre::TexturePtr     m_reflection_rtt_texture;
     Ogre::SceneNode* pBottomNode;
     Ogre::SceneNode* pWaterNode;
     Ogre::Viewport *vRtt1, *vRtt2;


### PR DESCRIPTION
![obrazek](https://user-images.githubusercontent.com/491088/35778532-b2fb66e2-09bf-11e8-8649-c80bb0fd4904.png)

Caused by generated textures not being properly unloaded.

Finally resolves a very old ticket by Max98: https://github.com/RigsOfRods/rigs-of-rods/issues/50