### PR TITLE
'node_t' cleanup

### DIFF
--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -52,8 +52,6 @@ struct node_t
     short pos;     //!< This node's index in Actor::ar_nodes array.
     short id;      //!< Numeric identifier assigned in truckfile (if used), or -1 if the node was generated dynamically.
 
-    Ogre::Vector3 initial_pos;
-
     Ogre::Vector3   nd_last_collision_slip;  //!< Physics state; last collision slip vector
     Ogre::Vector3   nd_last_collision_force; //!< Physics state; last collision force
     ground_model_t* nd_last_collision_gm;    //!< Physics state; last collision 'ground model' (surface definition)

--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -46,26 +46,25 @@ struct node_t
     Ogre::Real surface_coef;
     Ogre::Real volume_coef;
 
-    short iswheel; //!< 0=no, 1, 2=wheel1  3,4=wheel2, etc...
-    short wheelid; //!< Wheel index
+    char iswheel; //!< 0=NOWHEEL, 1=WHEEL_DEFAULT, 2=WHEEL_2  3=WHEEL_FLEXBODY
+    char nd_coll_bbox_id; //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
     short nd_lockgroup;
     short pos;     //!< This node's index in Actor::ar_nodes array.
     short id;      //!< Numeric identifier assigned in truckfile (if used), or -1 if the node was generated dynamically.
 
+    Ogre::Real      nd_avg_collision_slip;   //!< Physics state; average slip velocity across the last few physics frames
     Ogre::Vector3   nd_last_collision_slip;  //!< Physics state; last collision slip vector
     Ogre::Vector3   nd_last_collision_force; //!< Physics state; last collision force
     ground_model_t* nd_last_collision_gm;    //!< Physics state; last collision 'ground model' (surface definition)
-    float           nd_avg_collision_slip;   //!< Physics state; average slip velocity across the last few physics frames
-    int8_t          nd_coll_bbox_id;         //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
 
     // Bit flags
-    bool            nd_loaded_mass:1;        //!< User defined attr; mass is calculated from 'globals/loaded-mass' rather than 'globals/dry-mass'
-    bool            nd_override_mass:1;      //!< User defined attr; mass is user-specified rather than calculated (override the calculation)
-    bool            nd_immovable: 1;         //!< Attr; User-defined
-    bool            nd_no_mouse_grab:1;      //!< Attr; User-defined
     bool            nd_contacter:1;          //!< Attr; This node is part of collision triangle
-    bool            nd_no_ground_contact:1;  //!< User-defined attr; node ignores contact with ground
     bool            nd_has_ground_contact:1; //!< Physics state
     bool            nd_has_mesh_contact:1;   //!< Physics state
+    bool            nd_immovable:1;          //!< Attr; User-defined
+    bool            nd_loaded_mass:1;        //!< User defined attr; mass is calculated from 'globals/loaded-mass' rather than 'globals/dry-mass'
+    bool            nd_no_ground_contact:1;  //!< User-defined attr; node ignores contact with ground
+    bool            nd_override_mass:1;      //!< User defined attr; mass is user-specified rather than calculated (override the calculation)
     bool            nd_under_water:1;        //!< State; GFX hint
+    bool            nd_no_mouse_grab:1;      //!< Attr; User-defined
 };

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1549,9 +1549,9 @@ void SimController::UpdateSimulation(float dt)
                         new_actor->ar_nodes[i].RelPosition = m_player_actor->ar_nodes[i].RelPosition; // TODO: ditto
                         new_actor->ar_nodes[i].Velocity    = m_player_actor->ar_nodes[i].Velocity;    // TODO: ditto
                         new_actor->ar_nodes[i].Forces      = m_player_actor->ar_nodes[i].Forces;      // TODO: ditto
-                        new_actor->ar_nodes[i].initial_pos = m_player_actor->ar_nodes[i].initial_pos;
                         new_actor->ar_origin               = m_player_actor->ar_origin;
                     }
+                    new_actor->ar_initial_node_positions   = m_player_actor->ar_initial_node_positions;
                 }
 
                 new_actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -318,7 +318,7 @@ void Actor::ScaleActor(float value)
     Vector3 relpos = ar_nodes[0].RelPosition;
     for (int i = 1; i < ar_num_nodes; i++)
     {
-        ar_nodes[i].initial_pos = refpos + (ar_nodes[i].initial_pos - refpos) * value;
+        ar_initial_node_positions[i] = refpos + (ar_initial_node_positions[i] - refpos) * value;
         ar_nodes[i].AbsPosition = refpos + (ar_nodes[i].AbsPosition - refpos) * value;
         ar_nodes[i].RelPosition = relpos + (ar_nodes[i].RelPosition - relpos) * value;
         ar_nodes[i].Velocity *= value;
@@ -1190,7 +1190,7 @@ void Actor::ResetPosition(Vector3 translation, bool setInitPosition)
     {
         for (int i = 0; i < ar_num_nodes; i++)
         {
-            ar_nodes[i].initial_pos = ar_nodes[i].AbsPosition;
+            ar_initial_node_positions[i] = ar_nodes[i].AbsPosition;
         }
     }
 
@@ -1439,8 +1439,8 @@ void Actor::SyncReset(bool reset_position)
 
     for (int i = 0; i < ar_num_nodes; i++)
     {
-        ar_nodes[i].AbsPosition = ar_nodes[i].initial_pos;
-        ar_nodes[i].RelPosition = ar_nodes[i].initial_pos - ar_origin;
+        ar_nodes[i].AbsPosition = ar_initial_node_positions[i];
+        ar_nodes[i].RelPosition = ar_nodes[i].AbsPosition - ar_origin;
         ar_nodes[i].Velocity = Vector3::ZERO;
         ar_nodes[i].Forces = Vector3::ZERO;
     }

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -211,6 +211,7 @@ public:
     std::vector<flare_t>      ar_flares;
     Ogre::AxisAlignedBox      ar_bounding_box;     //!< standard bounding box (surrounds all nodes of an actor)
     Ogre::AxisAlignedBox      ar_predicted_bounding_box;
+    std::vector<Ogre::Vector3>     ar_initial_node_positions;
     std::vector<std::vector<int>>  ar_node_to_node_connections;
     std::vector<std::vector<int>>  ar_node_to_beam_connections;
     std::vector<Ogre::AxisAlignedBox>  ar_collision_bounding_boxes; //!< smart bounding boxes, used for determining the state of an actor (every box surrounds only a subset of nodes)

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -133,6 +133,8 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
     }
     /* POST-PROCESSING (Old-spawn code from Actor::loadTruck2) */
 
+    actor->ar_initial_node_positions.resize(actor->ar_num_nodes);
+
     // Apply spawn position & spawn rotation
     for (int i = 0; i < actor->ar_num_nodes; i++)
     {

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -4018,7 +4018,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
 
         outer_node.mass          = node_mass;
         outer_node.id            = -1; // Orig: hardcoded (addWheel2)
-        outer_node.wheelid       = m_actor->ar_num_wheels;
         outer_node.friction_coef = def.node_defaults->friction;
         AdjustNodeBuoyancy(outer_node, def.node_defaults);
 
@@ -4033,7 +4032,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
 
         inner_node.mass          = node_mass;
         inner_node.id            = -1; // Orig: hardcoded (addWheel2)
-        inner_node.wheelid       = m_actor->ar_num_wheels;
         inner_node.friction_coef = def.node_defaults->friction;
         AdjustNodeBuoyancy(inner_node, def.node_defaults);
 
@@ -4060,7 +4058,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         InitNode(outer_node, ray_point);
         outer_node.mass          = node_mass;
         outer_node.id            = -1; // Orig: hardcoded (addWheel3)
-        outer_node.wheelid       = m_actor->ar_num_wheels;
         outer_node.friction_coef = def.node_defaults->friction;
         outer_node.volume_coef   = def.node_defaults->volume;
         outer_node.surface_coef  = def.node_defaults->surface;
@@ -4080,7 +4077,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         InitNode(inner_node, ray_point);
         inner_node.mass          = node_mass;
         inner_node.id            = -1; // Orig: hardcoded (addWheel3)
-        inner_node.wheelid       = m_actor->ar_num_wheels;
         inner_node.friction_coef = def.node_defaults->friction;
         inner_node.volume_coef   = def.node_defaults->volume;
         inner_node.surface_coef  = def.node_defaults->surface;
@@ -4473,7 +4469,6 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
         outer_node.mass    = wheel_mass / (2.f * num_rays);
         outer_node.iswheel = (set_param_iswheel) ? WHEEL_DEFAULT : NOWHEEL;
         outer_node.id      = -1; // Orig: hardcoded (BTS_WHEELS)
-        outer_node.wheelid = m_actor->ar_num_wheels;
         AdjustNodeBuoyancy(outer_node, node_defaults);
 
         m_actor->ar_contacters[m_actor->ar_num_contacters] = outer_node.pos;
@@ -4490,7 +4485,6 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
         inner_node.mass    = wheel_mass / (2.f * num_rays);
         inner_node.iswheel = (set_param_iswheel) ? WHEEL_DEFAULT : NOWHEEL;
         inner_node.id      = -1; // Orig: hardcoded (BTS_WHEELS)
-        inner_node.wheelid = m_actor->ar_num_wheels; 
         AdjustNodeBuoyancy(inner_node, node_defaults);
 
         m_actor->ar_contacters[m_actor->ar_num_contacters] = inner_node.pos;
@@ -4505,9 +4499,9 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
 #ifdef DEBUG_TRUCKPARSER2013
         // TRUCK PARSER 2013 DEBUG
         int modifier = 0;
-        msg << "\nDBG\tN1: index=" << outer_node.pos + modifier <<", wheelid=" << outer_node.wheelid << ", iswheel=" << outer_node.iswheel 
+        msg << "\nDBG\tN1: index=" << outer_node.pos + modifier << ", iswheel=" << outer_node.iswheel 
             <<", X=" << outer_node.AbsPosition.x <<", Y=" << outer_node.AbsPosition.y <<", Z=" << outer_node.AbsPosition.z << std::endl
-            << "DBG\tN2: index=" << inner_node.pos + modifier <<", wheelid=" << inner_node.wheelid << ", iswheel=" << inner_node.iswheel 
+            << "DBG\tN2: index=" << inner_node.pos + modifier << ", iswheel=" << inner_node.iswheel 
             <<", X=" << inner_node.AbsPosition.x <<", Y=" << inner_node.AbsPosition.y <<", Z=" << inner_node.AbsPosition.z;
         // END
 #endif
@@ -4761,7 +4755,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         outer_node.mass    = node_mass;
         outer_node.iswheel = WHEEL_2;
         outer_node.id      = -1; // Orig: hardcoded (addWheel2)
-        outer_node.wheelid = m_actor->ar_num_wheels;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
 
@@ -4773,7 +4766,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         inner_node.mass    = node_mass;
         inner_node.iswheel = WHEEL_2;
         inner_node.id      = -1; // Orig: hardcoded (addWheel2)
-        inner_node.wheelid = m_actor->ar_num_wheels;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
 
@@ -4799,7 +4791,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         outer_node.mass          = (0.67f * wheel_2_def.mass) / (2.f * wheel_2_def.num_rays);
         outer_node.iswheel       = WHEEL_2;
         outer_node.id            = -1; // Orig: hardcoded (addWheel2)
-        outer_node.wheelid       = m_actor->ar_num_wheels;
         outer_node.friction_coef = wheel.wh_width * WHEEL_FRICTION_COEF;
         outer_node.volume_coef   = wheel_2_def.node_defaults->volume;
         outer_node.surface_coef  = wheel_2_def.node_defaults->surface;
@@ -4817,7 +4808,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         inner_node.mass          = (0.33f * wheel_2_def.mass) / (2.f * wheel_2_def.num_rays);
         inner_node.iswheel       = WHEEL_2;
         inner_node.id            = -1; // Orig: hardcoded (addWheel2)
-        inner_node.wheelid       = m_actor->ar_num_wheels;
         inner_node.friction_coef = wheel.wh_width * WHEEL_FRICTION_COEF;
         inner_node.volume_coef   = wheel_2_def.node_defaults->volume;
         inner_node.surface_coef  = wheel_2_def.node_defaults->surface;
@@ -5707,7 +5697,6 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
     node.RelPosition = node_position - m_actor->ar_origin;
 
     node.iswheel = NOWHEEL;
-    node.wheelid = -1; // Hardcoded in orig (bts_nodes, call to init_node())
     node.friction_coef = def.node_defaults->friction;
     node.volume_coef = def.node_defaults->volume;
     node.surface_coef = def.node_defaults->surface;
@@ -5886,7 +5875,6 @@ void ActorSpawner::ProcessCinecam(RigDef::Cinecam & def)
     Ogre::Vector3 node_pos = m_spawn_position + def.position;
     node_t & camera_node = GetAndInitFreeNode(node_pos);
     camera_node.nd_no_ground_contact = true; // Orig: hardcoded in BTS_CINECAM
-    camera_node.wheelid = -1;
     camera_node.friction_coef = NODE_FRICTION_COEF_DEFAULT; // Node defaults are ignored here.
     camera_node.id = -1;
     AdjustNodeBuoyancy(camera_node, def.node_defaults);


### PR DESCRIPTION
The initial node positions (`initial_pos`) are only used during truck reset and don't need to be part of the node struct.

The `wheelid` became obsolete during the drive train refactoring.

The `iswheel` documentation was incorrect.