### PR TITLE
Fixed a minor issue in the sleeping logic

### DIFF
--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -715,7 +715,10 @@ void ActorManager::UpdateSleepingState(Actor* player_actor, float dt)
             if (actor->ar_sim_state != Actor::SimState::LOCAL_SIMULATED)
                 continue;
             if (actor->getVelocity().squaredLength() > 0.01f)
+            {
+                actor->ar_sleep_counter = 0.0f;
                 continue;
+            }
 
             actor->ar_sleep_counter += dt;
 


### PR DESCRIPTION
The sleep counter should be reset if the average movement velocity reaches the threshold.