### PR TITLE
🎮 Use the 'WaterBottomLine' as collision boundary

### DIFF
--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -231,7 +231,7 @@ float TerrainGeometryManager::getHeightAt(float x, float z)
     float ty = (z + mBase - mPos.z) / ((mSize - 1) * -mScale);
 
     if (tx <= 0.0f || ty <= 0.0f || tx >= 1.0f || ty >= 1.0f)
-        return 0.0f;
+        return terrainManager->GetDef().water_bottom_height;
 
     return getHeightAtTerrainPosition(tx, ty);
 }


### PR DESCRIPTION
Improves the collision behavior on maps like Minima which have water outside of the actual terrain boundaries.