### PR TITLE
🎮 Reimplemented the cache regen logic

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -85,6 +85,7 @@ static TerrainManager*  g_sim_terrain;
  GVarStr_AP<50>           app_screenshot_format   ("app_screenshot_format",   "Screenshot Format",         "jpg",                   "jpg");
  GVarStr_A<100>           app_rendersys_override  ("app_rendersys_override",  "Render system",             "");
  GVarStr_A<300>           app_extra_mod_path      ("app_extra_mod_path",      "Extra mod path",            "");
+ GVarPod_A<bool>          app_force_cache_udpate  ("app_force_cache_udpate",  "Force cache update",        false);
 
 
 // Simulation

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -660,6 +660,7 @@ extern GVarPod_APS<int>        app_num_workers;
 extern GVarStr_AP<50>          app_screenshot_format;
 extern GVarStr_A<100>          app_rendersys_override;
 extern GVarStr_A<300>          app_extra_mod_path;
+extern GVarPod_A<bool>         app_force_cache_udpate;
 
 // Simulation
 extern GVarEnum_AP<SimState>   sim_state;

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -357,6 +357,11 @@ void RoR::GUI::GameSettings::Draw()
         DrawGCheckbox(App::diag_log_beam_break,      _LC("GameSettings", "Log beam breaking"));
         DrawGCheckbox(App::diag_log_beam_deform,     _LC("GameSettings", "Log beam deforming"));
         DrawGCheckbox(App::diag_log_beam_trigger,    _LC("GameSettings", "Log beam triggers"));
+        if (ImGui::Button(_LC("GameSettings", "Trigger cache update (and quit)")))
+        {
+            App::app_force_cache_udpate.SetActive(true);
+            App::app_state.SetPending(AppState::SHUTDOWN);
+        }
         if (ImGui::Button(_LC("GameSettings", "Clear cache (and quit)")))
         {
             std::remove(App::GetCacheSystem()->getCacheConfigFilename().c_str());

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -231,13 +231,20 @@ CacheSystem::CacheValidityState CacheSystem::EvaluateCacheValidity()
     if (j_doc["format_version"].GetInt() != CACHE_FILE_FORMAT)
     {
         m_entries.clear();
-        RoR::Log("[RoR|ModCache] invalid cachefile format, performing full rebuild.");
+        RoR::Log("[RoR|ModCache] Invalid cache file format, performing full rebuild.");
         return CACHE_NEEDS_UPDATE_FULL;
     }
 
     if (j_doc["global_hash"].GetString() != m_filenames_hash)
     {
-        RoR::Log("[RoR|ModCache] Cachefile out of date, regenerating new one ...");
+        RoR::Log("[RoR|ModCache] Cache file out of date, regenerating new one ...");
+        return CACHE_NEEDS_UPDATE_INCREMENTAL;
+    }
+
+    if (App::app_force_cache_udpate.GetActive())
+    {
+        App::app_force_cache_udpate.SetActive(false);
+        RoR::Log("[RoR|ModCache] Cache file check requested, regenerating new one ...");
         return CACHE_NEEDS_UPDATE_INCREMENTAL;
     }
 

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -57,6 +57,7 @@ enum {
     OPT_TRUCK,
     OPT_WDIR,
     OPT_VER,
+    OPT_CHECKCACHE,
     OPT_TRUCKCONFIG,
     OPT_ENTERTRUCK,
     OPT_JOINMPSERVER
@@ -74,6 +75,7 @@ CSimpleOpt::SOption cmdline_options[] = {
     { OPT_TRUCKCONFIG,    ("-actorconfig"), SO_REQ_SEP },
     { OPT_HELP,           ("--help"),       SO_NONE    },
     { OPT_HELP,           ("-help"),        SO_NONE    },
+    { OPT_CHECKCACHE,     ("-checkcache"),  SO_NONE    },
     { OPT_VER,            ("-version"),     SO_NONE    },
     { OPT_JOINMPSERVER,   ("-joinserver"),  SO_REQ_CMB },
     SO_END_OF_OPTIONS
@@ -87,10 +89,10 @@ void ShowCommandLineUsage()
         _L("Command Line Arguments"),
         _L("--help (this)"                              "\n"
             "-map <map> (loads map on startup)"         "\n"
-            "-pos <Vect> (overrides spawn position)" "\n"
+            "-pos <Vect> (overrides spawn position)"    "\n"
             "-rot <float> (overrides spawn rotation)"   "\n"
             "-truck <truck> (loads truck on startup)"   "\n"
-            "-setup shows the ogre configurator"        "\n"
+            "-checkcache forces cache update"           "\n"
             "-version shows the version information"    "\n"
             "-enter enters the selected truck"          "\n"
             "For example: RoR.exe -map simple2 -pos '518 0 518' -rot 45 -truck semi.truck -enter"));
@@ -155,6 +157,10 @@ void Settings::ProcessCommandLine(int argc, char *argv[])
 #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
             SetCurrentDirectory(args.OptionArg());
 #endif
+        }
+        else if (args.OptionId() == OPT_CHECKCACHE)
+        {
+            App::app_force_cache_udpate.SetActive(true);
         }
         else if (args.OptionId() == OPT_ENTERTRUCK)
         {
@@ -520,6 +526,7 @@ bool Settings::ParseGlobalVarSetting(std::string const & k, std::string const & 
     if (CheckBool (App::app_async_physics,         k, v)) { return true; }
     if (CheckInt  (App::app_num_workers,           k, v)) { return true; }
     if (CheckStr  (App::app_extra_mod_path,        k, v)) { return true; }
+    if (CheckBool (App::app_force_cache_udpate,    k, v)) { return true; }
     // Input&Output
     if (CheckBool (App::io_ffb_enabled,            k, v)) { return true; }
     if (CheckFloat(App::io_ffb_camera_gain,        k, v)) { return true; }
@@ -886,6 +893,7 @@ void Settings::SaveSettings()
     WriteYN  (f, App::app_async_physics     );
     WritePod (f, App::app_num_workers       );
     WriteStr (f, App::app_extra_mod_path    );
+    WritePod (f, App::app_force_cache_udpate);
 
     f.close();
 }


### PR DESCRIPTION
* Brings back the `-checkcache` command line argument
* Adds a new `Trigger cache update (and quit)` button to the (diag) settings

In an ideal world we would be able to update the cache without having to restart the game.