### PR TITLE
Fixed multiplayer selector window logic

### DIFF
--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -304,14 +304,13 @@ int main(int argc, char *argv[])
         AppState prev_app_state = App::app_state.GetActive();
         App::app_state.SetPending(AppState::MAIN_MENU);
 
-        if (! App::diag_preset_terrain.IsActiveEmpty())
-        {
-            App::app_state.SetPending(AppState::SIMULATION);
-        }
-
         if (App::mp_join_on_startup.GetActive() == true)
         {
             App::mp_state.SetPending(RoR::MpState::CONNECTED);
+        }
+        else if (!App::diag_preset_terrain.IsActiveEmpty())
+        {
+            App::app_state.SetPending(AppState::SIMULATION);
         }
 
         while (App::app_state.GetPending() != AppState::SHUTDOWN)
@@ -330,9 +329,9 @@ int main(int argc, char *argv[])
 #endif // USE_OPENAL
 
                 App::GetGuiManager()->ReflectGameState();
-                if (App::mp_state.GetPending() == MpState::CONNECTED || BSETTING("SkipMainMenu", false))
+                if (!App::mp_join_on_startup.GetActive() && BSETTING("SkipMainMenu", false))
                 {
-                    // Multiplayer started from configurator / MainMenu disabled -> go directly to map selector (traditional behavior)
+                    // MainMenu disabled (singleplayer mode) -> go directly to map selector (traditional behavior)
                     if (App::diag_preset_terrain.IsActiveEmpty())
                     {
                         App::GetGuiManager()->SetVisible_GameMainMenu(false);


### PR DESCRIPTION
Fixes the logic which controls the effects of the 'Network enable' and 'Preselected Map' settings.

The terrain selector window should only be shown if the server does not enforce a terrain and we do not have a pre-selected terrain.