### PR TITLE
Fixed the auto locking mechanism

### DIFF
--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1117,6 +1117,13 @@ void ActorManager::UpdatePhysicsSimulation()
                 }
             }
             gEnv->threadPool->Parallelize(tasks);
+            for (auto actor : m_actors)
+            {
+                if (actor->ar_update_physics)
+                {
+                    actor->CalcBeamsInterActor();
+                }
+            }
         }
         {
             std::vector<std::function<void()>> tasks;

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -59,7 +59,7 @@ void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
     if (doUpdate) this->ToggleHooks(-2, HOOK_LOCK, -1);
     this->UpdateSlideNodeForces(dt); // must be done before the integrator, or else the forces are not calculated properly
     this->CalcNodes();
-    this->CalcBeams(doUpdate);
+    this->CalcReplay();
     this->CalcAircraftForces(doUpdate);
     this->CalcFuseDrag();
     this->CalcBuoyance(doUpdate);
@@ -72,7 +72,7 @@ void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
     this->CalcTruckEngine(doUpdate); // must be done after the commands / engine triggers are updated
     this->CalcMouse();
     this->CalcForceFeedback(doUpdate);
-    this->CalcReplay();
+    this->CalcBeams(doUpdate);
 }
 
 void Actor::CalcForceFeedback(bool doUpdate)
@@ -1139,7 +1139,6 @@ bool Actor::CalcForcesEulerPrepare()
 
     this->CalcHooks();
     this->CalcRopes();
-    this->CalcBeamsInterActor();
 
     return true;
 }


### PR DESCRIPTION
This workaround is required because we had to change the execution order of 'calcNodes' and 'calcBeams' in https://github.com/RigsOfRods/rigs-of-rods/pull/1661/commits/212a0a97a6b7735ad0a7a4037c44fc195d820dff

Test procedure: Stack two 20ft Containers on top of each other and watch the beam debug view.