### PR TITLE
Unified existing drivetrain code

### DIFF
--- a/source/main/datatypes/wheel_t.h
+++ b/source/main/datatypes/wheel_t.h
@@ -53,6 +53,7 @@ struct wheel_t
     Ogre::Real  wh_antilock_coef;
     Ogre::Real  wh_tc_coef;
     Ogre::Real  wh_delta_rotation;    ///< Difference in wheel position
+    Ogre::Real  wh_torque;
     float       wh_net_rp;
     float       wh_net_rp1;           //<! Networking; triple buffer
     float       wh_net_rp2;           //<! Networking; triple buffer

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -474,6 +474,7 @@ private:
     bool              m_antilockbrake;         //!< GUI state
     bool              m_tractioncontrol;       //!< GUI state
     bool              m_ongoing_reset;         //!< Hack to prevent position/rotation creep during interactive truck reset
+    bool              m_has_axles_section;     //!< Temporary (legacy parsing helper) until central diffs are implemented
 
     bool m_hud_features_ok:1;      //!< Gfx state; Are HUD features matching actor's capabilities?
     bool m_slidenodes_locked:1;    //!< Physics state; Are SlideNodes locked?

--- a/source/main/physics/Differentials.h
+++ b/source/main/physics/Differentials.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <OgreUTFString.h>
 #include <vector>
 
 struct DifferentialData
@@ -36,6 +35,7 @@ enum DiffType
 {
     SPLIT_DIFF = 0,
     OPEN_DIFF,
+    VISCOUS_DIFF,
     LOCKED_DIFF,
     INVALID_DIFF
 };
@@ -57,6 +57,7 @@ public:
     
     static void      CalcSeparateDiff(DifferentialData& diff_data);  //!< a differential that always splits the torque evenly, this is the original method
     static void      CalcOpenDiff(DifferentialData& diff_data );     //!< more power goes to the faster spining wheel
+    static void      CalcViscousDiff(DifferentialData& diff_data );  //!< more power goes to the slower spining wheel
     static void      CalcLockedDiff(DifferentialData& diff_data );   //!< ensures both wheels rotate at the the same speed
 
 private:

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -452,6 +452,8 @@ void ActorSpawner::FinalizeRig()
     m_actor->ar_main_camera_node_dir  = std::max(0, m_actor->ar_camera_node_dir[0]);
     m_actor->ar_main_camera_node_roll = std::max(0, m_actor->ar_camera_node_roll[0]);
     
+    m_actor->m_has_axles_section = m_actor->m_num_axles > 0;
+
     if (m_actor->m_num_proped_wheels > 0)
     {
         float proped_wheels_radius_sum = 0.0f;
@@ -463,6 +465,25 @@ void ActorSpawner::FinalizeRig()
             }
         }
         m_actor->m_avg_proped_wheel_radius = proped_wheels_radius_sum / m_actor->m_num_proped_wheels;
+
+        // Automatically build axles from proped wheel pairs
+        if (m_actor->m_num_axles == 0)
+        {
+            for (int i = 1; i < m_actor->m_num_proped_wheels; i++)
+            {
+                if (i % 2)
+                {
+                    Axle *axle = new Axle();
+
+                    axle->ax_wheel_1 = m_actor->m_proped_wheel_pairs[i - 1];
+                    axle->ax_wheel_2 = m_actor->m_proped_wheel_pairs[i - 0];
+                    axle->AddDifferentialType(VISCOUS_DIFF);
+
+                    m_actor->m_axles[m_actor->m_num_axles] = axle;
+                    m_actor->m_num_axles++;
+                }
+            }
+        }
     }
 
     if (m_actor->ar_main_camera_node_dir == 0)


### PR DESCRIPTION
This unifies the old-style and new-style drivetrain code.

- Viscous mode is used by default when no axles section is present
- Axles are now built in the RigSpawner if no axles section is present
- Engine torque is still doubled when an axles section is present
- Wheel and axles code is now cleanly separated