### PR TITLE
Hotfix: segfault when custom particle init fails

### DIFF
--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -2666,7 +2666,6 @@ void ActorSpawner::ProcessParticle(RigDef::Particle & def)
     }
 
     unsigned int particle_index = m_actor->ar_num_custom_particles;
-    m_actor->ar_num_custom_particles++;
     cparticle_t & particle = m_actor->ar_custom_particles[particle_index];
 
     particle.emitterNode = GetNodeIndexOrThrow(def.emitter_node);
@@ -2694,6 +2693,8 @@ void ActorSpawner::ProcessParticle(RigDef::Particle & def)
     {
         particle.psys->getEmitter(i)->setEnabled(false);
     }
+
+    ++m_actor->ar_num_custom_particles;
 }
 
 void ActorSpawner::ProcessRopable(RigDef::Ropable & def)


### PR DESCRIPTION
Fixes #1555 