### PR TITLE
🔧 Automatic rotators(2) structure verification

### DIFF
--- a/source/main/physics/RigSpawner.h
+++ b/source/main/physics/RigSpawner.h
@@ -938,6 +938,11 @@ private:
     void FinalizeGfxSetup();
 
     /**
+    * Validator for the rotator reference structure
+    */
+    void ValidateRotator(int id, int axis1, int axis2, int *nodes1, int *nodes2);
+
+    /**
     * Helper for 'SetupNewEntity()' - see it's doc.
     */
     Ogre::MaterialPtr FindOrCreateCustomizedMaterial(std::string orig_name);


### PR DESCRIPTION
Example spawner log output:
```
WARNING (Keyword rotators_2) Off-centered axis on base plate of rotator 1
WARNING (Keyword rotators_2) Off-centered axis on rotating plate of rotator 1
WARNING (Keyword rotators_2) Misaligned plates on rotator 1
```