### PR TITLE
Separation of the trigger code from CalcShocks2

### DIFF
--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -387,7 +387,8 @@ private:
     void              CalcReplay();                        //!< TIGHT LOOP; Physics;
     void              CalcRopes();                         //!< TIGHT LOOP; Physics;
     void              CalcShocks(bool doUpdate, int num_steps); //!< TIGHT LOOP; Physics;
-    void              CalcShocks2(int beam_i, Ogre::Real difftoBeamL, Ogre::Real &k, Ogre::Real &d, bool update_hooks);
+    void              CalcShocks2(int i, Ogre::Real difftoBeamL, Ogre::Real &k, Ogre::Real &d);
+    void              CalcTriggers(int i, Ogre::Real difftoBeamL, bool update_hooks);
     void              CalcSlideNodes();                    //!< TIGHT LOOP; Physics;
     void              CalcTies();                          //!< TIGHT LOOP; Physics;
     void              CalcTruckEngine(bool doUpdate);      //!< TIGHT LOOP; Physics;

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -83,6 +83,7 @@ enum {
     NOSHOCK,        //!< not a shock
     SHOCK1,         //!< shock1
     SHOCK2,         //!< shock2
+    TRIGGER,        //!< trigger
     SUPPORTBEAM,    //!<
     ROPE            //!<
 };

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -3164,7 +3164,7 @@ void ActorSpawner::ProcessTrigger(RigDef::Trigger & def)
     CalculateBeamLength(beam);
     beam.shortbound = short_limit;
     beam.longbound = long_limit;
-    beam.bounded = SHOCK2;
+    beam.bounded = TRIGGER;
     beam.shock = &shock;
 
     if (! def.HasFlag_i_Invisible())


### PR DESCRIPTION
Triggers no longer share their `bounded` type with shocks2.

For reference: https://github.com/only-a-ptr/ror-legacy-svn-trunk/commit/74e77fa3017e7e9d464658d1bf2952647e1ad9a6