### PR TITLE
Simplified collision state update logic

### DIFF
--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -59,8 +59,8 @@ struct node_t
 
     Ogre::Vector3 initial_pos;
 
-    ground_model_t* nd_collision_gm;         //!< Physics state; last collision 'ground model' (surface definition)
-    float           nd_collision_slip;       //!< Physics state; last collision slip velocity
+    ground_model_t* nd_last_collision_gm;    //!< Physics state; last collision 'ground model' (surface definition)
+    float           nd_last_collision_slip;  //!< Physics state; last collision slip velocity
     int8_t          nd_coll_bbox_id;         //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
 
     // Bit flags
@@ -70,6 +70,6 @@ struct node_t
     bool            nd_no_mouse_grab:1;      //!< Attr; User-defined
     bool            nd_contacter:1;          //!< Attr; This node is part of collision triangle
     bool            nd_no_ground_contact:1;  //!< User-defined attr; node ignores contact with ground
-    bool            nd_has_contact:1;        //!< Physics state
+    bool            nd_has_ground_contact:1; //!< Physics state
     bool            nd_under_water:1;        //!< State; GFX hint
 };

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -586,21 +586,21 @@ void RoR::GfxActor::UpdateParticles(float dt_sec)
         }
 
         // Ground collision (dust, sparks, tyre smoke, clumps...)
-        if (n.nd_collision_gm != nullptr && !nfx.nx_no_particles)
+        if (!nfx.nx_no_particles && n.nd_has_ground_contact && n.nd_last_collision_gm != nullptr)
         {
-            switch (n.nd_collision_gm->fx_type)
+            switch (n.nd_last_collision_gm->fx_type)
             {
             case Collisions::FX_DUSTY:
                 if (m_particles_misc != nullptr)
                 {
-                    m_particles_misc->malloc(n.AbsPosition, n.Velocity / 2.0, n.nd_collision_gm->fx_colour);
+                    m_particles_misc->malloc(n.AbsPosition, n.Velocity / 2.0, n.nd_last_collision_gm->fx_colour);
                 }
                 break;
 
             case Collisions::FX_CLUMPY:
                 if (m_particles_clump != nullptr && n.Velocity.squaredLength() > 1.f)
                 {
-                    m_particles_clump->allocClump(n.AbsPosition, n.Velocity / 2.0, n.nd_collision_gm->fx_colour);
+                    m_particles_clump->allocClump(n.AbsPosition, n.Velocity / 2.0, n.nd_last_collision_gm->fx_colour);
                 }
                 break;
 
@@ -608,9 +608,9 @@ void RoR::GfxActor::UpdateParticles(float dt_sec)
                 if (n.iswheel != 0) // This is a wheel => skidmarks and tyre smoke
                 {
                     const float SKID_THRESHOLD = 10.f;
-                    if (n.nd_collision_slip > SKID_THRESHOLD)
+                    if (n.nd_last_collision_slip > SKID_THRESHOLD)
                     {
-                        SOUND_MODULATE(m_actor, SS_MOD_SCREETCH, (n.nd_collision_slip - SKID_THRESHOLD) / SKID_THRESHOLD);
+                        SOUND_MODULATE(m_actor, SS_MOD_SCREETCH, (n.nd_last_collision_slip - SKID_THRESHOLD) / SKID_THRESHOLD);
                         SOUND_PLAY_ONCE(m_actor, SS_TRIG_SCREETCH);
                         
                         if (m_particles_misc != nullptr)
@@ -621,7 +621,7 @@ void RoR::GfxActor::UpdateParticles(float dt_sec)
                 }
                 else // Not a wheel => sparks
                 {
-                    if ((!nfx.nx_no_sparks) && (n.nd_collision_slip > 1.f) && (m_particles_sparks != nullptr))
+                    if ((!nfx.nx_no_sparks) && (n.nd_last_collision_slip > 1.f) && (m_particles_sparks != nullptr))
                     {
                         m_particles_sparks->allocSparks(n.AbsPosition, n.Velocity);
                     }

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2591,12 +2591,12 @@ void Actor::updateSkidmarks()
         {
             const float SKID_THRESHOLD = 10.f;
             auto n = ar_wheels[i].wh_nodes[j];
-            if (n && n->nd_collision_gm != nullptr &&
-                    n->nd_collision_gm->fx_type == Collisions::FX_HARD && n->nd_collision_slip > SKID_THRESHOLD)
+            if (n && n->nd_has_ground_contact && n->nd_last_collision_gm != nullptr &&
+                    n->nd_last_collision_gm->fx_type == Collisions::FX_HARD && n->nd_last_collision_slip > SKID_THRESHOLD)
             {
-                ar_wheels[i].lastSlip = n->nd_collision_slip;
+                ar_wheels[i].lastSlip = n->nd_last_collision_slip;
                 ar_wheels[i].lastContactPoint= n->AbsPosition;
-                ar_wheels[i].lastGroundModelName = n->nd_collision_gm->name;
+                ar_wheels[i].lastGroundModelName = n->nd_last_collision_gm->name;
 
                 m_skid_trails[i]->update();
                 return;

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1591,22 +1591,14 @@ void Actor::CalcNodes()
         if (!ar_nodes[i].nd_no_ground_contact)
         {
             ar_nodes[i].collTestTimer += dt;
-            if (ar_nodes[i].nd_has_contact || ar_nodes[i].collTestTimer > 0.005 || ((ar_nodes[i].iswheel || ar_nodes[i].wheelid != -1) && (m_high_res_wheelnode_collisions || ar_nodes[i].collTestTimer > 0.0025)) || m_increased_accuracy)
+            if (ar_nodes[i].nd_has_ground_contact || ar_nodes[i].collTestTimer > 0.005 || ((ar_nodes[i].iswheel || ar_nodes[i].wheelid != -1) && (m_high_res_wheelnode_collisions || ar_nodes[i].collTestTimer > 0.0025)) || m_increased_accuracy)
             {
-                float ns = 0;
-                ground_model_t* gm = nullptr; // this is used as result storage, so we can use it later on
-                bool contacted = gEnv->collisions->groundCollision(&ar_nodes[i], ar_nodes[i].collTestTimer, &gm, &ns);
-                // reverted this construct to the old form, don't mess with it, the binary operator is intentionally!
-                if (contacted | gEnv->collisions->nodeCollision(&ar_nodes[i], contacted, ar_nodes[i].collTestTimer, &ns, &gm))
+                bool contacted = gEnv->collisions->groundCollision(&ar_nodes[i], ar_nodes[i].collTestTimer);
+                contacted = contacted | gEnv->collisions->nodeCollision(&ar_nodes[i], ar_nodes[i].collTestTimer);
+                ar_nodes[i].nd_has_ground_contact = contacted;
+                if (contacted)
                 {
-                    m_last_fuzzy_ground_model = gm;
-                    ar_nodes[i].nd_collision_gm = gm;
-                    ar_nodes[i].nd_collision_slip = ns;
-                }
-                else
-                {
-                    ar_nodes[i].nd_collision_gm = nullptr;
-                    ar_nodes[i].nd_collision_slip = 0.f;
+                    m_last_fuzzy_ground_model = ar_nodes[i].nd_last_collision_gm;
                 }
                 ar_nodes[i].collTestTimer = 0.0;
             }

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -164,10 +164,10 @@ public:
     eventsource_t* isTruckInEventBox(Actor* truck);
 
     bool collisionCorrect(Ogre::Vector3* refpos, bool envokeScriptCallbacks = true);
-    bool groundCollision(node_t* node, float dt, ground_model_t** gm, float* nso = 0);
+    bool groundCollision(node_t* node, float dt);
     bool isInside(Ogre::Vector3 pos, const Ogre::String& inst, const Ogre::String& box, float border = 0);
     bool isInside(Ogre::Vector3 pos, collision_box_t* cbox, float border = 0);
-    bool nodeCollision(node_t* node, bool contacted, float dt, float* nso, ground_model_t** ogm);
+    bool nodeCollision(node_t* node, float dt);
 
     void clearEventCache();
     void finishLoadingTerrain();
@@ -186,7 +186,6 @@ public:
     std::map<Ogre::String, ground_model_t>* getGroundModels() { return &ground_models; };
     void setupLandUse(const char* configfile);
     ground_model_t* getGroundModelByString(const Ogre::String name);
-    ground_model_t* last_used_ground_model;
 
     void getMeshInformation(Ogre::Mesh* mesh, size_t& vertex_count, Ogre::Vector3* & vertices,
         size_t& index_count, unsigned* & indices,
@@ -194,4 +193,4 @@ public:
         const Ogre::Quaternion& orient = Ogre::Quaternion::IDENTITY, const Ogre::Vector3& scale = Ogre::Vector3::UNIT_SCALE);
 };
 
-void primitiveCollision(node_t* node, Ogre::Vector3& force, const Ogre::Vector3& velocity, const Ogre::Vector3& normal, float dt, ground_model_t* gm, float* nso, float penetration = 0, float reaction = -1.0f);
+void primitiveCollision(node_t* node, Ogre::Vector3& force, const Ogre::Vector3& velocity, const Ogre::Vector3& normal, float dt, ground_model_t* gm, float penetration = 0, float reaction = -1.0f);

--- a/source/main/physics/collision/DynamicCollisions.cpp
+++ b/source/main/physics/collision/DynamicCollisions.cpp
@@ -125,10 +125,9 @@ void ResolveCollisionForces(const float penetration_depth,
     const float fl = (vi + trfnormal - pfnormal) * 0.5f;
 
     auto forcevec = Vector3::ZERO;
-    float nso;  // TODO unused
 
     //Calculate the collision forces
-    primitiveCollision(&hitnode, forcevec, vecrelVel, normal, ((float) dt), &submesh_ground_model, &nso, penetration_depth, fl);
+    primitiveCollision(&hitnode, forcevec, vecrelVel, normal, ((float) dt), &submesh_ground_model, penetration_depth, fl);
 
     // apply resulting collision force
     hitnode.Forces += forcevec;


### PR DESCRIPTION
Both `nd_last_collision_gm` and `nd_last_collision_slip` are currently used exclusively for GFX effects due to ground collisions.