### PR TITLE
Fixed broken actor stream setup

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4313,7 +4313,6 @@ Actor::Actor(
     , ar_autopilot(nullptr)
     , ar_is_police(false)
     , m_disable_default_sounds(false)
-    , ar_uses_networking(rq.asr_origin == RoR::ActorSpawnRequest::Origin::NETWORK)
     , ar_engine(nullptr)
     , ar_driveable(NOT_DRIVEABLE)
     , m_skid_trails{} // Init array to nullptr

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -358,7 +358,6 @@ public:
     bool ar_collision_relevant:1;      //!< Physics state;
     bool ar_replay_mode:1;      //!< Sim state
     bool ar_is_police:1;        //!< Gfx/sfx attr
-    bool ar_uses_networking:1;  //!< Networking attr; This actor is either remote or has remote counterpart
     bool ar_rescuer_flag:1;     //!< Gameplay attr; defined in truckfile. TODO: Does anybody use this anymore?
     bool ar_forward_commands:1; //!< Sim state
     bool ar_import_commands:1;  //!< Sim state


### PR DESCRIPTION
The actor stream setup was never executed due to a flaw in the `ar_uses_networking` logic.