### PR TITLE
Simplified threading logic

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -82,6 +82,8 @@ static TerrainManager*  g_sim_terrain;
  GVarStr_A<100>           app_language            ("app_language",            "Language",                  "English");
  GVarStr_A<50>            app_locale              ("app_locale",              "Language Short",            "en");
  GVarPod_A<bool>          app_multithread         ("app_multithread",         "Multi-threading",           true);
+ GVarPod_APS<int>         app_num_workers         ("app_num_workers",         "NumThreadsInThreadPool",    0,
+         0,         0);
  GVarStr_AP<50>           app_screenshot_format   ("app_screenshot_format",   "Screenshot Format",         "jpg",                   "jpg");
 
 // Simulation

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -81,8 +81,9 @@ static TerrainManager*  g_sim_terrain;
  GVarEnum_AP<AppState>    app_state               ("app_state",               nullptr,                     AppState::BOOTSTRAP,     AppState::MAIN_MENU);
  GVarStr_A<100>           app_language            ("app_language",            "Language",                  "English");
  GVarStr_A<50>            app_locale              ("app_locale",              "Language Short",            "en");
- GVarPod_A<bool>          app_multithread         ("app_multithread",         "Multi-threading",           true);
- GVarPod_APS<int>         app_num_workers         ("app_num_workers",         "NumThreadsInThreadPool",    0,
+ GVarPod_APS<bool>        app_async_physics       ("app_async_physics",       "AsyncPhysics",              true,
+         true,      true);
+ GVarPod_APS<int>         app_num_workers         ("app_num_workers",         "NumWorkerThreads",          0,
          0,         0);
  GVarStr_AP<50>           app_screenshot_format   ("app_screenshot_format",   "Screenshot Format",         "jpg",                   "jpg");
 

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -655,6 +655,7 @@ extern GVarEnum_AP<AppState>   app_state;
 extern GVarStr_A<100>          app_language;
 extern GVarStr_A<50>           app_locale;
 extern GVarPod_A<bool>         app_multithread;
+extern GVarPod_APS<int>        app_num_workers;
 extern GVarStr_AP<50>          app_screenshot_format;
 
 // Simulation

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -654,7 +654,7 @@ namespace App {
 extern GVarEnum_AP<AppState>   app_state;
 extern GVarStr_A<100>          app_language;
 extern GVarStr_A<50>           app_locale;
-extern GVarPod_A<bool>         app_multithread;
+extern GVarPod_APS<bool>       app_async_physics;
 extern GVarPod_APS<int>        app_num_workers;
 extern GVarStr_AP<50>          app_screenshot_format;
 

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -68,7 +68,7 @@ void RoR::GUI::GameSettings::Draw()
             App::app_screenshot_format.SetActive((sshot_select == 1) ? "jpg" : "png");
         }
 
-        DrawGCheckbox(App::app_multithread, "Multithreading");
+        DrawGCheckbox(App::app_async_physics, "Async physics");
 
         ImGui::Separator();
         ImGui::TextDisabled("Simulation settings");

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1014,7 +1014,7 @@ void ActorManager::UpdateActors(Actor* player_actor, float dt)
         });
     m_sim_task = gEnv->threadPool->RunTask(func);
 
-    if (!RoR::App::app_multithread.GetActive())
+    if (!RoR::App::app_async_physics.GetActive())
         m_sim_task->join();
 }
 

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -100,10 +100,11 @@ ActorManager::ActorManager()
     int logical_cores = std::thread::hardware_concurrency();
     LOG("BEAMFACTORY: " + TOSTRING(logical_cores) + " logical CPU cores" + " found");
 
-    int thread_pool_workers = ISETTING("NumThreadsInThreadPool", 0);
+    int thread_pool_workers = RoR::App::app_num_workers.GetActive();
     if (thread_pool_workers < 1 || thread_pool_workers > logical_cores)
     {
         thread_pool_workers = logical_cores - 1;
+        RoR::App::app_num_workers.SetActive(thread_pool_workers);
     }
 
     gEnv->threadPool = new ThreadPool(thread_pool_workers);

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -107,7 +107,6 @@ private:
 
     std::map<std::string, std::shared_ptr<RigDef::File>>   m_actor_defs;
     std::map<int, std::vector<int>> m_stream_mismatches; //!< Networking: A list of streams without a corresponding actor in the actor-array for each stream source
-    std::unique_ptr<ThreadPool>     m_sim_thread_pool;
     std::shared_ptr<Task>           m_sim_task;
     std::vector<Actor*>             m_actors;
     bool            m_forced_awake;      //!< disables sleep counters

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -616,7 +616,7 @@ bool Settings::ParseGlobalVarSetting(std::string const & k, std::string const & 
     // App
     if (CheckScreenshotFormat                     (k, v)) { return true; }
     if (CheckStr  (App::app_locale,                k, v)) { return true; }
-    if (CheckBool (App::app_multithread,           k, v)) { return true; }
+    if (CheckBool (App::app_async_physics,         k, v)) { return true; }
     if (CheckInt  (App::app_num_workers,           k, v)) { return true; }
     // Input&Output
     if (CheckBool (App::io_ffb_enabled,            k, v)) { return true; }
@@ -968,7 +968,7 @@ void Settings::SaveSettings()
     f << std::endl << "; Application"<< std::endl;
     WriteStr (f, App::app_screenshot_format );
     WriteStr (f, App::app_locale            );
-    WriteYN  (f, App::app_multithread       );
+    WriteYN  (f, App::app_async_physics     );
     WritePod (f, App::app_num_workers       );
 
     // Append misc legacy entries

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -617,6 +617,7 @@ bool Settings::ParseGlobalVarSetting(std::string const & k, std::string const & 
     if (CheckScreenshotFormat                     (k, v)) { return true; }
     if (CheckStr  (App::app_locale,                k, v)) { return true; }
     if (CheckBool (App::app_multithread,           k, v)) { return true; }
+    if (CheckInt  (App::app_num_workers,           k, v)) { return true; }
     // Input&Output
     if (CheckBool (App::io_ffb_enabled,            k, v)) { return true; }
     if (CheckFloat(App::io_ffb_camera_gain,        k, v)) { return true; }
@@ -968,6 +969,7 @@ void Settings::SaveSettings()
     WriteStr (f, App::app_screenshot_format );
     WriteStr (f, App::app_locale            );
     WriteYN  (f, App::app_multithread       );
+    WritePod (f, App::app_num_workers       );
 
     // Append misc legacy entries
     f << std::endl << "; Misc" << std::endl;


### PR DESCRIPTION
The physics worker thread is now handled by the thread pool:
- Gets rid of the dummy thread pool which was used as a background worker thread
- Makes the `DisableThreadPool` setting obsolete
- Renamed `NumThreadsInThreadPool` into `NumWorkerThreads`
- Introduces `GVarPod_APS<int> app_num_workers`
- Converts `GVarPod_A<bool> app_multithread` into `GVarPod_APS<bool> app_async_physics`

- [x] Decide if we should rename `RoR::App::app_multithread` into `RoR::App::app_async_physics`

Reference: https://github.com/only-a-ptr/rigs-of-rods/pull/22