### PR TITLE
Interactive truck reset fix

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -731,6 +731,10 @@ void SimController::UpdateInputEvents(float dt)
         {
             if (m_player_actor) // we are in a vehicle
             {
+                if (!RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
+                {
+                    m_advanced_vehicle_repair_timer = 0.0f;
+                }
                 if (RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_RESET_TRUCK) && !m_player_actor->ar_replay_mode)
                 {
                     this->StopRaceTimer();
@@ -752,10 +756,6 @@ void SimController::UpdateInputEvents(float dt)
                     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
                     {
                         m_advanced_vehicle_repair = m_advanced_vehicle_repair_timer > 1.0f;
-                    }
-                    else
-                    {
-                        m_advanced_vehicle_repair_timer = 0.0f;
                     }
 
                     Vector3 translation = Vector3::ZERO;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1472,6 +1472,8 @@ void Actor::SyncReset(bool reset_position)
     }
 
     this->resetSlideNodes();
+
+    m_ongoing_reset = true;
 }
 
 bool Actor::ReplayStep()
@@ -4230,6 +4232,7 @@ Actor::Actor(
     , m_used_skin(rq.asr_skin)
     , ar_filename(rq.asr_filename)
     , m_actor_config(rq.asr_config)
+    , m_ongoing_reset(false)
 {
     m_high_res_wheelnode_collisions = App::sim_hires_wheel_col.GetActive();
     m_use_skidmarks = RoR::App::gfx_skidmarks_mode.GetActive() == 1;

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -474,6 +474,7 @@ private:
     RoR::Skidmark*    m_skid_trails[MAX_WHEELS*2];
     bool              m_antilockbrake;         //!< GUI state
     bool              m_tractioncontrol;       //!< GUI state
+    bool              m_ongoing_reset;         //!< Hack to prevent position/rotation creep during interactive truck reset
 
     bool m_hud_features_ok:1;      //!< Gfx state; Are HUD features matching actor's capabilities?
     bool m_slidenodes_locked:1;    //!< Physics state; Are SlideNodes locked?

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1192,6 +1192,7 @@ void ActorManager::UpdatePhysicsSimulation()
     }
     for (auto actor : m_actors)
     {
+        actor->m_ongoing_reset = false;
         if (!actor->ar_update_physics)
             continue;
         actor->postUpdatePhysics(m_physics_steps * PHYSICS_DT);

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1158,6 +1158,8 @@ void Actor::calcForcesEulerCompute(int step, int num_steps)
 
 bool Actor::CalcForcesEulerPrepare()
 {
+    if (m_ongoing_reset)
+        return false;
     if (ar_sim_state != Actor::SimState::LOCAL_SIMULATED)
         return false;
 


### PR DESCRIPTION
- Fixes position/rotation creep during interactive truck reset
- You no longer get stuck in the permanent interactive truck reset mode unintended