### PR TITLE
Poor man's solution for the submesh overpenetration issue

### DIFF
--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -1218,7 +1218,8 @@ Vector3 primitiveCollision(node_t *node, Vector3 velocity, float mass, Vector3 n
         // impact force
         if (Vnormal < 0)
         {
-            Freaction -= Vnormal * mass / dt; // Newton's second law
+            float penetration_depth = gm->solid_ground_level - penetration;
+            Freaction -= (0.8f * Vnormal + 0.2f * penetration_depth / dt) * mass / dt; // Newton's second law
         }
         if (Freaction > 0)
         {


### PR DESCRIPTION
Inspired by the code we were previously using: https://github.com/RigsOfRods/rigs-of-rods/blob/cd0e9ebc574f975301552919d125800871e1a1bd/source/main/physics/collision/DynamicCollisions.cpp#L114

I don't like it, but it works exceptionally well, with minimal effort.