### PR TITLE
Fixed FPS drop on train spawners

### DIFF
--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -111,7 +111,7 @@ private:
 
     // collision boxes pool
     std::vector<collision_box_t> m_collision_boxes; // Formerly MAX_COLLISION_BOXES = 5000
-    collision_box_t* m_last_called_cbox;
+    std::vector<collision_box_t*> m_last_called_cboxes;
 
     // collision tris pool;
     std::vector<collision_tri_t> m_collision_tris; // Formerly MAX_COLLISION_TRIS = 100000


### PR DESCRIPTION
Shamelessly based on the idea of @only-a-ptr:
> Exactly. We need to use something like std::unordered_set<collision_box_t*> m_occupied_collision_boxes

Fixes: https://github.com/RigsOfRods/rigs-of-rods/issues/1627