### PR TITLE
🔧 Simplified and improved the lowest node logic

### DIFF
--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -1156,19 +1156,15 @@ void OverlayWrapper::UpdateMarineHUD(Actor* vehicle)
 
     // depth
     char tmp[50] = "";
-    if (vehicle->getLowestNode() != -1)
+    float height = vehicle->GetHeightAboveGround();
+    if (height > 0.1 && height < 99.9)
     {
-        Vector3 pos = vehicle->ar_nodes[vehicle->getLowestNode()].AbsPosition;
-        float height = pos.y - RoR::App::GetSimTerrain()->GetHeightAt(pos.x, pos.z);
-        if (height > 0.1 && height < 99.9)
-        {
-            sprintf(tmp, "%2.1f", height);
-            boat_depth_value_taoe->setCaption(tmp);
-        }
-        else
-        {
-            boat_depth_value_taoe->setCaption("--.-");
-        }
+        sprintf(tmp, "%2.1f", height);
+        boat_depth_value_taoe->setCaption(tmp);
+    }
+    else
+    {
+        boat_depth_value_taoe->setCaption("--.-");
     }
 
     // water speed

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -80,7 +80,9 @@ public:
     void              RequestRotation(float rotation) { m_rotation_request += rotation; };
     void              RequestAngleSnap(int division) { m_anglesnap_request = division; };
     void              RequestTranslation(Ogre::Vector3 translation) { m_translation_request += translation; };
-    Ogre::Vector3     GetRotationCenter();                 //!< Return the rotation center of the actor
+    Ogre::Vector3     GetRotationCenter();
+    float             GetMinHeight(bool skip_virtual_nodes=true);
+    float             GetHeightAboveGround(bool skip_virtual_nodes=true);
     bool              ReplayStep();
     void              ForceFeedbackStep(int steps);
     void              HandleInputEvents(float dt);
@@ -149,7 +151,6 @@ public:
     void              setBlinkType(blinktype blink);    
     void              setAirbrakeIntensity(float intensity);
     bool              getCustomParticleMode();
-    int               getLowestNode();
     void              receiveStreamData(unsigned int type, int source, unsigned int streamid, char *buffer, unsigned int len);
     void              sendStreamData();
     bool              isTied();
@@ -295,8 +296,6 @@ public:
     int               ar_camera_node_dir[MAX_CAMERAS]; //!< Physics attr; 'camera' = frame of reference; back node
     int               ar_camera_node_roll[MAX_CAMERAS]; //!< Physics attr; 'camera' = frame of reference; left node
     bool              ar_camera_node_roll_inv[MAX_CAMERAS]; //!< Physics attr; 'camera' = frame of reference; indicates roll node is right instead of left
-    int               ar_lowest_node;             //!< Physics attr, filled at spawn, limited use for boats
-    int               ar_lowest_contacting_node;  //!< Physics attr, filled at spawn, used for positioning on (re)spawn
     float             ar_posnode_spawn_height;
     VehicleAI*        ar_vehicle_ai;
     float             ar_scale;               //!< Physics state; scale of the actor (nominal = 1.0)

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -293,7 +293,6 @@ void ActorSpawner::InitializeRig()
     m_actor->ar_camera_node_pos[0]=-1;
     m_actor->ar_camera_node_dir[0]=-1;
     m_actor->ar_camera_node_roll[0]=-1;
-    m_actor->ar_lowest_node=0;
 
 #ifdef USE_ANGELSCRIPT
     m_actor->ar_vehicle_ai = new VehicleAI(m_actor);
@@ -596,9 +595,6 @@ void ActorSpawner::FinalizeRig()
         //wash calculator
         WashCalculator();
     }
-
-    m_actor->ar_lowest_node = FindLowestNodeInRig();
-    m_actor->ar_lowest_contacting_node = FindLowestContactingNodeInRig();
 
     this->UpdateCollcabContacterNodes();
 
@@ -4513,43 +4509,6 @@ void ActorSpawner::AdjustNodeBuoyancy(node_t & node, RigDef::Node & node_def, st
 void ActorSpawner::AdjustNodeBuoyancy(node_t & node, std::shared_ptr<RigDef::NodeDefaults> defaults)
 {
     node.buoyancy = BITMASK_IS_1(defaults->options, RigDef::Node::OPTION_b_EXTRA_BUOYANCY) ? 10000.f : m_actor->m_dry_mass/15.f;
-}
-
-int ActorSpawner::FindLowestNodeInRig()
-{
-    int lowest_node_index = 0;
-    float lowest_y = m_actor->ar_nodes[0].AbsPosition.y;
-
-    for (int i = 0; i < m_actor->ar_num_nodes; i++)
-    {
-        float y = m_actor->ar_nodes[i].AbsPosition.y;
-        if (y < lowest_y)
-        {
-            lowest_y = y;
-            lowest_node_index = i;
-        }
-    }
-
-    return lowest_node_index;
-}
-
-int ActorSpawner::FindLowestContactingNodeInRig()
-{
-    int lowest_node_index = FindLowestNodeInRig();
-    float lowest_y = std::numeric_limits<float>::max();
-
-    for (int i = 0; i < m_actor->ar_num_nodes; i++)
-    {
-        if (m_actor->ar_nodes[i].nd_no_ground_contact) continue;
-        float y = m_actor->ar_nodes[i].AbsPosition.y;
-        if (y < lowest_y)
-        {
-            lowest_y = y;
-            lowest_node_index = i;
-        }
-    }
-
-    return lowest_node_index;
 }
 
 void ActorSpawner::BuildWheelBeams(

--- a/source/main/physics/RigSpawner.h
+++ b/source/main/physics/RigSpawner.h
@@ -869,16 +869,6 @@ private:
 
     void UpdateCollcabContacterNodes();
 
-    /**
-    * Finds node with lowest Y in spawned rig.
-    */
-    int FindLowestNodeInRig();
-
-    /**
-    * Finds node (nd_no_ground_contact == false) with lowest Y in spawned rig.
-    */
-    int FindLowestContactingNodeInRig();
-
     wheel_t::BrakeCombo TranslateBrakingDef(RigDef::Wheels::Braking def);
 
     /**

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -227,7 +227,6 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "void setBlinkType(int)", AngelScript::asMETHOD(Actor,setBlinkType), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int getBlinkType()", AngelScript::asMETHOD(Actor,getBlinkType), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool getCustomParticleMode()", AngelScript::asMETHOD(Actor,getCustomParticleMode), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "int getLowestNode()", AngelScript::asMETHOD(Actor,getLowestNode), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool getReverseLightVisible()", AngelScript::asMETHOD(Actor,getCustomParticleMode), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "float getHeadingDirectionAngle()", AngelScript::asMETHOD(Actor,getRotation), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool isLocked()", AngelScript::asMETHOD(Actor,isLocked), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);


### PR DESCRIPTION
Replaces the archaic collision avoidance logic which was built around fixed reference nodes (`ar_lowest_node`, `ar_lowest_contacting_node`) with some more robust code.