### PR TITLE
Hotfix: Multiplayer crash when 2nd client joins

### DIFF
--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -59,6 +59,7 @@ Character::Character(int source, unsigned int streamid, int color_number, bool i
 {
     static int id_counter = 0;
     m_instance_name = "Character" + TOSTRING(id_counter);
+    ++id_counter;
 
     Entity* entity = gEnv->sceneManager->createEntity(m_instance_name + "_mesh", "character.mesh");
 #if OGRE_VERSION<0x010602


### PR DESCRIPTION
I simply forgot to increment the counter :blush:
Fixes #1527