### PR TITLE
Try Linux specific /usr/share resources path earlier

### DIFF
--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -1099,13 +1099,6 @@ bool Settings::SetupAllPaths()
         return true;
     }
 
-    System::GetParentDirectory(buf.GetBuffer(), App::sys_process_dir.GetActive());
-    if (FolderExists(buf))
-    {
-        App::sys_resources_dir.SetActive(buf);
-        return true;
-    }
-
 #if OGRE_PLATFORM == OGRE_PLATFORM_LINUX
     buf = "/usr/share/rigsofrods/resources/";
     if (FolderExists(buf))
@@ -1114,6 +1107,14 @@ bool Settings::SetupAllPaths()
         return true;
     }
 #endif
+
+    System::GetParentDirectory(buf.GetBuffer(), App::sys_process_dir.GetActive());
+    if (FolderExists(buf))
+    {
+        App::sys_resources_dir.SetActive(buf);
+        return true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
Try this earlier, before falling back to the generic App::sys_process_dir/..

I didn't test this, but the problem seems obvious on my Fedora 26 install:
App::sys_process_dir/.. will always exist (given that the binary is there), thus
the /usr/share/... path (where the resources are) will never be probed/ selected.