### PR TITLE
Fixed `HighResWheelNodeCollisions` setting name

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -70,7 +70,7 @@ static MumbleIntegration* g_mumble;
  GVarPod_A<bool>          sim_replay_enabled      ("sim_replay_enabled",      "Replay mode",               false);
  GVarPod_A<int>           sim_replay_length       ("sim_replay_length",       "Replay length",             200);
  GVarPod_A<int>           sim_replay_stepping     ("sim_replay_stepping",     "Replay Steps per second",   1000);
- GVarPod_A<bool>          sim_hires_wheel_col     ("sim_hires_wheel_col",     "HighResWheelNodeCollision", false);
+ GVarPod_A<bool>          sim_hires_wheel_col     ("sim_hires_wheel_col",     "HighResWheelNodeCollisions", true);
  GVarPod_A<bool>             sim_position_storage ("sim_position_storage",    "Position Storage",          false);
  GVarEnum_AP<SimGearboxMode> sim_gearbox_mode     ("sim_gearbox_mode",        "GearboxMode",               SimGearboxMode::AUTO,    SimGearboxMode::AUTO);
 


### PR DESCRIPTION
Added the missing `s` to the GVar name for backwards compatibility, see [this forum post](https://forum.rigsofrods.org/showrooms/184-1982-di-sportster-post1985.html#post1985).

Also now enabled by default as it improves the handling of every vehicle massively and makes the [now dead](https://github.com/RigsOfRods/rigs-of-rods/issues/1438) `SlopeBrake` truckfile section obsolete.