### PR TITLE
Keep trucks within the forwardcommands-range activated

### DIFF
--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -718,6 +718,12 @@ void ActorManager::ForwardCommands(Actor* source_actor)
                     (actor->getPosition().distance(source_actor->getPosition()) < 
                      actor->m_min_camera_radius + source_actor->m_min_camera_radius))
             {
+                // activate the truck
+                if (actor->ar_sim_state == Actor::SimState::LOCAL_SLEEPING)
+                {
+                    actor->ar_sleep_counter = 0.0f;
+                    actor->ar_sim_state = Actor::SimState::LOCAL_SIMULATED;
+                }
                 // forward commands
                 for (int j = 1; j <= MAX_COMMANDS; j++)
                 {


### PR DESCRIPTION
This will automatically activate trucks which are listening to import commands as soon as a truck that is sending forward commands comes into range and keep them activated as long as that truck is nearby.