### PR TITLE
Fixed driving aids on non-player truck vehicles

### DIFF
--- a/source/main/gameplay/AircraftSimulation.cpp
+++ b/source/main/gameplay/AircraftSimulation.cpp
@@ -33,8 +33,10 @@
 
 using namespace RoR;
 
-void AircraftSimulation::UpdateVehicle(Actor* vehicle, float seconds_since_last_frame)
+void AircraftSimulation::UpdateInputEvents(Actor* vehicle, float seconds_since_last_frame)
 {
+    if (vehicle->ar_replay_mode)
+        return;
     //autopilot
     if (vehicle->ar_autopilot && vehicle->ar_autopilot->wantsdisconnect)
     {
@@ -42,35 +44,12 @@ void AircraftSimulation::UpdateVehicle(Actor* vehicle, float seconds_since_last_
     }
     //AIRPLANE KEYS
     float commandrate = 4.0;
-    //turning
-    if (vehicle->ar_replay_mode)
-    {
-        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FORWARD, 0.1f) && vehicle->ar_replay_pos <= 0)
-        {
-            vehicle->ar_replay_pos++;
-        }
-        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_BACKWARD, 0.1f) && vehicle->ar_replay_pos > -vehicle->ar_replay_length)
-        {
-            vehicle->ar_replay_pos--;
-        }
-        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FAST_FORWARD, 0.1f) && vehicle->ar_replay_pos + 10 <= 0)
-        {
-            vehicle->ar_replay_pos += 10;
-        }
-        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FAST_BACKWARD, 0.1f) && vehicle->ar_replay_pos - 10 > -vehicle->ar_replay_length)
-        {
-            vehicle->ar_replay_pos -= 10;
-        }
-    }
-    else
-    {
-        float tmp_left = RoR::App::GetInputEngine()->getEventValue(EV_AIRPLANE_STEER_LEFT);
-        float tmp_right = RoR::App::GetInputEngine()->getEventValue(EV_AIRPLANE_STEER_RIGHT);
-        float sum_steer = -tmp_left + tmp_right;
-        RoR::App::GetInputEngine()->smoothValue(vehicle->ar_aileron, sum_steer, seconds_since_last_frame * commandrate);
-        vehicle->ar_hydro_dir_command = vehicle->ar_aileron;
-        vehicle->ar_hydro_speed_coupling = !(RoR::App::GetInputEngine()->isEventAnalog(EV_AIRPLANE_STEER_LEFT) && RoR::App::GetInputEngine()->isEventAnalog(EV_AIRPLANE_STEER_RIGHT));
-    }
+    float tmp_left = RoR::App::GetInputEngine()->getEventValue(EV_AIRPLANE_STEER_LEFT);
+    float tmp_right = RoR::App::GetInputEngine()->getEventValue(EV_AIRPLANE_STEER_RIGHT);
+    float sum_steer = -tmp_left + tmp_right;
+    RoR::App::GetInputEngine()->smoothValue(vehicle->ar_aileron, sum_steer, seconds_since_last_frame * commandrate);
+    vehicle->ar_hydro_dir_command = vehicle->ar_aileron;
+    vehicle->ar_hydro_speed_coupling = !(RoR::App::GetInputEngine()->isEventAnalog(EV_AIRPLANE_STEER_LEFT) && RoR::App::GetInputEngine()->isEventAnalog(EV_AIRPLANE_STEER_RIGHT));
 
     //pitch
     float tmp_pitch_up = RoR::App::GetInputEngine()->getEventValue(EV_AIRPLANE_ELEVATOR_UP);
@@ -85,7 +64,7 @@ void AircraftSimulation::UpdateVehicle(Actor* vehicle, float seconds_since_last_
     RoR::App::GetInputEngine()->smoothValue(vehicle->ar_rudder, sum_rudder, seconds_since_last_frame * commandrate);
 
     //brake
-    if (!vehicle->ar_replay_mode && !vehicle->ar_parking_brake)
+    if (!vehicle->ar_parking_brake)
     {
         vehicle->ar_brake = RoR::App::GetInputEngine()->getEventValue(EV_AIRPLANE_BRAKE) * 0.66f;
     }

--- a/source/main/gameplay/AircraftSimulation.h
+++ b/source/main/gameplay/AircraftSimulation.h
@@ -36,7 +36,7 @@ struct AircraftSimulation
     /**
     * SIM-CORE: 1x per frame. Logic: input, GUI, vehicle state.
     */
-    static void UpdateVehicle(Actor* vehicle, float seconds_since_last_frame);
+    static void UpdateInputEvents(Actor* vehicle, float seconds_since_last_frame);
 };
 
 } // namespace RoR

--- a/source/main/gameplay/LandVehicleSimulation.cpp
+++ b/source/main/gameplay/LandVehicleSimulation.cpp
@@ -143,362 +143,378 @@ void LandVehicleSimulation::CheckSpeedLimit(Actor* vehicle, float dt)
 
 void LandVehicleSimulation::UpdateVehicle(Actor* vehicle, float seconds_since_last_frame)
 {
-    using namespace Ogre;
-
-    if (!vehicle->ar_replay_mode)
-    {
-        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_LEFT_MIRROR_LEFT))
-            vehicle->ar_left_mirror_angle -= 0.001;
-
-        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_LEFT_MIRROR_RIGHT))
-            vehicle->ar_left_mirror_angle += 0.001;
-
-        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_RIGHT_MIRROR_LEFT))
-            vehicle->ar_right_mirror_angle -= 0.001;
-
-        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_RIGHT_MIRROR_RIGHT))
-            vehicle->ar_right_mirror_angle += 0.001;
-    } // end of (!vehicle->ar_replay_mode) block
-
+    if (vehicle->ar_replay_mode)
+        return;
 #ifdef USE_ANGELSCRIPT
-    if (!vehicle->ar_replay_mode && !vehicle->ar_vehicle_ai->IsActive())
-#else
-    if (!vehicle->ar_replay_mode)
+    if (vehicle->ar_vehicle_ai && vehicle->ar_vehicle_ai->IsActive())
+        return;
 #endif // USE_ANGELSCRIPT
+
+    EngineSim* engine = vehicle->ar_engine;
+
+    if (engine && engine->HasStarterContact() &&
+        engine->GetAutoShiftMode() == SimGearboxMode::AUTO &&
+        engine->getAutoShift() != EngineSim::NEUTRAL)
     {
-        // steering
-        float tmp_left_digital = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_STEER_LEFT, false, InputEngine::ET_DIGITAL);
-        float tmp_right_digital = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_STEER_RIGHT, false, InputEngine::ET_DIGITAL);
-        float tmp_left_analog = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_STEER_LEFT, false, InputEngine::ET_ANALOG);
-        float tmp_right_analog = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_STEER_RIGHT, false, InputEngine::ET_ANALOG);
+        Ogre::Vector3 dirDiff = vehicle->getDirection();
+        Ogre::Degree pitchAngle = Ogre::Radian(asin(dirDiff.dotProduct(Ogre::Vector3::UNIT_Y)));
 
-        float sum = -std::max(tmp_left_digital, tmp_left_analog) + std::max(tmp_right_digital, tmp_right_analog);
-
-        if (sum < -1)
-            sum = -1;
-        if (sum > 1)
-            sum = 1;
-
-        vehicle->ar_hydro_dir_command = sum;
-
-        if ((tmp_left_digital < tmp_left_analog) || (tmp_right_digital < tmp_right_analog))
+        if (std::abs(pitchAngle.valueDegrees()) > 2.0f)
         {
-            vehicle->ar_hydro_speed_coupling = false;
+            if (engine->getAutoShift() > EngineSim::NEUTRAL && vehicle->ar_avg_wheel_speed < +0.02f && pitchAngle.valueDegrees() > 0.0f ||
+                engine->getAutoShift() < EngineSim::NEUTRAL && vehicle->ar_avg_wheel_speed > -0.02f && pitchAngle.valueDegrees() < 0.0f)
+            {
+                // anti roll back in SimGearboxMode::AUTO (DRIVE, TWO, ONE) mode
+                // anti roll forth in SimGearboxMode::AUTO (REAR) mode
+                float g = std::abs(App::GetSimTerrain()->getGravity());
+                float downhill_force = std::abs(sin(pitchAngle.valueRadians()) * vehicle->getTotalMass()) * g;
+                float engine_force = std::abs(engine->GetTorque()) / vehicle->getAvgPropedWheelRadius();
+                float ratio = std::max(0.0f, 1.0f - (engine_force / downhill_force));
+                if (vehicle->ar_avg_wheel_speed * pitchAngle.valueDegrees() > 0.0f)
+                {
+                    ratio *= sqrt((0.02f - vehicle->ar_avg_wheel_speed) / 0.02f);
+                }
+                vehicle->ar_brake = sqrt(ratio);
+            }
+        }
+        else if (vehicle->ar_brake == 0.0f && !vehicle->ar_parking_brake && engine->GetTorque() == 0.0f)
+        {
+            float ratio = std::max(0.0f, 0.2f - std::abs(vehicle->ar_avg_wheel_speed)) / 0.2f;
+            vehicle->ar_brake = ratio;
+        }
+    }
+
+    if (vehicle->cc_mode)
+    {
+        LandVehicleSimulation::UpdateCruiseControl(vehicle, seconds_since_last_frame);
+    }
+    if (vehicle->sl_enabled)
+    {
+        LandVehicleSimulation::CheckSpeedLimit(vehicle, seconds_since_last_frame);
+    }
+}
+
+void LandVehicleSimulation::UpdateInputEvents(Actor* vehicle, float seconds_since_last_frame)
+{
+    if (vehicle->ar_replay_mode)
+        return;
+#ifdef USE_ANGELSCRIPT
+    if (vehicle->ar_vehicle_ai && vehicle->ar_vehicle_ai->IsActive())
+        return;
+#endif // USE_ANGELSCRIPT
+
+    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_LEFT_MIRROR_LEFT))
+        vehicle->ar_left_mirror_angle -= 0.001;
+
+    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_LEFT_MIRROR_RIGHT))
+        vehicle->ar_left_mirror_angle += 0.001;
+
+    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_RIGHT_MIRROR_LEFT))
+        vehicle->ar_right_mirror_angle -= 0.001;
+
+    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_RIGHT_MIRROR_RIGHT))
+        vehicle->ar_right_mirror_angle += 0.001;
+
+    // steering
+    float tmp_left_digital = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_STEER_LEFT, false, InputEngine::ET_DIGITAL);
+    float tmp_right_digital = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_STEER_RIGHT, false, InputEngine::ET_DIGITAL);
+    float tmp_left_analog = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_STEER_LEFT, false, InputEngine::ET_ANALOG);
+    float tmp_right_analog = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_STEER_RIGHT, false, InputEngine::ET_ANALOG);
+
+    float sum = -std::max(tmp_left_digital, tmp_left_analog) + std::max(tmp_right_digital, tmp_right_analog);
+
+    if (sum < -1)
+        sum = -1;
+    if (sum > 1)
+        sum = 1;
+
+    vehicle->ar_hydro_dir_command = sum;
+
+    if ((tmp_left_digital < tmp_left_analog) || (tmp_right_digital < tmp_right_analog))
+    {
+        vehicle->ar_hydro_speed_coupling = false;
+    }
+    else
+    {
+        vehicle->ar_hydro_speed_coupling = true;
+    }
+
+    EngineSim* engine = vehicle->ar_engine;
+
+    if (engine)
+    {
+        float accl = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE);
+        float brake = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE);
+
+        if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE_MODIFIER_25) ||
+            RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE_MODIFIER_50))
+        {
+            float acclModifier = 0.0f;
+            if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE_MODIFIER_25))
+            {
+                acclModifier += 0.25f;
+            }
+            if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE_MODIFIER_50))
+            {
+                acclModifier += 0.50f;
+            }
+            accl *= acclModifier;
+        }
+
+        if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE_MODIFIER_25) ||
+            RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE_MODIFIER_50))
+        {
+            float brakeModifier = 0.0f;
+            if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE_MODIFIER_25))
+            {
+                brakeModifier += 0.25f;
+            }
+            if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE_MODIFIER_50))
+            {
+                brakeModifier += 0.50f;
+            }
+            brake *= brakeModifier;
+        }
+
+        // arcade controls are only working with auto-clutch!
+        if (!App::io_arcade_controls.GetActive() || (engine->GetAutoShiftMode() >= SimGearboxMode::MANUAL))
+        {
+            // classic mode, realistic
+            engine->autoSetAcc(accl);
+            vehicle->ar_brake = brake;
         }
         else
         {
-            vehicle->ar_hydro_speed_coupling = true;
-        }
-
-        EngineSim* engine = vehicle->ar_engine;
-
-        if (engine)
-        {
-            float accl = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE);
-            float brake = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE);
-
-            if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE_MODIFIER_25) ||
-                RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE_MODIFIER_50))
+            // start engine
+            if (engine->HasStarterContact() && !engine->IsRunning() && (accl > 0 || brake > 0))
             {
-                float acclModifier = 0.0f;
-                if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE_MODIFIER_25))
-                {
-                    acclModifier += 0.25f;
-                }
-                if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_ACCELERATE_MODIFIER_50))
-                {
-                    acclModifier += 0.50f;
-                }
-                accl *= acclModifier;
+                engine->StartEngine();
             }
 
-            if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE_MODIFIER_25) ||
-                RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE_MODIFIER_50))
+            // arcade controls: hey - people wanted it x| ... <- and it's convenient
+            if (engine->GetGear() >= 0)
             {
-                float brakeModifier = 0.0f;
-                if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE_MODIFIER_25))
-                {
-                    brakeModifier += 0.25f;
-                }
-                if (RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_BRAKE_MODIFIER_50))
-                {
-                    brakeModifier += 0.50f;
-                }
-                brake *= brakeModifier;
-            }
-
-            // arcade controls are only working with auto-clutch!
-            if (!App::io_arcade_controls.GetActive() || (engine->GetAutoShiftMode() >= SimGearboxMode::MANUAL))
-            {
-                // classic mode, realistic
+                // neutral or drive forward, everything is as its used to be: brake is brake and accel. is accel.
                 engine->autoSetAcc(accl);
                 vehicle->ar_brake = brake;
             }
             else
             {
-                // start engine
-                if (engine->HasStarterContact() && !engine->IsRunning() && (accl > 0 || brake > 0))
-                {
-                    engine->StartEngine();
-                }
-
-                // arcade controls: hey - people wanted it x| ... <- and it's convenient
-                if (engine->GetGear() >= 0)
-                {
-                    // neutral or drive forward, everything is as its used to be: brake is brake and accel. is accel.
-                    engine->autoSetAcc(accl);
-                    vehicle->ar_brake = brake;
-                }
-                else
-                {
-                    // reverse gear, reverse controls: brake is accel. and accel. is brake.
-                    engine->autoSetAcc(brake);
-                    vehicle->ar_brake = accl;
-                }
-
-                // only when the truck really is not moving anymore
-                if (fabs(vehicle->ar_avg_wheel_speed) <= 1.0f)
-                {
-                    Vector3 hdir = vehicle->getDirection();
-                    float velocity = hdir.dotProduct(vehicle->ar_nodes[0].Velocity);
-
-                    // switching point, does the user want to drive forward from backward or the other way round? change gears?
-                    if (velocity < 1.0f && brake > 0.5f && accl < 0.5f && engine->GetGear() > 0)
-                    {
-                        // we are on the brake, jump to reverse gear
-                        if (engine->GetAutoShiftMode() == SimGearboxMode::AUTO)
-                        {
-                            engine->autoShiftSet(EngineSim::REAR);
-                        }
-                        else
-                        {
-                            engine->SetGear(-1);
-                        }
-                    }
-                    else if (velocity > -1.0f && brake < 0.5f && accl > 0.5f && engine->GetGear() < 0)
-                    {
-                        // we are on the gas pedal, jump to first gear when we were in rear gear
-                        if (engine->GetAutoShiftMode() == SimGearboxMode::AUTO)
-                        {
-                            engine->autoShiftSet(EngineSim::DRIVE);
-                        }
-                        else
-                        {
-                            engine->SetGear(1);
-                        }
-                    }
-                }
+                // reverse gear, reverse controls: brake is accel. and accel. is brake.
+                engine->autoSetAcc(brake);
+                vehicle->ar_brake = accl;
             }
 
-            // IMI
-            // gear management -- it might, should be transferred to a standalone function of Beam or SimController
-            if (engine->GetAutoShiftMode() == SimGearboxMode::AUTO)
+            // only when the truck really is not moving anymore
+            if (fabs(vehicle->ar_avg_wheel_speed) <= 1.0f)
             {
-                if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_UP))
+                Ogre::Vector3 hdir = vehicle->getDirection();
+                float velocity = hdir.dotProduct(vehicle->ar_nodes[0].Velocity);
+
+                // switching point, does the user want to drive forward from backward or the other way round? change gears?
+                if (velocity < 1.0f && brake > 0.5f && accl < 0.5f && engine->GetGear() > 0)
                 {
-                    engine->autoShiftUp();
-                }
-                if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_DOWN))
-                {
-                    engine->autoShiftDown();
-                }
-            }
-
-            if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_CONTACT))
-            {
-                engine->ToggleStarterContact();
-            }
-
-            if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_STARTER) && engine->HasStarterContact() && !engine->IsRunning())
-            {
-                // starter
-                engine->SetStarter(1);
-                SOUND_START(vehicle, SS_TRIG_STARTER);
-            }
-            else
-            {
-                engine->SetStarter(0);
-                SOUND_STOP(vehicle, SS_TRIG_STARTER);
-            }
-
-            if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SWITCH_SHIFT_MODES))
-            {
-                // toggle Auto shift
-                engine->ToggleAutoShiftMode();
-
-                // force gui update
-                vehicle->RequestUpdateHudFeatures();
-                const char* msg = nullptr;
-                switch (engine->GetAutoShiftMode())
-                {
-                case SimGearboxMode::AUTO: msg = "Automatic shift";
-                    break;
-                case SimGearboxMode::SEMI_AUTO: msg = "Manual shift - Auto clutch";
-                    break;
-                case SimGearboxMode::MANUAL: msg = "Fully Manual: sequential shift";
-                    break;
-                case SimGearboxMode::MANUAL_STICK: msg = "Fully manual: stick shift";
-                    break;
-                case SimGearboxMode::MANUAL_RANGES: msg = "Fully Manual: stick shift with ranges";
-                    break;
-                }
-                RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L(msg), "cog.png", 3000);
-                RoR::App::GetGuiManager()->PushNotification("Gearbox Mode:", msg);
-            }
-
-            // joy clutch
-            float cval = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_MANUAL_CLUTCH);
-            engine->setManualClutch(cval);
-
-            SimGearboxMode shiftmode = engine->GetAutoShiftMode();
-
-            if (shiftmode <= SimGearboxMode::MANUAL) // auto, semi auto and sequential shifting
-            {
-                if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_UP))
-                {
-                    engine->shift(1);
-                }
-                else if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_DOWN))
-                {
-                    if (shiftmode > SimGearboxMode::SEMI_AUTO ||
-                        shiftmode == SimGearboxMode::SEMI_AUTO && (!App::io_arcade_controls.GetActive()) ||
-                        shiftmode == SimGearboxMode::SEMI_AUTO && engine->GetGear() > 0 ||
-                        shiftmode == SimGearboxMode::AUTO)
+                    // we are on the brake, jump to reverse gear
+                    if (engine->GetAutoShiftMode() == SimGearboxMode::AUTO)
                     {
-                        engine->shift(-1);
-                    }
-                }
-                else if (shiftmode != SimGearboxMode::AUTO && RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL))
-                {
-                    engine->shiftTo(0);
-                }
-            }
-            else //if (shiftmode > SimGearboxMode::MANUAL) // h-shift or h-shift with ranges shifting
-            {
-                bool gear_changed = false;
-                bool found = false;
-                int curgear = engine->GetGear();
-                int curgearrange = engine->GetGearRange();
-                int gearoffset = std::max(0, curgear - curgearrange * 6);
-
-                // one can select range only if in neutral
-                if (shiftmode == SimGearboxMode::MANUAL_RANGES && curgear == 0)
-                {
-                    //  maybe this should not be here, but should experiment
-                    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_LOWRANGE) && curgearrange != 0)
-                    {
-                        engine->SetGearRange(0);
-                        gear_changed = true;
-                        RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png", 3000);
-                    }
-                    else if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_MIDRANGE) && curgearrange != 1 && engine->getNumGearsRanges() > 1)
-                    {
-                        engine->SetGearRange(1);
-                        gear_changed = true;
-                        RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png", 3000);
-                    }
-                    else if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_HIGHRANGE) && curgearrange != 2 && engine->getNumGearsRanges() > 2)
-                    {
-                        engine->SetGearRange(2);
-                        gear_changed = true;
-                        RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png", 3000);
-                    }
-                }
-                //zaxxon
-                if (curgear == -1)
-                {
-                    gear_changed = !RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE);
-                }
-                else if (curgear > 0 && curgear < 19)
-                {
-                    gear_changed = !RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + gearoffset - 1); // range mode
-                }
-
-                if (gear_changed || curgear == 0)
-                {
-                    if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE))
-                    {
-                        engine->shiftTo(-1);
-                        found = true;
-                    }
-                    else if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_NEUTRAL))
-                    {
-                        engine->shiftTo(0);
-                        found = true;
+                        engine->autoShiftSet(EngineSim::REAR);
                     }
                     else
                     {
-                        if (shiftmode == SimGearboxMode::MANUAL_STICK)
-                        {
-                            for (int i = 1; i < 19 && !found; i++)
-                            {
-                                if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
-                                {
-                                    engine->shiftTo(i);
-                                    found = true;
-                                }
-                            }
-                        }
-                        else // SimGearboxMode::MANUALMANUAL_RANGES
-                        {
-                            for (int i = 1; i < 7 && !found; i++)
-                            {
-                                if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
-                                {
-                                    engine->shiftTo(i + curgearrange * 6);
-                                    found = true;
-                                }
-                            }
-                        }
-                    }
-                    if (!found)
-                    {
-                        engine->shiftTo(0);
-                    }
-                } // end of if (gear_changed)
-            } // end of shitmode > SimGearboxMode::MANUAL
-
-            if (engine->HasStarterContact() &&
-                engine->GetAutoShiftMode() == SimGearboxMode::AUTO &&
-                engine->getAutoShift() != EngineSim::NEUTRAL)
-            {
-                Vector3 dirDiff = vehicle->getDirection();
-                Degree pitchAngle = Radian(asin(dirDiff.dotProduct(Vector3::UNIT_Y)));
-
-                if (std::abs(pitchAngle.valueDegrees()) > 2.0f)
-                {
-                    if (engine->getAutoShift() > EngineSim::NEUTRAL && vehicle->ar_avg_wheel_speed < +0.02f && pitchAngle.valueDegrees() > 0.0f ||
-                        engine->getAutoShift() < EngineSim::NEUTRAL && vehicle->ar_avg_wheel_speed > -0.02f && pitchAngle.valueDegrees() < 0.0f)
-                    {
-                        // anti roll back in SimGearboxMode::AUTO (DRIVE, TWO, ONE) mode
-                        // anti roll forth in SimGearboxMode::AUTO (REAR) mode
-                        float g = std::abs(App::GetSimTerrain()->getGravity());
-                        float downhill_force = std::abs(sin(pitchAngle.valueRadians()) * vehicle->getTotalMass()) * g;
-                        float engine_force = std::abs(engine->GetTorque()) / vehicle->getAvgPropedWheelRadius();
-                        float ratio = std::max(0.0f, 1.0f - (engine_force / downhill_force));
-                        if (vehicle->ar_avg_wheel_speed * pitchAngle.valueDegrees() > 0.0f)
-                        {
-                            ratio *= sqrt((0.02f - vehicle->ar_avg_wheel_speed) / 0.02f);
-                        }
-                        vehicle->ar_brake = sqrt(ratio);
+                        engine->SetGear(-1);
                     }
                 }
-                else if (vehicle->ar_brake == 0.0f && !vehicle->ar_parking_brake && engine->GetTorque() == 0.0f)
+                else if (velocity > -1.0f && brake < 0.5f && accl > 0.5f && engine->GetGear() < 0)
                 {
-                    float ratio = std::max(0.0f, 0.2f - std::abs(vehicle->ar_avg_wheel_speed)) / 0.2f;
-                    vehicle->ar_brake = ratio;
+                    // we are on the gas pedal, jump to first gear when we were in rear gear
+                    if (engine->GetAutoShiftMode() == SimGearboxMode::AUTO)
+                    {
+                        engine->autoShiftSet(EngineSim::DRIVE);
+                    }
+                    else
+                    {
+                        engine->SetGear(1);
+                    }
                 }
             }
-        } // end of ->engine
-        if (vehicle->ar_brake > 1.0f / 6.0f)
+        }
+
+        // IMI
+        // gear management -- it might, should be transferred to a standalone function of Beam or SimController
+        if (engine->GetAutoShiftMode() == SimGearboxMode::AUTO)
         {
-            SOUND_START(vehicle, SS_TRIG_BRAKE);
+            if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_UP))
+            {
+                engine->autoShiftUp();
+            }
+            if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_AUTOSHIFT_DOWN))
+            {
+                engine->autoShiftDown();
+            }
+        }
+
+        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_CONTACT))
+        {
+            engine->ToggleStarterContact();
+        }
+
+        if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_STARTER) && engine->HasStarterContact() && !engine->IsRunning())
+        {
+            // starter
+            engine->SetStarter(1);
+            SOUND_START(vehicle, SS_TRIG_STARTER);
         }
         else
         {
-            SOUND_STOP(vehicle, SS_TRIG_BRAKE);
+            engine->SetStarter(0);
+            SOUND_STOP(vehicle, SS_TRIG_STARTER);
         }
-    } // end of ->ar_replay_mode
+
+        if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SWITCH_SHIFT_MODES))
+        {
+            // toggle Auto shift
+            engine->ToggleAutoShiftMode();
+
+            // force gui update
+            vehicle->RequestUpdateHudFeatures();
+            const char* msg = nullptr;
+            switch (engine->GetAutoShiftMode())
+            {
+            case SimGearboxMode::AUTO: msg = "Automatic shift";
+                break;
+            case SimGearboxMode::SEMI_AUTO: msg = "Manual shift - Auto clutch";
+                break;
+            case SimGearboxMode::MANUAL: msg = "Fully Manual: sequential shift";
+                break;
+            case SimGearboxMode::MANUAL_STICK: msg = "Fully manual: stick shift";
+                break;
+            case SimGearboxMode::MANUAL_RANGES: msg = "Fully Manual: stick shift with ranges";
+                break;
+            }
+            RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L(msg), "cog.png", 3000);
+            RoR::App::GetGuiManager()->PushNotification("Gearbox Mode:", msg);
+        }
+
+        // joy clutch
+        float cval = RoR::App::GetInputEngine()->getEventValue(EV_TRUCK_MANUAL_CLUTCH);
+        engine->setManualClutch(cval);
+
+        SimGearboxMode shiftmode = engine->GetAutoShiftMode();
+
+        if (shiftmode <= SimGearboxMode::MANUAL) // auto, semi auto and sequential shifting
+        {
+            if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_UP))
+            {
+                engine->shift(1);
+            }
+            else if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_DOWN))
+            {
+                if (shiftmode > SimGearboxMode::SEMI_AUTO ||
+                    shiftmode == SimGearboxMode::SEMI_AUTO && (!App::io_arcade_controls.GetActive()) ||
+                    shiftmode == SimGearboxMode::SEMI_AUTO && engine->GetGear() > 0 ||
+                    shiftmode == SimGearboxMode::AUTO)
+                {
+                    engine->shift(-1);
+                }
+            }
+            else if (shiftmode != SimGearboxMode::AUTO && RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL))
+            {
+                engine->shiftTo(0);
+            }
+        }
+        else //if (shiftmode > SimGearboxMode::MANUAL) // h-shift or h-shift with ranges shifting
+        {
+            bool gear_changed = false;
+            bool found = false;
+            int curgear = engine->GetGear();
+            int curgearrange = engine->GetGearRange();
+            int gearoffset = std::max(0, curgear - curgearrange * 6);
+
+            // one can select range only if in neutral
+            if (shiftmode == SimGearboxMode::MANUAL_RANGES && curgear == 0)
+            {
+                //  maybe this should not be here, but should experiment
+                if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_LOWRANGE) && curgearrange != 0)
+                {
+                    engine->SetGearRange(0);
+                    gear_changed = true;
+                    RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png", 3000);
+                }
+                else if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_MIDRANGE) && curgearrange != 1 && engine->getNumGearsRanges() > 1)
+                {
+                    engine->SetGearRange(1);
+                    gear_changed = true;
+                    RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png", 3000);
+                }
+                else if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_HIGHRANGE) && curgearrange != 2 && engine->getNumGearsRanges() > 2)
+                {
+                    engine->SetGearRange(2);
+                    gear_changed = true;
+                    RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png", 3000);
+                }
+            }
+            //zaxxon
+            if (curgear == -1)
+            {
+                gear_changed = !RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE);
+            }
+            else if (curgear > 0 && curgear < 19)
+            {
+                gear_changed = !RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + gearoffset - 1); // range mode
+            }
+
+            if (gear_changed || curgear == 0)
+            {
+                if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE))
+                {
+                    engine->shiftTo(-1);
+                    found = true;
+                }
+                else if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_NEUTRAL))
+                {
+                    engine->shiftTo(0);
+                    found = true;
+                }
+                else
+                {
+                    if (shiftmode == SimGearboxMode::MANUAL_STICK)
+                    {
+                        for (int i = 1; i < 19 && !found; i++)
+                        {
+                            if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
+                            {
+                                engine->shiftTo(i);
+                                found = true;
+                            }
+                        }
+                    }
+                    else // SimGearboxMode::MANUALMANUAL_RANGES
+                    {
+                        for (int i = 1; i < 7 && !found; i++)
+                        {
+                            if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
+                            {
+                                engine->shiftTo(i + curgearrange * 6);
+                                found = true;
+                            }
+                        }
+                    }
+                }
+                if (!found)
+                {
+                    engine->shiftTo(0);
+                }
+            } // end of if (gear_changed)
+        } // end of shitmode > SimGearboxMode::MANUAL
+    } // end of ->engine
+    if (vehicle->ar_brake > 1.0f / 6.0f)
+    {
+        SOUND_START(vehicle, SS_TRIG_BRAKE);
+    }
+    else
+    {
+        SOUND_STOP(vehicle, SS_TRIG_BRAKE);
+    }
 
     if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_INTER_AXLE_DIFF))
     {
@@ -533,7 +549,7 @@ void LandVehicleSimulation::UpdateVehicle(Actor* vehicle, float seconds_since_la
     }
     else
     {
-        if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_HORN) && !vehicle->ar_replay_mode)
+        if (RoR::App::GetInputEngine()->getEventBoolValue(EV_TRUCK_HORN))
         {
             SOUND_START(vehicle, SS_TRIG_HORN);
         }
@@ -561,13 +577,5 @@ void LandVehicleSimulation::UpdateVehicle(Actor* vehicle, float seconds_since_la
     if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_CRUISE_CONTROL))
     {
         vehicle->ToggleCruiseControl();
-    }
-    if (vehicle->cc_mode)
-    {
-        LandVehicleSimulation::UpdateCruiseControl(vehicle, seconds_since_last_frame);
-    }
-    if (vehicle->sl_enabled)
-    {
-        LandVehicleSimulation::CheckSpeedLimit(vehicle, seconds_since_last_frame);
     }
 }

--- a/source/main/gameplay/LandVehicleSimulation.h
+++ b/source/main/gameplay/LandVehicleSimulation.h
@@ -39,9 +39,15 @@ struct LandVehicleSimulation
     static void CheckSpeedLimit(Actor* vehicle, float dt);
 
     /**
-    * Logic: input, sound, vehicle state
+    * Logic: driving aids and such
     */
     static void UpdateVehicle(Actor* vehicle, float seconds_since_last_frame);
+
+    /**
+    * Logic: input, sound, vehicle state
+    */
+    static void UpdateInputEvents(Actor* vehicle, float seconds_since_last_frame);
+
 };
 
 } // namespace RoR

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -896,11 +896,11 @@ void SimController::UpdateInputEvents(float dt)
 
                     if (m_player_actor->ar_driveable == TRUCK)
                     {
-                        LandVehicleSimulation::UpdateVehicle(m_player_actor, dt);
+                        LandVehicleSimulation::UpdateInputEvents(m_player_actor, dt);
                     }
                     if (m_player_actor->ar_driveable == AIRPLANE)
                     {
-                        AircraftSimulation::UpdateVehicle(m_player_actor, dt);
+                        AircraftSimulation::UpdateInputEvents(m_player_actor, dt);
                     }
                     if (m_player_actor->ar_driveable == BOAT)
                     {

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -36,6 +36,7 @@
 #include "GUIManager.h"
 #include "GUI_GameConsole.h"
 #include "GUI_TopMenubar.h"
+#include "LandVehicleSimulation.h"
 #include "Language.h"
 #include "MovableText.h"
 #include "Network.h"
@@ -976,12 +977,16 @@ void ActorManager::UpdateActors(Actor* player_actor, float dt)
         actor->HandleAngelScriptEvents(dt);
 
 #ifdef USE_ANGELSCRIPT
-        if (actor->ar_vehicle_ai && (actor->ar_vehicle_ai->IsActive()))
+        if (actor->ar_vehicle_ai && actor->ar_vehicle_ai->IsActive())
             actor->ar_vehicle_ai->update(dt, 0);
 #endif // USE_ANGELSCRIPT
 
         if (actor->ar_engine)
         {
+            if (actor->ar_driveable == TRUCK)
+            {
+                LandVehicleSimulation::UpdateVehicle(actor, dt);
+            }
             if (actor->ar_sim_state == Actor::SimState::LOCAL_SLEEPING)
             {
                 actor->ar_engine->UpdateEngineSim(dt, 1);


### PR DESCRIPTION
This separates the driving aids logic (anti-rollback, cruise control, ...) from the input event handling and fixes the issue that the driving aids were only working on the player vehicle.