### PR TITLE
🔧 Less strict cache validation

### DIFF
--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -433,7 +433,7 @@ std::string ContentManager::ListAllUserContent()
     {
         if ((file.archive != nullptr) || std::regex_match(file.filename, file_whitelist))
         {
-            buf << file.filename << ", " << file.uncompressedSize << std::endl;
+            buf << file.filename << std::endl;
         }
     }
 


### PR DESCRIPTION
Reverts: https://github.com/RigsOfRods/rigs-of-rods/pull/2018, because it hinders common content creator workflow.