### PR TITLE
Fixed the mesh contact logic

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2263,6 +2263,10 @@ void Actor::CalcAnimators(const int flag_state, float& cstate, int& div, Real ti
 
 void Actor::CalcContacters()
 {
+    for (int i = 0; i < ar_num_contacters; i++)
+    {
+        ar_nodes[ar_contacters[i]].nd_has_mesh_contact = false;
+    }
     if (!ar_disable_self_collision)
     {
         IntraPointCD()->UpdateIntraPoint(this);

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1566,7 +1566,6 @@ void Actor::CalcNodes()
                 ar_nodes[i].RelPosition += ar_nodes[i].AbsPosition - oripos;
             }
         }
-        ar_nodes[i].nd_has_mesh_contact = false;
 
         // record g forces on cameras
         if (i == ar_main_camera_node_pos)


### PR DESCRIPTION
This extra step is required because we once again had to reorder the function calls in `CalcForcesEulerCompute` in order to fix the slide-node collisions.