### PR TITLE
Fix segfault on truck respawn

### DIFF
--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -2739,6 +2739,7 @@ void ActorSpawner::ProcessTie(RigDef::Tie & def)
     tie.ti_tying = false;
     tie.ti_tied = false;
     tie.ti_beam = & beam;
+    tie.ti_locked_ropable = nullptr;
     tie.ti_command_value = -1.f;
     m_actor->ar_ties.push_back(tie);
 


### PR DESCRIPTION
Fixes the following issue:
> Load gavril omega or skyvan and press Backspace to reset -> segfault. Happens in master also.
https://pastebin.com/DBQqDhzj
https://www.dropbox.com/s/poo57yd8b8e5w1s/gavrilomega.zip?dl=1

Did we remove the custom zero allocator?