### PR TITLE
Much improved automatic camera reference generation

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -349,33 +349,14 @@ void Actor::moveOrigin(Vector3 offset)
 
 float Actor::getRotation()
 {
-    Vector3 cur_dir = getDirection();
+    Vector3 dir = getDirection();
 
-    return atan2(cur_dir.dotProduct(Vector3::UNIT_X), cur_dir.dotProduct(-Vector3::UNIT_Z));
+    return atan2(dir.dotProduct(Vector3::UNIT_X), dir.dotProduct(-Vector3::UNIT_Z));
 }
 
 Vector3 Actor::getDirection()
 {
-    Vector3 cur_dir = this->GetCameraDir();
-
-    if (cur_dir == Vector3::ZERO)
-    {
-        float max_dist = 0.0f;
-        int furthest_node = 1;
-        for (int i = 0; i < ar_num_nodes; i++)
-        {
-            float dist = ar_nodes[i].RelPosition.squaredDistance(ar_nodes[0].RelPosition);
-            if (dist > max_dist)
-            {
-                max_dist = dist;
-                furthest_node = i;
-            }
-        }
-        cur_dir = ar_nodes[0].RelPosition - ar_nodes[furthest_node].RelPosition;
-        cur_dir.normalise();
-    }
-
-    return cur_dir;
+    return ar_main_camera_dir_corr * this->GetCameraDir();
 }
 
 Vector3 Actor::getPosition()
@@ -4193,6 +4174,7 @@ Actor::Actor(
     , ar_lights(1)
     , m_avg_node_velocity(Ogre::Vector3::ZERO)
     , ar_custom_camera_node(-1)
+    , ar_main_camera_dir_corr(Ogre::Quaternion::IDENTITY)
     , ar_main_camera_node_pos(0)
     , ar_main_camera_node_dir(0)
     , ar_main_camera_node_roll(0)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -290,6 +290,7 @@ public:
     float             ar_speedo_max_kph;           //!< GUI attr
     Ogre::Vector3     ar_origin;                   //!< Physics state; base position for softbody nodes
     int               ar_num_cameras;
+    Ogre::Quaternion  ar_main_camera_dir_corr;     //!< Sim attr;
     int               ar_main_camera_node_pos;     //!< Sim attr; ar_camera_node_pos[0]  >= 0 ? ar_camera_node_pos[0]  : 0
     int               ar_main_camera_node_dir;     //!< Sim attr; ar_camera_node_dir[0]  >= 0 ? ar_camera_node_dir[0]  : 0
     int               ar_main_camera_node_roll;    //!< Sim attr; ar_camera_node_roll[0] >= 0 ? ar_camera_node_roll[0] : 0

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -452,6 +452,27 @@ void ActorSpawner::FinalizeRig()
     m_actor->ar_main_camera_node_dir  = std::max(0, m_actor->ar_camera_node_dir[0]);
     m_actor->ar_main_camera_node_roll = std::max(0, m_actor->ar_camera_node_roll[0]);
 
+    if (m_actor->ar_main_camera_node_dir == 0)
+    {
+        // Step 1: Find a suitable camera node dir
+        float max_dist = 0.0f;
+        int furthest_node = 0;
+        for (int i = 0; i < m_actor->ar_num_nodes; i++)
+        {
+            float dist = m_actor->ar_nodes[i].RelPosition.squaredDistance(m_actor->ar_nodes[0].RelPosition);
+            if (dist > max_dist)
+            {
+                max_dist = dist;
+                furthest_node = i;
+            }
+        }
+        m_actor->ar_main_camera_node_dir = furthest_node;
+        // Step 2: Correct the misalignment
+        Ogre::Vector3 dir = m_actor->ar_nodes[furthest_node].RelPosition - m_actor->ar_nodes[0].RelPosition;
+        float offset = atan2(dir.dotProduct(Ogre::Vector3::UNIT_Z), dir.dotProduct(Ogre::Vector3::UNIT_X));
+        m_actor->ar_main_camera_dir_corr = Ogre::Quaternion(Ogre::Radian(offset), Ogre::Vector3::UNIT_Y);
+    }
+
     if (m_actor->ar_camera_node_pos[0] > 0)
     {
         // store the y-difference between the trucks lowest node and the campos-node for the gwps system


### PR DESCRIPTION
Instead of trying to find an appropriate dir node each time getDirection() is called we now precalculate it, together with a quaternion that fixes the axis alignment.

This greatly improves the interactive truck reset feature and the camera alignment on loads without a cinecam.