### PR TITLE
Made the 'Anisotropy' setting adjustable

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -171,6 +171,7 @@ static TerrainManager*  g_sim_terrain;
  GVarEnum_AP<GfxTexFilter>   gfx_texture_filter   ("gfx_texture_filter",      "Texture Filtering",         GfxTexFilter::TRILINEAR, GfxTexFilter::TRILINEAR);
  GVarEnum_AP<GfxVegetation>  gfx_vegetation_mode  ("gfx_vegetation_mode",     "Vegetation",                GfxVegetation::NONE,     GfxVegetation::NONE);
  GVarEnum_AP<GfxWaterMode>   gfx_water_mode       ("gfx_water_mode",          "Water effects",             GfxWaterMode::BASIC,     GfxWaterMode::BASIC);
+ GVarPod_A<int>           gfx_anisotropy          ("gfx_anisotropy",          "Anisotropy",                4);
  GVarPod_A<bool>          gfx_water_waves         ("gfx_water_waves",         "Waves",                     false);
  GVarPod_A<bool>          gfx_minimap_enabled     ("gfx_minimap_enabled",     "OverviewMap",               true);
  GVarPod_A<int>           gfx_particles_mode      ("gfx_particles_mode",      "Particles",                 0);

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -742,6 +742,7 @@ extern GVarEnum_AP<GfxSkyMode>    gfx_sky_mode;
 extern GVarEnum_AP<GfxTexFilter>  gfx_texture_filter;
 extern GVarEnum_AP<GfxVegetation> gfx_vegetation_mode;
 extern GVarEnum_AP<GfxWaterMode>  gfx_water_mode;
+extern GVarPod_A<int>          gfx_anisotropy;
 extern GVarPod_A<bool>         gfx_water_waves;
 extern GVarPod_A<bool>         gfx_minimap_enabled;
 extern GVarPod_A<int>          gfx_particles_mode;

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -156,6 +156,16 @@ void RoR::GUI::GameSettings::Draw()
             "Trilinear\0"
             "Anisotropic\0\0");
 
+        if (App::gfx_texture_filter.GetActive() == GfxTexFilter::ANISOTROPIC)
+        {
+            int anisotropy = Ogre::Math::Clamp(App::gfx_anisotropy.GetActive(), 1, 16);
+            int  selection = std::log2(anisotropy);
+            if (ImGui::Combo("Anisotropy", &selection, "1\0""2\0""4\0""8\0""16\0\0"))
+            {
+                App::gfx_anisotropy.SetActive(std::pow(2, selection));
+            }
+        }
+
         DrawGCombo(App::gfx_vegetation_mode, "Vegetation density",
             "None\0"
             "20%\0"

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -220,7 +220,7 @@ bool ContentManager::OnApplicationStartup(void)
     case GfxTexFilter::BILINEAR:    tfo = TFO_BILINEAR;           break;
     case GfxTexFilter::NONE:        tfo = TFO_NONE;               break;
     }
-    MaterialManager::getSingleton().setDefaultAnisotropy(8);
+    MaterialManager::getSingleton().setDefaultAnisotropy(Math::Clamp(App::gfx_anisotropy.GetActive(), 1, 16));
     MaterialManager::getSingleton().setDefaultTextureFiltering(tfo);
 
     // load all resources now, so the zip files are also initiated

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -651,6 +651,7 @@ bool Settings::ParseGlobalVarSetting(std::string const & k, std::string const & 
     if (CheckGfxWaterMode                         (k, v)) { return true; }
     if (CheckGfxSkyMode                           (k, v)) { return true; }
     if (CheckSpeedoImperial                       (k, v)) { return true; }
+    if (CheckInt  (App::gfx_anisotropy,            k, v)) { return true; }
     if (CheckBool (App::gfx_water_waves,           k, v)) { return true; }
     if (CheckBool (App::gfx_minimap_enabled,       k, v)) { return true; }
     if (CheckB2I  (App::gfx_particles_mode,        k, v)) { return true; }
@@ -927,6 +928,7 @@ void Settings::SaveSettings()
     WriteAny (f, App::gfx_flares_mode.conf_name    , GfxFlaresToStr    (App::gfx_flares_mode.GetActive     ()));
     WriteAny (f, App::gfx_water_mode.conf_name     , GfxWaterToStr     (App::gfx_water_mode.GetActive      ()));
     WriteAny (f, App::gfx_sky_mode.conf_name       , GfxSkyToStr       (App::gfx_sky_mode.GetActive        ()));
+    WritePod (f, App::gfx_anisotropy      );
     WriteYN  (f, App::gfx_enable_videocams);
     WriteYN  (f, App::gfx_water_waves     );
     WriteYN  (f, App::gfx_minimap_enabled );


### PR DESCRIPTION
- Lowered the default value from 8 to 4

Lower values (2 or 4) drastically improve the performance on certain maps when playing on an integrated GPU.