### PR TITLE
Much improved mesh collision performance

### DIFF
--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -88,6 +88,7 @@ private:
         Ogre::Vector3 a;
         Ogre::Vector3 b;
         Ogre::Vector3 c;
+        Ogre::AxisAlignedBox aab;
         Ogre::Matrix3 forward;
         Ogre::Matrix3 reverse;
         ground_model_t* gm;


### PR DESCRIPTION
Performance was literally lying on the ground waiting to be picked up. :man_facepalming:

This simply hides the costly matrix multiplication behind a bounding box check.

| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/9437207/46875539-35c0fd80-ce3c-11e8-9cba-ed062a33ee23.jpg) | ![after](https://user-images.githubusercontent.com/9437207/46875542-36f22a80-ce3c-11e8-8210-65688fdfb13e.jpg) |