### PR TITLE
🔧 Fixed the contacter logic on locked trucks

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -812,10 +812,10 @@ Vector3 Actor::calculateCollisionOffset(Vector3 direction)
     direction.normalise();
 
     if (m_intra_point_col_detector)
-        m_intra_point_col_detector->UpdateIntraPoint(this);
+        m_intra_point_col_detector->UpdateIntraPoint();
 
     if (m_inter_point_col_detector)
-        m_inter_point_col_detector->UpdateInterPoint(this, true);
+        m_inter_point_col_detector->UpdateInterPoint(true);
 
     // collision displacement
     Vector3 collision_offset = Vector3::ZERO;
@@ -2297,7 +2297,7 @@ void Actor::CalcCabCollisions()
     }
     if (m_intra_point_col_detector != nullptr)
     {
-        m_intra_point_col_detector->UpdateIntraPoint(this);
+        m_intra_point_col_detector->UpdateIntraPoint();
         ResolveIntraActorCollisions(PHYSICS_DT,
             *m_intra_point_col_detector,
             ar_num_collcabs,

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1110,7 +1110,7 @@ void ActorManager::UpdatePhysicsSimulation()
                 {
                     auto func = std::function<void()>([this, actor]()
                         {
-                            actor->m_inter_point_col_detector->UpdateInterPoint(actor);
+                            actor->m_inter_point_col_detector->UpdateInterPoint();
                             if (actor->ar_collision_relevant)
                             {
                                 ResolveInterActorCollisions(PHYSICS_DT,

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -338,12 +338,12 @@ void ActorSpawner::InitializeRig()
 
     if (!App::sim_no_collisions.GetActive())
     {
-        m_actor->m_inter_point_col_detector = new PointColDetector();
+        m_actor->m_inter_point_col_detector = new PointColDetector(m_actor);
     }
 
     if (!App::sim_no_self_collisions.GetActive())
     {
-        m_actor->m_intra_point_col_detector = new PointColDetector();
+        m_actor->m_intra_point_col_detector = new PointColDetector(m_actor);
     }
 
     m_actor->ar_submesh_ground_model = gEnv->collisions->defaultgm;

--- a/source/main/physics/collision/PointColDetector.h
+++ b/source/main/physics/collision/PointColDetector.h
@@ -33,10 +33,10 @@ public:
 
     std::vector<pointid_t*> hit_list;
 
-    PointColDetector(): m_object_list_size(-1) {};
+    PointColDetector(Actor* actor): m_actor(actor), m_object_list_size(-1) {};
 
-    void UpdateIntraPoint(Actor* actor);
-    void UpdateInterPoint(Actor* actor, bool ignorestate = false);
+    void UpdateIntraPoint();
+    void UpdateInterPoint(bool ignorestate = false);
     void query(const Ogre::Vector3& vec1, const Ogre::Vector3& vec2, const Ogre::Vector3& vec3, const float enlargeBB);
 
 private:
@@ -57,6 +57,7 @@ private:
         int begin;
     };
 
+    Actor*                 m_actor;
     std::vector<Actor*>    m_actors;
     std::vector<refelem_t> m_ref_list;
     std::vector<pointid_t> m_pointid_list;
@@ -68,5 +69,5 @@ private:
     void queryrec(int kdindex, int axis);
     void build_kdtree_incr(int axis, int index);
     void partintwo(const int start, const int median, const int end, const int axis, float& minex, float& maxex);
-    void update_structures_for_contacters(bool inter);
+    void update_structures_for_contacters();
 };


### PR DESCRIPTION
Prevents unstable submesh collision when submeshed loads are tightly locked together.

The issue was introduced with: https://github.com/RigsOfRods/rigs-of-rods/commit/a1a297f076cd445bd65c4c9a1031a4c9bcec3baa