### PR TITLE
✨ Added wheel debug info mode

### DIFF
--- a/resources/skeleton/config/input.map
+++ b/resources/skeleton/config/input.map
@@ -183,7 +183,8 @@ COMMON_RESCUE_TRUCK            Keyboard             EXPL+R
 COMMON_RESET_TRUCK             Keyboard             EXPL+I 
 COMMON_SCREENSHOT              Keyboard             SYSRQ 
 COMMON_SECURE_LOAD             Keyboard             O 
-COMMON_SHOW_SKELETON           Keyboard             K 
+COMMON_TOGGLE_DEBUG_VIEW       Keyboard             EXPL+K 
+COMMON_CYCLE_DEBUG_VIEWS       Keyboard             EXPL+CTRL+K 
 COMMON_TOGGLE_TERRAIN_EDITOR   Keyboard             EXPL+CTRL+Y 
 COMMON_TOGGLE_CUSTOM_PARTICLES Keyboard             G 
 COMMON_TOGGLE_MAT_DEBUG        Keyboard             EXPL+CTRL+SHIFT+F 

--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -58,8 +58,9 @@ struct node_t
 
     Ogre::Vector3 initial_pos;
 
+    Ogre::Vector3   nd_last_collision_slip;  //!< Physics state; last collision slip vector
+    Ogre::Vector3   nd_last_collision_force; //!< Physics state; last collision force
     ground_model_t* nd_last_collision_gm;    //!< Physics state; last collision 'ground model' (surface definition)
-    float           nd_last_collision_slip;  //!< Physics state; last collision slip velocity
     int8_t          nd_coll_bbox_id;         //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
 
     // Bit flags

--- a/source/main/datatypes/wheel_t.h
+++ b/source/main/datatypes/wheel_t.h
@@ -60,5 +60,13 @@ struct wheel_t
     float       wh_width;
     int         wh_detacher_group;
     bool        wh_is_detached;
+
+    // Debug
+    float debug_rpm;
+    float debug_torque;
+    Ogre::Vector3 debug_vel;
+    Ogre::Vector3 debug_slip;
+    Ogre::Vector3 debug_force;
+    Ogre::Vector3 debug_scaled_cforce;
 };
 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1049,9 +1049,18 @@ void SimController::UpdateInputEvents(float dt)
                         m_player_actor->ToggleCustomParticles();
                     }
 
-                    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_SHOW_SKELETON))
+                    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_DEBUG_VIEW))
                     {
-                        m_player_actor->GetGfxActor()->ToggleSkeletonView();
+                        m_player_actor->GetGfxActor()->ToggleDebugView();
+                        for (auto actor : m_player_actor->GetAllLinkedActors())
+                        {
+                            actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());
+                        }
+                    }
+
+                    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_CYCLE_DEBUG_VIEWS))
+                    {
+                        m_player_actor->GetGfxActor()->CycleDebugViews();
                         for (auto actor : m_player_actor->GetAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -66,6 +66,7 @@ RoR::GfxActor::GfxActor(Actor* actor, std::string ogre_resource_group,
     m_custom_resource_group(ogre_resource_group),
     m_vidcam_state(VideoCamState::VCSTATE_ENABLED_ONLINE),
     m_debug_view(DebugViewType::DEBUGVIEW_NONE),
+    m_last_debug_view(DebugViewType::DEBUGVIEW_SKELETON),
     m_rods_parent_scenenode(nullptr),
     m_gfx_nodes(gfx_nodes),
     m_props(props),
@@ -1058,23 +1059,32 @@ void RoR::GfxActor::UpdateDebugView()
     }
 }
 
-void RoR::GfxActor::ToggleSkeletonView()
+void RoR::GfxActor::ToggleDebugView()
 {
     if (m_debug_view == DebugViewType::DEBUGVIEW_NONE)
-        m_debug_view = DebugViewType::DEBUGVIEW_SKELETON;
+        m_debug_view = m_last_debug_view;
     else
         m_debug_view = DebugViewType::DEBUGVIEW_NONE;
+}
+
+void RoR::GfxActor::SetDebugView(DebugViewType dv)
+{
+    m_debug_view = dv;
+    if (dv != DebugViewType::DEBUGVIEW_NONE)
+    {
+        m_last_debug_view = dv;
+    }
 }
 
 void RoR::GfxActor::CycleDebugViews()
 {
     switch (m_debug_view)
     {
-    case DebugViewType::DEBUGVIEW_NONE:     m_debug_view = DebugViewType::DEBUGVIEW_SKELETON; break;
-    case DebugViewType::DEBUGVIEW_SKELETON: m_debug_view = DebugViewType::DEBUGVIEW_NODES;    break;
-    case DebugViewType::DEBUGVIEW_NODES:    m_debug_view = DebugViewType::DEBUGVIEW_BEAMS;    break;
-    case DebugViewType::DEBUGVIEW_BEAMS:    m_debug_view = DebugViewType::DEBUGVIEW_WHEELS;   break;
-    case DebugViewType::DEBUGVIEW_WHEELS:   m_debug_view = DebugViewType::DEBUGVIEW_NONE;     break;
+    case DebugViewType::DEBUGVIEW_NONE:     SetDebugView(DebugViewType::DEBUGVIEW_SKELETON); break;
+    case DebugViewType::DEBUGVIEW_SKELETON: SetDebugView(DebugViewType::DEBUGVIEW_NODES);    break;
+    case DebugViewType::DEBUGVIEW_NODES:    SetDebugView(DebugViewType::DEBUGVIEW_BEAMS);    break;
+    case DebugViewType::DEBUGVIEW_BEAMS:    SetDebugView(DebugViewType::DEBUGVIEW_WHEELS);   break;
+    case DebugViewType::DEBUGVIEW_WHEELS:   SetDebugView(DebugViewType::DEBUGVIEW_SKELETON); break;
     default:;
     }
 }

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -79,6 +79,7 @@ public:
         DEBUGVIEW_SKELETON,
         DEBUGVIEW_NODES,
         DEBUGVIEW_BEAMS,
+        DEBUGVIEW_WHEELS,
     };
 
     /// An Ogre::Camera mounted on the actor and rendering into

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -279,7 +279,7 @@ public:
     void                      SetAllMeshesVisible(bool value);
     void                      SetCastShadows     (bool value);
     void                      UpdateDebugView    ();
-    void                      ToggleSkeletonView ();
+    void                      ToggleDebugView    ();
     void                      CycleDebugViews    ();
     void                      UpdateCabMesh      ();
     int                       GetActorId         () const;
@@ -292,8 +292,8 @@ public:
     void                      UpdateCParticles   ();
     void                      UpdateAeroEngines  ();
     void                      UpdateNetLabels    (float dt);
+    void                      SetDebugView       (DebugViewType dv);
     void                      AddFlexbody        (FlexBody* fb)           { m_flexbodies.push_back(fb); }
-    inline void               SetDebugView       (DebugViewType dv)       { m_debug_view = dv; }
     Attributes&               GetAttributes      ()                       { return m_attr; }
     inline Ogre::MaterialPtr& GetCabTransMaterial()                       { return m_cab_mat_visual_trans; }
     inline VideoCamState      GetVideoCamState   () const                 { return m_vidcam_state; }
@@ -321,6 +321,7 @@ private:
     VideoCamState               m_vidcam_state;
     std::vector<VideoCamera>    m_videocameras;
     DebugViewType               m_debug_view;
+    DebugViewType               m_last_debug_view;
     std::vector<NodeGfx>        m_gfx_nodes;
     std::vector<AirbrakeGfx>    m_gfx_airbrakes;
     std::vector<prop_t>         m_props;

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -356,6 +356,7 @@ void RoR::GUI::TopMenubar::Update()
                 ImGui::RadioButton("Skeleton view", &debug_view_type,  static_cast<int>(GfxActor::DebugViewType::DEBUGVIEW_SKELETON));
                 ImGui::RadioButton("Node details",  &debug_view_type,  static_cast<int>(GfxActor::DebugViewType::DEBUGVIEW_NODES));
                 ImGui::RadioButton("Beam details",  &debug_view_type,  static_cast<int>(GfxActor::DebugViewType::DEBUGVIEW_BEAMS));
+                ImGui::RadioButton("Wheel details",  &debug_view_type,  static_cast<int>(GfxActor::DebugViewType::DEBUGVIEW_WHEELS));
 
                 if ((current_actor != nullptr) && (debug_view_type != static_cast<int>(current_actor->GetGfxActor()->GetDebugView())))
                 {

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -345,7 +345,8 @@ void RoR::GUI::TopMenubar::Update()
                 ImGui::Separator();
 
                 ImGui::TextColored(GRAY_HINT_TEXT, "Live diagnostic views:");
-                ImGui::TextColored(GRAY_HINT_TEXT, "(Use 'K' hotkey to toggle)"); // !!TODO!! - display actual configured hotkey (EV_COMMON_SHOW_SKELETON)
+                ImGui::TextColored(GRAY_HINT_TEXT, "(Toggle with 'K')"); // !!TODO!! - display actual configured hotkey (EV_COMMON_TOGGLE_DEBUG_VIEW)
+                ImGui::TextColored(GRAY_HINT_TEXT, "(Cycle with 'CTRL+K')"); // !!TODO!! - display actual configured hotkey (EV_COMMON_CYCLE_DEBUG_VIEWS)
 
                 int debug_view_type = static_cast<int>(GfxActor::DebugViewType::DEBUGVIEW_NONE);
                 if (current_actor != nullptr)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2556,12 +2556,13 @@ void Actor::updateSkidmarks()
 
         for (int j = 0; j < ar_wheels[i].wh_num_nodes; j++)
         {
-            const float SKID_THRESHOLD = 10.f;
             auto n = ar_wheels[i].wh_nodes[j];
+            const float SKID_THRESHOLD = 10.f;
+            const float slipv = n->nd_last_collision_slip.length();
             if (n && n->nd_has_ground_contact && n->nd_last_collision_gm != nullptr &&
-                    n->nd_last_collision_gm->fx_type == Collisions::FX_HARD && n->nd_last_collision_slip > SKID_THRESHOLD)
+                    n->nd_last_collision_gm->fx_type == Collisions::FX_HARD && slipv > SKID_THRESHOLD)
             {
-                m_skid_trails[i]->update(n->AbsPosition, n->nd_last_collision_slip, n->nd_last_collision_gm->name);
+                m_skid_trails[i]->update(n->AbsPosition, slipv, n->nd_last_collision_gm->name);
                 return;
             }
         }

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -1234,7 +1234,8 @@ void primitiveCollision(node_t *node, Vector3 &force, const Vector3 &velocity, c
             }
             if (Freaction < 0) Freaction = 0.0f;
             // We only update this if we handle ground collisions
-            node->nd_last_collision_slip = slipv;
+            node->nd_last_collision_slip = slipv * slip;
+            node->nd_last_collision_force = std::min(Fnormal, 0.0f) * normal;
         } else
         {
             Freaction = reaction;

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -1028,10 +1028,16 @@ eventInfo_t eventInfo[] = {
         _L("tie a load to the truck")
     },
     {
-        "COMMON_SHOW_SKELETON", // TODO: rename. Re-purposed to cycle debug view
-        EV_COMMON_SHOW_SKELETON,
-        "Keyboard K",
-        _L("toggle skeleton display mode")
+        "COMMON_TOGGLE_DEBUG_VIEW",
+        EV_COMMON_TOGGLE_DEBUG_VIEW,
+        "Keyboard EXPL+K",
+        _L("toggle debug view")
+    },
+    {
+        "COMMON_CYCLE_DEBUG_VIEWS",
+        EV_COMMON_CYCLE_DEBUG_VIEWS,
+        "Keyboard EXPL+CTRL+K",
+        _L("cycle debug views")
     },
     {
         "COMMON_TOGGLE_TERRAIN_EDITOR",

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -245,7 +245,8 @@ enum events
     EV_COMMON_SCREENSHOT_BIG, //!< take a BIG screenshot
     EV_COMMON_SECURE_LOAD, //!< tie a load to the truck
     EV_COMMON_SEND_CHAT, //!< send the chat text
-    EV_COMMON_SHOW_SKELETON, //!< toggle skeleton display mode
+    EV_COMMON_TOGGLE_DEBUG_VIEW, //!< toggle debug view mode
+    EV_COMMON_CYCLE_DEBUG_VIEWS, //!< cycle debug view mode
     EV_COMMON_TOGGLE_TERRAIN_EDITOR, //!< toggle terrain editor
     EV_COMMON_TOGGLE_CUSTOM_PARTICLES, //!< toggle particle cannon
     EV_COMMON_TOGGLE_MAT_DEBUG, //!< debug purpose - dont use


### PR DESCRIPTION
Adds a wheel debug view mode:
- Reference arm system (including reaction forces)
- Wheel speed
- Torque
- Slip

Adds keyboard shortcuts:
- `COMMON_TOGGLE_DEBUG_VIEW` -> On/Off toggle for the current debug view
- `COMMON_CYCLE_DEBUG_VIEWS` -> Cycles through the different debug view modes

Removes keyboard shortcut:
- `COMMON_SHOW_SKELETON` -> On/Off toggle for the skeleton debug view

![unimog_406_wheel_debug_info-2-small](https://user-images.githubusercontent.com/9437207/47392281-719d7200-d71c-11e8-8ff7-921f256fae12.jpg)