### PR TITLE
Fixed submesh-collision behavior of slidenodes

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2261,6 +2261,23 @@ void Actor::CalcAnimators(const int flag_state, float& cstate, int& div, Real ti
     }
 }
 
+void Actor::CalcContacters()
+{
+    if (!ar_disable_self_collision)
+    {
+        IntraPointCD()->UpdateIntraPoint(this);
+        ResolveIntraActorCollisions(PHYSICS_DT,
+            *IntraPointCD(),
+            ar_num_collcabs,
+            ar_collcabs,
+            ar_cabs,
+            ar_intra_collcabrate,
+            ar_nodes,
+            ar_collision_range,
+            *ar_submesh_ground_model);
+    }
+}
+
 void Actor::CalcShocks2(int beam_i, Real difftoBeamL, Real& k, Real& d, bool trigger_hooks)
 {
     if (!ar_beams[beam_i].shock)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -366,7 +366,7 @@ public:
 
 private:
 
-    bool              CalcForcesEulerPrepare();            //!< TIGHT LOOP; Physics;
+    bool              CalcForcesEulerPrepare(bool doUpdate); //!< TIGHT LOOP; Physics;
     void              CalcAircraftForces(bool doUpdate);   //!< TIGHT LOOP; Physics;
     void              CalcAnimatedProps(bool doUpdate);    //!< TIGHT LOOP; Physics;
     void              CalcForcesEulerCompute(bool doUpdate, int num_steps); //!< TIGHT LOOP; Physics;
@@ -375,6 +375,7 @@ private:
     void              CalcBeamsInterActor();               //!< TIGHT LOOP; Physics;
     void              CalcBuoyance(bool doUpdate);         //!< TIGHT LOOP; Physics;
     void              CalcCommands(bool doUpdate);         //!< TIGHT LOOP; Physics;
+    void              CalcContacters();                    //!< TIGHT LOOP; Physics;
     void              CalcDifferentials();                 //!< TIGHT LOOP; Physics;
     void              CalcForceFeedback(bool doUpdate);    //!< TIGHT LOOP; Physics;
     void              CalcFuseDrag();                      //!< TIGHT LOOP; Physics;

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1089,24 +1089,11 @@ void ActorManager::UpdatePhysicsSimulation()
             std::vector<std::function<void()>> tasks;
             for (auto actor : m_actors)
             {
-                if (actor->ar_update_physics = actor->CalcForcesEulerPrepare())
+                if (actor->ar_update_physics = actor->CalcForcesEulerPrepare(i == 0))
                 {
                     auto func = std::function<void()>([this, i, actor]()
                         {
                             actor->CalcForcesEulerCompute(i == 0, m_physics_steps);
-                            if (!actor->ar_disable_self_collision)
-                            {
-                                actor->IntraPointCD()->UpdateIntraPoint(actor);
-                                ResolveIntraActorCollisions(PHYSICS_DT,
-                                    *(actor->IntraPointCD()),
-                                    actor->ar_num_collcabs,
-                                    actor->ar_collcabs,
-                                    actor->ar_cabs,
-                                    actor->ar_intra_collcabrate,
-                                    actor->ar_nodes,
-                                    actor->ar_collision_range,
-                                    *(actor->ar_submesh_ground_model));
-                            }
                         });
                     tasks.push_back(func);
                 }

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -53,8 +53,8 @@ const float dt = static_cast<float>(PHYSICS_DT);
 
 void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
 {
-    if (doUpdate) this->ToggleHooks(-2, HOOK_LOCK, -1);
-    this->UpdateSlideNodeForces(dt); // must be done before the integrator, or else the forces are not calculated properly
+    this->CalcNodes(); // must be done directly after the inter truck collisions are handled
+    this->CalcReplay();
     this->CalcAircraftForces(doUpdate);
     this->CalcFuseDrag();
     this->CalcBuoyance(doUpdate);
@@ -66,10 +66,10 @@ void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
     this->CalcTies();
     this->CalcTruckEngine(doUpdate); // must be done after the commands / engine triggers are updated
     this->CalcMouse();
-    this->CalcForceFeedback(doUpdate);
-    this->CalcNodes();
-    this->CalcReplay();
     this->CalcBeams(doUpdate);
+    this->CalcContacters();
+    this->UpdateSlideNodeForces(dt); // must be done after the contacters are updated
+    this->CalcForceFeedback(doUpdate);
 }
 
 void Actor::CalcForceFeedback(bool doUpdate)
@@ -1121,12 +1121,15 @@ void Actor::CalcReplay()
     }
 }
 
-bool Actor::CalcForcesEulerPrepare()
+bool Actor::CalcForcesEulerPrepare(bool doUpdate)
 {
     if (m_ongoing_reset)
         return false;
     if (ar_sim_state != Actor::SimState::LOCAL_SIMULATED)
         return false;
+
+    if (doUpdate)
+        this->ToggleHooks(-2, HOOK_LOCK, -1);
 
     this->CalcHooks();
     this->CalcRopes();


### PR DESCRIPTION
The slide-node forces need to be updated after the intra-truck collisions are handled and before the inter-truck collisions are handled.