### PR TITLE
Fixed out of bounds access

### DIFF
--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -798,10 +798,11 @@ void Disconnect()
 
 void AddPacket(int streamid, int type, int len, char *content)
 {
-    if (len > RORNET_MAX_MESSAGE_LENGTH)
+    const auto max_len = RORNET_MAX_MESSAGE_LENGTH - sizeof(RoRnet::Header);
+    if (len > max_len)
     {
         LOGSTREAM << "[RoR|Networking] Discarding network packet (StreamID: "
-            <<streamid<<", Type: "<<type<<"), length is " << len << ", max is " << RORNET_MAX_MESSAGE_LENGTH;
+            <<streamid<<", Type: "<<type<<"), length is " << len << ", max is " << max_len;
         return;
     }
 


### PR DESCRIPTION
Coverity Scan reports:
```
overrun-buffer-arg: Overrunning buffer pointed to by bufferContent of 16384 bytes
by passing it to a function which accesses it at byte offset 16399
using argument len (which evaluates to 16384).
```