### PR TITLE
Fixed the render system selection logic

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -83,6 +83,8 @@ static TerrainManager*  g_sim_terrain;
  GVarPod_APS<int>         app_num_workers         ("app_num_workers",         "NumWorkerThreads",          0,
          0,         0);
  GVarStr_AP<50>           app_screenshot_format   ("app_screenshot_format",   "Screenshot Format",         "jpg",                   "jpg");
+ GVarStr_A<100>           app_desired_render_sys  ("app_desired_render_sys",  "Render system",             "");
+
 
 // Simulation
  GVarEnum_AP<SimState>    sim_state               ("sim_state",               nullptr,                     SimState::OFF,           SimState::OFF);

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -658,6 +658,7 @@ extern GVarPod_A<bool>         app_skip_main_menu;
 extern GVarPod_APS<bool>       app_async_physics;
 extern GVarPod_APS<int>        app_num_workers;
 extern GVarStr_AP<50>          app_screenshot_format;
+extern GVarStr_A<100>          app_desired_render_sys;
 
 // Simulation
 extern GVarEnum_AP<SimState>   sim_state;

--- a/source/main/gfx/OgreSubsystem.cpp
+++ b/source/main/gfx/OgreSubsystem.cpp
@@ -68,6 +68,14 @@ bool OgreSubsystem::Configure()
         else
             m_ogre_root->showConfigDialog(OgreBites::getNativeConfigDialog());
     }
+    const auto rs = m_ogre_root->getRenderSystemByName(App::app_desired_render_sys.GetActive());
+    if (rs != nullptr && rs != m_ogre_root->getRenderSystem())
+    {
+        // The user has selected a different render system during the previous session.
+        m_ogre_root->setRenderSystem(rs);
+        m_ogre_root->saveConfig();
+    }
+    App::app_desired_render_sys.SetActive(m_ogre_root->getRenderSystem()->getName().c_str());
 
     m_render_window = m_ogre_root->initialise(false);
 

--- a/source/main/gfx/OgreSubsystem.cpp
+++ b/source/main/gfx/OgreSubsystem.cpp
@@ -62,7 +62,11 @@ bool OgreSubsystem::Configure()
 {
     if (!m_ogre_root->restoreConfig())
     {
-        m_ogre_root->showConfigDialog(OgreBites::getNativeConfigDialog());
+        const auto render_systems = App::GetOgreSubsystem()->GetOgreRoot()->getAvailableRenderers();
+        if (!render_systems.empty())
+            m_ogre_root->setRenderSystem(render_systems.front());
+        else
+            m_ogre_root->showConfigDialog(OgreBites::getNativeConfigDialog());
     }
 
     m_render_window = m_ogre_root->initialise(false);

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -67,21 +67,22 @@ void RoR::GUI::GameSettings::Draw()
     {
         ImGui::TextDisabled("Render system");
 
-        const Ogre::RenderSystemList render_systems = App::GetOgreSubsystem()->GetOgreRoot()->getAvailableRenderers();
+        const auto ogre_root = App::GetOgreSubsystem()->GetOgreRoot();
+        const auto render_systems = ogre_root->getAvailableRenderers();
         std::string render_system_names;
         for (auto rs : render_systems)
         {
             render_system_names += rs->getName() + '\0';
         }
-        const auto rs = App::GetOgreSubsystem()->GetOgreRoot()->getRenderSystem();
+        const auto rs = ogre_root->getRenderSystemByName(App::app_desired_render_sys.GetActive());
         const auto it = std::find(render_systems.begin(), render_systems.end(), rs);
         int render_id = it != render_systems.end() ? std::distance(render_systems.begin(), it) : 0;
         if (ImGui::Combo("Render System", &render_id, render_system_names.c_str()))
         {
-            App::GetOgreSubsystem()->GetOgreRoot()->setRenderSystem(render_systems[render_id]); // Can we do that here?
+            App::app_desired_render_sys.SetActive(render_systems[render_id]->getName().c_str());
         }
 
-        const Ogre::ConfigOptionMap config_options = rs->getConfigOptions();
+        const auto config_options = ogre_root->getRenderSystem()->getConfigOptions();
         for (auto opt : config_options)
         {
             auto co = opt.second;
@@ -102,7 +103,7 @@ void RoR::GUI::GameSettings::Draw()
                 rs->setConfigOption(co.name, co.possibleValues[option_id]);
                 if (rs->validateConfigOptions().empty())
                 {
-                    App::GetOgreSubsystem()->GetOgreRoot()->saveConfig();
+                    ogre_root->saveConfig();
                 }
             }
         }

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -614,6 +614,7 @@ bool Settings::ParseGlobalVarSetting(std::string const & k, std::string const & 
     // App
     if (CheckScreenshotFormat                     (k, v)) { return true; }
     if (CheckStr  (App::app_locale,                k, v)) { return true; }
+    if (CheckStr  (App::app_desired_render_sys,    k, v)) { return true; }
     if (CheckBool (App::app_skip_main_menu,        k, v)) { return true; }
     if (CheckBool (App::app_async_physics,         k, v)) { return true; }
     if (CheckInt  (App::app_num_workers,           k, v)) { return true; }
@@ -975,6 +976,7 @@ void Settings::SaveSettings()
     f << std::endl << "; Application"<< std::endl;
     WriteStr (f, App::app_screenshot_format );
     WriteStr (f, App::app_locale            );
+    WriteStr (f, App::app_desired_render_sys);
     WriteYN  (f, App::app_skip_main_menu    );
     WriteYN  (f, App::app_async_physics     );
     WritePod (f, App::app_num_workers       );


### PR DESCRIPTION
Neither can we change the render system on the fly, nor can we force Ogre to write a different render system to the `ogre.cfg` on the fly. This seems to be the easiest workaround ...