### PR TITLE
🐛 Fixed rim node synchronization in multiplayer

### DIFF
--- a/source/main/datatypes/wheel_t.h
+++ b/source/main/datatypes/wheel_t.h
@@ -39,6 +39,8 @@ struct wheel_t
 
     int         wh_num_nodes;
     node_t*     wh_nodes[50];             // TODO: remove limit, make this dyn-allocated ~ only_a_ptr, 08/2017
+    int         wh_num_rim_nodes;
+    node_t*     wh_rim_nodes[50];         // TODO: remove limit, make this dyn-allocated ~ only_a_ptr, 08/2017
     BrakeCombo  wh_braking;
     node_t*     wh_arm_node;
     node_t*     wh_near_attach_node;
@@ -46,6 +48,7 @@ struct wheel_t
     node_t*     wh_axis_node_1;
     int         wh_propulsed;             // TODO: add enum ~ only_a_ptr, 08/2017
     Ogre::Real  wh_radius;
+    Ogre::Real  wh_rim_radius;
     Ogre::Real  wh_speed;             //<! Current wheel speed in m/s
     Ogre::Real  wh_avg_speed;         //<! Internal physics state; Do not read from this
     Ogre::Real  wh_alb_coef;          //<! Sim state; Current anti-lock  brake modulation ratio

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -603,7 +603,7 @@ void RoR::GfxActor::UpdateParticles(float dt_sec)
                 break;
 
             case Collisions::FX_HARD:
-                if (n.iswheel != 0) // This is a wheel => skidmarks and tyre smoke
+                if (n.iswheel != NOWHEEL && !n.nd_rim_node) // This is a wheel => skidmarks and tyre smoke
                 {
                     const float SMOKE_THRESHOLD = 10.f;
                     const float SCREECH_THRESHOLD = 5.f;

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -241,7 +241,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
     actor->m_wheel_node_count = 0;
     for (int i = 0; i < actor->ar_num_nodes; i++)
     {
-        if (actor->ar_nodes[i].iswheel != NOWHEEL)
+        if (actor->ar_nodes[i].iswheel != NOWHEEL && !actor->ar_nodes[i].nd_rim_node)
             actor->m_wheel_node_count++;
     }
 
@@ -249,7 +249,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
     actor->m_net_first_wheel_node = actor->ar_num_nodes;
     for (int i = 0; i < actor->ar_num_nodes; i++)
     {
-        if (actor->ar_nodes[i].iswheel == WHEEL_DEFAULT)
+        if (actor->ar_nodes[i].iswheel != NOWHEEL || actor->ar_nodes[i].nd_rim_node)
         {
             actor->m_net_first_wheel_node = i;
             break;

--- a/source/main/physics/RigSpawner.h
+++ b/source/main/physics/RigSpawner.h
@@ -978,7 +978,6 @@ private:
         RigDef::Wheels::Braking braking,
         std::shared_ptr<RigDef::NodeDefaults> node_defaults,
         float wheel_mass,
-        bool set_param_iswheel = true,
         float wheel_width = -1.f
     );
 

--- a/source/main/physics/collision/DynamicCollisions.cpp
+++ b/source/main/physics/collision/DynamicCollisions.cpp
@@ -232,7 +232,7 @@ void ResolveIntraActorCollisions(const float dt, PointColDetector &intraPointCD,
                 const auto hitnode = &nodes[h->node_id];
 
                 //ignore wheel/chassis self contact
-                if (hitnode->iswheel) continue;
+                if (hitnode->iswheel && !hitnode->nd_rim_node) continue;
                 if (no == hitnode || na == hitnode || nb == hitnode) continue;
 
                 // transform point to triangle local coordinates


### PR DESCRIPTION
Singleplayer:
- All wheel (tyre & rim) nodes now carry the `iswheel` flag
- All rim nodes now carry the `nd_rim_node` flag

Multiplayer:
- Rim nodes are now treated similar to tyre nodes

| Before | After |
|:---------:| :------:|
| ![rim_before](https://user-images.githubusercontent.com/9437207/51110340-a7706500-17f8-11e9-8151-6f634f5ec90e.png) | ![rim_after](https://user-images.githubusercontent.com/9437207/51110343-a9d2bf00-17f8-11e9-9994-748f7fecfcfc.png) |