### PR TITLE
Submesh collision redesign

### DIFF
--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -57,9 +57,9 @@ void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
     MICROPROFILE_SCOPEI ("Actor", "calc Forces Euler Compute", MP_BLUE);
 
     if (doUpdate) this->ToggleHooks(-2, HOOK_LOCK, -1);
-    this->CalcBeams(doUpdate);
     this->UpdateSlideNodeForces(dt); // must be done before the integrator, or else the forces are not calculated properly
     this->CalcNodes();
+    this->CalcBeams(doUpdate);
     this->CalcAircraftForces(doUpdate);
     this->CalcFuseDrag();
     this->CalcBuoyance(doUpdate);

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -1357,19 +1357,12 @@ void ActorSpawner::ProcessSubmesh(RigDef::Submesh & def)
         m_actor->ar_cabs[m_actor->ar_num_cabs*3+1]=GetNodeIndexOrThrow(cab_itor->nodes[1]);
         m_actor->ar_cabs[m_actor->ar_num_cabs*3+2]=GetNodeIndexOrThrow(cab_itor->nodes[2]);
 
-        if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_c_CONTACT))
+        // TODO: Clean this up properly ~ ulteq 10/2018
+        if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_c_CONTACT) ||
+            BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_p_10xTOUGHER) ||
+            BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_u_INVULNERABLE))
         {
             m_actor->ar_collcabs[m_actor->ar_num_collcabs]=m_actor->ar_num_cabs;
-            m_actor->ar_num_collcabs++;
-        }
-        if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_p_10xTOUGHER))
-        {
-            m_actor->ar_collcabs[m_actor->ar_num_collcabs]=m_actor->ar_num_cabs; 
-            m_actor->ar_num_collcabs++;
-        }
-        if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_u_INVULNERABLE))
-        {
-            m_actor->ar_collcabs[m_actor->ar_num_collcabs]=m_actor->ar_num_cabs; 
             m_actor->ar_num_collcabs++;
         }
         if (BITMASK_IS_1(cab_itor->options, RigDef::Cab::OPTION_b_BUOYANT))

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -418,7 +418,7 @@ void Turboprop::updateForces(float dt, int doUpdate)
                 correctfactor = -1000.0;
             nodes[nodep[i]].Forces += totaltipforce + correctfactor * tipf;
         }
-        else
+        else if (!nodes[noderef].Velocity.isZeroLength())
         {
             //failed case
             //add drag

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -193,4 +193,4 @@ public:
         const Ogre::Quaternion& orient = Ogre::Quaternion::IDENTITY, const Ogre::Vector3& scale = Ogre::Vector3::UNIT_SCALE);
 };
 
-void primitiveCollision(node_t* node, Ogre::Vector3& force, const Ogre::Vector3& velocity, const Ogre::Vector3& normal, float dt, ground_model_t* gm, float penetration = 0, float reaction = -1.0f);
+Ogre::Vector3 primitiveCollision(node_t* node, Ogre::Vector3 velocity, float mass, Ogre::Vector3 normal, float dt, ground_model_t* gm, float penetration = 0);


### PR DESCRIPTION
This redesign aims to provide realistic submesh collisions. Realistic with respect to:
- Conservation of momentum
- Conservation of energy
- Friction

The previous collision model had serious design errors:
- The mass of the cab nodes was assumed to be always equal to the mass of the contacter. :man_facepalming:
- The order of execution was wrong. Collisions need to be resolved after 'CalcBeams' and before 'CalcNodes' or else friction won't work correctly.
:man_facepalming:
- The implementation of the cab options `p` and `u` was an expression of the purest stupidity.
:man_facepalming:
```
p: [ Version 0.36a+ ] Makes the force required to pierce the submesh ten times bigger.
u: [ Version 0.36a+ ] Makes it impossible to pierce the submesh.
```

This gets us rid of all the magic numbers in the collision code.

- [x] Fix airplane issue (Antonov 12, Piper J3, Skyvan, ...)
- [x] Find a solution for tracked vehicles
- [x] Clarify the `(sub-section) cab` options on the wiki page
- [x] Try to avoid duplicate code in `primitiveCollision` and `ResolveCollisionForces`