### PR TITLE
[WIP] In-game cache regen (main menu only)

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -86,7 +86,7 @@ static TerrainManager*  g_sim_terrain;
  GVarStr_A<100>           app_rendersys_override  ("app_rendersys_override",  "Render system",             "");
  GVarStr_A<300>           app_extra_mod_path      ("app_extra_mod_path",      "Extra mod path",            "");
  GVarPod_A<bool>          app_force_cache_udpate  ("app_force_cache_udpate",  "Force cache update",        false);
-
+ GVarPod_A<bool>          app_force_cache_purge   ("app_force_cache_purge",   nullptr,                     false);
 
 // Simulation
  GVarEnum_AP<SimState>    sim_state               ("sim_state",               nullptr,                     SimState::OFF,           SimState::OFF);

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -661,6 +661,7 @@ extern GVarStr_AP<50>          app_screenshot_format;
 extern GVarStr_A<100>          app_rendersys_override;
 extern GVarStr_A<300>          app_extra_mod_path;
 extern GVarPod_A<bool>         app_force_cache_udpate;
+extern GVarPod_A<bool>         app_force_cache_purge;
 
 // Simulation
 extern GVarEnum_AP<SimState>   sim_state;

--- a/source/main/MainMenu.cpp
+++ b/source/main/MainMenu.cpp
@@ -205,10 +205,21 @@ void MainMenu::MainMenuLoopUpdate(float seconds_since_last_frame)
     if (App::app_force_cache_udpate.GetActive())
     {
         App::GetGuiManager()->SetVisible_GameSettings(false);
-        RoR::App::GetGuiManager()->GetLoadingWindow()->SetMustUpdateRenderwindow(true);
+        App::GetGuiManager()->GetLoadingWindow()->SetMustUpdateRenderwindow(true);
         App::GetContentManager()->SynchUpdateModCache(); // NOTE: performs it's own render calls (status window)
-        App::GetGuiManager()->SetVisible_GameMainMenu(true); // Because 'Settings' panel doesn't remember last tab
+        App::GetGuiManager()->SetVisible_GameMainMenu(true); // Because 'Settings' panel doesn't remember last tab/scroll
         App::app_force_cache_udpate.SetActive(false);
+    }
+
+    if (App::app_force_cache_purge.GetActive())
+    {
+        App::GetGuiManager()->SetVisible_GameSettings(false);
+        App::GetGuiManager()->GetLoadingWindow()->SetMustUpdateRenderwindow(true);
+        App::GetGuiManager()->GetLoadingWindow()->setAutotrack(_LC("App", "Clearing mod cache...")); // Forces render call
+        App::GetCacheSystem()->SynchClearCache();
+        App::GetGuiManager()->SetVisible_LoadingWindow(false);
+        App::GetGuiManager()->SetVisible_GameMainMenu(true); // Because 'Settings' panel doesn't remember last tab/scroll
+        App::app_force_cache_purge.SetActive(false);
     }
 
     RoR::App::GetInputEngine()->Capture();

--- a/source/main/MainMenu.cpp
+++ b/source/main/MainMenu.cpp
@@ -29,6 +29,7 @@
 
 #include "CacheSystem.h"
 #include "ChatSystem.h"
+#include "ContentManager.h"
 #include "GUIManager.h"
 #include "GUI_LoadingWindow.h"
 #include "GUI_MainSelector.h"
@@ -200,6 +201,15 @@ void MainMenu::MainMenuLoopUpdate(float seconds_since_last_frame)
         App::GetGuiManager()->GetMpSelector()->CheckAndProcessRefreshResult();
     }
 #endif // USE_SOCKETW
+ 
+    if (App::app_force_cache_udpate.GetActive())
+    {
+        App::GetGuiManager()->SetVisible_GameSettings(false);
+        RoR::App::GetGuiManager()->GetLoadingWindow()->SetMustUpdateRenderwindow(true);
+        App::GetContentManager()->SynchUpdateModCache(); // NOTE: performs it's own render calls (status window)
+        App::GetGuiManager()->SetVisible_GameMainMenu(true); // Because 'Settings' panel doesn't remember last tab
+        App::app_force_cache_udpate.SetActive(false);
+    }
 
     RoR::App::GetInputEngine()->Capture();
 

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -364,10 +364,9 @@ void RoR::GUI::GameSettings::Draw()
         {
             App::app_force_cache_udpate.SetActive(true);
         }
-        if (ImGui::Button(_LC("GameSettings", "Clear cache (and quit)")))
+        if (ImGui::Button(_LC("GameSettings", "Clear cache (in-game)")))
         {
-            std::remove(App::GetCacheSystem()->getCacheConfigFilename().c_str());
-            App::app_state.SetPending(AppState::SHUTDOWN);
+            App::app_force_cache_purge.SetActive(true);
         }
     }
     else if (m_tab == SettingsTab::CONTROL)

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -360,10 +360,9 @@ void RoR::GUI::GameSettings::Draw()
         DrawGCheckbox(App::diag_log_beam_break,      _LC("GameSettings", "Log beam breaking"));
         DrawGCheckbox(App::diag_log_beam_deform,     _LC("GameSettings", "Log beam deforming"));
         DrawGCheckbox(App::diag_log_beam_trigger,    _LC("GameSettings", "Log beam triggers"));
-        if (ImGui::Button(_LC("GameSettings", "Trigger cache update (and quit)")))
+        if (ImGui::Button(_LC("GameSettings", "Update cache (in-game)")))
         {
             App::app_force_cache_udpate.SetActive(true);
-            App::app_state.SetPending(AppState::SHUTDOWN);
         }
         if (ImGui::Button(_LC("GameSettings", "Clear cache (and quit)")))
         {

--- a/source/main/gui/panels/GUI_LoadingWindow.cpp
+++ b/source/main/gui/panels/GUI_LoadingWindow.cpp
@@ -24,12 +24,14 @@
 #include "Application.h"
 #include "GUIManager.h"
 #include "Language.h"
+#include "OgreSubsystem.h"
 #include "Utils.h"
 
 namespace RoR {
 namespace GUI {
 
 LoadingWindow::LoadingWindow()
+    : m_must_update_renderwindow(false)
 {
     initialiseByAttributes(this);
 
@@ -81,6 +83,11 @@ void LoadingWindow::renderOneFrame(bool force)
         OgreBites::WindowEventUtilities::messagePump();
         Ogre::Root::getSingleton().renderOneFrame();
         t->reset();
+
+        if (m_must_update_renderwindow)
+        {
+            RoR::App::GetOgreSubsystem()->GetRenderWindow()->update(); // This is needed inside menu loop (ingame cache regen) although the renderwindow is set to 'auto update'. TODO: investigate ~ only_a_ptr, 01/2019
+        }
     }
 }
 

--- a/source/main/gui/panels/GUI_LoadingWindow.h
+++ b/source/main/gui/panels/GUI_LoadingWindow.h
@@ -44,6 +44,7 @@ public:
 
     void SetVisible(bool v);
     bool IsVisible();
+    void SetMustUpdateRenderwindow(bool val) { m_must_update_renderwindow = val; }
 
 private:
 
@@ -57,6 +58,8 @@ private:
     MyGUI::TextBox* mInfoStaticText;
 
     Ogre::Timer* t;
+
+    bool m_must_update_renderwindow; //!< Must call RenderWindow::update() after rendering
 };
 
 } // namespace GUI

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1501,3 +1501,15 @@ void CacheSystem::checkForNewContent() // Only used when performing "incremental
     checkForNewDirectoriesInResourceGroup(resource_bundles, "TerrainFolders");
 }
 
+void CacheSystem::SynchClearCache()
+{
+    std::remove(this->getCacheConfigFilename().c_str());
+
+    auto itor = m_entries.begin();
+    for (; itor != m_entries.end(); ++itor)
+    {
+        this->removeFileFromFileCache(itor);
+    }
+    m_entries.clear();
+}
+

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -147,6 +147,7 @@ public:
     CacheEntry*           FindEntryByFilename(std::string const & filename); //<! Returns NULL if none found
     void                  UnloadActorDefFromMemory(std::string const & filename);
     CacheValidityState    EvaluateCacheValidity();
+    void                  SynchClearCache();
 
     bool checkResourceLoaded(CacheEntry& t); //!< Loads the associated resource bundle if not already done. Updates the bundle (resource group, loaded state)
     bool checkResourceLoaded(Ogre::String &in_out_filename); //!< Finds + loads the associated resource bundle if not already done.

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -443,3 +443,16 @@ std::string ContentManager::ListAllUserContent()
     return buf.str();
 }
 
+void ContentManager::SynchUpdateModCache()
+{
+    // Res. groups were created on startup, now probably out of date.
+    auto& ogre_rgm = Ogre::ResourceGroupManager::getSingleton();
+    ogre_rgm.destroyResourceGroup("VehicleFolders");
+    ogre_rgm.destroyResourceGroup("TerrainFolders");
+    ogre_rgm.destroyResourceGroup("Packs");
+
+    // NOTE: The function below was originally designed for running at startup,
+    //       it works fully synchronously and makes it's own render calls to display status window.
+    this->InitModCache(); // obeys GVar 'app_force_cache_udpate'
+}
+

--- a/source/main/resources/ContentManager.h
+++ b/source/main/resources/ContentManager.h
@@ -74,6 +74,7 @@ public:
     void               InitContentManager();
     void               InitModCache();
     void               LoadGameplayResources();  //!< Checks GVar settings and loads required resources.
+    void               SynchUpdateModCache(); //!< Only to be called from main menu loop; performs rendering calls (status window)
     std::string        ListAllUserContent(); //!< Used by ModCache for quick detection of added/removed content
     RoR::SkinManager*  GetSkinManager()  { return m_skin_manager; }
 


### PR DESCRIPTION
**Test thoroughly, I coded it at 3AM!**

Settings panel / Diagnostics tab now contains button "Regen cache in-game" which forces an incremental check, but performs full regen if needed (i.e. user manually deletes cache files).

Not elegant in code but very convenient.