### PR TITLE
🎮 Automatic gear shifting now takes acceleration forces into account

### DIFF
--- a/source/main/gameplay/BeamEngine.cpp
+++ b/source/main/gameplay/BeamEngine.cpp
@@ -746,7 +746,8 @@ void EngineSim::UpdateEngineSim(float dt, int doUpdate)
             if (newGear < m_cur_gear && std::abs(m_cur_wheel_revolutions * (m_gear_ratios[newGear + 1] - m_gear_ratios[m_cur_gear + 1])) > m_one_third_rpm_range / 6.0f ||
                 newGear > m_cur_gear && std::abs(m_cur_wheel_revolutions * (m_gear_ratios[newGear + 1] - m_gear_ratios[m_cur_gear + 1])) > m_one_third_rpm_range / 3.0f)
             {
-                shiftTo(newGear);
+                if (std::abs(m_actor->GetGForcesCur().y) < 0.25f)
+                    shiftTo(newGear);
             }
 
             if (m_accs.size() > 200)


### PR DESCRIPTION
This will prevent the automatic transmission from unnecessary gear shifts, when there are high lateral forces.