### PR TITLE
Simplified the envmap logic

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -169,8 +169,8 @@ static TerrainManager*  g_sim_terrain;
  GVarPod_A<bool>          gfx_minimap_disabled    ("gfx_minimap_disabled",    "disableOverViewMap",        false);
  GVarPod_A<int>           gfx_particles_mode      ("gfx_particles_mode",      "Particles",                 0);
  GVarPod_A<bool>          gfx_enable_videocams    ("gfx_enable_videocams",    "gfx_enable_videocams",      false);
- GVarPod_A<bool>          gfx_envmap_enabled      ("gfx_envmap_enabled",      "Envmap",                    false);
- GVarPod_A<int>           gfx_envmap_rate         ("gfx_envmap_rate",         "EnvmapUpdateRate",          2);
+ GVarPod_A<bool>          gfx_envmap_enabled      ("gfx_envmap_enabled",      "Envmap",                    true);
+ GVarPod_A<int>           gfx_envmap_rate         ("gfx_envmap_rate",         "EnvmapUpdateRate",          0);
  GVarPod_A<int>           gfx_skidmarks_mode      ("gfx_skidmarks_mode",      "Skidmarks",                 0);
  GVarPod_A<float>         gfx_sight_range         ("gfx_sight_range",         "SightRange",                3000.f); // Previously either 2000 or 4500 (inconsistent)
  GVarPod_APS<float>       gfx_fov_external        ("gfx_fov_external",        "FOV External",              60.f,                      60.f,     60.f);

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -36,7 +36,7 @@ public:
     ~GfxEnvmap();
 
     void SetupEnvMap();
-    void UpdateEnvMap(Ogre::Vector3 center, Actor* beam = 0);
+    void UpdateEnvMap(Ogre::Vector3 center, Actor* actor);
 
 private:
 


### PR DESCRIPTION
`Envmap=Off` completely disables all hq reflections.

`Envmap=On` + `EnvmapUpdateRate=0` replicates the old `Envmap=Off` behavior.