### PR TITLE
🔧 Auto-detect flat height maps

### DIFF
--- a/source/main/terrain/TerrainGeometryManager.h
+++ b/source/main/terrain/TerrainGeometryManager.h
@@ -73,5 +73,8 @@ private:
     Ogre::uint16 mSize;
     float* mHeightData;
 
+    bool  mIsFlat;
+    float mMinHeight;
+    float mMaxHeight;
 };
 


### PR DESCRIPTION
This automatically optimizes the terrain height lookup on maps with a flat height map.

Examples: N-Labs, Minima, Penguinville, Community Map, ...