### PR TITLE
Improved 'Stall RPM' option parsing

### DIFF
--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -211,7 +211,7 @@ void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, floa
     m_post_shift_time = std::max(0.0f, m_post_shift_time);
     m_clutch_time = Math::Clamp(m_clutch_time, 0.0f, 0.9f * m_shift_time);
 
-    m_engine_stall_rpm = Math::Clamp(m_engine_stall_rpm, 0.0f, m_idle_rpm);
+    m_engine_stall_rpm = Math::Clamp(m_engine_stall_rpm, 0.0f, 0.9f * m_idle_rpm);
 
     if (etype == 'c')
     {

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -51,7 +51,7 @@ EngineSim::EngineSim(float _min_rpm, float _max_rpm, float torque, std::vector<f
     , m_engine_has_air(true)
     , m_engine_has_turbo(true)
     , m_hydropump_state(0.0f)
-    , m_idle_rpm(std::min(_min_rpm, 800.0f))
+    , m_idle_rpm(std::min(std::abs(_min_rpm), 800.0f))
     , m_engine_inertia(10.0f)
     , m_kickdown_delay_counter(0)
     , m_max_idle_mixture(0.2f)
@@ -207,15 +207,11 @@ void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, floa
     if (minimix > 0)
         m_min_idle_mixture = minimix;
 
-    m_clutch_time = std::max(0.0f, m_clutch_time);
     m_shift_time = std::max(0.0f, m_shift_time);
     m_post_shift_time = std::max(0.0f, m_post_shift_time);
+    m_clutch_time = Math::Clamp(m_clutch_time, 0.0f, 0.9f * m_shift_time);
 
-    m_clutch_time = std::min(m_clutch_time, m_shift_time * 0.9f);
-
-    m_idle_rpm = std::max(0.0f, m_idle_rpm);
-    m_engine_stall_rpm = std::max(0.0f, m_engine_stall_rpm);
-    m_engine_stall_rpm = std::min(m_idle_rpm, m_engine_stall_rpm);
+    m_engine_stall_rpm = Math::Clamp(m_engine_stall_rpm, 0.0f, m_idle_rpm);
 
     if (etype == 'c')
     {

--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -51,7 +51,7 @@ EngineSim::EngineSim(float _min_rpm, float _max_rpm, float torque, std::vector<f
     , m_engine_has_air(true)
     , m_engine_has_turbo(true)
     , m_hydropump_state(0.0f)
-    , m_idle_rpm(std::min(std::abs(_min_rpm), 800.0f))
+    , m_engine_idle_rpm(std::min(std::abs(_min_rpm), 800.0f))
     , m_engine_inertia(10.0f)
     , m_kickdown_delay_counter(0)
     , m_max_idle_mixture(0.2f)
@@ -199,7 +199,7 @@ void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, floa
     if (pstime > 0)
         m_post_shift_time = pstime;
     if (irpm > 0)
-        m_idle_rpm = irpm;
+        m_engine_idle_rpm = irpm;
     if (srpm > 0)
         m_engine_stall_rpm = srpm;
     if (maximix > 0)
@@ -211,7 +211,7 @@ void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, floa
     m_post_shift_time = std::max(0.0f, m_post_shift_time);
     m_clutch_time = Math::Clamp(m_clutch_time, 0.0f, 0.9f * m_shift_time);
 
-    m_engine_stall_rpm = Math::Clamp(m_engine_stall_rpm, 0.0f, 0.9f * m_idle_rpm);
+    m_engine_stall_rpm = Math::Clamp(m_engine_stall_rpm, 0.0f, 0.9f * m_engine_idle_rpm);
 
     if (etype == 'c')
     {
@@ -927,7 +927,7 @@ void EngineSim::SetWheelSpin(float rpm)
 // for hydros acceleration
 float EngineSim::GetCrankFactor()
 {
-    float minWorkingRPM = m_idle_rpm * 1.1f; // minWorkingRPM > m_idle_rpm avoids commands deadlocking the engine
+    float minWorkingRPM = m_engine_idle_rpm * 1.1f; // minWorkingRPM > m_engine_idle_rpm avoids commands deadlocking the engine
 
     float rpmRatio = (m_cur_engine_rpm - minWorkingRPM) / (m_engine_max_rpm - minWorkingRPM);
     rpmRatio = std::max(0.0f, rpmRatio); // Avoids a negative rpmRatio when m_cur_engine_rpm < minWorkingRPM
@@ -970,7 +970,7 @@ void EngineSim::StartEngine()
 {
     this->OffStart();
     m_starter_has_contact = true;
-    m_cur_engine_rpm = m_idle_rpm;
+    m_cur_engine_rpm = m_engine_idle_rpm;
     m_engine_is_running = true;
     if (m_auto_mode <= SEMIAUTO)
     {
@@ -1215,9 +1215,9 @@ float EngineSim::getAccToHoldRPM(float rpm)
 
 float EngineSim::getIdleMixture()
 {
-    if (m_cur_engine_rpm < m_idle_rpm)
+    if (m_cur_engine_rpm < m_engine_idle_rpm)
         // determine the fuel injection needed to counter the engine braking force
-        return Math::Clamp(getAccToHoldRPM(m_idle_rpm), m_min_idle_mixture, m_max_idle_mixture);
+        return Math::Clamp(getAccToHoldRPM(m_engine_idle_rpm), m_min_idle_mixture, m_max_idle_mixture);
 
     return 0.0f;
 }

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -90,7 +90,7 @@ public:
     char           GetEngineType() const    { return m_engine_type; };
     float          getEngineTorque() const  { return m_engine_torque; };
     float          getBrakingTorque() const { return m_braking_torque; };
-    float          getIdleRPM() const       { return m_idle_rpm; };
+    float          getIdleRPM() const       { return m_engine_idle_rpm; };
     float          getMaxRPM() const        { return m_engine_max_rpm; };
     float          getMinRPM() const        { return m_engine_min_rpm; };
     int            getNumGears() const      { return m_gear_ratios.size() - 2; };
@@ -161,26 +161,26 @@ private:
     float          m_cur_clutch_torque;
 
     // Engine
-    bool           m_engine_is_electric;    //!< attribute
+    bool           m_engine_is_electric;    //!< Engine attribute
     bool           m_starter_has_contact;   //!< Engine state
     bool           m_engine_has_air;        //!< Engine attribute
     bool           m_engine_has_turbo;      //!< Engine attribute
     int            m_engine_turbo_mode;     //!< Engine attribute
     bool           m_engine_is_running;     //!< Engine state
     char           m_engine_type;           //!< Engine attribute {'t' = truck (default), 'c' = car}
-    float          m_braking_torque;        //!< Engine
+    float          m_braking_torque;        //!< Engine attribute
     float          m_cur_acc;               //!< Engine
     float          m_cur_engine_rpm;        //!< Engine
     float          m_diff_ratio;            //!< Engine
-    float          m_engine_torque;         //!< Engine
+    float          m_engine_torque;         //!< Engine attribute
     float          m_hydropump_state;       //!< Engine
-    float          m_idle_rpm;              //!< Engine attribute
     float          m_min_idle_mixture;      //!< Engine attribute
     float          m_max_idle_mixture;      //!< Engine attribute
     float          m_engine_inertia;        //!< Engine attribute
     float          m_engine_max_rpm;        //!< Engine attribute
     float          m_engine_min_rpm;        //!< Engine attribute
-    float          m_engine_stall_rpm;      //!< Engine
+    float          m_engine_idle_rpm;       //!< Engine attribute
+    float          m_engine_stall_rpm;      //!< Engine attribute
     bool           m_engine_is_priming;     //!< Engine
     TorqueCurve*   m_torque_curve;
     float          m_air_pressure;

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -4938,6 +4938,11 @@ void ActorSpawner::ProcessEngoption(RigDef::Engoption & def)
         }
     }
 
+    if (engoption->idle_rpm > 0 && engoption->stall_rpm > 0 && engoption->stall_rpm > engoption->idle_rpm)
+    {
+        AddMessage(Message::TYPE_WARNING, "Stall RPM is set higher than Idle RPM.");
+    }
+
     /* Process it */
     m_actor->ar_engine->SetEngineOptions(
         engoption->inertia,


### PR DESCRIPTION
Fixes trucks like the `international-4400-single-axle-rollback.truck` which define a stall rpm higher than the idle rpm.