### PR TITLE
🐛 Fixed the commands2 auto center logic

### DIFF
--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -784,6 +784,7 @@ void Actor::CalcCommands(bool doUpdate)
                 if (ar_command_key[i].commandValue >= 0.5)
                 {
                     ar_command_key[i].beams[j].cmb_state->auto_move_lock = true;
+                    ar_command_key[i].beams[j].cmb_state->auto_moving_mode = 0;
                 }
             }
         }


### PR DESCRIPTION
Affected trucks: `Ultra Bouncer`, `Grave Digger 16 Revamp v2 (crappy breakable)` and others.

Fixes: https://github.com/RigsOfRods/rigs-of-rods/pull/1121