### PR TITLE
Automatic skeleton integrity verification on startup

### DIFF
--- a/source/main/gfx/OgreSubsystem.cpp
+++ b/source/main/gfx/OgreSubsystem.cpp
@@ -28,7 +28,6 @@
 #include "OgreSubsystem.h"
 
 #include "Application.h"
-#include "ErrorUtils.h"
 #include "Language.h"
 #include "PlatformUtils.h"
 #include "RoRVersion.h"
@@ -66,7 +65,7 @@ bool OgreSubsystem::Configure()
         if (!render_systems.empty())
             m_ogre_root->setRenderSystem(render_systems.front());
         else
-            m_ogre_root->showConfigDialog(OgreBites::getNativeConfigDialog());
+            LOG("No render system plugin available. Check your plugins.cfg");
     }
     const auto rs = m_ogre_root->getRenderSystemByName(App::app_rendersys_override.GetActive());
     if (rs != nullptr && rs != m_ogre_root->getRenderSystem())
@@ -148,6 +147,9 @@ bool OgreSubsystem::StartOgre(Ogre::String const & hwnd, Ogre::String const & ma
 {
     m_hwnd = hwnd;
     m_main_hwnd = mainhwnd;
+
+    CreateFolder(RoR::App::sys_logs_dir.GetActive());
+    CreateFolder(RoR::App::sys_config_dir.GetActive());
 
     std::string log_filepath = PathCombine(RoR::App::sys_logs_dir.GetActive(),   "RoR.log");
     std::string cfg_filepath = PathCombine(RoR::App::sys_config_dir.GetActive(), "ogre.cfg");

--- a/source/main/utils/PlatformUtils.cpp
+++ b/source/main/utils/PlatformUtils.cpp
@@ -114,8 +114,11 @@ bool FolderExists(const char* path)
 
 void CreateFolder(const char* path)
 {
-    std::wstring wpath = MSW_Utf8ToWchar(path);
-    CreateDirectoryW(wpath.c_str(), nullptr);
+    if (!FolderExists(path))
+    {
+        std::wstring wpath = MSW_Utf8ToWchar(path);
+        CreateDirectoryW(wpath.c_str(), nullptr);
+    }
 }
 
 std::string GetUserHomeDirectory()


### PR DESCRIPTION
* Automatically restores partially destructed user directories (it recreates the file structure)
* Replaces the dummy render system selection window with a proper error message
* Prevents `CreateDirectoryW` throwing asserts if the folder already exists

Related with: https://github.com/RigsOfRods/rigs-of-rods/pull/1937

Closes: https://github.com/RigsOfRods/rigs-of-rods/pull/1988

Fixes: https://github.com/RigsOfRods/rigs-of-rods/issues/1935
Fixes: https://github.com/RigsOfRods/rigs-of-rods/issues/1433