### PR TITLE
✨ Multithreaded sha1 calculation during cache regen

### DIFF
--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -277,6 +277,7 @@ protected:
 
     std::vector<CacheEntry> entries; //!< this holds all files
 
+    std::mutex m_zip_hashes_mutex;
     std::map<Ogre::String, Ogre::String> zipHashes;
 
     // categories


### PR DESCRIPTION
This cuts the cache regeneration time in half on my system.

The alternative would be to switch to something like [xxHash64](https://github.com/Cyan4973/xxHash), [MurmurHash3](https://github.com/aappleby/smhasher/wiki/MurmurHash3) or [CityHash](https://github.com/google/cityhash).