### PR TITLE
Fixed survey / teleport map

### DIFF
--- a/source/main/gfx/DustManager.cpp
+++ b/source/main/gfx/DustManager.cpp
@@ -74,7 +74,7 @@ void RoR::GfxScene::InitSurveyMap(Ogre::Vector3 terrain_size)
 {
     if (!RoR::App::gfx_minimap_disabled.GetActive())
     {
-        m_survey_map = std::unique_ptr<SurveyMapManager>(new SurveyMapManager(terrain_size));
+        m_survey_map = std::unique_ptr<SurveyMapManager>(new SurveyMapManager(Vector2(terrain_size.x, terrain_size.z)));
     }
 }
 

--- a/source/main/terrain/map/SurveyMapEntity.cpp
+++ b/source/main/terrain/map/SurveyMapEntity.cpp
@@ -31,8 +31,9 @@ using namespace Ogre;
 
 String SurveyMapEntity::entityStates[MaxEntityStates] = {"activated", "deactivated", "sleeping", "networked"};
 
-SurveyMapEntity::SurveyMapEntity(SurveyMapManager* ctrl, String type, MyGUI::StaticImagePtr parent) :
-    mMapControl(ctrl)
+SurveyMapEntity::SurveyMapEntity(SurveyMapManager* ctrl, Vector2 terrain_size, String type, MyGUI::StaticImagePtr parent) :
+      mMapControl(ctrl)
+    , mMapSize(terrain_size)
     , mType(type)
     , mParent(parent)
     , mRotation(0)
@@ -163,23 +164,21 @@ void SurveyMapEntity::update()
     if (!mMainWidget->getVisible())
         return;
 
-    if (!mMapControl->getMapEntitiesVisible())
+    if (!mMapControl->getMapEntitiesVisible() || mMapControl->getMapZoom() > 0.0f)
     {
         mMainWidget->setVisible(false);
         mIcon->setVisible(false);
         return;
     }
 
-    Ogre::Vector3 max_size = RoR::App::GetSimTerrain()->getMaxTerrainSize();
-    Vector2 m_terrain_page_size = Vector2(max_size.x, max_size.z);
-    float wscale = mMapControl->getWindowSize().length() / m_terrain_page_size.length();
+    float wscale = mMapControl->getWindowSize().length() / mMapSize.length();
 
     // TODO: Fix the icon positions based on the overview map size and zoom value
     // TODO: Split visibility calculation and position update into two functions
 
     mMainWidget->setPosition(
-        mX / mMapControl->getMapSize().x * mParent->getWidth() - mMainWidget->getWidth() / 2,
-        mZ / mMapControl->getMapSize().z * mParent->getHeight() - mMainWidget->getHeight() / 2
+        mX / mMapSize.x * mParent->getWidth()  - mMainWidget->getWidth()  / 2,
+        mZ / mMapSize.y * mParent->getHeight() - mMainWidget->getHeight() / 2
     );
     mIcon->setCoord(
         mMainWidget->getWidth() / 2 - mIconSize.width * wscale / 2,

--- a/source/main/terrain/map/SurveyMapEntity.h
+++ b/source/main/terrain/map/SurveyMapEntity.h
@@ -33,7 +33,7 @@ class SurveyMapEntity : public wraps::BaseLayout, public ZeroedMemoryAllocator
 {
 public:
 
-    SurveyMapEntity(SurveyMapManager* ctrl, Ogre::String type, MyGUI::StaticImagePtr parent);
+    SurveyMapEntity(SurveyMapManager* ctrl, Ogre::Vector2 terrain_size, Ogre::String type, MyGUI::StaticImagePtr parent);
 
     Ogre::String getDescription();
     bool getVisibility();
@@ -80,6 +80,7 @@ private:
     Ogre::Real mX, mZ;
     Ogre::String mDescription;
     Ogre::String mType;
+    Ogre::Vector2 mMapSize;
     bool mIsStatic;
 
     void init();

--- a/source/main/terrain/map/SurveyMapManager.h
+++ b/source/main/terrain/map/SurveyMapManager.h
@@ -35,7 +35,7 @@ class SurveyMapManager : public wraps::BaseLayout
 {
 public:
 
-    SurveyMapManager(Ogre::Vector3 terrain_size);
+    SurveyMapManager(Ogre::Vector2 terrain_size);
     ~SurveyMapManager();
 
     SurveyMapEntity* createMapEntity(Ogre::String type);
@@ -50,20 +50,15 @@ public:
     void setVisibility(bool value);
     bool getVisibility();
 
-    void setMapZoom(Ogre::Real zoomValue, bool update = true, bool permanent = true);
-    void setMapZoomRelative(Ogre::Real zoomDelta, bool update = true, bool permanent = true);
+    void setMapZoom(Ogre::Real zoomValue, bool permanent = true);
+    void setMapZoomRelative(Ogre::Real zoomDelta, bool permanent = true);
     Ogre::Real getMapZoom() { return mMapZoom; }
 
-    void setMapCenter(Ogre::Vector2 position, bool update = true);
-    void setMapCenter(Ogre::Vector3 position, bool update = true);
-    void setMapCenter(Ogre::Vector2 position, float maxOffset, bool update = true);
-    void setMapCenter(Ogre::Vector3 position, float maxOffset, bool update = true);
+    void setMapCenter(Ogre::Vector2 position);
+    void setMapCenter(Ogre::Vector3 position);
+    void setMapCenter(Ogre::Vector2 position, float maxOffset);
+    void setMapCenter(Ogre::Vector3 position, float maxOffset);
     Ogre::Vector2 getMapCenter() { return mMapCenter; };
-
-    void setMapTexture(Ogre::String name);
-
-    Ogre::Vector3 getMapSize() { return mMapSize; };
-    int getMapMode() { return mMapMode; };
 
     void windowResized();
     void setWindowPosition(int x, int y, float size);
@@ -89,19 +84,16 @@ public:
 
 protected:
 
-    void init();
-
     Ogre::Real mAlpha, mMapZoom;
 
     Ogre::Vector2 mMapCenter;
-    Ogre::Vector3 mMapSize;
+    Ogre::Vector2 mMapSize;
 
     ATTRIBUTE_FIELD_WIDGET_NAME(SurveyMapManager, mMapTexture, "mMapTexture");
 
     MyGUI::StaticImage* mMapTexture;
 
     SurveyMapTextureCreator* mMapTextureCreator;
-    bool mMapTextureNeedsUpdate;
 
     std::map<Ogre::String, SurveyMapEntity *> mNamedEntities;
     std::set<SurveyMapEntity *> mMapEntities;

--- a/source/main/terrain/map/SurveyMapTextureCreator.cpp
+++ b/source/main/terrain/map/SurveyMapTextureCreator.cpp
@@ -31,7 +31,7 @@ using namespace RoR;
 
 int SurveyMapTextureCreator::mCounter = 0;
 
-SurveyMapTextureCreator::SurveyMapTextureCreator(Ogre::Vector3 terrain_size) :
+SurveyMapTextureCreator::SurveyMapTextureCreator(Ogre::Vector2 terrain_size) :
     mCamera(nullptr)
     , mRttTex(nullptr)
     , mStatics(nullptr)
@@ -104,7 +104,7 @@ void SurveyMapTextureCreator::update()
     }
 
     float orthoWindowWidth = mMapSize.x - (mMapSize.x - 20.0f) * mMapZoom;
-    float orthoWindowHeight = mMapSize.z - (mMapSize.z - 20.0f) * mMapZoom;
+    float orthoWindowHeight = mMapSize.y - (mMapSize.y - 20.0f) * mMapZoom;
 
     mCamera->setFarClipDistance(mMapSize.y + 3.0f);
     mCamera->setOrthoWindow(orthoWindowWidth, orthoWindowHeight);

--- a/source/main/terrain/map/SurveyMapTextureCreator.h
+++ b/source/main/terrain/map/SurveyMapTextureCreator.h
@@ -28,7 +28,7 @@ class SurveyMapTextureCreator : public Ogre::RenderTargetListener, public Zeroed
 {
 public:
 
-    SurveyMapTextureCreator(Ogre::Vector3 terrain_size);
+    SurveyMapTextureCreator(Ogre::Vector2 terrain_size);
 
     Ogre::String getMaterialName();
     Ogre::String getCameraName();
@@ -54,7 +54,7 @@ protected:
 
     Ogre::Real mMapZoom;
     Ogre::Vector2 mMapCenter;
-    Ogre::Vector3 mMapSize;
+    Ogre::Vector2 mMapSize;
 
     static int mCounter;
 };


### PR DESCRIPTION
Reason for the bug: `mMapTextureCreator->update()` was called too early.
- Removed obsolete methods
- Removed `mMapTextureNeedsUpdate` logic