### PR TITLE
✨ Added blender 2.79 import/export plugins

### DIFF
--- a/tools/blender/ror_export.py
+++ b/tools/blender/ror_export.py
@@ -1,0 +1,155 @@
+# <pep8-80 compliant>
+
+bl_info = {
+    "name": "RoR Exporter",
+    "author": "ulteq",
+    "version": (0, 0, 1),
+    "blender": (2, 79, 0),
+    "category": "RoR",
+}
+
+import bpy
+import json
+import bmesh
+from bpy_extras.io_utils import ExportHelper
+
+def register():
+    bpy.app.debug = True
+    bpy.utils.register_class(ror_export)
+    bpy.types.INFO_MT_file_export.append(menu_func)
+    return
+
+def unregister():
+    bpy.types.INFO_MT_file_export.remove(menu_func)
+    bpy.utils.unregister_class(ror_export)
+    return
+
+def menu_func(self, context):
+    self.layout.operator(ror_export.bl_idname, text="Truck (.truck)")
+
+class ror_export(bpy.types.Operator, ExportHelper):
+    bl_idname = "export_truck.truck"
+    bl_label = "Export RoR Truck"
+    filename_ext = ".truck"
+    filepath = bpy.props.StringProperty(subtype="FILE_PATH")
+
+    def execute(self, context):
+        nodes = []
+        beams = []
+        cabs = []
+
+        for obj in context.selected_objects[:1]:
+            if obj.type != 'MESH':
+                continue
+
+            bpy.ops.object.mode_set(mode="EDIT")
+            bm = bmesh.from_edit_mesh(obj.data)
+
+            group_names = {group.index : group.name for group in obj.vertex_groups}
+            node_digits = len(str(len(obj.data.vertices) - 1))
+
+            format_string = '{:'+str(node_digits)+'d}, {: 8.3f}, {: 8.3f}, {: 8.3f}'
+            defaults_key = bm.verts.layers.string.get("defaults")
+            options_key = bm.verts.layers.string.get("options")
+            bm.verts.ensure_lookup_table()
+            for v, bv in zip(obj.data.vertices, bm.verts):
+                defaults = ''
+                if defaults_key:
+                    defaults = bv[defaults_key].decode()
+                options = ''
+                if options_key:
+                    options = bv[options_key].decode()
+                if not options:
+                    options = 'n'
+                groups = [group_names[g.group] for g in v.groups]
+                nodes.append([format_string.format(v.index, v.co[1], v.co[2], v.co[0]), options, groups, defaults])
+
+            format_string = '{:'+str(node_digits)+'d}, {:'+str(node_digits)+'d}'
+            defaults_key = bm.edges.layers.string.get("defaults")
+            options_key = bm.edges.layers.string.get("options")
+            bm.edges.ensure_lookup_table()
+            for e, be in zip(obj.data.edges, bm.edges):
+                defaults = ''
+                if defaults_key:
+                    defaults = be[defaults_key].decode()
+                options = ''
+                if options_key:
+                    options = be[options_key].decode()
+                if not options:
+                    options = 'v'
+                ids = sorted([[g.group for g in obj.data.vertices[e.vertices[i]].groups] for i in [0, 1]])
+                vg1, vg2 = [[group_names[g] for g in ids[i]] for i in [0, 1]]
+                groups = vg1 if vg1 == vg2 else [', '.join(vg1)] + [">"] + [', '.join(vg2)]
+                beams.append([ids, groups, format_string.format(e.vertices[0], e.vertices[1]), options, defaults])
+
+            format_string = '{:'+str(node_digits)+'d}, {:'+str(node_digits)+'d}, {:'+str(node_digits)+'d}'
+            options_key = bm.faces.layers.string.get("options")
+            bm.faces.ensure_lookup_table()
+            for p, bp in zip(obj.data.polygons, bm.faces):
+                if len(p.vertices) == 3:
+                    options = ''
+                    if options_key:
+                        options = bp[options_key].decode()
+                    if not options:
+                        options = 'c'
+                    cabs.append([format_string.format(p.vertices[0], p.vertices[1], p.vertices[2]), options])
+
+            bpy.ops.object.mode_set(mode="OBJECT")
+            bm.free()
+
+        truckfile = []
+        indices = [0, 0, 0]
+        try:
+            truckfile = json.loads(bpy.context.active_object.RoRTruckFile)
+            indices = json.loads(bpy.context.active_object.RoRInsertIndices)
+        except:
+            pass
+
+        with open(self.filepath, 'w') as f:
+            for line in truckfile[:indices[0]]:
+                print (line, file=f)
+
+            print("nodes", file=f)
+            defaults = ''
+            vertex_groups = []
+            for n in sorted(nodes):
+                if n[-1] != defaults:
+                    defaults = n[-1]
+                    print (defaults, file=f)
+                if n[-2] != vertex_groups:
+                    vertex_groups = n[-2]
+                    print (";grp:", ', '.join(vertex_groups), file=f)
+                print (*n[:-2], sep=', ', file=f)
+
+            lines = truckfile[indices[0]:indices[1]]
+            if not lines:
+                lines = ['']
+            for line in lines:
+                print (line, file=f)
+
+            print("beams", file=f)
+            edge_groups = []
+            for b in sorted(beams):
+                if b[-1] != defaults:
+                    defaults = b[-1]
+                    print (defaults, file=f)
+                if b[1] != edge_groups:
+                    edge_groups = b[1]
+                    print (";grp:", *edge_groups, file=f)
+                print (*b[2:-1], sep=', ', file=f)
+
+            lines = truckfile[indices[1]:indices[2]]
+            if not lines:
+                lines = ['']
+            for line in lines:
+                print (line, file=f)
+
+            if cabs:
+                print ("cab", file=f)
+                for c in cabs:
+                    print (*c, sep=', ', file=f)
+
+            for line in truckfile[indices[2]:]:
+                print (line, file=f)
+
+        return {'FINISHED'}

--- a/tools/blender/ror_import.py
+++ b/tools/blender/ror_import.py
@@ -1,0 +1,155 @@
+# <pep8-80 compliant>
+
+bl_info = {
+    "name": "RoR Importer",
+    "author": "ulteq",
+    "version": (0, 0, 1),
+    "blender": (2, 79, 0),
+    "category": "RoR",
+}
+
+import bpy
+import json
+import bmesh
+from bpy_extras.io_utils import ImportHelper
+
+def register():
+    bpy.app.debug = True
+    bpy.utils.register_class(ror_import)
+    bpy.types.INFO_MT_file_import.append(menu_func)
+    return
+
+def unregister():
+    bpy.types.INFO_MT_file_import.remove(menu_func)
+    bpy.utils.unregister_class(ror_import)
+    return
+
+def menu_func(self, context):
+    self.layout.operator(ror_import.bl_idname, text="Truck (.truck)")
+
+class ror_import(bpy.types.Operator, ImportHelper):
+    bl_idname = "import_truck.truck"
+    bl_label = "Import RoR Truck"
+    filename_ext = ".truck"
+    filepath = bpy.props.StringProperty(subtype="FILE_PATH")
+
+    def execute(self, context):
+        truckfile = []
+        node_idx = 0
+        nodes = []
+        beam_idx = 0
+        beams = []
+        cab_idx = 0
+        cabs = []
+
+        with open(self.filepath, 'r') as f:
+            node_defaults = ''
+            beam_defaults = ''
+            mode = 'ignore'
+            groups = []
+            for line in f:
+                line = line.strip()
+                if not line or line[0] == ';':
+                    truckfile.append(line)
+                    if mode == 'nodes' and line[:5] == ';grp:':
+                        groups = line[5:].split(', ')
+                    continue
+
+                args = line.replace(',', ' ').split()
+                if not args or "set_" in args[0]:
+                    if args and mode == 'nodes' and "set_n" in args[0]:
+                        node_defaults = line
+                    if args and mode == 'beams' and "set_b" in args[0]:
+                        beam_defaults = line
+                    else:
+                        truckfile.append(line)
+                    continue
+
+                if args[0] == 'nodes':
+                    mode = 'nodes'
+                    node_defaults = ''
+                    node_idx = len(truckfile)
+                    continue
+                elif args[0] == 'beams':
+                    mode = 'beams'
+                    beam_defaults = ''
+                    beam_idx = len(truckfile)
+                    continue
+                elif args[0] == 'cab':
+                    mode = 'cab'
+                    cab_idx = len(truckfile)
+                    continue
+                elif not args[0].isdigit() or mode == 'ignore':
+                    truckfile.append(line)
+                    mode = 'ignore'
+
+                if mode == 'nodes':
+                    nodes.append([node_defaults] + [groups] + args[1:])
+                elif mode == 'beams':
+                    beams.append([beam_defaults] + args)
+                elif mode == 'cab':
+                    cabs.append(args)
+
+        mesh = bpy.data.meshes.new(self.filepath + "-mesh")
+        obj  = bpy.data.objects.new(self.filepath + "-obj", mesh)
+
+        bpy.context.scene.objects.link(obj)
+        bpy.context.scene.objects.active = obj
+        obj.select = True
+
+        bpy.types.Object.RoRTruckFile = bpy.props.StringProperty()
+        bpy.context.active_object.RoRTruckFile = json.dumps(truckfile)
+
+        if (beam_idx < node_idx):
+            beam_idx = len(truckfile)
+        if (cab_idx < beam_idx):
+            cab_idx = len(truckfile)
+        indices = [node_idx, beam_idx, cab_idx]
+        bpy.types.Object.RoRInsertIndices = bpy.props.StringProperty()
+        bpy.context.active_object.RoRInsertIndices = json.dumps(indices)
+
+        mesh = bpy.context.object.data
+        bm   = bmesh.new()
+        dl   = bm.verts.layers.deform.verify()
+
+        defaults_key = bm.verts.layers.string.new("defaults")
+        options_key = bm.verts.layers.string.new("options")
+        for n in nodes:
+            try:
+                v = bm.verts.new((float(n[4]), float(n[2]), float(n[3])))
+                bm.verts.ensure_lookup_table()
+                bm.verts.index_update()
+                bm.verts[-1][defaults_key] = n[0].encode()
+                bm.verts[-1][options_key] = ' '.join(n[5:]).encode()
+                for g in n[1]:
+                    vg = obj.vertex_groups.get(g)
+                    if not vg:
+                        vg = obj.vertex_groups.new(g)
+                    v[dl][vg.index] = 1.0
+            except:
+                print ("Failed to add vertex:", n)
+
+        defaults_key = bm.edges.layers.string.new("defaults")
+        options_key = bm.edges.layers.string.new("options")
+        for b in beams:
+            try:
+                bm.edges.new((bm.verts[int(i)] for i in b[1:3]))
+                bm.edges.ensure_lookup_table()
+                bm.edges[-1][defaults_key] = b[0].encode()
+                bm.edges[-1][options_key] = ' '.join(b[3:]).encode()
+            except:
+                print ("Failed to add edge:", b)
+
+        options_key = bm.faces.layers.string.new("options")
+        for c in cabs:
+            try:
+                bm.faces.new((bm.verts[int(i)] for i in c[:3]))
+                bm.faces.ensure_lookup_table()
+                bm.faces[-1][options_key] = ' '.join(c[3:]).encode()
+            except:
+                print ("Failed to add face:", c)
+
+        bm.to_mesh(mesh)
+        bm.free()
+
+        return {'FINISHED'}


### PR DESCRIPTION
Features:
- Full vertex group support
- Automatic column alignment
- Sophisticated vertex position rounding
- Full preservation of the original truck file
- Automatic beam sorting based on the vertex groups
- All node, beam and cab options are preserved during import / export
- All `set_node_defaults`, `set_beam_defaults` and `set_beam_defaults_scale` entries are preserved

Repository entry: https://www.rigsofrods.org/forum/resources/blender-import-export-plugin.25/