### PR TITLE
Fixed 'Unimog U5000 Dakar' segfaults

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -2535,9 +2535,9 @@ void RoR::GfxActor::SetCastShadows(bool value)
     // Props
     for (prop_t& prop: m_props)
     {
-        if (prop.mo != nullptr)
+        if (prop.mo != nullptr && prop.mo->getEntity())
             prop.mo->getEntity()->setCastShadows(value);
-        if (prop.wheelmo != nullptr)
+        if (prop.wheelmo != nullptr && prop.wheelmo->getEntity())
             prop.wheelmo->getEntity()->setCastShadows(value);
     }
 

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -6700,6 +6700,9 @@ Ogre::MaterialPtr ActorSpawner::CreateSimpleMaterial(Ogre::ColourValue color)
 
 void ActorSpawner::SetupNewEntity(Ogre::Entity* ent, Ogre::ColourValue simple_color)
 {
+    if (ent == nullptr)
+        return;
+
     // Use simple materials if applicable
     if (m_apply_simple_materials)
     {


### PR DESCRIPTION
I'm unable to find a better solution. But this seems to work fine.

Truck file: http://archives.rigsofrods.net/repo/files/repofiles-1st-batch/58dcfc39b7024d3eacb3d70d8dca3bc9709ed7ae_UnimogU5000Dakar.zip

Underlying issue:
```
error loading mesh: dashboard1.mesh: OGRE EXCEPTION(2:InvalidParametersException):
Couldn't read 16 bit header value from input stream.
```