### PR TITLE
removed leftover boost from configurator (Linux)

### DIFF
--- a/source/configurator/CMakeLists.txt
+++ b/source/configurator/CMakeLists.txt
@@ -20,7 +20,7 @@ elseif (UNIX)
     PKG_CHECK_MODULES(GTK gtk+-2.0 REQUIRED)
     include_directories(${GTK_INCLUDE_DIRS})
 
-    set(OS_LIBS "-lboost_system")
+    set(OS_LIBS)
 
 endif ()
 


### PR DESCRIPTION
Built deps and ror with and without boost and boost-libs, tested on Arch.