### PR TITLE
Removed unnecessary double id from the node struct

### DIFF
--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -46,11 +46,10 @@ struct node_t
     Ogre::Real surface_coef;
     Ogre::Real volume_coef;
 
-    char iswheel; //!< 0=NOWHEEL, 1=WHEEL_DEFAULT, 2=WHEEL_2  3=WHEEL_FLEXBODY
-    char nd_coll_bbox_id; //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
-    short nd_lockgroup;
-    short pos;     //!< This node's index in Actor::ar_nodes array.
-    short id;      //!< Numeric identifier assigned in truckfile (if used), or -1 if the node was generated dynamically.
+    int16_t iswheel;          //!< 0=NOWHEEL, 1=WHEEL_DEFAULT, 2=WHEEL_2  3=WHEEL_FLEXBODY
+    int16_t pos;              //!< This node's index in Actor::ar_nodes array.
+    int16_t nd_coll_bbox_id;  //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
+    int16_t nd_lockgroup;     //!< Optional attribute (-1 = default, 9999 = deny lock) - used in the hook lock logic
 
     Ogre::Real      nd_avg_collision_slip;   //!< Physics state; average slip velocity across the last few physics frames
     Ogre::Vector3   nd_last_collision_slip;  //!< Physics state; last collision slip vector

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -171,7 +171,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
 
             for (std::vector<hook_t>::iterator it = grab_truck->ar_hooks.begin(); it != grab_truck->ar_hooks.end(); it++)
             {
-                if (it->hk_hook_node->id == minnode)
+                if (it->hk_hook_node->pos == minnode)
                 {
                     grab_truck->ToggleHooks(it->hk_group, MOUSE_HOOK_TOGGLE, minnode);
                 }

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -779,7 +779,7 @@ void RoR::GfxActor::UpdateDebugView()
                 {
                     ImVec2 pos_xy(pos.x, pos.y);
                     Str<25> id_buf;
-                    id_buf << nodes[i].id;
+                    id_buf << nodes[i].pos;
                     drawlist->AddText(pos_xy, NODE_TEXT_COLOR, id_buf.ToCStr());
 
                     if (m_debug_view != DebugViewType::DEBUGVIEW_BEAMS)
@@ -1082,10 +1082,10 @@ void RoR::GfxActor::UpdateDebugView()
 
                 // Node info
                 Str<25> id1_buf;
-                id1_buf << beams[i].p1->id;
+                id1_buf << beams[i].p1->pos;
                 drawlist->AddText(pos1xy, NODE_TEXT_COLOR, id1_buf.ToCStr());
                 Str<25> id2_buf;
-                id2_buf << beams[i].p2->id;
+                id2_buf << beams[i].p2->pos;
                 drawlist->AddText(pos2xy, NODE_TEXT_COLOR, id2_buf.ToCStr());
 
                 // Shock info

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -3261,8 +3261,8 @@ void Actor::ToggleTies(int group)
                         if (!itr->multilock && itr->in_use)
                             continue;
 
-                        //skip if tienode is ropable too (no hk_selflock)
-                        if (itr->node->id == it->ti_beam->p1->id)
+                        // skip if tienode is ropable too (no selflock)
+                        if (this == actor && itr->node->pos == it->ti_beam->p1->pos)
                             continue;
 
                         // calculate the distance and record the nearest ropable
@@ -3390,7 +3390,7 @@ void Actor::ToggleHooks(int group, hook_states mode, int node_number)
     // iterate over all hooks
     for (std::vector<hook_t>::iterator it = ar_hooks.begin(); it != ar_hooks.end(); it++)
     {
-        if (mode == MOUSE_HOOK_TOGGLE && it->hk_hook_node->id != node_number)
+        if (mode == MOUSE_HOOK_TOGGLE && it->hk_hook_node->pos != node_number)
         {
             //skip all other nodes except the one manually toggled by mouse
             continue;
@@ -3459,7 +3459,7 @@ void Actor::ToggleHooks(int group, hook_states mode, int node_number)
                             continue;
 
                         // exclude this truck and its current hooknode from the locking search
-                        if (this == actor && i == it->hk_hook_node->id)
+                        if (this == actor && i == it->hk_hook_node->pos)
                             continue;
 
                         // a lockgroup for this hooknode is set -> skip all nodes that do not have the same lockgroup (-1 = default(all nodes))

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1130,14 +1130,6 @@ bool Actor::CalcForcesEulerPrepare(bool doUpdate)
 template <size_t L>
 void LogNodeId(RoR::Str<L>& msg, node_t* node) // Internal helper
 {
-    if (node->id <= 0) // Named nodes have '0', generated have '-1'
-    {
-        msg << "\"?unknown?\"";
-    }
-    else
-    {
-        msg << "\"" << node->id << "\"";
-    }
     msg << " (index: " << node->pos << ")";
 }
 

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -4017,7 +4017,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         InitNode(outer_node, ray_point, def.node_defaults);
 
         outer_node.mass          = node_mass;
-        outer_node.id            = -1; // Orig: hardcoded (addWheel2)
         outer_node.friction_coef = def.node_defaults->friction;
         AdjustNodeBuoyancy(outer_node, def.node_defaults);
 
@@ -4031,7 +4030,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         InitNode(inner_node, ray_point, def.node_defaults);
 
         inner_node.mass          = node_mass;
-        inner_node.id            = -1; // Orig: hardcoded (addWheel2)
         inner_node.friction_coef = def.node_defaults->friction;
         AdjustNodeBuoyancy(inner_node, def.node_defaults);
 
@@ -4057,7 +4055,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         node_t & outer_node = GetFreeNode();
         InitNode(outer_node, ray_point);
         outer_node.mass          = node_mass;
-        outer_node.id            = -1; // Orig: hardcoded (addWheel3)
         outer_node.friction_coef = def.node_defaults->friction;
         outer_node.volume_coef   = def.node_defaults->volume;
         outer_node.surface_coef  = def.node_defaults->surface;
@@ -4076,7 +4073,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         node_t & inner_node = GetFreeNode();
         InitNode(inner_node, ray_point);
         inner_node.mass          = node_mass;
-        inner_node.id            = -1; // Orig: hardcoded (addWheel3)
         inner_node.friction_coef = def.node_defaults->friction;
         inner_node.volume_coef   = def.node_defaults->volume;
         inner_node.surface_coef  = def.node_defaults->surface;
@@ -4468,7 +4464,6 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
         InitNode(outer_node, ray_point, node_defaults);
         outer_node.mass    = wheel_mass / (2.f * num_rays);
         outer_node.iswheel = (set_param_iswheel) ? WHEEL_DEFAULT : NOWHEEL;
-        outer_node.id      = -1; // Orig: hardcoded (BTS_WHEELS)
         AdjustNodeBuoyancy(outer_node, node_defaults);
 
         m_actor->ar_contacters[m_actor->ar_num_contacters] = outer_node.pos;
@@ -4484,7 +4479,6 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
         InitNode(inner_node, ray_point, node_defaults);
         inner_node.mass    = wheel_mass / (2.f * num_rays);
         inner_node.iswheel = (set_param_iswheel) ? WHEEL_DEFAULT : NOWHEEL;
-        inner_node.id      = -1; // Orig: hardcoded (BTS_WHEELS)
         AdjustNodeBuoyancy(inner_node, node_defaults);
 
         m_actor->ar_contacters[m_actor->ar_num_contacters] = inner_node.pos;
@@ -4754,7 +4748,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         InitNode(outer_node, ray_point, wheel_2_def.node_defaults);
         outer_node.mass    = node_mass;
         outer_node.iswheel = WHEEL_2;
-        outer_node.id      = -1; // Orig: hardcoded (addWheel2)
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
 
@@ -4765,7 +4758,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         InitNode(inner_node, ray_point, wheel_2_def.node_defaults);
         inner_node.mass    = node_mass;
         inner_node.iswheel = WHEEL_2;
-        inner_node.id      = -1; // Orig: hardcoded (addWheel2)
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
 
@@ -4790,7 +4782,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         InitNode(outer_node, ray_point);
         outer_node.mass          = (0.67f * wheel_2_def.mass) / (2.f * wheel_2_def.num_rays);
         outer_node.iswheel       = WHEEL_2;
-        outer_node.id            = -1; // Orig: hardcoded (addWheel2)
         outer_node.friction_coef = wheel.wh_width * WHEEL_FRICTION_COEF;
         outer_node.volume_coef   = wheel_2_def.node_defaults->volume;
         outer_node.surface_coef  = wheel_2_def.node_defaults->surface;
@@ -4807,7 +4798,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         InitNode(inner_node, ray_point);
         inner_node.mass          = (0.33f * wheel_2_def.mass) / (2.f * wheel_2_def.num_rays);
         inner_node.iswheel       = WHEEL_2;
-        inner_node.id            = -1; // Orig: hardcoded (addWheel2)
         inner_node.friction_coef = wheel.wh_width * WHEEL_FRICTION_COEF;
         inner_node.volume_coef   = wheel_2_def.node_defaults->volume;
         inner_node.surface_coef  = wheel_2_def.node_defaults->surface;
@@ -5689,7 +5679,6 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
 
     node_t & node = m_actor->ar_nodes[inserted_node.first];
     node.pos = inserted_node.first; /* Node index */
-    node.id = static_cast<int>(def.id.Num());
 
     /* Positioning */
     Ogre::Vector3 node_position = m_spawn_position + def.position;
@@ -5876,7 +5865,6 @@ void ActorSpawner::ProcessCinecam(RigDef::Cinecam & def)
     node_t & camera_node = GetAndInitFreeNode(node_pos);
     camera_node.nd_no_ground_contact = true; // Orig: hardcoded in BTS_CINECAM
     camera_node.friction_coef = NODE_FRICTION_COEF_DEFAULT; // Node defaults are ignored here.
-    camera_node.id = -1;
     AdjustNodeBuoyancy(camera_node, def.node_defaults);
     camera_node.volume_coef   = def.node_defaults->volume;
     camera_node.surface_coef  = def.node_defaults->surface;

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -503,7 +503,7 @@ int ScriptEngine::envokeCallback(int functionId, eventsource_t *source, node_t *
     context->SetArgObject(1, instance_name);
     context->SetArgObject(2, boxname);
     if (node)
-        context->SetArgDWord (3, node->id);
+        context->SetArgDWord (3, node->pos);
     else
         context->SetArgDWord (3, -1); // conversion from 'int' to 'AngelScript::asDWORD', signed/unsigned mismatch!
 


### PR DESCRIPTION
Positive side effect: The true wheel nodes indices made their way back into the node details debug overlay.

@only-a-ptr Do we really have to keep track of which nodes are auto-generated an which are not? I don't think so, but I might be wrong.