### PR TITLE
Fix prop anim. for event:TRUCK_TOGGLE_CONTACT

### DIFF
--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -211,6 +211,7 @@ public:
         float                       simbuf_engine_crankfactor;
         float                       simbuf_engine_turbo_psi;
         float                       simbuf_engine_accel;
+        bool                        simbuf_engine_starter_contact;
         bool                        simbuf_beaconlight_active;
         float                       simbuf_hydro_dir_state; // State of steering actuator ('hydro'), for steeringwheel display
         float                       simbuf_hydro_aileron_state;
@@ -317,6 +318,7 @@ public:
 private:
 
     static Ogre::Quaternion SpecialGetRotationTo(const Ogre::Vector3& src, const Ogre::Vector3& dest);
+    float                   FetchPropAnimEventValue(int ev_type) const; //!< Resolve state of animated props with `source:event`
 
     Actor*                      m_actor;
 


### PR DESCRIPTION
This is a minor issue, but I couldn't resist fixing it because it presented a challenge.

Animated props only checked actual controller input, so `event:TRUCK_TOGGLE_CONTACT` didn't work when vehicle was spawned with started engine.

I've laid out an architecture which handles both cases.