### PR TITLE
Revamped engine braking logic

### DIFF
--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -187,7 +187,7 @@ void EngineSim::SetTurboOptions(int type, float tinertiaFactor, int nturbos, flo
     }
 }
 
-void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, float ctime, float stime, float pstime, float irpm, float srpm, float maximix, float minimix)
+void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, float ctime, float stime, float pstime, float irpm, float srpm, float maximix, float minimix, float ebraking)
 {
     m_engine_inertia = einertia;
     m_engine_type = etype;
@@ -207,6 +207,8 @@ void EngineSim::SetEngineOptions(float einertia, char etype, float eclutch, floa
         m_max_idle_mixture = maximix;
     if (minimix > 0)
         m_min_idle_mixture = minimix;
+    if (ebraking > 0)
+        m_braking_torque = -ebraking;
 
     m_shift_time = std::max(0.0f, m_shift_time);
     m_post_shift_time = std::max(0.0f, m_post_shift_time);

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -51,7 +51,7 @@ public:
     /// @param srpm Stall RPM
     /// @param maximix Max. idle mixture
     /// @param minimix Min. idle mixture
-    void SetEngineOptions(float einertia, char etype, float eclutch, float ctime, float stime, float pstime, float irpm, float srpm, float maximix, float minimix);
+    void SetEngineOptions(float einertia, char etype, float eclutch, float ctime, float stime, float pstime, float irpm, float srpm, float maximix, float minimix, float ebraking);
 
     /// Sets turbo options.
     /// @param tinertiatinertiaFactor Turbo inertia factor

--- a/source/main/gameplay/BeamEngine.h
+++ b/source/main/gameplay/BeamEngine.h
@@ -89,8 +89,6 @@ public:
     bool           HasTurbo() const         { return m_engine_has_turbo; };
     bool           IsRunning() const        { return m_engine_is_running; };
     char           GetEngineType() const    { return m_engine_type; };
-    float          getEngineTorque() const  { return m_engine_torque; };
-    float          getBrakingTorque() const { return m_braking_torque; };
     float          getIdleRPM() const       { return m_engine_idle_rpm; };
     float          getMaxRPM() const        { return m_engine_max_rpm; };
     float          getMinRPM() const        { return m_engine_min_rpm; };
@@ -101,9 +99,9 @@ public:
     float          GetInputShaftRpm()       { return m_cur_wheel_revolutions * m_gear_ratios[m_cur_gear + 1]; };
     float          GetDriveRatio()          { return m_gear_ratios[m_cur_gear + 1]; };
     float          GetEngineInertia()       { return m_engine_inertia; };
-    float          getAccToHoldRPM(float rpm);
-    float          getTurboPower();
+    float          getEnginePower()         { return getEnginePower(m_cur_engine_rpm); };
     float          getEnginePower(float rpm);
+    float          getTurboPower();
     float          getIdleMixture();
     float          getPrimeMixture();
     int            getAutoShift();

--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -50,12 +50,12 @@ void LandVehicleSimulation::UpdateCruiseControl(Actor* vehicle, float dt)
         return;
     }
 
-    float acc = engine->getAccToHoldRPM(engine->GetEngineRpm());
+    float acc = 0.0f;
 
     if (engine->GetGear() > 0)
     {
         // Try to maintain the target speed
-        float power_weight_ratio = vehicle->getTotalMass(true) / engine->getEnginePower(engine->GetEngineRpm());
+        float power_weight_ratio = vehicle->getTotalMass(true) / engine->getEnginePower();
         acc += (vehicle->cc_target_speed - vehicle->ar_wheel_speed) * power_weight_ratio * 0.25;
     }
     else if (engine->GetGear() == 0) // out of gear

--- a/source/main/gui/panels/GUI_SimUtils.cpp
+++ b/source/main/gui/panels/GUI_SimUtils.cpp
@@ -254,7 +254,7 @@ void CLASS::UpdateStats(float dt, Actor* actor)
 
             m_actor_stats_str = m_actor_stats_str + MainThemeColor + _L("Input shaft RPM: ") + WhiteColor + TOUTFSTRING(Round(std::max(0.0f, actor->ar_engine->GetInputShaftRpm()))) + "\n\n";
 
-            float currentTorque = actor->ar_engine->getEnginePower(actor->ar_engine->GetEngineRpm()) * actor->ar_engine->GetAcceleration();
+            float currentTorque = actor->ar_engine->getEnginePower() * actor->ar_engine->GetAcceleration();
 
             m_actor_stats_str = m_actor_stats_str + MainThemeColor + _L("Current torque: ") + WhiteColor + TOUTFSTRING(Round(currentTorque)) + U(" Nm") + "\n";
 

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -5121,7 +5121,8 @@ void ActorSpawner::ProcessEngoption(RigDef::Engoption & def)
         engoption->idle_rpm,
         engoption->stall_rpm,
         engoption->max_idle_mixture,
-        engoption->min_idle_mixture
+        engoption->min_idle_mixture,
+        engoption->braking_torque
     );
 };
 

--- a/source/main/resources/rig_def_fileformat/RigDef_File.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.cpp
@@ -96,7 +96,8 @@ Engoption::Engoption():
     idle_rpm(-1.f),
     stall_rpm(-1.f),
     max_idle_mixture(0.2f),
-    min_idle_mixture(0.f) /* This is a default */
+    min_idle_mixture(0.f), /* This is a default */
+    braking_torque(-1.f) /* Default = 1/5 of engine_torque */
 {}
 
 Engturbo::Engturbo() :

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -628,6 +628,7 @@ struct Engoption
     float stall_rpm;
     float max_idle_mixture;
     float min_idle_mixture;
+    float braking_torque;
 };
 
 /* -------------------------------------------------------------------------- */

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -1505,6 +1505,7 @@ void Parser::ParseEngoption()
     if (m_num_args > 7) { engoption.idle_rpm         = this->GetArgFloat(7); }
     if (m_num_args > 8) { engoption.max_idle_mixture = this->GetArgFloat(8); }
     if (m_num_args > 9) { engoption.min_idle_mixture = this->GetArgFloat(9); }
+    if (m_num_args > 10){ engoption.braking_torque   = this->GetArgFloat(10);}
 
     m_current_module->engoption = std::shared_ptr<Engoption>( new Engoption(engoption) );
 }

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -1586,6 +1586,7 @@ void Serializer::ProcessEngoption(File::Module* module)
         " IdleRPM,"
         " MaxIdleMixture,"
         " MinIdleMixture"
+        " BrakingForce"
         "\n\t" 
         << setw(10)   << module->engoption->inertia           << ", "
         << setw(10)   << (char)module->engoption->type        << ", "
@@ -1596,7 +1597,8 @@ void Serializer::ProcessEngoption(File::Module* module)
         << setw( 8)   << module->engoption->stall_rpm         << ", "
         << setw( 7)   << module->engoption->idle_rpm          << ", "
         << setw(14)   << module->engoption->max_idle_mixture  << ", "
-        << setw(14)   << module->engoption->min_idle_mixture;
+        << setw(14)   << module->engoption->min_idle_mixture  << ", "
+        << setw(15)   << module->engoption->braking_torque;
     
     m_stream << endl << endl;
 }


### PR DESCRIPTION
- Introduces a new `braking torque` parameter to the `engoption` section.
- Fixes the lack of "engine braking" in low rpm scenarios when the ignition is on.
- Greatly reduces the impact of the braking logic on the torque curve.
- Improves the torque / power output info in the SimUtils overlay.