### PR TITLE
Unified actor-spawn/change API (using queues)

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1520,6 +1520,31 @@ void SimController::UpdateSimulation(float dt)
                 fresh_actor->ar_engine->StartEngine();
             }
         }
+        else if (rq.asr_origin == ActorSpawnRequest::Origin::TERRN_DEF)
+        {
+            Actor* fresh_actor = m_actor_manager.CreateLocalActor(
+                rq.asr_position, rq.asr_rotation, rq.asr_filename, rq.asr_cache_entry_num,
+                nullptr, &rq.asr_config, rq.asr_skin, !rq.asr_terrn_adjust, true); // true = Preloaded with terrain
+
+            if (rq.asr_terrn_machine)
+            {
+                fresh_actor->ar_driveable = MACHINE;
+            }
+
+            if (App::GetSimController()->GetGfxScene().GetSurveyMap() != nullptr)
+            {
+                SurveyMapEntity* e = App::GetSimController()->GetGfxScene().GetSurveyMap()->createNamedMapEntity(
+                    "Truck" + std::to_string(fresh_actor->ar_instance_id),
+                    SurveyMapManager::getTypeByDriveable(fresh_actor->ar_driveable));
+                if (e != nullptr)
+                {
+                    e->setState(static_cast<int>(Actor::SimState::LOCAL_SIMULATED));
+                    e->setVisibility(true);
+                    e->setPosition(rq.asr_position.x, rq.asr_position.z);
+                    e->setRotation(-Radian(fresh_actor->getRotation()));
+                }
+            }
+        }
         else
         {
             Actor* fresh_actor = m_actor_manager.CreateLocalActor(

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -66,7 +66,7 @@ public:
     // Actor management interface
     std::vector<Actor*> GetActors() const                             { return m_actor_manager.GetActors(); }
     Actor* GetActorById          (int actor_id)                       { return m_actor_manager.GetActorByIdInternal(actor_id); }
-    void   SetPlayerActor        (Actor* actor);                      
+    void   SetPendingPlayerActor (Actor* actor)                       { m_pending_player_actor = actor; }                      
     Actor* GetPlayerActor        ()                                   { return m_player_actor; }    
     void   QueueActorSpawn       (RoR::ActorSpawnRequest const & rq)  { m_actor_spawn_queue.push_back(rq); }
     void   QueueActorModify      (RoR::ActorModifyRequest const & rq) { m_actor_modify_queue.push_back(rq); }
@@ -120,9 +120,11 @@ private:
     void   HideGUI                 (bool hidden);
     void   CleanupAfterSimulation  (); /// Unloads all data
     void   UpdateSimulation        (float dt_sec);
+    void   ChangePlayerActor       (Actor* actor);
 
     Actor*                   m_player_actor;           //!< Actor (vehicle or machine) mounted and controlled by player
     Actor*                   m_prev_player_actor;      //!< Previous actor (vehicle or machine) mounted and controlled by player
+    Actor*                   m_pending_player_actor;   //!< Actor scheduled to be seated by player (when none scheduled, equals `player_actor`)
     RoR::ActorManager        m_actor_manager;
     std::vector<RoR::ActorSpawnRequest>  m_actor_spawn_queue;
     std::vector<RoR::ActorModifyRequest> m_actor_modify_queue;

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -74,6 +74,7 @@ public:
     void   RemoveActor           (Actor* actor);
     void   RemoveActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name); ///< Scripting utility. TODO: Does anybody use it? ~ only_a_ptr, 08/2017
     void   QueueActorSpawn       (RoR::ActorSpawnRequest const & rq) { m_actor_spawn_queue.push_back(rq); }
+    void   QueueActorModify      (RoR::ActorModifyRequest const & rq) { m_actor_modify_queue.push_back(rq); }
 
     std::vector<Actor*>          GetActors          () const;
 
@@ -129,6 +130,7 @@ private:
     Actor*                   m_prev_player_actor;      //!< Previous actor (vehicle or machine) mounted and controlled by player
     RoR::ActorManager        m_actor_manager;
     std::vector<RoR::ActorSpawnRequest> m_actor_spawn_queue;
+    std::vector<RoR::ActorModifyRequest> m_actor_modify_queue;
     RoR::CharacterFactory    m_character_factory;
     RoR::GfxScene            m_gfx_scene;
     RoR::SkidmarkConfig*     m_skidmark_conf;

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -129,8 +129,9 @@ private:
     Actor*                   m_player_actor;           //!< Actor (vehicle or machine) mounted and controlled by player
     Actor*                   m_prev_player_actor;      //!< Previous actor (vehicle or machine) mounted and controlled by player
     RoR::ActorManager        m_actor_manager;
-    std::vector<RoR::ActorSpawnRequest> m_actor_spawn_queue;
+    std::vector<RoR::ActorSpawnRequest>  m_actor_spawn_queue;
     std::vector<RoR::ActorModifyRequest> m_actor_modify_queue;
+    std::vector<Actor*>                  m_actor_remove_queue;             
     RoR::CharacterFactory    m_character_factory;
     RoR::GfxScene            m_gfx_scene;
     RoR::SkidmarkConfig*     m_skidmark_conf;

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -71,6 +71,7 @@ public:
     void   QueueActorSpawn       (RoR::ActorSpawnRequest const & rq)  { m_actor_spawn_queue.push_back(rq); }
     void   QueueActorModify      (RoR::ActorModifyRequest const & rq) { m_actor_modify_queue.push_back(rq); }
     void   QueueActorRemove      (Actor* actor)                       { m_actor_remove_queue.push_back(actor); }
+    Actor* SpawnActorDirectly    (RoR::ActorSpawnRequest rq);
     void   RemoveActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name); ///< Scripting utility. TODO: Does anybody use it? ~ only_a_ptr, 08/2017
 
     // Scripting interface

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -116,7 +116,7 @@ private:
 
     void   UpdateForceFeedback     (float dt);
     void   UpdateInputEvents       (float dt);
-    void   FinalizeActorSpawning   (Actor* local_actor, Actor* previous_actor);
+    void   FinalizeActorSpawning   (Actor* local_actor, Actor* previous_actor, RoR::ActorSpawnRequest rq);
     void   HideGUI                 (bool hidden);
     void   CleanupAfterSimulation  (); /// Unloads all data
     void   UpdateSimulation        (float dt_sec);
@@ -137,7 +137,6 @@ private:
     bool                     m_is_pace_reset_pressed;
     int                      m_stats_on;
     float                    m_netcheck_gui_timer;
-    collision_box_t*         m_reload_box;
     double                   m_time;
     RoR::ForceFeedback*      m_force_feedback;
     bool                     m_hide_gui;

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -73,6 +73,7 @@ public:
     void   RemovePlayerActor     ();
     void   RemoveActor           (Actor* actor);
     void   RemoveActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name); ///< Scripting utility. TODO: Does anybody use it? ~ only_a_ptr, 08/2017
+    void   QueueActorSpawn       (RoR::ActorSpawnRequest const & rq) { m_actor_spawn_queue.push_back(rq); }
 
     std::vector<Actor*>          GetActors          () const;
 

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -127,6 +127,7 @@ private:
     Actor*                   m_player_actor;           //!< Actor (vehicle or machine) mounted and controlled by player
     Actor*                   m_prev_player_actor;      //!< Previous actor (vehicle or machine) mounted and controlled by player
     RoR::ActorManager        m_actor_manager;
+    std::vector<RoR::ActorSpawnRequest> m_actor_spawn_queue;
     RoR::CharacterFactory    m_character_factory;
     RoR::GfxScene            m_gfx_scene;
     RoR::SkidmarkConfig*     m_skidmark_conf;

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -64,19 +64,14 @@ public:
     SimController(RoR::ForceFeedback* ff, RoR::SkidmarkConfig* skid_conf);
 
     // Actor management interface
-    std::vector<Actor*> GetActors()                        { return m_actor_manager.GetActors(); }
-    Actor* GetActorById          (int actor_id)            { return m_actor_manager.GetActorByIdInternal(actor_id); }
-    void   SetPlayerActorById    (int actor_id);                                                          // TODO: Eliminate, use pointers ~ only_a_ptr, 06/2017
-    void   SetPlayerActor        (Actor* actor);
-    Actor* GetPlayerActor        ()                        { return m_player_actor; }
-    void   ReloadPlayerActor     ();
-    void   RemovePlayerActor     ();
-    void   RemoveActor           (Actor* actor);
-    void   RemoveActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name); ///< Scripting utility. TODO: Does anybody use it? ~ only_a_ptr, 08/2017
-    void   QueueActorSpawn       (RoR::ActorSpawnRequest const & rq) { m_actor_spawn_queue.push_back(rq); }
+    std::vector<Actor*> GetActors() const                             { return m_actor_manager.GetActors(); }
+    Actor* GetActorById          (int actor_id)                       { return m_actor_manager.GetActorByIdInternal(actor_id); }
+    void   SetPlayerActor        (Actor* actor);                      
+    Actor* GetPlayerActor        ()                                   { return m_player_actor; }    
+    void   QueueActorSpawn       (RoR::ActorSpawnRequest const & rq)  { m_actor_spawn_queue.push_back(rq); }
     void   QueueActorModify      (RoR::ActorModifyRequest const & rq) { m_actor_modify_queue.push_back(rq); }
-
-    std::vector<Actor*>          GetActors          () const;
+    void   QueueActorRemove      (Actor* actor)                       { m_actor_remove_queue.push_back(actor); }
+    void   RemoveActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name); ///< Scripting utility. TODO: Does anybody use it? ~ only_a_ptr, 08/2017
 
     // Scripting interface
     double getTime               () { return m_time; }

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -737,7 +737,7 @@ void CLASS::OnSelectionDone()
         rq.asr_skin           = m_selected_skin;
         rq.asr_cache_entry    = m_selected_entry;
         rq.asr_config         = m_vehicle_configs;
-        rq.asr_user_selected  = true;
+        rq.asr_origin         = ActorSpawnRequest::Origin::USER;
         App::GetSimController()->QueueActorSpawn(rq);
         
         RoR::App::GetGuiManager()->UnfocusGui();

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -47,6 +47,7 @@ CLASS::CLASS() :
     , m_selected_skin(nullptr)
     , m_selected_entry(nullptr)
     , m_selection_done(true)
+    , m_actor_spawn_rq_valid(false)
 {
     MAIN_WIDGET->setVisible(false);
     m_skin_manager = RoR::App::GetContentManager()->GetSkinManager();
@@ -734,12 +735,17 @@ void CLASS::OnSelectionDone()
     if (new_actor_selected)
     {
         ActorSpawnRequest rq;
+        if (m_actor_spawn_rq_valid)
+        {
+            rq = m_actor_spawn_rq;
+            m_actor_spawn_rq_valid = false;
+        }
         rq.asr_skin           = m_selected_skin;
         rq.asr_cache_entry    = m_selected_entry;
         rq.asr_config         = m_vehicle_configs;
         rq.asr_origin         = ActorSpawnRequest::Origin::USER;
         App::GetSimController()->QueueActorSpawn(rq);
-        
+
         RoR::App::GetGuiManager()->UnfocusGui();
         App::sim_state.SetActive(SimState::RUNNING); // TODO: use 'Pending' mechanism!
     }
@@ -987,6 +993,17 @@ void CLASS::ResizePreviewImage()
 bool CLASS::IsFinishedSelecting()
 {
     return m_selection_done;
+}
+
+void CLASS::Show(LoaderType type, RoR::ActorSpawnRequest req)
+{
+    if (!m_selection_done)
+    {
+        return;
+    }
+    m_actor_spawn_rq_valid = true;
+    m_actor_spawn_rq = req;
+    this->Show(type);
 }
 
 void CLASS::Show(LoaderType type)

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "BeamFactory.h" // ActorSpawnRequest
+#include "BeamData.h" // ActorSpawnRequest
 #include "ForwardDeclarations.h"
 #include "GUI_MainSelectorLayout.h"
 

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BeamFactory.h" // ActorSpawnRequest
 #include "ForwardDeclarations.h"
 #include "GUI_MainSelectorLayout.h"
 
@@ -39,6 +40,7 @@ public:
 
     bool IsFinishedSelecting();
     void Show(LoaderType type);
+    void Show(LoaderType type, ActorSpawnRequest req);
     void Hide(bool smooth = true);
     bool IsVisible();
     void Reset();
@@ -87,6 +89,8 @@ private:
     std::vector<RoR::SkinDef *> m_current_skins;
     bool m_keys_bound;
     RoR::SkinManager* m_skin_manager;
+    ActorSpawnRequest m_actor_spawn_rq; //!< Pre-configured by on-terrain spawner scripts
+    bool m_actor_spawn_rq_valid;
 };
 
 } // namespace GUI

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -139,16 +139,23 @@ void RoR::GUI::TopMenubar::Update()
 
             if (ImGui::Button("Reload current vehicle")) // TODO: make button disabled (fake it!) when no active vehicle
             {
-                if (current_actor != nullptr)
+                if ((current_actor != nullptr) && (current_actor->ar_sim_state != Actor::SimState::NETWORKED_OK))
                 {
-                    App::GetSimController()->ReloadPlayerActor();
+                    ActorModifyRequest rq;
+                    rq.amr_type = ActorModifyRequest::Type::RELOAD;
+                    rq.amr_actor = current_actor;
+                    App::GetSimController()->QueueActorModify(rq);
+
                     App::GetGuiManager()->UnfocusGui();
                 }
             }
 
             if (ImGui::Button("Remove current vehicle")) // TODO: make button disabled (fake it!) when no active vehicle
             {
-                App::GetSimController()->RemovePlayerActor();
+                if ((current_actor != nullptr) && (current_actor->ar_sim_state != Actor::SimState::NETWORKED_OK))
+                {
+                    App::GetSimController()->QueueActorRemove(current_actor);
+                }
             }
 
             if (App::mp_state.GetActive() != MpState::CONNECTED) // Singleplayer only!

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -175,7 +175,7 @@ void RoR::GUI::TopMenubar::Update()
                 {
                     if (current_actor != nullptr) // Get out first
                     {
-                        App::GetSimController()->SetPlayerActor(nullptr);
+                        App::GetSimController()->SetPendingPlayerActor(nullptr);
                     }
                     App::GetSimController()->GetBeamFactory()->SendAllActorsSleeping();
                 }
@@ -414,7 +414,7 @@ void RoR::GUI::TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
             snprintf(actortext_buf, 400, "  + %s (%s)", actor->ar_design_name.c_str(), actor->ar_filename.c_str());
             if (ImGui::Button(actortext_buf)) // Button clicked?
             {
-                App::GetSimController()->SetPlayerActor(actor);
+                App::GetSimController()->SetPendingPlayerActor(actor);
             }
         }
     }
@@ -446,7 +446,7 @@ void RoR::GUI::TopMenubar::DrawActorListSinglePlayer()
             snprintf(text_buf, 200, "[%d] %s", i++, actor->ar_design_name.c_str());
             if (ImGui::Button(text_buf)) // Button clicked?
             {
-                App::GetSimController()->SetPlayerActor(actor);
+                App::GetSimController()->SetPendingPlayerActor(actor);
             }
         }
     }

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4125,14 +4125,11 @@ Actor::Actor(
     std::shared_ptr<RigDef::File> def,
     Ogre::Vector3 pos,
     Ogre::Quaternion rot,
-    const char* fname,
-    bool _networked, /* = false  */
+    const char* filename,
     bool _networking, /* = false  */
-    collision_box_t* spawnbox, /* = nullptr */
     const std::vector<Ogre::String>* actor_config, /* = nullptr */
     RoR::SkinDef* skin, /* = nullptr */
-    bool preloaded_with_terrain, /* = false */
-    int cache_entry_number /* = -1 */
+    bool preloaded_with_terrain /* = false */
 ) 
     : ar_nodes(nullptr), ar_num_nodes(0)
     , ar_beams(nullptr), ar_num_beams(0)
@@ -4233,7 +4230,7 @@ Actor::Actor(
     , ar_autopilot(nullptr)
     , ar_is_police(false)
     , m_disable_default_sounds(false)
-    , ar_uses_networking(false)
+    , ar_uses_networking(_networking)
     , ar_engine(nullptr)
     , ar_driveable(NOT_DRIVEABLE)
     , m_skid_trails{} // Init array to nullptr
@@ -4259,14 +4256,12 @@ Actor::Actor(
     , ar_num_contacters() // zero-init
     , ar_wheels() // array
     , ar_num_wheels() // int
+    , m_used_skin(skin)
+    , ar_filename(filename)
 {
     m_high_res_wheelnode_collisions = App::sim_hires_wheel_col.GetActive();
     m_use_skidmarks = RoR::App::gfx_skidmarks_mode.GetActive() == 1;
-    LOG(" ===== LOADING VEHICLE: " + Ogre::String(fname));
-
-    m_used_skin = skin;
-    ar_uses_networking = _networking;
-    ar_filename = fname;
+    LOG(" ===== LOADING VEHICLE: " + Ogre::String(ar_filename));
 
     // copy config
     if (actor_config != nullptr && actor_config->size() > 0u)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1327,14 +1327,6 @@ String Actor::getAxleLockName()
     return m_axles[0]->GetDifferentialTypeName();
 }
 
-void Actor::RequestActorReset(bool keepPosition)
-{
-    if (keepPosition)
-        m_reset_request = REQUEST_RESET_ON_SPOT;
-    else
-        m_reset_request = REQUEST_RESET_ON_INIT_POS;
-}
-
 void Actor::RequestRotation(float rotation)
 {
     m_rotation_request += rotation;
@@ -1366,7 +1358,7 @@ Ogre::Vector3 Actor::GetRotationCenter()
     return rotation_center;
 }
 
-void Actor::SyncReset()
+void Actor::SyncReset(bool reset_position)
 {
     ar_hydro_dir_state = 0.0;
     ar_hydro_aileron_state = 0.0;
@@ -1465,7 +1457,7 @@ void Actor::SyncReset()
 
     this->GetGfxActor()->ResetFlexbodies();
     // reset on spot with backspace
-    if (m_reset_request != REQUEST_RESET_ON_INIT_POS)
+    if (!reset_position)
     {
         this->ResetAngle(cur_rot);
         this->ResetPosition(cur_position.x, cur_position.z, false, yPos);
@@ -1480,15 +1472,6 @@ void Actor::SyncReset()
     }
 
     this->resetSlideNodes();
-
-    if (m_reset_request != REQUEST_RESET_ON_SPOT)
-    {
-        m_reset_request = REQUEST_RESET_NONE;
-    }
-    else
-    {
-        m_reset_request = REQUEST_RESET_FINAL;
-    }
 }
 
 bool Actor::ReplayStep()
@@ -1586,11 +1569,6 @@ void Actor::HandleInputEvents(float dt)
         m_translation_request = Vector3::ZERO;
         this->UpdateBoundingBoxes();
         calculateAveragePosition();
-    }
-
-    if (m_reset_request)
-    {
-        SyncReset();
     }
 }
 
@@ -4183,7 +4161,6 @@ Actor::Actor(
     , m_hide_own_net_label(BSETTING("HideOwnNetLabel", false))
     , m_cinecam_is_rotation_center(false)
     , m_preloaded_with_terrain(preloaded_with_terrain)
-    , m_reset_request(REQUEST_RESET_NONE)
     , ar_net_source_id(0)
     , m_spawn_rotation(0.0)
     , ar_net_stream_id(0)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4358,11 +4358,6 @@ Replay* Actor::getReplay()
     return m_replay_handler;
 }
 
-bool Actor::getSlideNodesLockInstant()
-{
-    return m_slidenodes_connect_on_spawn;
-}
-
 bool Actor::inRange(float num, float min, float max)
 {
     return (num <= max && num >= min);

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4101,13 +4101,7 @@ Actor::Actor(
     int actor_id,
     unsigned int vector_index,
     std::shared_ptr<RigDef::File> def,
-    Ogre::Vector3 pos,
-    Ogre::Quaternion rot,
-    const char* filename,
-    bool _networking, /* = false  */
-    const std::vector<Ogre::String>* actor_config, /* = nullptr */
-    RoR::SkinDef* skin, /* = nullptr */
-    bool preloaded_with_terrain /* = false */
+    RoR::ActorSpawnRequest rq
 ) 
     : ar_nodes(nullptr), ar_num_nodes(0)
     , ar_beams(nullptr), ar_num_beams(0)
@@ -4150,7 +4144,7 @@ Actor::Actor(
     , m_inter_point_col_detector(nullptr)
     , m_intra_point_col_detector(nullptr)
     , ar_net_last_update_time(0)
-    , m_avg_node_position_prev(pos)
+    , m_avg_node_position_prev(rq.asr_position)
     , ar_left_mirror_angle(0.52)
     , ar_lights(1)
     , m_avg_node_velocity(Ogre::Vector3::ZERO)
@@ -4160,7 +4154,7 @@ Actor::Actor(
     , ar_main_camera_node_roll(0)
     , m_hide_own_net_label(BSETTING("HideOwnNetLabel", false))
     , m_cinecam_is_rotation_center(false)
-    , m_preloaded_with_terrain(preloaded_with_terrain)
+    , m_preloaded_with_terrain(rq.asr_origin == RoR::ActorSpawnRequest::Origin::TERRN_DEF)
     , ar_net_source_id(0)
     , m_spawn_rotation(0.0)
     , ar_net_stream_id(0)
@@ -4176,7 +4170,7 @@ Actor::Actor(
     , m_replay_pos_prev(-1)
     , ar_parking_brake(0)
     , m_position_storage(0)
-    , m_avg_node_position(pos)
+    , m_avg_node_position(rq.asr_position)
     , m_previous_gear(0)
     , m_ref_tyre_pressure(50.0)
     , m_replay_handler(nullptr)
@@ -4207,7 +4201,7 @@ Actor::Actor(
     , ar_autopilot(nullptr)
     , ar_is_police(false)
     , m_disable_default_sounds(false)
-    , ar_uses_networking(_networking)
+    , ar_uses_networking(rq.asr_origin == RoR::ActorSpawnRequest::Origin::NETWORK)
     , ar_engine(nullptr)
     , ar_driveable(NOT_DRIVEABLE)
     , m_skid_trails{} // Init array to nullptr
@@ -4233,21 +4227,12 @@ Actor::Actor(
     , ar_num_contacters() // zero-init
     , ar_wheels() // array
     , ar_num_wheels() // int
-    , m_used_skin(skin)
-    , ar_filename(filename)
+    , m_used_skin(rq.asr_skin)
+    , ar_filename(rq.asr_filename)
+    , m_actor_config(rq.asr_config)
 {
     m_high_res_wheelnode_collisions = App::sim_hires_wheel_col.GetActive();
     m_use_skidmarks = RoR::App::gfx_skidmarks_mode.GetActive() == 1;
-    LOG(" ===== LOADING VEHICLE: " + Ogre::String(ar_filename));
-
-    // copy config
-    if (actor_config != nullptr && actor_config->size() > 0u)
-    {
-        for (std::vector<Ogre::String>::const_iterator it = actor_config->begin(); it != actor_config->end(); ++it)
-        {
-            m_actor_config.push_back(*it);
-        }
-    }
 }
 
 ground_model_t* Actor::getLastFuzzyGroundModel()

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -63,13 +63,7 @@ public:
           int actor_id
         , unsigned int vector_index
         , std::shared_ptr<RigDef::File> def
-        , Ogre::Vector3 pos
-        , Ogre::Quaternion rot
-        , const char* fname
-        , bool networking = false
-        , const std::vector<Ogre::String> *actor_config = nullptr
-        , RoR::SkinDef *skin = nullptr
-        , bool preloaded_with_terrain = false
+        , RoR::ActorSpawnRequest rq
         );
 
     ~Actor();

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -155,7 +155,6 @@ public:
     int               getLowestNode();
     void              receiveStreamData(unsigned int type, int source, unsigned int streamid, char *buffer, unsigned int len);
     bool              inRange(float num, float min, float max);
-    bool              getSlideNodesLockInstant();
     void              sendStreamData();
     bool              isTied();
     bool              isLocked(); 
@@ -495,7 +494,6 @@ private:
     bool m_has_command_beams:1;    //!< Physics attr;
     bool m_beacon_light_is_active:1;        //!< Gfx state
     bool m_custom_particles_enabled:1;      //!< Gfx state
-    bool m_slidenodes_connect_on_spawn:1;   //<! spawn context: try to connect slide-nodes directly after spawning (TODO: remove!)
     bool m_cinecam_is_rotation_center:1;    //<! Attribute; filled at spawn
     bool m_preloaded_with_terrain:1;        //!< Spawn context (TODO: remove!)
     bool m_high_res_wheelnode_collisions:1; //!< Physics attr; set at spawn

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -57,10 +57,8 @@ public:
     /// @param pos
     /// @param rot
     /// @param fname Rig file name.
-    /// @param ismachine (see BeamData.h)
     /// @param actor_config Networking related.
     /// @param preloaded_with_terrain Is this rig being pre-loaded along with terrain?
-    /// @param cache_entry_number Needed for flexbody caching. Pass -1 if unavailable (flexbody caching will be disabled)
     Actor(
           int actor_id
         , unsigned int vector_index
@@ -68,13 +66,10 @@ public:
         , Ogre::Vector3 pos
         , Ogre::Quaternion rot
         , const char* fname
-        , bool networked = false
         , bool networking = false
-        , collision_box_t *spawnbox = nullptr
         , const std::vector<Ogre::String> *actor_config = nullptr
         , RoR::SkinDef *skin = nullptr
         , bool preloaded_with_terrain = false
-        , int cache_entry_number = -1
         );
 
     ~Actor();

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -86,7 +86,6 @@ public:
     /// @param translation Offset to move in world coordinates
     /// @param setInitPosition Set initial positions of nodes to current position?
     void              ResetPosition(Ogre::Vector3 translation, bool setInitPosition);
-    void              RequestActorReset(bool keepPosition = false);    //!< reset the actor from any context
     void              RequestRotation(float rotation);
     void              RequestTranslation(Ogre::Vector3 translation);
     Ogre::Vector3     GetRotationCenter();                 //!< Return the rotation center of the actor
@@ -168,6 +167,7 @@ public:
     bool              CalcForcesEulerPrepare();            //!< A single physics step (see PHYSICS_DT)
     void              calcForcesEulerCompute(int step, int num_steps); //!< TIGHT LOOP; Physics;
     void              calcForcesEulerFinal();              //!< A single physics step (see PHYSICS_DT)
+    void              SyncReset(bool reset_position);      //!< this one should be called only synchronously (without physics running in background)
     blinktype         getBlinkType();
     std::vector<authorinfo_t>     getAuthors();
     std::vector<std::string>      getDescription();
@@ -370,14 +370,6 @@ public:
 
 private:
 
-    enum ResetRequest
-    {
-        REQUEST_RESET_NONE,
-        REQUEST_RESET_ON_INIT_POS,
-        REQUEST_RESET_ON_SPOT,
-        REQUEST_RESET_FINAL
-    };
-
     void              calcBeams(bool trigger_hooks);       //!< Single physics step (see PHYSICS_DT); Physics & sound;
     void              CalcBeamsInterActor();               //!< Physics (1 step) & sound - only beams between multiple actors (noshock or ropes)
     void              CalcNodes();                         //!< Single physics step (see PHYSICS_DT)
@@ -385,7 +377,6 @@ private:
     void              calcRopes();                         //!< TIGHT LOOP; Physics;
     void              calcShocks2(int beam_i, Ogre::Real difftoBeamL, Ogre::Real &k, Ogre::Real &d, bool update_hooks);
     void              calcAnimators(const int flag_state, float &cstate, int &div, float timer, const float lower_limit, const float upper_limit, const float option3);
-    void              SyncReset();                         //!< this one should be called only synchronously (without physics running in background)
     void              DetermineLinkedActors();
     void              RecalculateNodeMasses(Ogre::Real total, bool reCalc=false); //!< Previously 'calc_masses2()'
     void              calcNodeConnectivityGraph();
@@ -440,7 +431,6 @@ private:
     Ogre::Vector3     m_mouse_grab_pos;
     float             m_mouse_grab_move_force;
     float             m_spawn_rotation;
-    ResetRequest      m_reset_request;
     RoRnet::VehicleState* oob1;                  //!< Network; Triple buffer for incoming data (actor properties)
     RoRnet::VehicleState* oob2;                  //!< Network; Triple buffer for incoming data (actor properties)
     RoRnet::VehicleState* oob3;                  //!< Network; Triple buffer for incoming data (actor properties)

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -35,7 +35,7 @@
 */
 
 // The RoR required includes (should be included already)
-#include "RoRPrerequisites.h"
+#include "ForwardDeclarations.h"
 #include "RoRnet.h"
 #include "SlideNode.h"
 #include "BeamConstants.h"
@@ -541,3 +541,47 @@ struct authorinfo_t
     Ogre::String name;
     Ogre::String email;
 };
+
+namespace RoR {
+
+struct ActorSpawnRequest
+{
+    enum class Origin //!< Enables special processing
+    {
+        UNKNOWN,
+        CONFIG_FILE,  //!< 'Preselected vehicle' in RoR.cfg
+        TERRN_DEF,    //!< Preloaded with terrain
+        USER,         //!< Direct selection by user via GUI
+        NETWORK       //!< Remote controlled
+    };
+
+    ActorSpawnRequest();
+
+    CacheEntry*       asr_cache_entry; //!< Optional, overrides 'asr_filename' and 'asr_cache_entry_num'
+    std::string       asr_filename;
+    std::vector<Ogre::String> asr_config;
+    Ogre::Vector3     asr_position;
+    Ogre::Quaternion  asr_rotation;
+    int               asr_cache_entry_num;
+    collision_box_t*  asr_spawnbox;
+    RoR::SkinDef*     asr_skin;
+    Origin            asr_origin;
+    bool              asr_terrn_adjust:1;    //!< Fix position to match ground level
+    bool              asr_terrn_machine:1;   //!< This is a fixed machinery
+};
+
+struct ActorModifyRequest
+{
+    enum class Type
+    {
+        INVALID,
+        RELOAD,               //!< Full reload from filesystem, requested by user
+        RESET_ON_INIT_POS,
+        RESET_ON_SPOT
+    };
+
+    Actor* amr_actor;
+    Type   amr_type;
+};
+
+} // namespace RoR

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -566,7 +566,7 @@ struct ActorSpawnRequest
     collision_box_t*  asr_spawnbox;
     RoR::SkinDef*     asr_skin;
     Origin            asr_origin;
-    bool              asr_terrn_adjust:1;    //!< Fix position to match ground level
+    bool              asr_free_position:1;   //!< Disables the automatic spawn position adjustment
     bool              asr_terrn_machine:1;   //!< This is a fixed machinery
 };
 

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1431,4 +1431,6 @@ ActorSpawnRequest::ActorSpawnRequest()
     , asr_skin(nullptr)
     , asr_origin(Origin::UNKNOWN)
     , asr_cache_entry(nullptr)
+    , asr_terrn_adjust(false)
+    , asr_terrn_machine(false)
 {}

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1431,4 +1431,5 @@ ActorSpawnRequest::ActorSpawnRequest()
     , asr_skin(nullptr)
     , asr_free_position(false)
     , asr_loaded_with_terrn(false)
+    , asr_cache_entry(nullptr)
 {}

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1422,3 +1422,13 @@ std::shared_ptr<RigDef::File> ActorManager::FetchActorDef(const char* filename, 
         return nullptr;
     }
 }
+
+ActorSpawnRequest::ActorSpawnRequest()
+    : asr_position(Ogre::Vector3::ZERO)
+    , asr_rotation(Ogre::Quaternion::ZERO)
+    , asr_cache_entry_num(-1) // flexbody cache disabled
+    , asr_spawnbox(nullptr)
+    , asr_skin(nullptr)
+    , asr_free_position(false)
+    , asr_loaded_with_terrn(false)
+{}

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1423,6 +1423,15 @@ std::shared_ptr<RigDef::File> ActorManager::FetchActorDef(const char* filename, 
     }
 }
 
+void ActorManager::UnloadTruckfileFromMemory(const char* filename)
+{
+    auto search_res = m_actor_defs.find(filename);
+    if (search_res != m_actor_defs.end())
+    {
+        m_actor_defs.erase(search_res);
+    }
+}
+
 ActorSpawnRequest::ActorSpawnRequest()
     : asr_position(Ogre::Vector3::ZERO)
     , asr_rotation(Ogre::Quaternion::ZERO)

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -907,12 +907,12 @@ void ActorManager::RepairActor(Collisions* collisions, const Ogre::String& inst,
     Actor* actor = this->FindActorInsideBox(collisions, inst, box);
     if (actor >= 0)
     {
-        // take a position reference
         SOUND_PLAY_ONCE(actor, SS_TRIG_REPAIR);
-        Vector3 ipos = actor->ar_nodes[0].AbsPosition;
-        actor->RequestActorReset();
-        actor->ResetPosition(ipos.x, ipos.z, false, 0);
-        actor->updateVisual();
+
+        ActorModifyRequest rq;
+        rq.amr_actor = actor;
+        rq.amr_type = ActorModifyRequest::Type::RESET_ON_SPOT;
+        App::GetSimController()->QueueActorModify(rq);
     }
 }
 

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1429,7 +1429,6 @@ ActorSpawnRequest::ActorSpawnRequest()
     , asr_cache_entry_num(-1) // flexbody cache disabled
     , asr_spawnbox(nullptr)
     , asr_skin(nullptr)
-    , asr_free_position(false)
-    , asr_loaded_with_terrn(false)
+    , asr_origin(Origin::UNKNOWN)
     , asr_cache_entry(nullptr)
 {}

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -473,7 +473,7 @@ Actor* ActorManager::CreateLocalActor(
     m_actors.push_back(actor);
 
     // lock slide nodes after spawning the actor?
-    if (actor->getSlideNodesLockInstant())
+    if (def->slide_nodes_connect_instantly)
     {
         actor->ToggleSlideNodeLock();
     }

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -462,13 +462,10 @@ Actor* ActorManager::CreateLocalActor(
         pos,
         rot,
         fname.c_str(),
-        false, // networked
         (RoR::App::mp_state.GetActive() == RoR::MpState::CONNECTED), // networking
-        spawnbox,
         actor_config,
         skin,
-        preloaded_with_terrain,
-        cache_entry_number
+        preloaded_with_terrain
     );
 
     this->SetupActor(actor, def, pos, rot, spawnbox, free_position, false, cache_entry_number);
@@ -544,9 +541,7 @@ int ActorManager::CreateRemoteInstance(RoRnet::ActorStreamRegister* reg)
         pos,
         Quaternion::ZERO,
         reg->name,
-        true, // networked
         (RoR::App::mp_state.GetActive() == RoR::MpState::CONNECTED), // networking
-        nullptr, // spawnbox
         &actor_config,
         nullptr // skin
     );

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -210,7 +210,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
             miny = rq.asr_spawnbox->relo.y + rq.asr_spawnbox->center.y;
         }
 
-        if (!rq.asr_terrn_adjust)
+        if (rq.asr_free_position)
             actor->ResetPosition(vehicle_position, true);
         else
             actor->ResetPosition(vehicle_position.x, vehicle_position.z, true, miny);
@@ -1354,6 +1354,6 @@ ActorSpawnRequest::ActorSpawnRequest()
     , asr_skin(nullptr)
     , asr_origin(Origin::UNKNOWN)
     , asr_cache_entry(nullptr)
-    , asr_terrn_adjust(false)
+    , asr_free_position(false)
     , asr_terrn_machine(false)
 {}

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -44,9 +44,9 @@ struct ActorSpawnRequest
     enum class Origin //!< Enables special processing
     {
         UNKNOWN,
-        CONFIG_FILE, //!< 'Preselected vehicle' in RoR.cfg
-        TERRN_DEF,   //!< Preloaded with terrain 
-        USER         //!< Direct selection by user via GUI
+        CONFIG_FILE,  //!< 'Preselected vehicle' in RoR.cfg
+        TERRN_DEF,    //!< Preloaded with terrain
+        USER          //!< Direct selection by user via GUI
     };
 
     ActorSpawnRequest();
@@ -60,6 +60,8 @@ struct ActorSpawnRequest
     collision_box_t*  asr_spawnbox;
     RoR::SkinDef*     asr_skin;
     Origin            asr_origin;
+    bool              asr_terrn_adjust:1;    //!< Fix position to match ground level
+    bool              asr_terrn_machine:1;   //!< This is a fixed machinery
 };
 
 /// Builds and manages softbody actors. Manage physics and threading.

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -95,14 +95,7 @@ public:
 
 private:
 
-    void           SetupActor(Actor* actor,
-                              std::shared_ptr<RigDef::File> def,
-                              Ogre::Vector3 const& spawn_position,
-                              Ogre::Quaternion const& spawn_rotation,
-                              collision_box_t* spawn_box,
-                              bool free_positioned,
-                              bool _networked,
-                              int cache_entry_number = -1);
+    void           SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_ptr<RigDef::File> def);
     bool           CheckAabbIntersection(Ogre::AxisAlignedBox a, Ogre::AxisAlignedBox b, float scale = 1.0f); //!< Returns whether or not the two (scaled) bounding boxes intersect.
     bool           CheckActorAabbIntersection(int a, int b, float scale = 1.0f);     //!< Returns whether or not the bounding boxes of truck a and truck b intersect. Based on the default truck bounding boxes.
     bool           PredictActorAabbIntersection(int a, int b, float scale = 1.0f);   //!< Returns whether or not the bounding boxes of truck a and truck b might intersect during the next framestep. Based on the default truck bounding boxes.

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -69,8 +69,10 @@ struct ActorModifyRequest
     enum class Type
     {
         INVALID,
-        RELOAD //!< Full reload from filesystem, requested by user
-    };// to be extended
+        RELOAD,               //!< Full reload from filesystem, requested by user
+        RESET_ON_INIT_POS,
+        RESET_ON_SPOT
+    };
 
     Actor* amr_actor;
     Type   amr_type;

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -41,6 +41,14 @@ namespace RoR {
 
 struct ActorSpawnRequest
 {
+    enum class Origin //!< Enables special processing
+    {
+        UNKNOWN,
+        CONFIG_FILE, //!< 'Preselected vehicle' in RoR.cfg
+        TERRN_DEF,   //!< Preloaded with terrain 
+        USER         //!< Direct selection by user via GUI
+    };
+
     ActorSpawnRequest();
 
     CacheEntry*       asr_cache_entry; //!< Optional, overrides 'asr_filename' and 'asr_cache_entry_num'
@@ -51,9 +59,7 @@ struct ActorSpawnRequest
     int               asr_cache_entry_num;
     collision_box_t*  asr_spawnbox;
     RoR::SkinDef*     asr_skin;
-    bool              asr_free_position;
-    bool              asr_loaded_with_terrn;
-    bool              asr_user_selected; //!< Selected by user via GUI; triggers special processing
+    Origin            asr_origin;
 };
 
 /// Builds and manages softbody actors. Manage physics and threading.

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -30,11 +30,29 @@
 #include "Network.h"
 #include "Singleton.h"
 
+#include <string>
+#include <vector>
+
 #define PHYSICS_DT 0.0005 // fixed dt of 0.5 ms
 
 class ThreadPool;
 
 namespace RoR {
+
+struct ActorSpawnRequest
+{
+    ActorSpawnRequest();
+
+    std::string       asr_filename;
+    std::vector<Ogre::String> asr_config;
+    Ogre::Vector3     asr_position;
+    Ogre::Quaternion  asr_rotation;
+    int               asr_cache_entry_num;
+    collision_box_t*  asr_spawnbox;
+    RoR::SkinDef*     asr_skin;
+    bool              asr_free_position;
+    bool              asr_loaded_with_terrn;
+};
 
 /// Builds and manages softbody actors. Manage physics and threading.
 /// TODO: Currently also manages gfx, which should be done by GfxActor

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -43,6 +43,7 @@ struct ActorSpawnRequest
 {
     ActorSpawnRequest();
 
+    CacheEntry*       asr_cache_entry; //!< Optional, overrides 'asr_filename' and 'asr_cache_entry_num'
     std::string       asr_filename;
     std::vector<Ogre::String> asr_config;
     Ogre::Vector3     asr_position;
@@ -52,6 +53,7 @@ struct ActorSpawnRequest
     RoR::SkinDef*     asr_skin;
     bool              asr_free_position;
     bool              asr_loaded_with_terrn;
+    bool              asr_user_selected; //!< Selected by user via GUI; triggers special processing
 };
 
 /// Builds and manages softbody actors. Manage physics and threading.

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -64,6 +64,18 @@ struct ActorSpawnRequest
     bool              asr_terrn_machine:1;   //!< This is a fixed machinery
 };
 
+struct ActorModifyRequest
+{
+    enum class Type
+    {
+        INVALID,
+        RELOAD //!< Full reload from filesystem, requested by user
+    };// to be extended
+
+    Actor* amr_actor;
+    Type   amr_type;
+};
+
 /// Builds and manages softbody actors. Manage physics and threading.
 /// TODO: Currently also manages gfx, which should be done by GfxActor
 /// HISTORICAL NOTE: Until 01/2018, this class was named `BeamFactory` (because `Actor` was `Beam`)
@@ -113,6 +125,7 @@ public:
     void           DeleteActorInternal(Actor* b);      //!< DO NOT CALL DIRECTLY! Use `SimController` for public interface
     Actor*         GetActorByIdInternal(int actor_id); //!< DO NOT CALL DIRECTLY! Use `SimController` for public interface
     Actor*         FindActorInsideBox(Collisions* collisions, const Ogre::String& inst, const Ogre::String& box);
+    void           UnloadTruckfileFromMemory(const char* filename);
 
 #ifdef USE_SOCKETW
     void           HandleActorStreamData(std::vector<RoR::Networking::recv_packet_t> packet);
@@ -145,11 +158,9 @@ private:
     bool           PredictActorCollAabbIntersect(int a, int b, float scale = 1.0f);  //!< Returns whether or not the bounding boxes of truck a and truck b might intersect during the next framestep. Based on the truck collision bounding boxes.
     int            CreateRemoteInstance(RoRnet::ActorStreamRegister* reg);
     void           RemoveStreamSource(int sourceid);
-    void           LogParserMessages();
-    void           LogSpawnerMessages();
-    int            GetActorIndex(Actor* actor);         //!< Returns the m_actors index of the actor (-1 if not found)
     void           RecursiveActivation(int j, std::vector<bool>& visited);
     std::shared_ptr<RigDef::File>   FetchActorDef(const char* filename, bool predefined_on_terrain = false);
+    
 
     std::map<std::string, std::shared_ptr<RigDef::File>>   m_actor_defs;
     std::map<int, std::vector<int>> m_stream_mismatches; //!< Networking: A list of streams without a corresponding actor in the actor-array for each stream source

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -131,7 +131,11 @@ void Actor::calcForcesEulerCompute(int step, int num_steps)
         ar_bounding_box.getMinimum().y + ar_bounding_box.getMaximum().y +
         ar_bounding_box.getMinimum().z + ar_bounding_box.getMaximum().z, -1e9, 1e9))
     {
-        m_reset_request = REQUEST_RESET_ON_INIT_POS; // actor exploded, schedule reset
+        ActorModifyRequest rq; // actor exploded, schedule reset
+        rq.amr_actor = this;
+        rq.amr_type = ActorModifyRequest::Type::RESET_ON_INIT_POS;
+        App::GetSimController()->QueueActorModify(rq);
+
         return; // return early to avoid propagating invalid values
     }
 
@@ -1154,8 +1158,6 @@ void Actor::calcForcesEulerCompute(int step, int num_steps)
 
 bool Actor::CalcForcesEulerPrepare()
 {
-    if (m_reset_request)
-        return false;
     if (ar_sim_state != Actor::SimState::LOCAL_SIMULATED)
         return false;
 

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -269,7 +269,6 @@ void ActorSpawner::InitializeRig()
     m_actor->ar_extern_camera_mode=0;
     m_actor->ar_extern_camera_node=-1;
     m_actor->authors.clear();
-    m_actor->m_slidenodes_connect_on_spawn=false;
 
     m_actor->m_odometer_total = 0;
     m_actor->m_odometer_user  = 0;

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -91,8 +91,6 @@ void ActorSpawner::Setup(
     int cache_entry_number
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     m_actor = rig;
     m_file = file;
     m_cache_entry_number = cache_entry_number;
@@ -218,8 +216,6 @@ void ActorSpawner::CalcMemoryRequirements(ActorMemoryRequirements& req, RigDef::
 
 void ActorSpawner::InitializeRig()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     ActorMemoryRequirements req;
     for (auto module: m_selected_modules) // _Root_ module is included
     {
@@ -411,8 +407,6 @@ void ActorSpawner::InitializeRig()
 
 void ActorSpawner::FinalizeRig()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     // we should post-process the torque curve if existing
     if (m_actor->ar_engine)
     {
@@ -524,8 +518,6 @@ void ActorSpawner::FinalizeRig()
 
 void ActorSpawner::WashCalculator()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     //we will compute wash
     int w,p;
     for (p=0; p<m_actor->ar_num_aeroengines; p++)
@@ -567,8 +559,6 @@ void ActorSpawner::WashCalculator()
 
 void ActorSpawner::ProcessTurbojet(RigDef::Turbojet & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int front,back,ref;
     front = GetNodeIndexOrThrow(def.front_node);
     back  = GetNodeIndexOrThrow(def.back_node);
@@ -627,8 +617,6 @@ void ActorSpawner::ComposeName(RoR::Str<100>& str, const char* type, int number,
 
 void ActorSpawner::ProcessScrewprop(RigDef::Screwprop & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (! CheckScrewpropLimit(1))
     {
         return;
@@ -652,8 +640,6 @@ void ActorSpawner::ProcessScrewprop(RigDef::Screwprop & def)
 
 void ActorSpawner::ProcessFusedrag(RigDef::Fusedrag & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     //parse fusedrag
     int front_node_idx = GetNodeIndexOrThrow(def.front_node);
     float width = 1.f;
@@ -704,8 +690,6 @@ void ActorSpawner::BuildAerialEngine(
     float pitch
     )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int aeroengine_index = m_actor->ar_num_aeroengines;
 
     Turboprop *turbo_prop = new Turboprop(
@@ -751,8 +735,6 @@ void ActorSpawner::BuildAerialEngine(
 
 void ActorSpawner::ProcessTurboprop2(RigDef::Turboprop2 & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int p3_node_index = (def.blade_tip_nodes[2].IsValidAnyState()) ? GetNodeIndexOrThrow(def.blade_tip_nodes[2]) : -1;
     int p4_node_index = (def.blade_tip_nodes[3].IsValidAnyState()) ? GetNodeIndexOrThrow(def.blade_tip_nodes[3]) : -1;
     int couple_node_index = (def.couple_node.IsValidAnyState()) ? GetNodeIndexOrThrow(def.couple_node) : -1;
@@ -774,8 +756,6 @@ void ActorSpawner::ProcessTurboprop2(RigDef::Turboprop2 & def)
 
 void ActorSpawner::ProcessPistonprop(RigDef::Pistonprop & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int p3_node_index = (def.blade_tip_nodes[2].IsValidAnyState()) ? GetNodeIndexOrThrow(def.blade_tip_nodes[2]) : -1;
     int p4_node_index = (def.blade_tip_nodes[3].IsValidAnyState()) ? GetNodeIndexOrThrow(def.blade_tip_nodes[3]) : -1;
     int couple_node_index = (def.couple_node.IsValidAnyState()) ? GetNodeIndexOrThrow(def.couple_node) : -1;
@@ -797,8 +777,6 @@ void ActorSpawner::ProcessPistonprop(RigDef::Pistonprop & def)
 
 void ActorSpawner::ProcessAirbrake(RigDef::Airbrake & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (! CheckAirBrakeLimit(1))
     {
         return;
@@ -827,8 +805,6 @@ void ActorSpawner::ProcessAirbrake(RigDef::Airbrake & def)
 
 void ActorSpawner::ProcessWing(RigDef::Wing & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_first_wing_index != -1) && (m_actor->ar_wings[m_actor->ar_num_wings - 1].fa == nullptr))
     {
         this->AddMessage(Message::TYPE_ERROR, "Unable to process wing, previous wing has no Airfoil");
@@ -1092,16 +1068,12 @@ void ActorSpawner::ProcessWing(RigDef::Wing & def)
 
 float ActorSpawner::ComputeWingArea(Ogre::Vector3 const & ref, Ogre::Vector3 const & x, Ogre::Vector3 const & y, Ogre::Vector3 const & aref)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     return (((x-ref).crossProduct(y-ref)).length()+((x-aref).crossProduct(y-aref)).length())*0.5f;
 }
 
 void ActorSpawner::ProcessSoundSource2(RigDef::SoundSource2 & def)
 {
 #ifdef USE_OPENAL
-    SPAWNER_PROFILE_SCOPED();
-
     int mode = (def.mode == RigDef::SoundSource2::MODE_CINECAM) ? def.cinecam_index : def.mode;
     int node_index = FindNodeIndex(def.node);
     if (node_index == -1)
@@ -1119,7 +1091,6 @@ void ActorSpawner::ProcessSoundSource2(RigDef::SoundSource2 & def)
 
 void ActorSpawner::AddSoundSourceInstance(Actor *vehicle, Ogre::String const & sound_script_name, int node_index, int type)
 {
-    SPAWNER_PROFILE_SCOPED();
 #ifdef USE_OPENAL
     AddSoundSource(vehicle, SoundScriptManager::getSingleton().createInstance(sound_script_name, vehicle->ar_instance_id, nullptr), node_index);
 #endif // USE_OPENAL
@@ -1127,8 +1098,6 @@ void ActorSpawner::AddSoundSourceInstance(Actor *vehicle, Ogre::String const & s
 
 void ActorSpawner::AddSoundSource(Actor *vehicle, SoundScriptInstance *sound_script, int node_index, int type)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (! CheckSoundScriptLimit(vehicle, 1))
     {
         return;
@@ -1148,8 +1117,6 @@ void ActorSpawner::AddSoundSource(Actor *vehicle, SoundScriptInstance *sound_scr
 void ActorSpawner::ProcessSoundSource(RigDef::SoundSource & def)
 {
 #ifdef USE_OPENAL
-    SPAWNER_PROFILE_SCOPED();
-
     AddSoundSource(
             m_actor,
             SoundScriptManager::getSingleton().createInstance(def.sound_script_name, m_actor->ar_instance_id), 
@@ -1161,8 +1128,6 @@ void ActorSpawner::ProcessSoundSource(RigDef::SoundSource & def)
 
 void ActorSpawner::ProcessCameraRail(RigDef::CameraRail & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     auto itor = def.nodes.begin();
     auto end  = def.nodes.end();
     for(; itor != end; ++itor)
@@ -1178,8 +1143,6 @@ void ActorSpawner::ProcessCameraRail(RigDef::CameraRail & def)
 
 void ActorSpawner::ProcessExtCamera(RigDef::ExtCamera & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     m_actor->ar_extern_camera_mode = def.mode;
     if (def.node.IsValidAnyState())
     {
@@ -1189,8 +1152,6 @@ void ActorSpawner::ProcessExtCamera(RigDef::ExtCamera & def)
 
 void ActorSpawner::ProcessGuiSettings(RigDef::GuiSettings & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     // Currently unused (was relevant to overlay-based HUD): def.tacho_material; def.speedo_material;
 
     if (! def.help_material.empty())
@@ -1221,8 +1182,6 @@ void ActorSpawner::ProcessFixedNode(RigDef::Node::Ref node_ref)
 
 void ActorSpawner::ProcessExhaust(RigDef::Exhaust & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     // parse exhausts
     if (m_actor->m_disable_smoke)
     {
@@ -1298,8 +1257,6 @@ std::string ActorSpawner::GetSubmeshGroundmodelName()
 
 void ActorSpawner::ProcessSubmesh(RigDef::Submesh & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (! CheckSubmeshLimit(1))
     {
         return;
@@ -1503,8 +1460,6 @@ void ActorSpawner::ProcessSubmesh(RigDef::Submesh & def)
 
 void ActorSpawner::ProcessFlexbody(std::shared_ptr<RigDef::Flexbody> def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     // Collect nodes
     std::vector<unsigned int> node_indices;
     bool nodes_found = true;
@@ -1562,8 +1517,6 @@ void ActorSpawner::ProcessFlexbody(std::shared_ptr<RigDef::Flexbody> def)
 
 void ActorSpawner::ProcessProp(RigDef::Prop & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     prop_t prop;
     int prop_index = m_props.size();
     memset(&prop, 0, sizeof(prop_t));
@@ -2068,8 +2021,6 @@ void ActorSpawner::ProcessProp(RigDef::Prop & def)
 
 void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (m_actor->m_flares_mode == GfxFlaresMode::NONE) { return; }
 
     int blink_delay = def.blink_delay_milis;
@@ -2223,8 +2174,6 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
 
 Ogre::MaterialPtr ActorSpawner::InstantiateManagedMaterial(Ogre::String const & source_name, Ogre::String const & clone_name)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     Ogre::MaterialPtr src_mat = RoR::OgreSubsystem::GetMaterialByName(source_name);
     if (src_mat.isNull())
     {
@@ -2239,8 +2188,6 @@ Ogre::MaterialPtr ActorSpawner::InstantiateManagedMaterial(Ogre::String const & 
 
 void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (m_managed_materials.find(def.name) != m_managed_materials.end())
     {
         this->AddMessage(Message::TYPE_ERROR, "Duplicate managed material name: '" + def.name + "'. Ignoring definition...");
@@ -2366,8 +2313,6 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
 
 void ActorSpawner::ProcessCollisionBox(RigDef::CollisionBox & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int8_t bbox_id = static_cast<int8_t>(m_actor->ar_collision_bounding_boxes.size());
     for (RigDef::Node::Ref& node_ref: def.nodes)
     {
@@ -2393,8 +2338,6 @@ void ActorSpawner::ProcessCollisionBox(RigDef::CollisionBox & def)
 
 bool ActorSpawner::AssignWheelToAxle(int & _out_axle_wheel, node_t *axis_node_1, node_t *axis_node_2)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     for (int i = 0; i < m_actor->ar_num_wheels; i++)
     {
         wheel_t & wheel = m_actor->ar_wheels[i];
@@ -2411,8 +2354,6 @@ bool ActorSpawner::AssignWheelToAxle(int & _out_axle_wheel, node_t *axis_node_1,
 
 void ActorSpawner::ProcessAxle(RigDef::Axle & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (! CheckAxleLimit(1))
     {
         return;
@@ -2475,16 +2416,12 @@ void ActorSpawner::ProcessAxle(RigDef::Axle & def)
 
 void ActorSpawner::ProcessSpeedLimiter(RigDef::SpeedLimiter & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     m_actor->sl_enabled     = def.is_enabled;
     m_actor->sl_speed_limit = def.max_speed;
 }
 
 void ActorSpawner::ProcessCruiseControl(RigDef::CruiseControl & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     m_actor->cc_target_speed_lower_limit = def.min_speed;
     if (m_actor->cc_target_speed_lower_limit <= 0.f)
     {
@@ -2497,8 +2434,6 @@ void ActorSpawner::ProcessCruiseControl(RigDef::CruiseControl & def)
 
 void ActorSpawner::ProcessTorqueCurve(RigDef::TorqueCurve & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (m_actor->ar_engine == nullptr)
     {
         AddMessage(Message::TYPE_WARNING, "Section 'torquecurve' found but no 'engine' defined, skipping...");
@@ -2524,8 +2459,6 @@ void ActorSpawner::ProcessTorqueCurve(RigDef::TorqueCurve & def)
 
 void ActorSpawner::ProcessParticle(RigDef::Particle & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (App::gfx_particles_mode.GetActive() != 1)
     {
         return;
@@ -2565,8 +2498,6 @@ void ActorSpawner::ProcessParticle(RigDef::Particle & def)
 
 void ActorSpawner::ProcessRopable(RigDef::Ropable & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     ropable_t ropable;
     ropable.node = GetNodePointerOrThrow(def.node);
     ropable.group = def.group;
@@ -2577,8 +2508,6 @@ void ActorSpawner::ProcessRopable(RigDef::Ropable & def)
 
 void ActorSpawner::ProcessTie(RigDef::Tie & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t & node_1 = GetNodeOrThrow(def.root_node);
     node_t & node_2 = GetNode( (node_1.pos == 0) ? 1 : 0 );
 
@@ -2616,8 +2545,6 @@ void ActorSpawner::ProcessTie(RigDef::Tie & def)
 
 void ActorSpawner::ProcessRope(RigDef::Rope & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t & root_node = GetNodeOrThrow(def.root_node);
     node_t & end_node = GetNodeOrThrow(def.end_node);
 
@@ -2643,8 +2570,6 @@ void ActorSpawner::ProcessRope(RigDef::Rope & def)
 
 void ActorSpawner::ProcessRailGroup(RigDef::RailGroup & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     RailGroup* rail_group = this->CreateRail(def.node_list);
     rail_group->rg_id = def.id;
     if (rail_group != nullptr)
@@ -2655,8 +2580,6 @@ void ActorSpawner::ProcessRailGroup(RigDef::RailGroup & def)
 
 void ActorSpawner::ProcessSlidenode(RigDef::SlideNode & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t & node = GetNodeOrThrow(def.slide_node);
     SlideNode slide_node(& node, nullptr);
     slide_node.SetCorThreshold(def.tolerance);
@@ -2731,8 +2654,6 @@ void ActorSpawner::ProcessSlidenode(RigDef::SlideNode & def)
 
 int ActorSpawner::FindNodeIndex(RigDef::Node::Ref & node_ref, bool silent /* Default: false */)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     std::pair<unsigned int, bool> result = GetNodeIndex(node_ref, /* quiet */ true);
     if (result.second)
     {
@@ -2755,8 +2676,6 @@ bool ActorSpawner::CollectNodesFromRanges(
     std::vector<unsigned int> & out_node_indices
     )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     std::vector<RigDef::Node::Range>::iterator itor = node_ranges.begin();
     for ( ; itor != node_ranges.end(); itor++)
     {
@@ -2824,8 +2743,6 @@ bool ActorSpawner::CollectNodesFromRanges(
 
 RailGroup *ActorSpawner::CreateRail(std::vector<RigDef::Node::Range> & node_ranges)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     // Collect nodes
     std::vector<unsigned int> node_indices;
     this->CollectNodesFromRanges(node_ranges, node_indices);
@@ -2872,8 +2789,6 @@ RailGroup *ActorSpawner::CreateRail(std::vector<RigDef::Node::Range> & node_rang
 
 beam_t *ActorSpawner::FindBeamInRig(unsigned int node_a_index, unsigned int node_b_index)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t *node_a = & m_actor->ar_nodes[node_a_index];
     node_t *node_b = & m_actor->ar_nodes[node_b_index];
 
@@ -2892,8 +2807,6 @@ beam_t *ActorSpawner::FindBeamInRig(unsigned int node_a_index, unsigned int node
 
 void ActorSpawner::ProcessHook(RigDef::Hook & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* Find the node */
     node_t *node = GetNodePointer(def.node);
     if (node ==  nullptr)
@@ -2974,8 +2887,6 @@ void ActorSpawner::ProcessHook(RigDef::Hook & def)
 
 void ActorSpawner::ProcessLockgroup(RigDef::Lockgroup & lockgroup)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     auto itor = lockgroup.nodes.begin();
     auto end  = lockgroup.nodes.end();
     for (; itor != end; ++itor)
@@ -2986,8 +2897,6 @@ void ActorSpawner::ProcessLockgroup(RigDef::Lockgroup & lockgroup)
 
 void ActorSpawner::ProcessTrigger(RigDef::Trigger & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     shock_t & shock = this->GetFreeShock();
 
     // Disable trigger on startup? (default enabled)
@@ -3150,8 +3059,6 @@ void ActorSpawner::ProcessTrigger(RigDef::Trigger & def)
 
 void ActorSpawner::ProcessContacter(RigDef::Node::Ref & node_ref)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int node_index = GetNodeIndexOrThrow(node_ref);
     m_actor->ar_contacters[m_actor->ar_num_contacters].nodeid = node_index;
     m_actor->ar_num_contacters++;
@@ -3159,8 +3066,6 @@ void ActorSpawner::ProcessContacter(RigDef::Node::Ref & node_ref)
 
 void ActorSpawner::ProcessRotator(RigDef::Rotator & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     rotator_t & rotator = m_actor->ar_rotators[m_actor->ar_num_rotators];
 
     rotator.angle = 0;
@@ -3192,8 +3097,6 @@ void ActorSpawner::ProcessRotator(RigDef::Rotator & def)
 
 void ActorSpawner::ProcessRotator2(RigDef::Rotator2 & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     rotator_t & rotator = m_actor->ar_rotators[m_actor->ar_num_rotators];
 
     rotator.angle = 0;
@@ -3238,8 +3141,6 @@ void ActorSpawner::_ProcessKeyInertia(
     int extend_key
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (key_inertia != nullptr)
     {
         /* Handle placeholders */
@@ -3294,8 +3195,6 @@ void ActorSpawner::_ProcessKeyInertia(
 
 void ActorSpawner::ProcessCommand(RigDef::Command2 & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int beam_index = m_actor->ar_num_beams;
     int node_1_index = FindNodeIndex(def.nodes[0]);
     int node_2_index = FindNodeIndex(def.nodes[1]);
@@ -3370,8 +3269,6 @@ void ActorSpawner::ProcessCommand(RigDef::Command2 & def)
 
 void ActorSpawner::ProcessAnimator(RigDef::Animator & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (m_actor->m_hydro_inertia != nullptr)
     {
         if (def.inertia_defaults->start_delay_factor > 0 && def.inertia_defaults->stop_delay_factor > 0)
@@ -3536,8 +3433,6 @@ beam_t & ActorSpawner::AddBeam(
     int detacher_group
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* Init */
     beam_t & beam = GetAndInitFreeBeam(node_1, node_2);
     beam.detacher_group = detacher_group;
@@ -3558,15 +3453,11 @@ beam_t & ActorSpawner::AddBeam(
 
 void ActorSpawner::SetBeamStrength(beam_t & beam, float strength)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     beam.strength = strength;
 }
 
 void ActorSpawner::ProcessHydro(RigDef::Hydro & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     bool invisible = false;
     unsigned int hydro_flags = 0;
 
@@ -3669,8 +3560,6 @@ void ActorSpawner::ProcessHydro(RigDef::Hydro & def)
 
 void ActorSpawner::ProcessShock2(RigDef::Shock2 & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t & node_1 = GetNode(def.nodes[0]);
     node_t & node_2 = GetNode(def.nodes[1]);
     float short_bound = def.short_bound;
@@ -3752,8 +3641,6 @@ void ActorSpawner::ProcessShock2(RigDef::Shock2 & def)
 
 void ActorSpawner::ProcessShock(RigDef::Shock & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t & node_1 = GetNode(def.nodes[0]);
     node_t & node_2 = GetNode(def.nodes[1]);
     float short_bound = def.short_bound;
@@ -3815,8 +3702,6 @@ void ActorSpawner::FetchAxisNodes(
     RigDef::Node::Ref const & axis_node_2_id
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     axis_node_1 = GetNodePointer(axis_node_1_id);
     axis_node_2 = GetNodePointer(axis_node_2_id);
 
@@ -3834,8 +3719,6 @@ void ActorSpawner::FetchAxisNodes(
 
 void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int base_node_index = m_actor->ar_num_nodes;
     wheel_t & wheel = m_actor->ar_wheels[m_actor->ar_num_wheels];
 
@@ -4117,8 +4000,6 @@ void ActorSpawner::ProcessMeshWheel(RigDef::MeshWheel & meshwheel_def)
         return;
     }
 
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int base_node_index = m_actor->ar_num_nodes;
     node_t *axis_node_1 = GetNodePointer(meshwheel_def.nodes[0]);
     node_t *axis_node_2 = GetNodePointer(meshwheel_def.nodes[1]);
@@ -4169,8 +4050,6 @@ void ActorSpawner::ProcessMeshWheel(RigDef::MeshWheel & meshwheel_def)
 
 void ActorSpawner::ProcessMeshWheel2(RigDef::MeshWheel & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int base_node_index = m_actor->ar_num_nodes;
     node_t *axis_node_1 = GetNodePointer(def.nodes[0]);
     node_t *axis_node_2 = GetNodePointer(def.nodes[1]);
@@ -4245,8 +4124,6 @@ void ActorSpawner::BuildMeshWheelVisuals(
     bool rim_reverse
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     try
     {
         FlexMeshWheel* flexmesh_wheel = m_flex_factory.CreateFlexMeshWheel(
@@ -4291,8 +4168,6 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
     float wheel_width       /* Default: -1.f */
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     wheel_t & wheel = m_actor->ar_wheels[m_actor->ar_num_wheels];
 
     /* Axis */
@@ -4405,23 +4280,17 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
 
 void ActorSpawner::AdjustNodeBuoyancy(node_t & node, RigDef::Node & node_def, std::shared_ptr<RigDef::NodeDefaults> defaults)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int options = (defaults->options | node_def.options); // Merge flags
     node.buoyancy = BITMASK_IS_1(options, RigDef::Node::OPTION_b_EXTRA_BUOYANCY) ? 10000.f : m_actor->m_dry_mass/15.f;
 }
 
 void ActorSpawner::AdjustNodeBuoyancy(node_t & node, std::shared_ptr<RigDef::NodeDefaults> defaults)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node.buoyancy = BITMASK_IS_1(defaults->options, RigDef::Node::OPTION_b_EXTRA_BUOYANCY) ? 10000.f : m_actor->m_dry_mass/15.f;
 }
 
 int ActorSpawner::FindLowestNodeInRig()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int lowest_node_index = 0;
     float lowest_y = m_actor->ar_nodes[0].AbsPosition.y;
 
@@ -4440,8 +4309,6 @@ int ActorSpawner::FindLowestNodeInRig()
 
 int ActorSpawner::FindLowestContactingNodeInRig()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int lowest_node_index = FindLowestNodeInRig();
     float lowest_y = std::numeric_limits<float>::max();
 
@@ -4473,15 +4340,6 @@ void ActorSpawner::BuildWheelBeams(
     float max_extension // = 0.f
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-    
-#ifdef DEBUG_TRUCKPARSER2013
-    // DEBUG
-    std::stringstream msg;
-    msg << "==== BEAMS ====";
-    // END DEBUG
-#endif
-
     /* Find out where to connect rigidity node */
     bool rigidity_beam_side_1 = false;
     node_t *rigidity_node = nullptr;
@@ -4515,49 +4373,18 @@ void ActorSpawner::BuildWheelBeams(
         AddWheelBeam(inner_ring_node, next_inner_ring_node, rim_spring, rim_damping, beam_defaults);
         AddWheelBeam(inner_ring_node, next_outer_ring_node, rim_spring, rim_damping, beam_defaults);
 
-#ifdef DEBUG_TRUCKPARSER2013
-        // TRUCK PARSER 2013 DEBUG
-        int modifier = 0;
-        msg<<"\nDBG\tBounded: ";
-        msg<<"["<<axis_node_1->pos + modifier<<" "<<outer_ring_node->pos + modifier<<"] ";
-        msg<<"["<<axis_node_2->pos + modifier<<" "<<inner_ring_node->pos + modifier<<"] ";
-        msg<<"["<<axis_node_2->pos + modifier<<" "<<outer_ring_node->pos + modifier<<"] ";
-        msg<<"["<<axis_node_1->pos + modifier<<" "<<inner_ring_node->pos + modifier<<"]";
-        //reinforcement
-        msg<<"\nDBG\tReinforcement: ";
-        msg<<"["<<outer_ring_node->pos + modifier<<" "<<inner_ring_node->pos      + modifier<<"] ";
-        msg<<"["<<outer_ring_node->pos + modifier<<" "<<next_outer_ring_node->pos + modifier<<"] ";
-        msg<<"["<<inner_ring_node->pos + modifier<<" "<<next_inner_ring_node->pos + modifier<<"] ";
-        msg<<"["<<inner_ring_node->pos + modifier<<" "<<next_outer_ring_node->pos + modifier<<"] ";
-        // END
-#endif
-
         /* Rigidity beams */
         if (rigidity_node != nullptr)
         {
             node_t *target_node = (rigidity_beam_side_1) ? outer_ring_node : inner_ring_node;
             unsigned int beam_index = AddWheelBeam(rigidity_node, target_node, tyre_spring, tyre_damping, beam_defaults, -1.f, -1.f, BEAM_VIRTUAL);
             m_actor->ar_beams[beam_index].bm_type = BEAM_VIRTUAL;
-
-#ifdef DEBUG_TRUCKPARSER2013
-            // DEBUG
-            msg<<"\nDBG\tRigidityBeam: ["<<rigidity_node->pos + modifier<<" "<<target_node->pos + modifier<<"] ";
-            msg<<((rigidity_beam_side_1) ? "(outer)" : "(inner)");
-            // END
-#endif
         }
     }
-#ifdef DEBUG_TRUCKPARSER2013
-    // TRUCK PARSER 2013 DEBUG
-    LOG(msg.str());
-    // END
-#endif
 }
 
 unsigned int ActorSpawner::AddWheel(RigDef::Wheel & wheel_def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int base_node_index = m_actor->ar_num_nodes;
     node_t *axis_node_1 = GetNodePointer(wheel_def.nodes[0]);
     node_t *axis_node_2 = GetNodePointer(wheel_def.nodes[1]);
@@ -4626,139 +4453,8 @@ void ActorSpawner::CreateWheelSkidmarks(unsigned int wheel_index)
         RoR::App::GetSimController()->GetSkidmarkConf(), &m_actor->ar_wheels[wheel_index], m_particles_parent_scenenode, 300, 20);
 }
 
-#if 0 // refactored into pieces
-unsigned int ActorSpawner::AddWheel(RigDef::Wheel & wheel_def)
-{
-    /* Check capacity */
-    CheckNodeLimit(wheel_def.num_rays * 2);
-    CheckBeamLimit(wheel_def.num_rays * 8);
-
-    unsigned int base_node_index = m_actor->ar_num_nodes;
-    wheel_t & wheel = m_actor->ar_wheels[m_actor->ar_num_wheels];
-
-    /* Enforce the "second node must have a larger Z coordinate than the first" constraint */
-    unsigned int axis_nodes[2];
-    if (GetNode(wheel_def.nodes[0]).RelPosition.z < GetNode(wheel_def.nodes[1]).RelPosition.z)
-    {
-        axis_nodes[0] = GetNodeIndexOrThrow(wheel_def.nodes[0]);
-        axis_nodes[1] = GetNodeIndexOrThrow(wheel_def.nodes[1]);
-    }
-    else
-    {
-        axis_nodes[0] = GetNodeIndexOrThrow(wheel_def.nodes[1]);
-        axis_nodes[1] = GetNodeIndexOrThrow(wheel_def.nodes[0]);
-    }
-    node_t & axis_node_1 = m_actor->ar_nodes[axis_nodes[0]];
-    node_t & axis_node_2 = m_actor->ar_nodes[axis_nodes[1]];
-
-    Ogre::Vector3 axis_vector = axis_node_2.RelPosition - axis_node_1.RelPosition;
-    axis_vector.normalise();
-    Ogre::Vector3 ray_vector = axis_vector.perpendicular() * wheel_def.radius;
-    Ogre::Quaternion ray_rotator = Ogre::Quaternion(Ogre::Degree(-360.f / wheel_def.num_rays * 2), axis_vector);
-
-    /* Nodes */
-    for (unsigned int i = 0; i < wheel_def.num_rays; i++)
-    {
-        /* Outer ring */
-        Ogre::Vector3 ray_point = axis_node_1.RelPosition + ray_vector;
-        ray_vector = ray_rotator * ray_vector;
-
-        node_t & outer_node = GetFreeNode();
-        InitNode(outer_node, ray_point, wheel_def.node_defaults);
-        outer_node.mass    = wheel_def.mass / (2.f * wheel_def.num_rays);
-        outer_node.iswheel = (m_actor->ar_num_wheels * 2) + 1;
-        outer_node.id      = -1; // Orig: hardcoded (BTS_WHEELS)
-        outer_node.wheelid = m_actor->ar_num_wheels;
-
-        contacter_t & contacter = m_actor->ar_contacters[m_actor->ar_num_contacters];
-        contacter.nodeid        = outer_node.pos; /* Node index */
-        m_actor->ar_num_contacters++;
-
-        /* Inner ring */
-        ray_point = axis_node_2.RelPosition + ray_vector;
-        ray_vector = ray_rotator * ray_vector;
-
-        node_t & inner_node = GetFreeNode();
-        InitNode(inner_node, ray_point, wheel_def.node_defaults);
-        inner_node.mass    = wheel_def.mass / (2.f * wheel_def.num_rays);
-        inner_node.iswheel = (m_actor->ar_num_wheels * 2) + 2;
-        inner_node.id      = -1; // Orig: hardcoded (BTS_WHEELS)
-        inner_node.wheelid = m_actor->ar_num_wheels; 
-
-        contacter_t & contacter = m_actor->ar_contacters[m_actor->ar_num_contacters];
-        contacter.nodeid        = inner_node.pos; /* Node index */
-        m_actor->ar_num_contacters++;
-
-        /* Wheel object */
-        wheel.ar_nodes[i * 2] = & outer_node;
-        wheel.ar_nodes[(i * 2) + 1] = & inner_node;
-    }
-
-    /* Beams */
-    for (unsigned int i = 0; i < wheel_def.num_rays; i++)
-    {
-        /* Bounded */
-        unsigned int outer_ring_node_index = base_node_index + (i * 2);
-        node_t *outer_ring_node = & m_actor->ar_nodes[outer_ring_node_index];
-        node_t *inner_ring_node = & m_actor->ar_nodes[outer_ring_node_index + 1];
-        
-        unsigned int beam_index = SectionWheelsAddBeam(wheel_def, & axis_node_1, outer_ring_node);
-        GetBeam(beam_index).shortbound = 0.66f;
-        GetBeam(beam_index).longbound = 0.0f;
-        beam_index = SectionWheelsAddBeam(wheel_def, & axis_node_2, inner_ring_node);
-        GetBeam(beam_index).shortbound = 0.66f;
-        GetBeam(beam_index).longbound = 0.0f;
-        SectionWheelsAddBeam(wheel_def, & axis_node_2, outer_ring_node);
-        SectionWheelsAddBeam(wheel_def, & axis_node_1, inner_ring_node);
-
-        /* Reinforcement */
-        unsigned int next_outer_ring_node_index = base_node_index + (((i + 1) % wheel_def.num_rays) * 2);
-        node_t *next_outer_ring_node = & m_actor->ar_nodes[next_outer_ring_node_index];
-        node_t *next_inner_ring_node = & m_actor->ar_nodes[next_outer_ring_node_index + 1];
-
-        SectionWheelsAddBeam(wheel_def, outer_ring_node, inner_ring_node);
-        SectionWheelsAddBeam(wheel_def, outer_ring_node, next_outer_ring_node);
-        SectionWheelsAddBeam(wheel_def, inner_ring_node, next_inner_ring_node);
-        SectionWheelsAddBeam(wheel_def, inner_ring_node, next_outer_ring_node);
-    }
-
-    /* Wheel object */
-    wheel.braked    = wheel_def.braking;
-    wheel.propulsed = wheel_def.propulsion;
-    wheel.nbnodes   = 2 * wheel_def.num_rays;
-    wheel.refnode0  = & axis_node_1;
-    wheel.refnode1  = & axis_node_2;
-    wheel.radius    = wheel_def.radius;
-    wheel.width     = axis_vector.length(); /* wheel_def.width is ignored. */
-    wheel.arm       = GetNodePointer(wheel_def.reference_arm_node);
-
-    if (wheel_def.propulsion != RigDef::Wheels::PROPULSION_NONE)
-    {
-        /* for inter-differential locking */
-        m_actor->m_num_proped_wheels++;
-        m_actor->m_proped_wheel_pairs[m_actor->m_num_proped_wheels] = m_actor->ar_num_wheels;
-    }
-    if (wheel_def.braking != RigDef::Wheels::BRAKING_NO)
-    {
-        m_actor->m_num_braked_wheels++;
-    }
-
-    /* Find near attach */
-    Ogre::Real length_1 = (axis_node_1.RelPosition - wheel.arm->RelPosition).length();
-    Ogre::Real length_2 = (axis_node_2.RelPosition - wheel.arm->RelPosition).length();
-    wheel.near_attach = & ((length_1 < length_2) ? axis_node_1 : axis_node_2);
-
-    /* Advance */
-    unsigned int wheel_index = m_actor->ar_num_wheels;
-    m_actor->ar_num_wheels++;
-    return wheel_index;
-}
-#endif
-
 unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int base_node_index = m_actor->ar_num_nodes;
     wheel_t & wheel = m_actor->ar_wheels[m_actor->ar_num_wheels];
     node_t *axis_node_1 = GetNodePointer(wheel_2_def.nodes[0]);
@@ -5005,8 +4701,6 @@ void ActorSpawner::CreateWheelVisuals(
     float rim_ratio
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     wheel_t & wheel = m_actor->ar_wheels[wheel_index];
 
     try
@@ -5053,8 +4747,6 @@ unsigned int ActorSpawner::AddWheelBeam(
     int type                 /* Default: BEAM_INVISIBLE */
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int index = m_actor->ar_num_beams;
     beam_t & beam = AddBeam(*node_1, *node_2, beam_defaults, DEFAULT_DETACHER_GROUP); 
     beam.bm_type = type;
@@ -5073,8 +4765,6 @@ unsigned int ActorSpawner::AddWheelBeam(
 
 unsigned int ActorSpawner::AddWheelRimBeam(RigDef::Wheel2 & wheel_2_def, node_t *node_1, node_t *node_2)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int beam_index = _SectionWheels2AddBeam(wheel_2_def, node_1, node_2);
     beam_t & beam = GetBeam(beam_index);
     beam.k = wheel_2_def.rim_springiness;
@@ -5084,8 +4774,6 @@ unsigned int ActorSpawner::AddWheelRimBeam(RigDef::Wheel2 & wheel_2_def, node_t 
 
 unsigned int ActorSpawner::AddTyreBeam(RigDef::Wheel2 & wheel_2_def, node_t *node_1, node_t *node_2)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int beam_index = _SectionWheels2AddBeam(wheel_2_def, node_1, node_2);
     beam_t & beam = GetBeam(beam_index);
     beam.k = wheel_2_def.tyre_springiness;
@@ -5099,8 +4787,6 @@ unsigned int ActorSpawner::AddTyreBeam(RigDef::Wheel2 & wheel_2_def, node_t *nod
 
 unsigned int ActorSpawner::_SectionWheels2AddBeam(RigDef::Wheel2 & wheel_2_def, node_t *node_1, node_t *node_2)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int index = m_actor->ar_num_beams;
     beam_t & beam = GetFreeBeam();
     InitBeam(beam, node_1, node_2);
@@ -5112,8 +4798,6 @@ unsigned int ActorSpawner::_SectionWheels2AddBeam(RigDef::Wheel2 & wheel_2_def, 
 
 void ActorSpawner::ProcessWheel2(RigDef::Wheel2 & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     unsigned int node_base_index = m_actor->ar_num_nodes;
     unsigned int wheel_index = AddWheel2(def);
     m_wheel_visuals_queue.push_back(WheelVisualsTicket(wheel_index, node_base_index, &def));
@@ -5126,8 +4810,6 @@ void ActorSpawner::ProcessWheel(RigDef::Wheel & def)
 
 void ActorSpawner::ProcessWheelDetacher(RigDef::WheelDetacher & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (def.wheel_id > m_actor->ar_num_wheels - 1)
     {
         AddMessage(Message::TYPE_ERROR, std::string("Invalid wheel_id: ") + TOSTRING(def.wheel_id));
@@ -5139,8 +4821,6 @@ void ActorSpawner::ProcessWheelDetacher(RigDef::WheelDetacher & def)
 
 void ActorSpawner::ProcessTractionControl(RigDef::TractionControl & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* #1: regulating_force */
     float force = def.regulation_force;
     if (force < 1.f || force > 20.f)
@@ -5174,8 +4854,6 @@ void ActorSpawner::ProcessTractionControl(RigDef::TractionControl & def)
 
 void ActorSpawner::ProcessAntiLockBrakes(RigDef::AntiLockBrakes & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* #1: regulating_force */
     float force = def.regulation_force;
     if (force < 1.f || force > 20.f)
@@ -5208,8 +4886,6 @@ void ActorSpawner::ProcessAntiLockBrakes(RigDef::AntiLockBrakes & def)
 
 void ActorSpawner::ProcessBrakes(RigDef::Brakes & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     m_actor->ar_brake_force = def.default_braking_force;
     m_actor->m_handbrake_force = 2.f * m_actor->ar_brake_force;
     if (def.parking_brake_force != -1.f)
@@ -5244,8 +4920,6 @@ void ActorSpawner::ProcessEngturbo(RigDef::Engturbo & def)
 
 void ActorSpawner::ProcessEngoption(RigDef::Engoption & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* Is this a land vehicle? */
     if (m_actor->ar_engine == nullptr)
     {
@@ -5281,8 +4955,6 @@ void ActorSpawner::ProcessEngoption(RigDef::Engoption & def)
 
 void ActorSpawner::ProcessEngine(RigDef::Engine & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* Process it */
     m_actor->ar_driveable = TRUCK;
 
@@ -5312,8 +4984,6 @@ void ActorSpawner::ProcessEngine(RigDef::Engine & def)
 
 void ActorSpawner::ProcessHelp()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     SetCurrentKeyword(RigDef::File::KEYWORD_HELP);
     unsigned int material_count = 0;
 
@@ -5340,8 +5010,6 @@ void ActorSpawner::ProcessHelp()
 
 void ActorSpawner::ProcessAuthors()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     SetCurrentKeyword(RigDef::File::KEYWORD_FILEFORMATVERSION);
 
     std::vector<RigDef::Author>::iterator author_itor = m_file->authors.begin();
@@ -5363,8 +5031,6 @@ void ActorSpawner::ProcessAuthors()
 
 unsigned int ActorSpawner::GetNodeIndexOrThrow(RigDef::Node::Ref const & node_ref)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     std::pair<unsigned int, bool> result = GetNodeIndex(node_ref);
     if (! result.second)
     {
@@ -5377,15 +5043,11 @@ unsigned int ActorSpawner::GetNodeIndexOrThrow(RigDef::Node::Ref const & node_re
 
 node_t & ActorSpawner::GetNodeOrThrow(RigDef::Node::Ref const & node_ref)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     return m_actor->ar_nodes[GetNodeIndexOrThrow(node_ref)];
 }
 
 void ActorSpawner::ProcessCamera(RigDef::Camera & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* Center node */
     if (def.center_node.IsValidAnyState())
     {
@@ -5425,8 +5087,6 @@ void ActorSpawner::ProcessCamera(RigDef::Camera & def)
 
 node_t* ActorSpawner::GetBeamNodePointer(RigDef::Node::Ref const & node_ref)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t* node = GetNodePointer(node_ref);
     if (node != nullptr)
     {
@@ -5437,8 +5097,6 @@ node_t* ActorSpawner::GetBeamNodePointer(RigDef::Node::Ref const & node_ref)
 
 void ActorSpawner::ProcessBeam(RigDef::Beam & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     // Nodes
     node_t* ar_nodes[] = {nullptr, nullptr};
     ar_nodes[0] = GetBeamNodePointer(def.nodes[0]);
@@ -5489,8 +5147,6 @@ void ActorSpawner::ProcessBeam(RigDef::Beam & def)
 
 void ActorSpawner::SetBeamDeformationThreshold(beam_t & beam, std::shared_ptr<RigDef::BeamDefaults> beam_defaults)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /*
     ---------------------------------------------------------------------------
         Old parser logic
@@ -5617,8 +5273,6 @@ void ActorSpawner::SetBeamDeformationThreshold(beam_t & beam, std::shared_ptr<Ri
 
 void ActorSpawner::CreateBeamVisuals(beam_t const & beam, int beam_index, bool visible, std::shared_ptr<RigDef::BeamDefaults> const& beam_defaults)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     //Set material
     std::string material_name = beam_defaults->beam_material_name;
     if (beam.bm_type == BEAM_HYDRO)
@@ -5631,8 +5285,6 @@ void ActorSpawner::CreateBeamVisuals(beam_t const & beam, int beam_index, bool v
 
 void ActorSpawner::CalculateBeamLength(beam_t & beam)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     float beam_length = (beam.p1->RelPosition - beam.p2->RelPosition).length();
     beam.L = beam_length;
     beam.refL = beam_length;
@@ -5640,8 +5292,6 @@ void ActorSpawner::CalculateBeamLength(beam_t & beam)
 
 void ActorSpawner::InitBeam(beam_t & beam, node_t *node_1, node_t *node_2)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     beam.p1 = node_1;
     beam.p2 = node_2;
 
@@ -5651,8 +5301,6 @@ void ActorSpawner::InitBeam(beam_t & beam, node_t *node_1, node_t *node_2)
 
 void ActorSpawner::AddMessage(ActorSpawner::Message::Type type,	Ogre::String const & text)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* Add message to report */
     m_messages.push_back(Message(type, text, m_current_keyword));
 
@@ -5687,8 +5335,6 @@ void ActorSpawner::AddMessage(ActorSpawner::Message::Type type,	Ogre::String con
 
 std::pair<unsigned int, bool> ActorSpawner::GetNodeIndex(RigDef::Node::Ref const & node_ref, bool quiet /* Default: false */)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (!node_ref.IsValidAnyState())
     {
         if (! quiet)
@@ -5733,8 +5379,6 @@ std::pair<unsigned int, bool> ActorSpawner::GetNodeIndex(RigDef::Node::Ref const
 
 node_t* ActorSpawner::GetNodePointer(RigDef::Node::Ref const & node_ref)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     std::pair<unsigned int, bool> result = GetNodeIndex(node_ref);
     if (result.second)
     {
@@ -5748,8 +5392,6 @@ node_t* ActorSpawner::GetNodePointer(RigDef::Node::Ref const & node_ref)
 
 node_t* ActorSpawner::GetNodePointerOrThrow(RigDef::Node::Ref const & node_ref)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t *node = GetNodePointer(node_ref);
     if (node == nullptr)
     {
@@ -5762,8 +5404,6 @@ node_t* ActorSpawner::GetNodePointerOrThrow(RigDef::Node::Ref const & node_ref)
 
 std::pair<unsigned int, bool> ActorSpawner::AddNode(RigDef::Node::Id & id)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (!id.IsValid())
     {
         std::stringstream msg;
@@ -5804,8 +5444,6 @@ std::pair<unsigned int, bool> ActorSpawner::AddNode(RigDef::Node::Id & id)
 
 void ActorSpawner::ProcessNode(RigDef::Node & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     std::pair<unsigned int, bool> inserted_node = AddNode(def.id);
     if (! inserted_node.second)
     {
@@ -5919,14 +5557,6 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
     nfx.nx_no_particles = BITMASK_IS_1(options, RigDef::Node::OPTION_p_NO_PARTICLES);
     nfx.nx_no_sparks    = BITMASK_IS_1(options, RigDef::Node::OPTION_f_NO_SPARKS);
     m_gfx_nodes.push_back(nfx);
-
-#ifdef DEBUG_TRUCKPARSER2013
-    // DEBUG
-    std::stringstream msg;
-    msg<<"DBG ProcessNode() pos="<<node.pos<<", id="<<node.id << ", X=" << node.AbsPosition.x << ", Y=" << node.AbsPosition.y << ", Z=" << node.AbsPosition.z;
-    LOG(msg.str());
-    // END
-#endif
 }
 
 void ActorSpawner::AddExhaust(
@@ -5936,8 +5566,6 @@ void ActorSpawner::AddExhaust(
         Ogre::String *user_material_name
     )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if (m_actor->m_disable_smoke)
     {
         return;
@@ -5993,8 +5621,6 @@ void ActorSpawner::AddExhaust(
 
 bool ActorSpawner::AddModule(Ogre::String const & module_name)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     auto result = m_file->user_modules.find(module_name);
 
     if (result != m_file->user_modules.end())
@@ -6009,8 +5635,6 @@ bool ActorSpawner::AddModule(Ogre::String const & module_name)
 
 void ActorSpawner::ProcessCinecam(RigDef::Cinecam & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     // Node
     Ogre::Vector3 node_pos = m_spawn_position + def.position;
     node_t & camera_node = GetAndInitFreeNode(node_pos);
@@ -6040,8 +5664,6 @@ void ActorSpawner::ProcessCinecam(RigDef::Cinecam & def)
 
 void ActorSpawner::InitNode(node_t & node, Ogre::Vector3 const & position)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     /* Position */
     node.AbsPosition = position;
     node.RelPosition = position - m_actor->ar_origin;
@@ -6053,8 +5675,6 @@ void ActorSpawner::InitNode(
     std::shared_ptr<RigDef::NodeDefaults> node_defaults
 )
 {
-    SPAWNER_PROFILE_SCOPED();
-
     InitNode(node, position);
     node.friction_coef = node_defaults->friction;
     node.volume_coef = node_defaults->volume;
@@ -6063,8 +5683,6 @@ void ActorSpawner::InitNode(
 
 void ActorSpawner::ProcessGlobals(RigDef::Globals & def)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     m_actor->m_dry_mass = def.dry_mass;
     m_actor->m_load_mass = def.cargo_mass;
 
@@ -6093,8 +5711,6 @@ void ActorSpawner::ProcessGlobals(RigDef::Globals & def)
 
 bool ActorSpawner::CheckParticleLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_actor->ar_num_custom_particles + count) > MAX_CPARTICLES)
     {
         std::stringstream msg;
@@ -6107,8 +5723,6 @@ bool ActorSpawner::CheckParticleLimit(unsigned int count)
 
 bool ActorSpawner::CheckAxleLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_actor->m_num_axles + count) > MAX_WHEELS/2)
     {
         std::stringstream msg;
@@ -6121,8 +5735,6 @@ bool ActorSpawner::CheckAxleLimit(unsigned int count)
 
 bool ActorSpawner::CheckSubmeshLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_oldstyle_cab_submeshes.size() + count) > MAX_SUBMESHES)
     {
         std::stringstream msg;
@@ -6135,8 +5747,6 @@ bool ActorSpawner::CheckSubmeshLimit(unsigned int count)
 
 bool ActorSpawner::CheckTexcoordLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-    
     if ((m_oldstyle_cab_texcoords.size() + count) > MAX_TEXCOORDS)
     {
         std::stringstream msg;
@@ -6150,9 +5760,6 @@ bool ActorSpawner::CheckTexcoordLimit(unsigned int count)
 /* Static version */
 bool ActorSpawner::CheckSoundScriptLimit(Actor *vehicle, unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
-    //return CheckSoundScriptLimit(m_actor, count);
     if ((vehicle->ar_num_soundsources + count) > MAX_SOUNDSCRIPTS_PER_TRUCK)
     {
         std::stringstream msg;
@@ -6165,8 +5772,6 @@ bool ActorSpawner::CheckSoundScriptLimit(Actor *vehicle, unsigned int count)
 
 bool ActorSpawner::CheckCabLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_actor->ar_num_cabs + count) > MAX_CABS)
     {
         std::stringstream msg;
@@ -6179,8 +5784,6 @@ bool ActorSpawner::CheckCabLimit(unsigned int count)
 
 bool ActorSpawner::CheckCameraRailLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_actor->ar_num_camera_rails + count) > MAX_CAMERARAIL)
     {
         std::stringstream msg;
@@ -6193,8 +5796,6 @@ bool ActorSpawner::CheckCameraRailLimit(unsigned int count)
 
 bool ActorSpawner::CheckAirBrakeLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_actor->ar_num_airbrakes + count) > MAX_AIRBRAKES)
     {
         std::stringstream msg;
@@ -6207,8 +5808,6 @@ bool ActorSpawner::CheckAirBrakeLimit(unsigned int count)
 
 bool ActorSpawner::CheckAeroEngineLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_actor->ar_num_aeroengines + count) > MAX_AEROENGINES)
     {
         std::stringstream msg;
@@ -6221,8 +5820,6 @@ bool ActorSpawner::CheckAeroEngineLimit(unsigned int count)
 
 bool ActorSpawner::CheckScrewpropLimit(unsigned int count)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     if ((m_actor->ar_num_screwprops + count) > MAX_SCREWPROPS)
     {
         std::stringstream msg;
@@ -6240,8 +5837,6 @@ node_t &ActorSpawner:: GetNode(unsigned int node_index)
 
 void ActorSpawner::InitNode(unsigned int node_index, Ogre::Vector3 const & position)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     InitNode(m_actor->ar_nodes[node_index], position);
 }
 
@@ -6252,8 +5847,6 @@ beam_t & ActorSpawner::GetBeam(unsigned int index)
 
 node_t & ActorSpawner::GetFreeNode()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t & node = m_actor->ar_nodes[m_actor->ar_num_nodes];
     node.pos = m_actor->ar_num_nodes;
     m_actor->ar_num_nodes++;
@@ -6262,8 +5855,6 @@ node_t & ActorSpawner::GetFreeNode()
 
 beam_t & ActorSpawner::GetFreeBeam()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     beam_t & beam = m_actor->ar_beams[m_actor->ar_num_beams];
     m_actor->ar_num_beams++;
     return beam;
@@ -6271,8 +5862,6 @@ beam_t & ActorSpawner::GetFreeBeam()
 
 shock_t & ActorSpawner::GetFreeShock()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     shock_t & shock = m_actor->ar_shocks[m_actor->ar_num_shocks];
     m_actor->ar_num_shocks++;
     return shock;
@@ -6280,8 +5869,6 @@ shock_t & ActorSpawner::GetFreeShock()
 
 beam_t & ActorSpawner::GetAndInitFreeBeam(node_t & node_1, node_t & node_2)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     beam_t & beam = GetFreeBeam();
     beam.p1 = & node_1;
     beam.p2 = & node_2;
@@ -6290,8 +5877,6 @@ beam_t & ActorSpawner::GetAndInitFreeBeam(node_t & node_1, node_t & node_2)
 
 node_t & ActorSpawner::GetAndInitFreeNode(Ogre::Vector3 const & position)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     node_t & node = GetFreeNode();
     InitNode(node, position);
     return node;
@@ -6309,8 +5894,6 @@ void ActorSpawner::SetBeamDamping(beam_t & beam, float damping)
 
 void ActorSpawner::SetupDefaultSoundSources(Actor *vehicle)
 {
-    SPAWNER_PROFILE_SCOPED();
-
     int trucknum = vehicle->ar_instance_id;
     int ar_exhaust_pos_node = vehicle->ar_exhaust_pos_node;
 
@@ -6471,8 +6054,6 @@ void ActorSpawner::SetupDefaultSoundSources(Actor *vehicle)
 
 void ActorSpawner::UpdateCollcabContacterNodes()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     for (int i=0; i<m_actor->ar_num_collcabs; i++)
     {
         int tmpv = m_actor->ar_collcabs[i] * 3;
@@ -6484,8 +6065,6 @@ void ActorSpawner::UpdateCollcabContacterNodes()
 
 std::string ActorSpawner::ProcessMessagesToString()
 {
-    SPAWNER_PROFILE_SCOPED();
-
     std::stringstream report;
 
     auto itor = m_messages.begin();

--- a/source/main/physics/RigSpawner_ProcessControl.cpp
+++ b/source/main/physics/RigSpawner_ProcessControl.cpp
@@ -149,7 +149,6 @@ Actor *ActorSpawner::SpawnActor()
     m_actor->ar_rescuer_flag             = m_file->rescuer;
     m_actor->m_disable_default_sounds    = m_file->disable_default_sounds;
     m_actor->ar_hide_in_actor_list       = m_file->hide_in_chooser;
-    m_actor->m_slidenodes_connect_on_spawn  = m_file->slide_nodes_connect_instantly;
 
     // Section 'authors' in root module
     ProcessAuthors();

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -992,8 +992,11 @@ VehicleAI* GameScript::getTruckAIByNum(int num)
 
 Actor* GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot)
 {
-    Ogre::Quaternion rotation = Quaternion(Degree(rot.x), Vector3::UNIT_X) * Quaternion(Degree(rot.y), Vector3::UNIT_Y) * Quaternion(Degree(rot.z), Vector3::UNIT_Z);
-    return App::GetSimController()->GetBeamFactory()->CreateLocalActor(pos, rotation, truckName);
+    ActorSpawnRequest rq;
+    rq.asr_position = pos;
+    rq.asr_rotation = Quaternion(Degree(rot.x), Vector3::UNIT_X) * Quaternion(Degree(rot.y), Vector3::UNIT_Y) * Quaternion(Degree(rot.z), Vector3::UNIT_Z);
+    rq.asr_filename = truckName;
+    return App::GetSimController()->SpawnActorDirectly(rq);
 }
 
 void GameScript::showMessageBox(Ogre::String& title, Ogre::String& text, bool use_btn1, Ogre::String& btn1_text, bool allow_close, bool use_btn2, Ogre::String& btn2_text)

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -55,6 +55,7 @@
 #include "CBytecodeStream.h"
 #include "PlatformUtils.h"
 #include "ScriptEvents.h"
+#include "RoRFrameListener.h" // SimController
 
 #include "BeamFactory.h"
 #include "VehicleAI.h"
@@ -113,6 +114,14 @@ void ScriptEngine::messageLogged( const String& message, LogMessageLevel lml, bo
     Console *c = RoR::App::GetConsole();
     if (c) c->putMessage(Console::CONSOLE_MSGTYPE_SCRIPT, Console::CONSOLE_LOGMESSAGE_SCRIPT, message, "page_white_code.png");
 
+}
+
+void AS_RequestActorReset(Actor* a, bool keep_position) // Substitute for removed `Actor` function
+{
+    ActorModifyRequest rq;
+    rq.amr_actor = a;
+    rq.amr_type  = (keep_position) ? ActorModifyRequest::Type::RESET_ON_SPOT : ActorModifyRequest::Type::RESET_ON_INIT_POS;
+    RoR::App::GetSimController()->QueueActorModify(rq);
 }
 
 // continue with initializing everything
@@ -201,7 +210,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", AngelScript::asMETHOD(Actor,GetActorDesignName), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,GetActorFileName), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,GetActorType), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asMETHOD(Actor,RequestActorReset), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asFUNCTION(AS_RequestActorReset), AngelScript::asCALL_CDECL_OBJFIRST); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void setDetailLevel(int)", AngelScript::asMETHOD(Actor,setDetailLevel), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", AngelScript::asMETHOD(Actor,ToggleParkingBrake), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void tractioncontrolToggle()", AngelScript::asMETHOD(Actor,ToggleTractionControl), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -1344,37 +1344,14 @@ void TerrainObjectManager::LoadPredefinedActors()
 
     for (unsigned int i = 0; i < m_predefined_actors.size(); i++)
     {
-        Vector3 pos = Vector3(m_predefined_actors[i].px, m_predefined_actors[i].py, m_predefined_actors[i].pz);
-        Actor* actor = App::GetSimController()->GetBeamFactory()->CreateLocalActor(
-            pos,
-            m_predefined_actors[i].rotation,
-            m_predefined_actors[i].name,
-            -1,
-            nullptr, /* spawnbox */
-            nullptr, /* config */
-            nullptr, /* skin */
-            m_predefined_actors[i].freePosition,
-            true /* preloaded_with_terrain */
-        );
-
-        if (m_predefined_actors[i].ismachine)
-        {
-            actor->ar_driveable = MACHINE;
-        }
-
-        SurveyMapManager* survey_map = App::GetSimController()->GetGfxScene().GetSurveyMap();
-        if (actor && survey_map)
-        {
-            SurveyMapEntity* e = survey_map->createNamedMapEntity("Truck" + TOSTRING(actor->ar_instance_id), SurveyMapManager::getTypeByDriveable(actor->ar_driveable));
-            if (e)
-            {
-                e->setState(static_cast<int>(Actor::SimState::LOCAL_SIMULATED));
-                e->setVisibility(true);
-                e->setPosition(m_predefined_actors[i].px, m_predefined_actors[i].pz);
-                e->setRotation(-Radian(actor->getRotation()));
-            }
-        }
-
+        ActorSpawnRequest rq;
+        rq.asr_position      = Vector3(m_predefined_actors[i].px, m_predefined_actors[i].py, m_predefined_actors[i].pz);
+        rq.asr_filename      = m_predefined_actors[i].name;
+        rq.asr_rotation      = m_predefined_actors[i].rotation;
+        rq.asr_origin        = ActorSpawnRequest::Origin::TERRN_DEF;
+        rq.asr_terrn_adjust  = !m_predefined_actors[i].freePosition;
+        rq.asr_terrn_machine = m_predefined_actors[i].ismachine;
+        App::GetSimController()->QueueActorSpawn(rq);
     }
 }
 

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -1349,7 +1349,7 @@ void TerrainObjectManager::LoadPredefinedActors()
         rq.asr_filename      = m_predefined_actors[i].name;
         rq.asr_rotation      = m_predefined_actors[i].rotation;
         rq.asr_origin        = ActorSpawnRequest::Origin::TERRN_DEF;
-        rq.asr_terrn_adjust  = !m_predefined_actors[i].freePosition;
+        rq.asr_free_position = m_predefined_actors[i].freePosition;
         rq.asr_terrn_machine = m_predefined_actors[i].ismachine;
         App::GetSimController()->QueueActorSpawn(rq);
     }

--- a/source/main/utils/profiler/RigLoadingProfilerControl.h
+++ b/source/main/utils/profiler/RigLoadingProfilerControl.h
@@ -50,22 +50,12 @@
 // Prints simple, per-flexbody stats to RoR.log
 //#define FLEXBODY_LOG_LOADING_TIMES
 
-// HTML profiler
-// Profile entire class ActorSpawner, per-function
-//#define SPAWNER_USE_PROFILER
-
 // ============================================================================
 // END SETUP
 // ============================================================================
 
-#ifdef SPAWNER_USE_PROFILER
-#   define ROR_PROFILE_RIG_LOADING
-#   include "Profiler.h"
-// Use root namespace ::
-#   define SPAWNER_PROFILE_SCOPED() ::PROFILE_SCOPED()
-#else
-#   define SPAWNER_PROFILE_SCOPED()
-#endif
+// Removed
+#define SPAWNER_PROFILE_SCOPED()
 
 #ifdef FLEXBODY_USE_PROFILER
 #   define ROR_PROFILE_RIG_LOADING

--- a/source/main/utils/profiler/RigLoadingProfilerControl.h
+++ b/source/main/utils/profiler/RigLoadingProfilerControl.h
@@ -54,9 +54,6 @@
 // END SETUP
 // ============================================================================
 
-// Removed
-#define SPAWNER_PROFILE_SCOPED()
-
 #ifdef FLEXBODY_USE_PROFILER
 #   define ROR_PROFILE_RIG_LOADING
 #   include "Profiler.h"


### PR DESCRIPTION
Our spawning logic is very convoluted, there are lots of special cases and redundant reset requests that likely cancel each other out. My plan:
* Add queues for actor changes {spawn/modify/remove}
* Add 'pending player vehicle change' mechanism
* Process the queues + pending changes in one place -> less callbacks and ad-hoc state updates.
* Create unified 'spawn request' ticket which keeps all input data.

Known bugs:
* Terrain-preloaded actors are visible in top menubar. EDIT: this is upstream glitch, actually
* Not very thoroughly tested - expect glitches