### PR TITLE
Improved collision bounding boxes

### DIFF
--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -32,9 +32,10 @@ struct node_t
     //     although there was always a hidden soft limit of 2^16 nodes (because of `short node_t::pos`).
     //     Let's use `uint16_t` indices everywhere to be clear.      ~ only_a_ptr, 04/2018
     static const uint16_t INVALID_IDX = std::numeric_limits<uint16_t>::max();
+    static const int8_t   INVALID_BBOX = -1;
 
-    node_t()               { memset(this, 0, sizeof(node_t)); }
-    node_t(size_t _pos)    { memset(this, 0, sizeof(node_t)); pos = static_cast<short>(_pos); }
+    node_t()               { memset(this, 0, sizeof(node_t)); nd_coll_bbox_id = INVALID_BBOX; }
+    node_t(size_t _pos)    { memset(this, 0, sizeof(node_t)); nd_coll_bbox_id = INVALID_BBOX; pos = static_cast<short>(_pos); }
 
     Ogre::Vector3 RelPosition; //!< relative to the local physics origin (one origin per actor) (shaky)
     Ogre::Vector3 AbsPosition; //!< absolute position in the world (shaky)
@@ -55,12 +56,12 @@ struct node_t
     short nd_lockgroup;
     short pos;     //!< This node's index in Actor::ar_nodes array.
     short id;      //!< Numeric identifier assigned in truckfile (if used), or -1 if the node was generated dynamically.
-    char collisionBoundingBoxID;
 
     Ogre::Vector3 initial_pos;
 
     ground_model_t* nd_collision_gm;         //!< Physics state; last collision 'ground model' (surface definition)
     float           nd_collision_slip;       //!< Physics state; last collision slip velocity
+    int8_t          nd_coll_bbox_id;         //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
 
     // Bit flags
     bool            nd_loaded_mass:1;        //!< User defined attr; mass is calculated from 'globals/loaded-mass' rather than 'globals/dry-mass'

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -166,7 +166,7 @@ public:
     bool              isTied();
     bool              isLocked(); 
     void              updateDashBoards(float dt);
-    void              updateBoundingBox(); 
+    void              UpdateBoundingBoxes();
     void              calculateAveragePosition();
     void              checkAndMovePhysicsOrigin();
     void              postUpdatePhysics(float dt);         //!< TIGHT LOOP; Physics;

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -201,7 +201,7 @@ void ActorManager::SetupActor(
         Ogre::Vector3 vehicle_position = spawn_position;
 
         // check if over-sized
-        ActorSpawner::RecalculateBoundingBoxes(actor);
+        actor->UpdateBoundingBoxes();
         vehicle_position.x -= (actor->ar_bounding_box.getMaximum().x + actor->ar_bounding_box.getMinimum().x) / 2.0 - vehicle_position.x;
         vehicle_position.z -= (actor->ar_bounding_box.getMaximum().z + actor->ar_bounding_box.getMinimum().z) / 2.0 - vehicle_position.z;
 
@@ -255,7 +255,7 @@ void ActorManager::SetupActor(
     //compute node connectivity graph
     actor->calcNodeConnectivityGraph();
 
-    ActorSpawner::RecalculateBoundingBoxes(actor);
+    actor->UpdateBoundingBoxes();
 
     // fix up submesh collision model
     std::string subMeshGroundModelName = spawner.GetSubmeshGroundmodelName();

--- a/source/main/physics/RigSpawner.h
+++ b/source/main/physics/RigSpawner.h
@@ -157,8 +157,6 @@ public:
     */
     unsigned int GetNodeIndexOrThrow(RigDef::Node::Ref const & id);
 
-    static void RecalculateBoundingBoxes(Actor *rig);
-
     static void SetupDefaultSoundSources(Actor *vehicle);
 
     static void ComposeName(RoR::Str<100>& str, const char* type, int number, int actor_id);


### PR DESCRIPTION
* New prediction method - OLD: "current aabb padded by node 0 velocity", NEW: "for each node, account current + future position (add velocity)".
* Removed duplicate code in ActorSpawner, Created new unified Actor method.
* Clarified 'bounding box ID' node attribute, added INVALID_BBOX constant.
* Improved spawning partial collision boxes - instead of clearing the std::vector and re-inserting AABBs every step, only insert on spawn and then reset+rebuild in-place.