### PR TITLE
Download cotire.cmake to source directory instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_SOU
 
 
 # Download cotire automatically
-if (NOT EXISTS "${CMAKE_BINARY_DIR}/cotire.cmake")
+if (NOT EXISTS "${CMAKE_SOURCE_DIR}/cotire.cmake")
     message(STATUS "Downloading cotire.cmake from https://github.com/sakra/cotire/")
     file(DOWNLOAD "https://raw.githubusercontent.com/sakra/cotire/master/CMake/cotire.cmake"
-            "${CMAKE_BINARY_DIR}/cotire.cmake")
+            "${CMAKE_SOURCE_DIR}/cotire.cmake")
 endif ()
 
-include(${CMAKE_BINARY_DIR}/cotire.cmake)
+include(${CMAKE_SOURCE_DIR}/cotire.cmake)
 
 
 ################################################################################


### PR DESCRIPTION
This is a little friendlier to my particular package manager which doesn't allow downloading during the build process. (specifically, it can't copy cotire.cmake to the build directory because I need to create the build directory first in order to copy cotire.cmake into it, but if the build directory already exists then the package manager's build process fails because it tries to create a directory that already exists)

I don't think this change will break the build process in any way, and I think it makes more sense anyway to download something that is part of the source to the source directory.