### PR TITLE
🐛 Fixed various 'Texture ... not found' errors

### DIFF
--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -189,6 +189,8 @@ int main(int argc, char *argv[])
             Ogre::PF_R8G8B8, Ogre::TU_RENDERTARGET);
 
 
+        App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::FLAGS);
+        App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::ICONS);
         App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::OGRE_CORE);
         App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::WALLPAPERS);
 

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -374,9 +374,7 @@ void ContentManager::LoadGameplayResources()
     {
         this->AddResourcePack(ContentManager::ResourcePack::AIRFOILS);
         this->AddResourcePack(ContentManager::ResourcePack::TEXTURES);
-        this->AddResourcePack(ContentManager::ResourcePack::ICONS);
         this->AddResourcePack(ContentManager::ResourcePack::FAMICONS);
-        this->AddResourcePack(ContentManager::ResourcePack::FLAGS);
         this->AddResourcePack(ContentManager::ResourcePack::MATERIALS);
         this->AddResourcePack(ContentManager::ResourcePack::MESHES);
         this->AddResourcePack(ContentManager::ResourcePack::OVERLAYS);


### PR DESCRIPTION
Fixes: `Texture 'error.png' not found` in main menu
Fixes: `Texture 'user_go.png' not found` in main menu
Fixes: `Texture 'us.png' not found` in the multiplayer "lobby"

Closes: https://github.com/RigsOfRods/rigs-of-rods/pull/2009