### PR TITLE
Optimized ComputeFlexbody execution order

### DIFF
--- a/source/main/gfx/DustManager.cpp
+++ b/source/main/gfx/DustManager.cpp
@@ -75,8 +75,8 @@ void RoR::GfxScene::UpdateScene(float dt_sec)
     // Actors - start threaded tasks
     for (GfxActor* gfx_actor: m_live_gfx_actors)
     {
-        gfx_actor->UpdateWheelVisuals(); // Push flexwheel tasks to threadpool
         gfx_actor->UpdateFlexbodies(); // Push flexbody tasks to threadpool
+        gfx_actor->UpdateWheelVisuals(); // Push flexwheel tasks to threadpool
     }
 
     // Var

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -2664,6 +2664,11 @@ void RoR::GfxActor::UpdatePropAnimations(const float dt)
     }
 }
 
+void RoR::GfxActor::SortFlexbodies()
+{
+    std::sort(m_flexbodies.begin(), m_flexbodies.end(), [](FlexBody* a, FlexBody* b) { return a->size() > b->size(); });
+}
+
 void RoR::GfxActor::UpdateFlexbodies()
 {
     m_flexbody_tasks.clear();

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -294,6 +294,7 @@ public:
     void                      UpdateAeroEngines  ();
     void                      UpdateNetLabels    (float dt);
     void                      SetDebugView       (DebugViewType dv);
+    void                      SortFlexbodies     ();
     void                      AddFlexbody        (FlexBody* fb)           { m_flexbodies.push_back(fb); }
     Attributes&               GetAttributes      ()                       { return m_attr; }
     inline Ogre::MaterialPtr& GetCabTransMaterial()                       { return m_cab_mat_visual_trans; }

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -599,6 +599,8 @@ void ActorSpawner::FinalizeRig()
     this->UpdateCollcabContacterNodes();
 
     m_flex_factory.SaveFlexbodiesToCache();
+
+    m_actor->GetGfxActor()->SortFlexbodies();
 }
 
 /* -------------------------------------------------------------------------- */

--- a/source/main/physics/flex/FlexBody.h
+++ b/source/main/physics/flex/FlexBody.h
@@ -71,6 +71,8 @@ public:
 
     void SetFlexbodyCastShadow(bool val);
 
+    int size() { return m_vertex_count; };
+
 private:
 
     RoR::GfxActor*    m_gfx_actor;


### PR DESCRIPTION
This exploits the fact that not all flexbodies require the same amount of computation time.

The result is a decent FPS improvement (5-7%) on low core count (2-4) CPUs on trucks like the `Tatra-T813-Dakar`.