### PR TITLE
Fixed AirBrake segfault

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -44,6 +44,7 @@
 #include "imgui.h"
 #include "TurboProp.h"
 
+#include <OgreMesh.h>
 #include <OgrePass.h>
 #include <OgreRenderWindow.h>
 #include <OgreRenderWindow.h>
@@ -161,8 +162,7 @@ RoR::GfxActor::~GfxActor()
         // entity
         gEnv->sceneManager->destroyEntity(abx.abx_entity);
         // mesh
-        abx.abx_mesh->unload();
-        abx.abx_mesh.setNull();
+        Ogre::MeshManager::getSingleton().remove(abx.abx_mesh);
     }
     m_gfx_airbrakes.clear();
 


### PR DESCRIPTION
The segfault happens when you spawn the `767 AA Airliner`, go back to menu, then spawn the `767 AA Airliner` again.
```
Thread 1 "RoR" received signal SIGSEGV, Segmentation fault.
Ogre::Mesh::createSubMesh (this=0x0)
    at /home/babis/Downloads/ror-dependencies/Source/ogre/OgreMain/src/OgreMesh.cpp:92
92            mSubMeshList.push_back(sub);
#0  Ogre::Mesh::createSubMesh (this=0x0)
#1  0x000055555583880d in Airbrake::Airbrake (this=0x55555af25ac0)
#2  0x0000555555827e20 in ActorSpawner::ProcessAirbrake (...)
#3  0x0000555555836aeb in ActorSpawner::SpawnActor (this=this@entry=0x7fffffffd660)
```