### PR TITLE
🔧 Proper race stoppage logic

### DIFF
--- a/resources/scripts/races.as
+++ b/resources/scripts/races.as
@@ -160,10 +160,11 @@ class racesManager {
 		// register the required callbacks
 		game.registerForEvent(SE_TRUCK_ENTER);
 		game.registerForEvent(SE_TRUCK_EXIT);
+		game.registerForEvent(SE_TRUCK_RESET);
+		game.registerForEvent(SE_TRUCK_TELEPORT);
+		game.registerForEvent(SE_GENERIC_DELETED_TRUCK);
 		game.registerForEvent(SE_ANGELSCRIPT_MANIPULATIONS);
-		// game.registerForEvent(SE_GENERIC_DELETED_TRUCK);
 		// game.registerForEvent(SE_GENERIC_MOUSE_BEAM_INTERACTION);
-		// game.registerForEvent(SE_TRUCK_RESET);
 		
 		// add the eventcallback method if it doesn't exist
 		if(game.scriptFunctionExists("void eventCallback(int, int)")<0)
@@ -781,15 +782,25 @@ class racesManager {
 			else if( !this.silentMode )
 				this.message("Get back in the vehicle!", "stop.png");
 		}
-		else if( eventnum == SE_TRUCK_ENTER and this.truckNum != game.getCurrentTruckNumber() and !this.allowVehicleChanging)
+		else if( eventnum == SE_TRUCK_ENTER and this.truckNum != value and !this.allowVehicleChanging)
 		{
 			this.cancelCurrentRace();
 			this.message("You cannot switch vehicles during a race! Race aborted.", "stop.png");
 		}
-		else if( eventnum == SE_GENERIC_DELETED_TRUCK )
+		else if( eventnum == SE_TRUCK_RESET and this.truckNum == value)
 		{
-			// debug: game.log("Truck deleted");
-			// TODO: abort race here
+			this.cancelCurrentRace();
+			this.message("You must not reset the vehicle during a race! Race aborted.", "stop.png");
+		}
+		else if( eventnum == SE_TRUCK_TELEPORT and this.truckNum == value)
+		{
+			this.cancelCurrentRace();
+			this.message("You must not teleport the vehicle during a race! Race aborted.", "stop.png");
+		}
+		else if( eventnum == SE_GENERIC_DELETED_TRUCK and this.truckNum == value and !this.allowVehicleChanging)
+		{
+			this.cancelCurrentRace();
+			this.message("You must finish the race with the vehicle you started it! Race aborted.", "stop.png");
 		}
 		else if( eventnum == SE_GENERIC_MOUSE_BEAM_INTERACTION )
 		{
@@ -859,10 +870,11 @@ class racesManager {
 			args.set("raceID", this.currentRace);
 			handle(args);
 		}
-		
+
 		this.lastCheckpoint = -1;
 		this.currentRace = -1;
 		this.currentLap = -1;
+		this.lastRaceEventInstance = "";
 		this.state = this.STATE_NotInRace;
 		game.stopTimer();
 		this.removeArrow();

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -948,7 +948,7 @@ void SimController::UpdateInputEvents(float dt)
                     }
                     //COMMON KEYS
 
-                    if (RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_ACCELERATE_SIMULATION))
+                    if (m_race_id == -1 && RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_ACCELERATE_SIMULATION))
                     {
                         float simulation_speed = m_actor_manager.GetSimulationSpeed() * pow(2.0f, dt / 2.0f);
                         m_actor_manager.SetSimulationSpeed(simulation_speed);
@@ -956,7 +956,7 @@ void SimController::UpdateInputEvents(float dt)
                         RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
                         RoR::App::GetGuiManager()->PushNotification("Notice:", ssmsg);
                     }
-                    if (RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_DECELERATE_SIMULATION))
+                    if (m_race_id == -1 && RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_DECELERATE_SIMULATION))
                     {
                         float simulation_speed = m_actor_manager.GetSimulationSpeed() * pow(0.5f, dt / 2.0f);
                         m_actor_manager.SetSimulationSpeed(simulation_speed);
@@ -964,7 +964,7 @@ void SimController::UpdateInputEvents(float dt)
                         RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
                         RoR::App::GetGuiManager()->PushNotification("Notice:", ssmsg);
                     }
-                    if (RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_RESET_SIMULATION_PACE))
+                    if (m_race_id == -1 && RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_RESET_SIMULATION_PACE))
                     {
                         if (!m_is_pace_reset_pressed)
                         {
@@ -1422,6 +1422,8 @@ void SimController::TeleportPlayerXZ(float x, float z)
         return;
     }
 
+    TRIGGER_EVENT(SE_TRUCK_TELEPORT, m_player_actor->ar_instance_id);
+
     Vector3 translation = Vector3(x, y, z) - m_player_actor->ar_nodes[0].AbsPosition;
 
     std::list<Actor*> actors = m_player_actor->GetAllLinkedActors();
@@ -1731,6 +1733,13 @@ void SimController::UpdateSimulation(float dt)
 
     if (simRUNNING(s) || simEDITOR(s))
     {
+        float simulation_speed = m_actor_manager.GetSimulationSpeed();
+        if (m_race_id != -1 && simulation_speed != 1.0f)
+        {
+            m_last_simulation_speed = simulation_speed;
+            m_actor_manager.SetSimulationSpeed(1.0f);
+        }
+
         this->UpdateForceFeedback();
 
         RoR::App::GetGuiManager()->UpdateSimUtils(dt, m_player_actor);

--- a/source/main/gameplay/ScriptEvents.h
+++ b/source/main/gameplay/ScriptEvents.h
@@ -49,8 +49,8 @@ enum scriptEvents
     SE_GENERIC_INPUT_EVENT             = 0x00080000, //!< triggered when an input event bound to the scripting engine is toggled, the argument refers to event id
     SE_GENERIC_MOUSE_BEAM_INTERACTION  = 0x00100000, //!< triggered when the user uses the mouse to interact with the actor, the argument refers to the actor ID
 
-    SE_TRUCK_TRACTIONCONTROL_TOGGLE    = 0x00200000, //!< triggered when the user toggles the tractioncontrol system, the argument refers to the actor ID of the vehicle
-    SE_TRUCK_ANTILOCKBRAKE_TOGGLE      = 0x00400000, //!< triggered when the user toggles the antilockbrake, the argument refers to the actor ID of the vehicle
+    SE_TRUCK_RESET                     = 0x00200000, //!< triggered when the user resets the truck, the argument refers to the actor ID of the vehicle
+    SE_TRUCK_TELEPORT                  = 0x00400000, //!< triggered when the user teleports the truck, the argument refers to the actor ID of the vehicle
 
     SE_ANGELSCRIPT_MANIPULATIONS       = 0x00800000, //!< triggered when the user tries to dynamically use the scripting capabilities (prevent cheating)
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1455,6 +1455,8 @@ float Actor::GetHeightAboveGround(bool skip_virtual_nodes)
 
 void Actor::SyncReset(bool reset_position)
 {
+    TRIGGER_EVENT(SE_TRUCK_RESET, ar_instance_id);
+
     ar_hydro_dir_state = 0.0;
     ar_hydro_aileron_state = 0.0;
     ar_hydro_rudder_state = 0.0;

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -100,17 +100,9 @@ void GameScript::SetTrucksForcedAwake(bool forceActive)
     App::GetSimController()->GetBeamFactory()->SetTrucksForcedAwake(forceActive);
 }
 
-double GameScript::getTime()
+float GameScript::getTime()
 {
-    auto sim_controller = App::GetSimController();
-    if (sim_controller == nullptr)
-    {
-        return 0.0;
-    }
-    else
-    {
-        return sim_controller->getTime();
-    }
+    return App::GetSimController()->getTime();
 }
 
 void GameScript::setPersonPosition(const Vector3& vec)

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -82,7 +82,7 @@ public:
      * returns the time in seconds since the game was started
      * @return time in seconds
      */
-    double getTime();
+    float getTime();
 
     //anglescript test
     void boostCurrentTruck(float factor);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -253,7 +253,7 @@ void ScriptEngine::init()
     // class GameScript
     result = engine->RegisterObjectType("GameScriptClass", sizeof(GameScript), AngelScript::asOBJ_VALUE | AngelScript::asOBJ_POD | AngelScript::asOBJ_APP_CLASS); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void log(const string &in)", AngelScript::asMETHOD(GameScript,log), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "double getTime()", AngelScript::asMETHOD(GameScript,getTime), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "float getTime()", AngelScript::asMETHOD(GameScript,getTime), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
     result = engine->RegisterObjectMethod("GameScriptClass", "float rangeRandom(float, float)", AngelScript::asMETHOD(GameScript,rangeRandom), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
 
     result = engine->RegisterObjectMethod("GameScriptClass", "void activateAllVehicles()", AngelScript::asMETHOD(GameScript,activateAllVehicles), AngelScript::asCALL_THISCALL); MYASSERT(result>=0);
@@ -357,8 +357,8 @@ void ScriptEngine::init()
     result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_SKELETON_TOGGLE", SE_TRUCK_SKELETON_TOGGLE); MYASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_TIE_TOGGLE", SE_TRUCK_TIE_TOGGLE); MYASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_PARKINGBREAK_TOGGLE", SE_TRUCK_PARKINGBREAK_TOGGLE); MYASSERT(result>=0);
-    result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_TRACTIONCONTROL_TOGGLE", SE_TRUCK_TRACTIONCONTROL_TOGGLE); MYASSERT(result>=0);
-    result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_ANTILOCKBRAKE_TOGGLE", SE_TRUCK_ANTILOCKBRAKE_TOGGLE); MYASSERT(result>=0);
+    result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_RESET", SE_TRUCK_RESET); MYASSERT(result>=0);
+    result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_TELEPORT", SE_TRUCK_TELEPORT); MYASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_BEACONS_TOGGLE", SE_TRUCK_BEACONS_TOGGLE); MYASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_CPARTICLES_TOGGLE", SE_TRUCK_CPARTICLES_TOGGLE); MYASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_TRUCK_GROUND_CONTACT_CHANGED", SE_TRUCK_GROUND_CONTACT_CHANGED); MYASSERT(result>=0);


### PR DESCRIPTION
* Automatically stops the currently active race if you `reset`, `delete` or `teleport` the vehicle you started the race with.
* Automatically disables slow- / fast motion while any race is active.
* Fixes a bug in the race cancellation logic (which prevents you from restarting a race)