### PR TITLE
Variable cleanup and optimization and clang-cl related fixes

### DIFF
--- a/source/configurator/CMakeLists.txt
+++ b/source/configurator/CMakeLists.txt
@@ -9,7 +9,10 @@ project(RoR_Configurator)
 
 if (WIN32)
     set(OS_LIBS "${PThread_LIBRARIES};dinput8.lib;dxguid.lib")
-    set(OS_SOURCE "icon.rc")
+    # clang-cl doesn't support resource files
+	if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+		set(OS_SOURCE "icon.rc")
+	endif()
 
     # disable some annoying VS warnings:
     # warning C4244: 'initializing' : conversion from 'const float' to 'int', possible loss of data

--- a/source/configurator/CMakeLists.txt
+++ b/source/configurator/CMakeLists.txt
@@ -10,9 +10,9 @@ project(RoR_Configurator)
 if (WIN32)
     set(OS_LIBS "${PThread_LIBRARIES};dinput8.lib;dxguid.lib")
     # clang-cl doesn't support resource files
-	if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-		set(OS_SOURCE "icon.rc")
-	endif()
+    if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+        set(OS_SOURCE "icon.rc")
+    endif()
 
     # disable some annoying VS warnings:
     # warning C4244: 'initializing' : conversion from 'const float' to 'int', possible loss of data

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -283,10 +283,10 @@ generate_source_groups(${SOURCE_FILES})
 
 
 if (WIN32)
-	# clang-cl doesn't support resource files
-	if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-		list(APPEND SOURCE_FILES "icon.rc")
-	endif()
+    # clang-cl doesn't support resource files
+    if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+        list(APPEND SOURCE_FILES "icon.rc")
+    endif()
 endif ()
 
 

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -283,7 +283,10 @@ generate_source_groups(${SOURCE_FILES})
 
 
 if (WIN32)
-    list(APPEND SOURCE_FILES "icon.rc")
+	# clang-cl doesn't support resource files
+	if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+		list(APPEND SOURCE_FILES "icon.rc")
+	endif()
 endif ()
 
 

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -252,7 +252,7 @@ void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, floa
 
 void EngineSim::UpdateEngineSim(float dt, int doUpdate)
 {
-    int actor_id = m_actor->ar_instance_id;
+	//int actor_id = m_actor->ar_instance_id; // unused variable
     float acc = m_cur_acc;
 
     acc = std::max(getIdleMixture(), acc);

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -252,7 +252,6 @@ void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, floa
 
 void EngineSim::UpdateEngineSim(float dt, int doUpdate)
 {
-	//int actor_id = m_actor->ar_instance_id; // unused variable
     float acc = m_cur_acc;
 
     acc = std::max(getIdleMixture(), acc);

--- a/source/main/gameplay/Landusemap.cpp
+++ b/source/main/gameplay/Landusemap.cpp
@@ -58,20 +58,20 @@ Landusemap::~Landusemap()
 ground_model_t* Landusemap::getGroundModelAt(int x, int z)
 {
     if (!data)
-        return 0;
+        return nullptr;
 #ifdef USE_PAGED
-	const Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
+    const Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
     // we return the default ground model if we are not anymore in this map
     if (x < 0 || x >= mapsize.x || z < 0 || z >= mapsize.z)
         return default_ground_model;
 
     return data[x + z * (int)mapsize.x];
 #else
-	return 0;
+	return nullptr;
 #endif // USE_PAGED
 }
 
-int Landusemap::loadConfig(Ogre::String filename)
+int Landusemap::loadConfig(const Ogre::String& filename)
 {
     std::map<unsigned int, String> usemap;
     String textureFilename = "";
@@ -157,7 +157,7 @@ int Landusemap::loadConfig(Ogre::String filename)
 
         bool bgr = colourMap->getPixelBox().format == PF_A8B8G8R8;
 
-		const Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
+        const Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
         Ogre::TRect<Ogre::Real> bounds = Forests::TBounds(0, 0, mapsize.x, mapsize.z);
 
         // now allocate the data buffer to hold pointers to ground models

--- a/source/main/gameplay/Landusemap.cpp
+++ b/source/main/gameplay/Landusemap.cpp
@@ -59,8 +59,8 @@ ground_model_t* Landusemap::getGroundModelAt(int x, int z)
 {
     if (!data)
         return 0;
-    Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
 #ifdef USE_PAGED
+	Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
     // we return the default ground model if we are not anymore in this map
     if (x < 0 || x >= mapsize.x || z < 0 || z >= mapsize.z)
         return default_ground_model;
@@ -73,7 +73,6 @@ ground_model_t* Landusemap::getGroundModelAt(int x, int z)
 
 int Landusemap::loadConfig(Ogre::String filename)
 {
-    Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
     std::map<unsigned int, String> usemap;
     String textureFilename = "";
 
@@ -158,6 +157,7 @@ int Landusemap::loadConfig(Ogre::String filename)
 
         bool bgr = colourMap->getPixelBox().format == PF_A8B8G8R8;
 
+		Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
         Ogre::TRect<Ogre::Real> bounds = Forests::TBounds(0, 0, mapsize.x, mapsize.z);
 
         // now allocate the data buffer to hold pointers to ground models

--- a/source/main/gameplay/Landusemap.cpp
+++ b/source/main/gameplay/Landusemap.cpp
@@ -60,7 +60,7 @@ ground_model_t* Landusemap::getGroundModelAt(int x, int z)
     if (!data)
         return 0;
 #ifdef USE_PAGED
-	Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
+	const Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
     // we return the default ground model if we are not anymore in this map
     if (x < 0 || x >= mapsize.x || z < 0 || z >= mapsize.z)
         return default_ground_model;
@@ -157,7 +157,7 @@ int Landusemap::loadConfig(Ogre::String filename)
 
         bool bgr = colourMap->getPixelBox().format == PF_A8B8G8R8;
 
-		Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
+		const Vector3 mapsize = App::GetSimTerrain()->getMaxTerrainSize();
         Ogre::TRect<Ogre::Real> bounds = Forests::TBounds(0, 0, mapsize.x, mapsize.z);
 
         // now allocate the data buffer to hold pointers to ground models

--- a/source/main/gameplay/Landusemap.h
+++ b/source/main/gameplay/Landusemap.h
@@ -32,7 +32,7 @@ public:
     ~Landusemap();
 
     ground_model_t* getGroundModelAt(int x, int z);
-    int loadConfig(Ogre::String filename);
+    int loadConfig(const Ogre::String& filename);
 
 protected:
 

--- a/source/main/gfx/Skidmark.cpp
+++ b/source/main/gfx/Skidmark.cpp
@@ -168,7 +168,7 @@ void RoR::Skidmark::AddObject(Ogre::Vector3 start, Ogre::String texture)
     skid.material = Ogre::MaterialManager::getSingleton().create(bname, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     Ogre::Pass* p = skid.material->getTechnique(0)->getPass(0);
 
-    Ogre::TextureUnitState* tus = p->createTextureUnitState(texture);
+    p->createTextureUnitState(texture);
     p->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
     p->setLightingEnabled(false);
     p->setDepthWriteEnabled(false);

--- a/source/main/gfx/hydrax/GodRaysManager.cpp
+++ b/source/main/gfx/hydrax/GodRaysManager.cpp
@@ -410,7 +410,6 @@ namespace Hydrax
 		Ogre::Ray SunToCameraRay = Ogre::Ray(SunPosition, CameraPosition-SunPosition);
 
 		Ogre::Vector3 WaterProjectionPoint = SunToCameraRay.getPoint(SunToCameraRay.intersects(WaterPlane).second);
-		//Ogre::Vector3 WaterPosition = Ogre::Vector3(WaterProjectionPoint.x, mHydrax->getHeigth(WaterProjectionPoint), WaterProjectionPoint.z); // unused variable
 
 		mProjectorSN->setPosition(WaterProjectionPoint);
 		mProjectorCamera->setFarClipDistance((WaterProjectionPoint-CameraPosition).length());

--- a/source/main/gfx/hydrax/GodRaysManager.cpp
+++ b/source/main/gfx/hydrax/GodRaysManager.cpp
@@ -410,7 +410,7 @@ namespace Hydrax
 		Ogre::Ray SunToCameraRay = Ogre::Ray(SunPosition, CameraPosition-SunPosition);
 
 		Ogre::Vector3 WaterProjectionPoint = SunToCameraRay.getPoint(SunToCameraRay.intersects(WaterPlane).second);
-		Ogre::Vector3 WaterPosition = Ogre::Vector3(WaterProjectionPoint.x, mHydrax->getHeigth(WaterProjectionPoint), WaterProjectionPoint.z);
+		//Ogre::Vector3 WaterPosition = Ogre::Vector3(WaterProjectionPoint.x, mHydrax->getHeigth(WaterProjectionPoint), WaterProjectionPoint.z); // unused variable
 
 		mProjectorSN->setPosition(WaterProjectionPoint);
 		mProjectorCamera->setFarClipDistance((WaterProjectionPoint-CameraPosition).length());

--- a/source/main/gfx/skyx/VClouds/Lightning.cpp
+++ b/source/main/gfx/skyx/VClouds/Lightning.cpp
@@ -59,7 +59,6 @@ namespace SkyX { namespace VClouds
 	{
 		remove();
 
-		// Ogre::Vector3 end = mOrigin + mDirection*mLength; // unused variable
 		Ogre::Vector3 current, last = mOrigin;
 
 		// Create ray segments

--- a/source/main/gfx/skyx/VClouds/Lightning.cpp
+++ b/source/main/gfx/skyx/VClouds/Lightning.cpp
@@ -59,7 +59,7 @@ namespace SkyX { namespace VClouds
 	{
 		remove();
 
-		Ogre::Vector3 end = mOrigin + mDirection*mLength;
+		// Ogre::Vector3 end = mOrigin + mDirection*mLength; // unused variable
 		Ogre::Vector3 current, last = mOrigin;
 
 		// Create ray segments

--- a/source/main/gui/panels/GUI_GameConsole.cpp
+++ b/source/main/gui/panels/GUI_GameConsole.cpp
@@ -401,7 +401,7 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
 
         String nmsg = RoR::Color::ScriptCommandColour + ">>> " + RoR::Color::NormalColour + command;
         putMessage(CONSOLE_MSGTYPE_SCRIPT, CONSOLE_LOCAL_SCRIPT, nmsg, "script_go.png");
-        int res = ScriptEngine::getSingleton().executeString(command);
+        ScriptEngine::getSingleton().executeString(command);
         return;
     }
 #endif //ANGELSCRIPT

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -847,7 +847,7 @@ float Actor::GetTyrePressure()
 
 void Actor::RecalculateNodeMasses(Real total, bool reCalc)
 {
-    bool debugMass = App::diag_truck_mass.GetActive();
+    //bool debugMass = App::diag_truck_mass.GetActive(); // unused variable
 
     //reset
     for (int i = 0; i < ar_num_nodes; i++)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -847,8 +847,6 @@ float Actor::GetTyrePressure()
 
 void Actor::RecalculateNodeMasses(Real total, bool reCalc)
 {
-    //bool debugMass = App::diag_truck_mass.GetActive(); // unused variable
-
     //reset
     for (int i = 0; i < ar_num_nodes; i++)
     {

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -768,7 +768,6 @@ void ActorSpawner::ProcessFusedrag(RigDef::Fusedrag & def)
 
     //parse fusedrag
     int front_node_idx = GetNodeIndexOrThrow(def.front_node);
-    //int back_node_idx = GetNodeIndexOrThrow(def.rear_node); // unused variable
     float width = 1.f;
     float factor = 1.f;
     char fusefoil[256];

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -768,7 +768,7 @@ void ActorSpawner::ProcessFusedrag(RigDef::Fusedrag & def)
 
     //parse fusedrag
     int front_node_idx = GetNodeIndexOrThrow(def.front_node);
-    int back_node_idx = GetNodeIndexOrThrow(def.rear_node);
+    //int back_node_idx = GetNodeIndexOrThrow(def.rear_node); // unused variable
     float width = 1.f;
     float factor = 1.f;
     char fusefoil[256];

--- a/source/main/scripting/CBytecodeStream.cpp
+++ b/source/main/scripting/CBytecodeStream.cpp
@@ -39,7 +39,7 @@ int CBytecodeStream::Write(const void* ptr, AngelScript::asUINT size)
 {
     if (!f)
         return -1;
-    size_t result = fwrite(ptr, size, 1, f);
+    fwrite(ptr, size, 1, f);
     return 0;
 }
 

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -703,7 +703,7 @@ int ScriptEngine::deleteVariable(const String &arg)
 void ScriptEngine::triggerEvent(int eventnum, int value)
 {
     if (!engine) return;
-    if (eventCallbackFunctionPtr==0) return;
+    if (eventCallbackFunctionPtr==nullptr) return;
     if (eventMask & eventnum)
     {
         // script registered for that event, so sent it

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -425,7 +425,7 @@ int ScriptEngine::framestep(Real dt)
     }
 
     // framestep stuff below
-    if (frameStepFunctionPtr==0) return 1;
+    if (frameStepFunctionPtr==nullptr) return 1;
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();
     context->Prepare(frameStepFunctionPtr);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -425,7 +425,7 @@ int ScriptEngine::framestep(Real dt)
     }
 
     // framestep stuff below
-    if (frameStepFunctionPtr<=0) return 1;
+    if (frameStepFunctionPtr==0) return 1;
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();
     context->Prepare(frameStepFunctionPtr);
@@ -703,7 +703,7 @@ int ScriptEngine::deleteVariable(const String &arg)
 void ScriptEngine::triggerEvent(int eventnum, int value)
 {
     if (!engine) return;
-    if (eventCallbackFunctionPtr<=0) return;
+    if (eventCallbackFunctionPtr==0) return;
     if (eventMask & eventnum)
     {
         // script registered for that event, so sent it

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -137,7 +137,6 @@ void TerrainObjectManager::LoadTObjFile(Ogre::String odefname)
 
     Vector3 r2lastpos = Vector3::ZERO;
     Quaternion r2lastrot = Quaternion::IDENTITY;
-    int r2counter = 0;
 
     //long line = 0;
     char line[4096] = "";

--- a/source/main/utils/CollisionTools.cpp
+++ b/source/main/utils/CollisionTools.cpp
@@ -328,7 +328,7 @@ bool CollisionTools::raycast(const Ogre::Ray& ray, Ogre::Vector3& result, Ogre::
         else if ((query_result[qr_idx].movable != NULL) && !query_result[qr_idx].movable->getMovableType().compare("StaticGeometry"))
         {
             // static geometry
-            Ogre::MovableObject* pentity = static_cast<Ogre::MovableObject*>(query_result[qr_idx].movable);
+            //Ogre::MovableObject* pentity = static_cast<Ogre::MovableObject*>(query_result[qr_idx].movable); // unused variable
             Ogre::StaticGeometry::Region* rg = static_cast<Ogre::StaticGeometry::Region*>(query_result[qr_idx].movable);
 
             // this is a quick hack to prevent that we allocate unlimited amount of memory

--- a/source/main/utils/CollisionTools.cpp
+++ b/source/main/utils/CollisionTools.cpp
@@ -328,7 +328,6 @@ bool CollisionTools::raycast(const Ogre::Ray& ray, Ogre::Vector3& result, Ogre::
         else if ((query_result[qr_idx].movable != NULL) && !query_result[qr_idx].movable->getMovableType().compare("StaticGeometry"))
         {
             // static geometry
-            //Ogre::MovableObject* pentity = static_cast<Ogre::MovableObject*>(query_result[qr_idx].movable); // unused variable
             Ogre::StaticGeometry::Region* rg = static_cast<Ogre::StaticGeometry::Region*>(query_result[qr_idx].movable);
 
             // this is a quick hack to prevent that we allocate unlimited amount of memory

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -2080,10 +2080,10 @@ void InputEngine::grabMouse(bool enable)
 
 void InputEngine::hideMouse(bool visible)
 {
-    static int mode = -1;
     if (!mMouse)
         return;
 #if OGRE_PLATFORM == OGRE_PLATFORM_LINUX
+	static int mode = -1;
     if ((visible && mode == 0) || (!visible && mode == 1) || mode == -1)
     {
     //((LinuxMouse *)mMouse)->hide(visible);

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -2078,20 +2078,6 @@ void InputEngine::grabMouse(bool enable)
 #endif
 }
 
-void InputEngine::hideMouse(bool visible)
-{
-    if (!mMouse)
-        return;
-#if OGRE_PLATFORM == OGRE_PLATFORM_LINUX
-	static int mode = -1;
-    if ((visible && mode == 0) || (!visible && mode == 1) || mode == -1)
-    {
-    //((LinuxMouse *)mMouse)->hide(visible);
-        mode = visible?1:0;
-    }
-#endif
-}
-
 void InputEngine::setMousePosition(int x, int y, bool padding)
 {
     if (!mMouse)

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -514,7 +514,6 @@ public:
     bool updateConfigline(event_trigger_t* t);
 
     void grabMouse(bool enable);
-    void hideMouse(bool visible);
     void setMousePosition(int x, int y, bool padding = true);
 
     int getKeboardKeyForCommand(int eventID);

--- a/source/main/utils/PlatformUtils.cpp
+++ b/source/main/utils/PlatformUtils.cpp
@@ -72,7 +72,7 @@ std::wstring MSW_Utf8ToWchar(const char* path)
         RoR::LogFormat("[RoR] Internal error: MSW_Utf8ToWchar() could not convert UTF-8 to UTF-16; MultiByteToWideChar() returned %d", raw_result);
         return std::wstring();
     }
-    return std::move(out_wstr);
+    return out_wstr;
 }
 
 DWORD MSW_GetFileAttrs(const char* path)
@@ -104,7 +104,7 @@ std::string MSW_WcharToUtf8(const wchar_t* wstr) // wstr _must_ be NUL-terminate
         RoR::LogFormat("[RoR] Internal error: MSW_WcharToUtf8() could not convert UTF-16 to UTF-8; WideCharToMultiByte() returned %d", raw_result);
         return std::string();
     }
-    return std::move(dst);
+    return dst;
 }
 
 bool FileExists(const char *path)
@@ -224,7 +224,7 @@ std::string GetParentDirectory(const char* src_buff)
         --count;
     }
     
-    return std::move(std::string(start, count));
+    return std::string(start, count);
 }
 
 

--- a/source/main/utils/SHA1.cpp
+++ b/source/main/utils/SHA1.cpp
@@ -190,13 +190,13 @@ bool CSHA1::HashFile(char *szFileName)
 
     for (i = 0; i < ulBlocks; i++)
     {
-        size_t res = fread(uData, 1, SHA1_MAX_FILE_BUFFER, fIn);
+        fread(uData, 1, SHA1_MAX_FILE_BUFFER, fIn);
         UpdateHash((uint8_t *)uData, SHA1_MAX_FILE_BUFFER);
     }
 
     if (ulRest != 0)
     {
-        size_t res = fread(uData, 1, ulRest, fIn);
+        fread(uData, 1, ulRest, fIn);
         UpdateHash((uint8_t *)uData, ulRest);
     }
 


### PR DESCRIPTION
[WIP] Highlights:

- Made the CMakeLists.txt disable resource files '.rc'  when building with clang-cl.exe (Windows) since they are not supported, and small code changes to avoid compile-time errors: https://github.com/RigsOfRods/rigs-of-rods/commit/8a45d34a177cd472750fa4ed41edcb6292a95083
- Removed, commented or moved some variables to either optimize the code a bit or remove unused variables: https://github.com/RigsOfRods/rigs-of-rods/commit/8c2caa35a478bf9f54cc2961544815fd3545085f https://github.com/RigsOfRods/rigs-of-rods/commit/d9484519ca73d75c996b641b544ae0a042b54c43