### PR TITLE
✨ Truck rotation with angle snapping

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -790,6 +790,10 @@ void SimController::UpdateInputEvents(float dt)
 
                         m_advanced_vehicle_repair_timer = 0.0f;
                     }
+                    else if (RoR::App::GetInputEngine()->isKeyDownValueBounce(OIS::KC_SPACE))
+                    {
+                        m_player_actor->RequestAngleSnap(45);
+                    }
                     else
                     {
                         m_advanced_vehicle_repair_timer += dt;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1398,16 +1398,6 @@ String Actor::GetTransferCaseName()
     return name;
 }
 
-void Actor::RequestRotation(float rotation)
-{
-    m_rotation_request += rotation;
-}
-
-void Actor::RequestTranslation(Vector3 translation)
-{
-    m_translation_request += translation;
-}
-
 Ogre::Vector3 Actor::GetRotationCenter()
 {
     Vector3 rotation_center = Vector3::ZERO;
@@ -1627,6 +1617,14 @@ void Actor::HandleAngelScriptEvents(float dt)
 
 void Actor::HandleInputEvents(float dt)
 {
+    if (m_anglesnap_request > 0)
+    {
+        float rotation = Radian(getRotation()).valueDegrees();
+        float target_rotation = std::round(rotation / m_anglesnap_request) * m_anglesnap_request;
+        m_rotation_request = -Degree(target_rotation - rotation).valueRadians();
+        m_anglesnap_request = 0;
+    }
+
     if (m_rotation_request != 0.0f)
     {
         Vector3 rotation_center = GetRotationCenter();

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -76,8 +76,9 @@ public:
     /// @param translation Offset to move in world coordinates
     /// @param setInitPosition Set initial positions of nodes to current position?
     void              ResetPosition(Ogre::Vector3 translation, bool setInitPosition);
-    void              RequestRotation(float rotation);
-    void              RequestTranslation(Ogre::Vector3 translation);
+    void              RequestRotation(float rotation) { m_rotation_request += rotation; };
+    void              RequestAngleSnap(int division) { m_anglesnap_request = division; };
+    void              RequestTranslation(Ogre::Vector3 translation) { m_translation_request += translation; };
     Ogre::Vector3     GetRotationCenter();                 //!< Return the rotation center of the actor
     bool              ReplayStep();
     void              ForceFeedbackStep(int steps);
@@ -456,6 +457,7 @@ private:
     Ogre::String      m_net_username;
     float             m_custom_light_toggle_countdown; //!< Input system helper status
     float             m_rotation_request;         //!< Accumulator
+    int               m_anglesnap_request;        //!< Accumulator
     Ogre::Vector3     m_translation_request;      //!< Accumulator
     Ogre::Vector3     m_camera_gforces_accu;      //!< Accumulator for 'camera' G-forces
     Ogre::Vector3     m_camera_gforces;           //!< Physics state


### PR DESCRIPTION
Pressing `SPACE` in the interactive-truck-reset mode will automatically align the truck with the nearest multiple of 45 degrees.