### PR TITLE
Fix NAV autopilot (Instrument Landing System)

### DIFF
--- a/source/main/gameplay/AutoPilot.cpp
+++ b/source/main/gameplay/AutoPilot.cpp
@@ -57,6 +57,9 @@ void Autopilot::reset()
     m_ils_runway_heading = 0;
     last_closest_hdist = 0;
     wantsdisconnect = false;
+
+    m_vertical_locator_available = false;
+    m_horizontal_locator_available = false;
 }
 
 void Autopilot::disconnect()
@@ -421,12 +424,22 @@ void Autopilot::UpdateIls(std::vector<TerrainObjectManager::localizer_t> localiz
     m_ils_angle_hdev = closest_hangle;
     m_ils_angle_vdev = closest_vangle;
 
+    m_horizontal_locator_available = (closest_hdist != -1);
+    m_vertical_locator_available = (closest_vdist != -1);
+
     if (mode_heading == HEADING_NAV && mode_gpws && closest_hdist > 10.0 && closest_hdist < 350.0 && last_closest_hdist > 10.0 && last_closest_hdist > 350.0)
     {
         SOUND_PLAY_ONCE(m_actor_id, SS_TRIG_GPWS_MINIMUMS);
     }
 
     last_closest_hdist = closest_hdist;
-    if (mode_heading == HEADING_NAV && (closest_hdist < 20.0 || closest_vdist < 20.0))
-        wantsdisconnect = true;
+    if (mode_heading == HEADING_NAV)
+    {
+        // disconnect if close to runway or no locators are available
+        if (closest_hdist < 20.0 || closest_vdist < 20.0)
+            wantsdisconnect = true;
+        if (!this->IsIlsAvailable())
+            wantsdisconnect = true;
+    }
+        
 }

--- a/source/main/gameplay/AutoPilot.cpp
+++ b/source/main/gameplay/AutoPilot.cpp
@@ -352,7 +352,7 @@ void Autopilot::gpws_update(float spawnheight)
 #endif //OPENAL
 }
 
-void Autopilot::getRadioFix(TerrainObjectManager::localizer_t* localizers, int free_localizer, float* vdev, float* hdev)
+void Autopilot::getRadioFix(std::vector<TerrainObjectManager::localizer_t> localizers, float* vdev, float* hdev)
 {
     if (!ref_l || !ref_r)
         return;
@@ -362,7 +362,7 @@ void Autopilot::getRadioFix(TerrainObjectManager::localizer_t* localizers, int f
     float closest_vdist = -1;
     float closest_vangle = -90;
     lastradiorwh = 0;
-    for (int i = 0; i < free_localizer; i++)
+    for (std::vector<TerrainObjectManager::localizer_t>::size_type i = 0; i < localizers.size(); i++)
     {
         Plane hplane = Plane(Vector3::UNIT_Y, 0);
         Vector3 plocd = hplane.projectVector(localizers[i].rotation * Vector3::UNIT_Z);

--- a/source/main/gameplay/AutoPilot.h
+++ b/source/main/gameplay/AutoPilot.h
@@ -73,7 +73,9 @@ public:
 
     void gpws_update(float spawnheight);
 
-    void getRadioFix(std::vector<TerrainObjectManager::localizer_t> localizers, float* vdev, float* hdev);
+    void UpdateIls(std::vector<TerrainObjectManager::localizer_t> localizers);
+    float GetVerticalApproachDeviation() { return m_ils_angle_vdev; }
+    float GetHorizontalApproachDeviation() { return m_ils_angle_hdev; }
 
 private:
 
@@ -94,10 +96,11 @@ private:
     float last_rudder;
     float last_gpws_height;
     float last_pullup_height;
-    float lastradiov;
-    float lastradioh;
-    float lastradiorwh;
-    float lastradiorwd;
+
+    float m_ils_angle_vdev;
+    float m_ils_angle_hdev;
+    float m_ils_runway_heading;
+    float m_ils_runway_distance;
     float last_closest_hdist;
 
     int m_actor_id;

--- a/source/main/gameplay/AutoPilot.h
+++ b/source/main/gameplay/AutoPilot.h
@@ -76,7 +76,7 @@ public:
     void UpdateIls(std::vector<TerrainObjectManager::localizer_t> localizers);
     float GetVerticalApproachDeviation() { return m_ils_angle_vdev; }
     float GetHorizontalApproachDeviation() { return m_ils_angle_hdev; }
-
+    bool IsIlsAvailable() { return m_horizontal_locator_available && m_vertical_locator_available; }
 private:
 
     int mode_heading;
@@ -97,6 +97,8 @@ private:
     float last_gpws_height;
     float last_pullup_height;
 
+    bool m_vertical_locator_available;
+    bool m_horizontal_locator_available;
     float m_ils_angle_vdev;
     float m_ils_angle_hdev;
     float m_ils_runway_heading;

--- a/source/main/gameplay/AutoPilot.h
+++ b/source/main/gameplay/AutoPilot.h
@@ -73,7 +73,7 @@ public:
 
     void gpws_update(float spawnheight);
 
-	void getRadioFix(std::vector<TerrainObjectManager::localizer_t> localizers, float* vdev, float* hdev);
+    void getRadioFix(std::vector<TerrainObjectManager::localizer_t> localizers, float* vdev, float* hdev);
 
 private:
 

--- a/source/main/gameplay/AutoPilot.h
+++ b/source/main/gameplay/AutoPilot.h
@@ -73,7 +73,7 @@ public:
 
     void gpws_update(float spawnheight);
 
-    void getRadioFix(TerrainObjectManager::localizer_t* localizers, int free_localizer, float* vdev, float* hdev);
+	void getRadioFix(std::vector<TerrainObjectManager::localizer_t> localizers, float* vdev, float* hdev);
 
 private:
 

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -994,8 +994,7 @@ void OverlayWrapper::UpdateAerialHUD(Beam* vehicle)
         hsibugtexture->setTextureRotate(Radian(dirangle) - Degree(vehicle->autopilot->heading));
         float vdev = 0;
         float hdev = 0;
-        // TODO: FIXME
-        //vehicle->autopilot->getRadioFix(localizers, free_localizer, &vdev, &hdev);
+        vehicle->autopilot->getRadioFix(gEnv->terrainManager->getObjectManager()->GetLocalizers(), &vdev, &hdev);
         if (hdev > 15)
             hdev = 15;
         if (hdev < -15)

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -992,9 +992,8 @@ void OverlayWrapper::UpdateAerialHUD(Beam* vehicle)
     if (vehicle->autopilot)
     {
         hsibugtexture->setTextureRotate(Radian(dirangle) - Degree(vehicle->autopilot->heading));
-        float vdev = 0;
-        float hdev = 0;
-        vehicle->autopilot->getRadioFix(gEnv->terrainManager->getObjectManager()->GetLocalizers(), &vdev, &hdev);
+        float vdev = vehicle->autopilot->GetVerticalApproachDeviation();
+        float hdev = vehicle->autopilot->GetHorizontalApproachDeviation();
         if (hdev > 15)
             hdev = 15;
         if (hdev < -15)

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -992,8 +992,14 @@ void OverlayWrapper::UpdateAerialHUD(Beam* vehicle)
     if (vehicle->autopilot)
     {
         hsibugtexture->setTextureRotate(Radian(dirangle) - Degree(vehicle->autopilot->heading));
-        float vdev = vehicle->autopilot->GetVerticalApproachDeviation();
-        float hdev = vehicle->autopilot->GetHorizontalApproachDeviation();
+
+        float vdev = 0;
+        float hdev = 0;
+        if (vehicle->autopilot->IsIlsAvailable())
+        {
+            vdev = vehicle->autopilot->GetVerticalApproachDeviation();
+            hdev = vehicle->autopilot->GetHorizontalApproachDeviation();
+        }
         if (hdev > 15)
             hdev = 15;
         if (hdev < -15)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -3636,6 +3636,7 @@ void Beam::updateVisual(float dt)
     float autoelevator = 0;
     if (autopilot)
     {
+        autopilot->UpdateIls(gEnv->terrainManager->getObjectManager()->GetLocalizers());
         autoaileron = autopilot->getAilerons();
         autorudder = autopilot->getRudder();
         autoelevator = autopilot->getElevator();

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -105,7 +105,6 @@ TerrainObjectManager::~TerrainObjectManager()
         delete proceduralManager;
     }
     gEnv->sceneManager->destroyAllEntities();
-
 }
 
 void TerrainObjectManager::loadObjectConfigFile(Ogre::String odefname)

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -105,6 +105,7 @@ TerrainObjectManager::~TerrainObjectManager()
         delete proceduralManager;
     }
     gEnv->sceneManager->destroyAllEntities();
+
 }
 
 void TerrainObjectManager::loadObjectConfigFile(Ogre::String odefname)
@@ -115,7 +116,7 @@ void TerrainObjectManager::loadObjectConfigFile(Ogre::String odefname)
     }
 
     objcounter = 0;
-    free_localizer = 0;
+    localizers.clear();
 
     ProceduralObject po;
     po.loadingState = -1;
@@ -862,34 +863,38 @@ void TerrainObjectManager::loadObject(const Ogre::String& name, const Ogre::Vect
         };
         if (!strcmp("localizer-h", ptline))
         {
-            localizers[free_localizer].position = Vector3(pos.x, pos.y, pos.z);
-            localizers[free_localizer].rotation = rotation;
-            localizers[free_localizer].type = Autopilot::LOCALIZER_HORIZONTAL;
-            free_localizer++;
+			localizer_t loc;
+			loc.position = Vector3(pos.x, pos.y, pos.z);
+			loc.rotation = rotation;
+			loc.type = Autopilot::LOCALIZER_HORIZONTAL;
+			localizers.push_back(loc);
             continue;
         }
         if (!strcmp("localizer-v", ptline))
         {
-            localizers[free_localizer].position = Vector3(pos.x, pos.y, pos.z);
-            localizers[free_localizer].rotation = rotation;
-            localizers[free_localizer].type = Autopilot::LOCALIZER_VERTICAL;
-            free_localizer++;
+			localizer_t loc;
+			loc.position = Vector3(pos.x, pos.y, pos.z);
+			loc.rotation = rotation;
+			loc.type = Autopilot::LOCALIZER_VERTICAL;
+			localizers.push_back(loc);
             continue;
         }
         if (!strcmp("localizer-ndb", ptline))
         {
-            localizers[free_localizer].position = Vector3(pos.x, pos.y, pos.z);
-            localizers[free_localizer].rotation = rotation;
-            localizers[free_localizer].type = Autopilot::LOCALIZER_NDB;
-            free_localizer++;
+			localizer_t loc;
+			loc.position = Vector3(pos.x, pos.y, pos.z);
+			loc.rotation = rotation;
+			loc.type = Autopilot::LOCALIZER_NDB;
+			localizers.push_back(loc);
             continue;
         }
         if (!strcmp("localizer-vor", ptline))
         {
-            localizers[free_localizer].position = Vector3(pos.x, pos.y, pos.z);
-            localizers[free_localizer].rotation = rotation;
-            localizers[free_localizer].type = Autopilot::LOCALIZER_VOR;
-            free_localizer++;
+			localizer_t loc;
+			loc.position = Vector3(pos.x, pos.y, pos.z);
+			loc.rotation = rotation;
+			loc.type = Autopilot::LOCALIZER_VOR;
+			localizers.push_back(loc);
             continue;
         }
         if (!strcmp("standard", ptline))

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -862,38 +862,38 @@ void TerrainObjectManager::loadObject(const Ogre::String& name, const Ogre::Vect
         };
         if (!strcmp("localizer-h", ptline))
         {
-			localizer_t loc;
-			loc.position = Vector3(pos.x, pos.y, pos.z);
-			loc.rotation = rotation;
-			loc.type = Autopilot::LOCALIZER_HORIZONTAL;
-			localizers.push_back(loc);
+            localizer_t loc;
+            loc.position = Vector3(pos.x, pos.y, pos.z);
+            loc.rotation = rotation;
+            loc.type = Autopilot::LOCALIZER_HORIZONTAL;
+            localizers.push_back(loc);
             continue;
         }
         if (!strcmp("localizer-v", ptline))
         {
-			localizer_t loc;
-			loc.position = Vector3(pos.x, pos.y, pos.z);
-			loc.rotation = rotation;
-			loc.type = Autopilot::LOCALIZER_VERTICAL;
-			localizers.push_back(loc);
+            localizer_t loc;
+            loc.position = Vector3(pos.x, pos.y, pos.z);
+            loc.rotation = rotation;
+            loc.type = Autopilot::LOCALIZER_VERTICAL;
+            localizers.push_back(loc);
             continue;
         }
         if (!strcmp("localizer-ndb", ptline))
         {
-			localizer_t loc;
-			loc.position = Vector3(pos.x, pos.y, pos.z);
-			loc.rotation = rotation;
-			loc.type = Autopilot::LOCALIZER_NDB;
-			localizers.push_back(loc);
+            localizer_t loc;
+            loc.position = Vector3(pos.x, pos.y, pos.z);
+            loc.rotation = rotation;
+            loc.type = Autopilot::LOCALIZER_NDB;
+            localizers.push_back(loc);
             continue;
         }
         if (!strcmp("localizer-vor", ptline))
         {
-			localizer_t loc;
-			loc.position = Vector3(pos.x, pos.y, pos.z);
-			loc.rotation = rotation;
-			loc.type = Autopilot::LOCALIZER_VOR;
-			localizers.push_back(loc);
+            localizer_t loc;
+            loc.position = Vector3(pos.x, pos.y, pos.z);
+            loc.rotation = rotation;
+            loc.type = Autopilot::LOCALIZER_VOR;
+            localizers.push_back(loc);
             continue;
         }
         if (!strcmp("standard", ptline))

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -70,6 +70,7 @@ public:
     } object_t;
 
     std::vector<object_t> getObjects() { return objects; };
+	std::vector<localizer_t> GetLocalizers() { return localizers; }
 
     bool update(float dt);
 
@@ -118,10 +119,9 @@ protected:
     Forests::TreeLoader2D* treeLoader;
 #endif //USE_PAGED
 
-    localizer_t localizers[64];
+    std::vector<localizer_t> localizers;
 
     int objcounter;
-    int free_localizer;
 
     std::vector<animated_object_t> animatedObjects;
     std::vector<MeshObject*> meshObjects;

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -70,7 +70,7 @@ public:
     } object_t;
 
     std::vector<object_t> getObjects() { return objects; };
-	std::vector<localizer_t> GetLocalizers() { return localizers; }
+    std::vector<localizer_t> GetLocalizers() { return localizers; }
 
     bool update(float dt);
 


### PR DESCRIPTION
This feature was broken for a very long time. If you enable the NAV mode in an airplane it will try to land on the closest airport equipped with locators (poles with red and white stripes).
See also http://docs.rigsofrods.org/gameplay/aircraft-handling/.