### PR TITLE
Expanded the transfercase section

### DIFF
--- a/source/main/physics/Differentials.h
+++ b/source/main/physics/Differentials.h
@@ -34,15 +34,15 @@ struct DifferentialData
 class TransferCase
 {
 public:
-    TransferCase(int a1, int a2, float gr, bool has_2wd_lo):
-        tr_ax_1(a1), tr_ax_2(a2), tr_4wd_mode(false), tr_lo_mode(false), tr_2wd_lo(has_2wd_lo), tr_gear_ratio(gr) {};
+    TransferCase(int a1, int a2, bool has_2wd, bool has_2wd_lo, std::vector<float> grs):
+        tr_ax_1(a1), tr_ax_2(a2), tr_2wd(has_2wd), tr_2wd_lo(has_2wd_lo), tr_4wd_mode(false), tr_gear_ratios(grs) {};
 
-    int   tr_ax_1;           //!< This axle is always driven
-    int   tr_ax_2;           //!< This axle is only driven in 4WD mode
-    bool  tr_4wd_mode;       //!< Enables 4WD mode
-    bool  tr_lo_mode;        //!< Enables gear reduction
-    bool  tr_2wd_lo;         //!< Does it support 2WD Lo mode?
-    float tr_gear_ratio;     //!< Gear reduction ratio (applied in lo mode)
+    int   tr_ax_1;                      //!< This axle is always driven
+    int   tr_ax_2;                      //!< This axle is only driven in 4WD mode
+    bool  tr_2wd;                       //!< Does it support 2WD mode?
+    bool  tr_2wd_lo;                    //!< Does it support 2WD Lo mode?
+    bool  tr_4wd_mode;                  //!< Enables 4WD mode
+    std::vector<float> tr_gear_ratios;  //!< Gear reduction ratios
 };
 
 enum DiffType

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -2559,12 +2559,20 @@ void ActorSpawner::ProcessTransferCase(RigDef::TransferCase & def)
         AddMessage(Message::TYPE_ERROR, "Invalid 'transfercase' axle ids, skipping...");
         return;
     }
-    if (def.a2 < 0)
+    if (def.a2 < 0) // No 4WD mode
     {
-        AddMessage(Message::TYPE_INFO, "No alternate axle defined, defaulting to 2WD only");
+        if (!def.has_2wd) // No 2WD mode
+        {
+            AddMessage(Message::TYPE_ERROR, "Invalid 'transfercase': Define alternate axle or allow 2WD, skipping...");
+            return;
+        }
+        else // Only 2WD
+        {
+            AddMessage(Message::TYPE_INFO, "No alternate axle defined, defaulting to 2WD only");
+        }
     }
 
-    m_actor->m_transfer_case = new TransferCase(def.a1, def.a2, def.gear_ratio, def.has_2wd_lo);
+    m_actor->m_transfer_case = new TransferCase(def.a1, def.a2, def.has_2wd, def.has_2wd_lo, def.gear_ratios);
 
     for (int i = 0; i < m_actor->ar_num_wheels; i++)
     {
@@ -2572,8 +2580,14 @@ void ActorSpawner::ProcessTransferCase(RigDef::TransferCase & def)
     }
     m_actor->ar_wheels[m_actor->m_wheel_diffs[def.a1]->di_idx_1].wh_propulsed = true;
     m_actor->ar_wheels[m_actor->m_wheel_diffs[def.a1]->di_idx_2].wh_propulsed = true;
-
     m_actor->m_num_proped_wheels = 2;
+    if (!def.has_2wd)
+    {
+        m_actor->ar_wheels[m_actor->m_wheel_diffs[def.a2]->di_idx_1].wh_propulsed = true;
+        m_actor->ar_wheels[m_actor->m_wheel_diffs[def.a2]->di_idx_2].wh_propulsed = true;
+        m_actor->m_num_proped_wheels = 4;
+        m_actor->m_transfer_case->tr_4wd_mode = true;
+    }
 }
 
 void ActorSpawner::ProcessSpeedLimiter(RigDef::SpeedLimiter & def)

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -428,14 +428,16 @@ struct TransferCase
     TransferCase():
         a1(0),
         a2(-1),
-        gear_ratio(1.0f),
-        has_2wd_lo(false)
+        has_2wd(true),
+        has_2wd_lo(false),
+        gear_ratios({1.0f})
     {}
 
     int a1;
     int a2;
-    float gear_ratio;
+    bool has_2wd;
     bool has_2wd_lo;
+    std::vector<float> gear_ratios;
 };
 
 /* -------------------------------------------------------------------------- */

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -480,18 +480,19 @@ void Parser::ParseTractionControl()
 
 void Parser::ParseTransferCase()
 {
-    if (! this->CheckNumArguments(4)) { return; }
+    if (! this->CheckNumArguments(2)) { return; }
 
     TransferCase tc;
 
-    tc.a1         = this->GetArgInt  (0) - 1;
-    tc.a2         = this->GetArgInt  (1) - 1;
-    tc.gear_ratio = this->GetArgFloat(2);
-    tc.has_2wd_lo = this->GetArgInt  (3);
+    tc.a1 = this->GetArgInt(0) - 1;
+    tc.a2 = this->GetArgInt(1) - 1;
+    if (m_num_args > 2) { tc.has_2wd    = this->GetArgInt(2); }
+    if (m_num_args > 3) { tc.has_2wd_lo = this->GetArgInt(3); }
+    for (int i = 4; i < m_num_args; i++) { tc.gear_ratios.push_back(this->GetArgFloat(i)); }
 
     if (m_current_module->transfer_case != nullptr)
     {
-        this->AddMessage(Message::TYPE_WARNING, "Multiple inline-sections 'TransferCase' in a module, using last one ...");
+        this->AddMessage(Message::TYPE_WARNING, "Multiple inline-sections 'transfercase' in a module, using last one ...");
     }
 
     m_current_module->transfer_case = std::shared_ptr<TransferCase>( new TransferCase(tc) );

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -929,9 +929,13 @@ void Serializer::ProcessTransferCase(File::Module* module)
     m_stream << "transfercase\t" 
         << module->transfer_case->a1 << ", "
         << module->transfer_case->a2 << ", "
-        << module->transfer_case->gear_ratio << ", "
-        << module->transfer_case->has_2wd_lo
-        << endl << endl;
+        << module->transfer_case->has_2wd << ", "
+        << module->transfer_case->has_2wd_lo;
+        for (float gear_ratio : module->transfer_case->gear_ratios)
+        {
+            m_stream << ", " << gear_ratio;
+        }
+        m_stream << endl << endl;
 }
 
 void Serializer::ProcessCruiseControl(File::Module* module)


### PR DESCRIPTION
- Allows for multiple alternate ratios
- Allows to disable 2WD mode entirely

Example section:
```
transfercase
;default driven axle, alternate axle, has 2wd mode, has 2wd lo mode, alternate ratio(s)
2, 1, 1, 0, 4.11, 3.1, 2.72
```