### PR TITLE
Fixed crash to desktop after regen

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -2206,7 +2206,7 @@ void CacheSystem::loadSingleDirectory(String dirname, String group, bool already
 #ifdef USE_OPENAL
             SoundScriptManager::getSingleton().clearNonBaseTemplates();
 #endif //OPENAL
-            //ParticleSystemManager::getSingleton().removeTemplatesByResourceGroup(rgname);
+            ParticleSystemManager::getSingleton().removeTemplatesByResourceGroup(rgname);
             ResourceGroupManager::getSingleton().clearResourceGroup(rgname);
             ResourceGroupManager::getSingleton().unloadResourceGroup(rgname);
             ResourceGroupManager::getSingleton().removeResourceLocation(dirname, rgname);
@@ -2275,7 +2275,7 @@ void CacheSystem::loadSingleZip(String zippath, int cfactor, bool unload, bool o
 #ifdef USE_OPENAL
             SoundScriptManager::getSingleton().clearNonBaseTemplates();
 #endif //OPENAL
-            //ParticleSystemManager::getSingleton().removeTemplatesByResourceGroup(rgname);
+            ParticleSystemManager::getSingleton().removeTemplatesByResourceGroup(rgname);
             rgm.removeResourceLocation(realzipPath, rgname);
             rgm.clearResourceGroup(rgname);
             rgm.unloadResourceGroup(rgname);


### PR DESCRIPTION
How to reproduce:

1. Rebuild the cache
2. Load [Aspen Grove](https://github.com/RigsOfRods/rigs-of-rods/files/2619701/AspenGrove.zip) without restarting the game

```
FATAL ERROR: An internal error occured in Rigs of Rods.

Technical details below: 

ItemIdentityException: ParticleSystem template with name 'tracks/TurbopropSmoke' already exists. in ParticleSystemManager::createTemplate at /home/archie/ror-dependencies/Source/ogre/OgreMain/src/OgreParticleSystemManager.cpp (line 199)
```
@only-a-ptr I don't know if this is the correct way of fixing it. I also experimented around with `destroyParticleSystem`, but that didn't work.