### PR TITLE
Fixed arcade control braking in reverse gear

### DIFF
--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -502,7 +502,7 @@ void LandVehicleSimulation::UpdateVehicle(Actor* vehicle, float seconds_since_la
                         vehicle->ar_brake = vehicle->ar_brake_force * sqrt(ratio);
                     }
                 }
-                else if (brake == 0.0f && !vehicle->ar_parking_brake && engine->GetTorque() == 0.0f)
+                else if (vehicle->ar_brake == 0.0f && !vehicle->ar_parking_brake && engine->GetTorque() == 0.0f)
                 {
                     float ratio = std::max(0.0f, 0.2f - std::abs(vehicle->ar_avg_wheel_speed)) / 0.2f;
                     vehicle->ar_brake = vehicle->ar_brake_force * ratio;


### PR DESCRIPTION
`brake` and `accl` have a reverse meaning in reverse gear if arcade controls are enabled.