### PR TITLE
Fixed nasty bug in the idle mixture calculation

### DIFF
--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -1205,11 +1205,7 @@ float EngineSim::getEnginePower(float rpm)
 
 float EngineSim::getAccToHoldRPM(float rpm)
 {
-    float rpmRatio = rpm / (m_engine_max_rpm * 1.25f);
-
-    rpmRatio = std::min(rpmRatio, 1.0f);
-
-    return (-m_braking_torque * rpmRatio) / getEnginePower(m_cur_engine_rpm);
+    return (-m_braking_torque * rpm / m_engine_max_rpm) / getEnginePower(m_cur_engine_rpm);
 }
 
 float EngineSim::getIdleMixture()

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -55,12 +55,6 @@ void Actor::calcForcesEulerCompute(int step, int num_steps)
     IWater* water = App::GetSimTerrain()->getWater();
     const bool is_player_actor = (this == RoR::App::GetSimController()->GetPlayerActor());
 
-    //engine callback
-    if (ar_engine)
-    {
-        ar_engine->UpdateEngineSim(dt, doUpdate);
-    }
-
     this->CalcBeams(doUpdate);
 
     if (doUpdate)
@@ -1112,6 +1106,12 @@ void Actor::calcForcesEulerCompute(int step, int num_steps)
         {
             it->ti_tying = false;
         }
+    }
+
+    // Should happen after the shocks / commands / engine triggers are updated
+    if (ar_engine)
+    {
+        ar_engine->UpdateEngineSim(dt, doUpdate);
     }
 
     // we also store a new replay frame


### PR DESCRIPTION
The bug was hidden by the previous idle mixture logic (https://github.com/RigsOfRods/rigs-of-rods/commit/912be9ec1ecce946707db36232b944cad6408831)

This indirectly fixes the idle mixture calculation, which results in a correct idle rpm, which fixes the broken engine triggers. It also makes the rpm hold feature behave better.

In addition it prevents bad interaction between manual inputs and engine trigger inputs.