### PR TITLE
🔧 Contacter logic improvements

### DIFF
--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -58,6 +58,7 @@ struct node_t
 
     // Bit flags
     bool            nd_cab_node:1;           //!< Attr; This node is part of collision triangle
+    bool            nd_rim_node:1;           //!< Attr; This node is part of the rim
     bool            nd_contacter:1;          //!< Attr; User-defined
     bool            nd_has_ground_contact:1; //!< Physics state
     bool            nd_has_mesh_contact:1;   //!< Physics state

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -414,20 +414,6 @@ void ActorSpawner::FinalizeRig()
         }
     }
 
-    // Precalculate number of contacters / contactable nodes
-    for (int i = 0; i < m_actor->ar_num_nodes; i++)
-    {
-        if (m_actor->ar_nodes[i].nd_contacter)
-        {
-            m_actor->ar_num_contactable_nodes++;
-            m_actor->ar_num_contacters++;
-        }
-        else if (!m_actor->ar_nodes[i].nd_no_ground_contact)
-        {
-            m_actor->ar_num_contactable_nodes++;
-        }
-    }
-
     //calculate gwps height offset
     //get a starting value
     m_actor->ar_posnode_spawn_height=m_actor->ar_nodes[0].RelPosition.y;
@@ -4024,6 +4010,7 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
 
         outer_node.mass          = node_mass;
         outer_node.friction_coef = def.node_defaults->friction;
+        outer_node.nd_rim_node   = true;
         AdjustNodeBuoyancy(outer_node, def.node_defaults);
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
@@ -4037,6 +4024,7 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
 
         inner_node.mass          = node_mass;
         inner_node.friction_coef = def.node_defaults->friction;
+        inner_node.nd_rim_node   = true;
         AdjustNodeBuoyancy(inner_node, def.node_defaults);
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
@@ -6247,6 +6235,19 @@ void ActorSpawner::UpdateCollcabContacterNodes()
         m_actor->ar_nodes[m_actor->ar_cabs[tmpv]].nd_cab_node = true;
         m_actor->ar_nodes[m_actor->ar_cabs[tmpv+1]].nd_cab_node = true;
         m_actor->ar_nodes[m_actor->ar_cabs[tmpv+2]].nd_cab_node = true;
+    }
+    for (int i = 0; i < m_actor->ar_num_nodes; i++)
+    {
+        if (m_actor->ar_nodes[i].nd_contacter)
+        {
+            m_actor->ar_num_contactable_nodes++;
+            m_actor->ar_num_contacters++;
+        }
+        else if (!m_actor->ar_nodes[i].nd_no_ground_contact &&
+                 (m_actor->ar_nodes[i].nd_cab_node || m_actor->ar_nodes[i].nd_rim_node || m_actor->ar_num_collcabs == 0))
+        {
+            m_actor->ar_num_contactable_nodes++;
+        }
     }
 }
 

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -97,7 +97,9 @@ void PointColDetector::update_structures_for_contacters()
         bool internal_collision = (actor == m_actor) || is_linked;
         for (int i = 0; i < actor->ar_num_nodes; i++)
         {
-            if (actor->ar_nodes[i].nd_contacter || (!internal_collision && !actor->ar_nodes[i].nd_no_ground_contact))
+            bool upgradeable = !actor->ar_nodes[i].nd_no_ground_contact &&
+                (actor->ar_nodes[i].nd_cab_node || actor->ar_nodes[i].nd_rim_node || actor->ar_num_collcabs == 0);
+            if (actor->ar_nodes[i].nd_contacter || (!internal_collision && upgradeable))
             {
                 m_pointid_list[refi].actor = actor;
                 m_pointid_list[refi].node_id = i;


### PR DESCRIPTION
Only 'upgrade' ground contactable nodes, which are either part of a collision triangle or part of the rim, to contacters.

This:
* Reduces the performance impact of the new logic
* Allows you to define nodes which can contact the ground, but not submesh