### PR TITLE
Revert "🐛 Fixed material issues during truck reload (from disk)"

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1553,7 +1553,6 @@ void SimController::UpdateSimulation(float dt)
                 auto reload_pos = m_player_actor->getPosition();
                 auto reload_dir = Quaternion(Degree(270) - Radian(m_player_actor->getRotation()), Vector3::UNIT_Y);
                 auto debug_view = m_player_actor->GetGfxActor()->GetDebugView();
-                int instance_id = m_player_actor->ar_instance_id;
 
                 reload_pos.y = m_player_actor->GetMinHeight();
 
@@ -1567,7 +1566,6 @@ void SimController::UpdateSimulation(float dt)
                 srq.asr_position = reload_pos;
                 srq.asr_rotation = reload_dir;
                 srq.asr_filename = filename;
-                srq.asr_uniqueid = instance_id;
                 Actor* new_actor = this->SpawnActorDirectly(srq); // try to load the same actor again
                 this->FinalizeActorSpawning(new_actor, m_player_actor, srq);
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -4293,6 +4293,7 @@ void Actor::EngineTriggerHelper(int engineNumber, int type, float triggerValue)
 }
 
 Actor::Actor(
+    int actor_id,
     unsigned int vector_index,
     std::shared_ptr<RigDef::File> def,
     RoR::ActorSpawnRequest rq
@@ -4398,7 +4399,7 @@ Actor::Actor(
     , ar_driveable(NOT_DRIVEABLE)
     , m_skid_trails{} // Init array to nullptr
     , ar_collision_range(DEFAULT_COLLISION_RANGE)
-    , ar_instance_id(rq.asr_uniqueid)
+    , ar_instance_id(actor_id)
     , ar_vector_index(vector_index)
     , ar_rescuer_flag(false)
     , m_antilockbrake(false)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -56,7 +56,8 @@ public:
     /// @param actor_config Networking related.
     /// @param preloaded_with_terrain Is this rig being pre-loaded along with terrain?
     Actor(
-          unsigned int vector_index
+          int actor_id
+        , unsigned int vector_index
         , std::shared_ptr<RigDef::File> def
         , RoR::ActorSpawnRequest rq
         );

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -557,7 +557,6 @@ struct ActorSpawnRequest
     Ogre::Vector3     asr_position;
     Ogre::Quaternion  asr_rotation;
     int               asr_cache_entry_num;
-    int               asr_uniqueid;
     collision_box_t*  asr_spawnbox;
     RoR::SkinDef*     asr_skin;
     Origin            asr_origin;

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -353,12 +353,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
 
 Actor* ActorManager::CreateActorInstance(ActorSpawnRequest rq, std::shared_ptr<RigDef::File> def)
 {
-    if (rq.asr_uniqueid == -1)
-    {
-        rq.asr_uniqueid = m_actor_counter++;
-    }
-
-    Actor* actor = new Actor(static_cast<int>(m_actors.size()), def, rq);
+    Actor* actor = new Actor(m_actor_counter++, static_cast<int>(m_actors.size()), def, rq);
 
     this->SetupActor(actor, rq, def);
 
@@ -1285,7 +1280,6 @@ ActorSpawnRequest::ActorSpawnRequest()
     : asr_position(Ogre::Vector3::ZERO)
     , asr_rotation(Ogre::Quaternion::ZERO)
     , asr_cache_entry_num(-1) // flexbody cache disabled
-    , asr_uniqueid(-1) // -1 -> auto assign unique id
     , asr_spawnbox(nullptr)
     , asr_skin(nullptr)
     , asr_origin(Origin::UNKNOWN)


### PR DESCRIPTION
This reverts commit 6ca096683d00456b6b5586da715139947f8b5dd4 (which was a really bad idea).

Related with: https://github.com/RigsOfRods/rigs-of-rods/issues/2067