### PR TITLE
🎮 Realistic forward commands

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -96,6 +96,7 @@ static TerrainManager*  g_sim_terrain;
  GVarPod_A<int>           sim_replay_length       ("sim_replay_length",       "Replay length",             200);
  GVarPod_A<int>           sim_replay_stepping     ("sim_replay_stepping",     "Replay Steps per second",   1000);
  GVarPod_A<bool>          sim_position_storage    ("sim_position_storage",    "Position Storage",          false);
+ GVarPod_A<bool>          sim_realistic_commands  ("sim_realistic_commands",  "Realistic forward commands",false);
  GVarPod_A<bool>          sim_races_enabled       ("sim_races_enabled",       "Races",                     false);
  GVarPod_A<bool>          sim_no_collisions       ("sim_no_collisions",       "DisableCollisions",         false);
  GVarPod_A<bool>          sim_no_self_collisions  ("sim_no_self_collisions",  "DisableSelfCollisions",     false);

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -670,6 +670,7 @@ extern GVarPod_A<bool>         sim_replay_enabled;
 extern GVarPod_A<int>          sim_replay_length;
 extern GVarPod_A<int>          sim_replay_stepping;
 extern GVarPod_A<bool>         sim_position_storage;
+extern GVarPod_A<bool>         sim_realistic_commands;
 extern GVarPod_A<bool>         sim_races_enabled;
 extern GVarPod_A<bool>         sim_no_collisions;
 extern GVarPod_A<bool>         sim_no_self_collisions;

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -207,6 +207,8 @@ void RoR::GUI::GameSettings::Draw()
 
         DrawGCheckbox(App::sim_position_storage, _LC("GameSettings", "Use position storage"));
 
+        DrawGCheckbox(App::sim_realistic_commands, _LC("GameSettings", "Realistic forward commands"));
+
         DrawGCheckbox(App::sim_races_enabled, _LC("GameSettings", "Enable races"));
 
         DrawGCheckbox(App::sim_no_self_collisions, _LC("GameSettings", "No intra truck collisions"));

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -650,6 +650,8 @@ void ActorManager::ForwardCommands(Actor* source_actor)
 {
     if (source_actor->ar_forward_commands)
     {
+        auto linked_actors = source_actor->GetAllLinkedActors();
+
         for (auto actor : RoR::App::GetSimController()->GetActors())
         {
             if (actor != source_actor && actor->ar_import_commands &&
@@ -662,6 +664,13 @@ void ActorManager::ForwardCommands(Actor* source_actor)
                     actor->ar_sleep_counter = 0.0f;
                     actor->ar_sim_state = Actor::SimState::LOCAL_SIMULATED;
                 }
+
+                if (App::sim_realistic_commands.GetActive())
+                {
+                    if (std::find(linked_actors.begin(), linked_actors.end(), actor) == linked_actors.end())
+                        continue;
+                }
+
                 // forward commands
                 for (int j = 1; j <= MAX_COMMANDS; j++)
                 {

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -605,6 +605,7 @@ bool Settings::ParseGlobalVarSetting(std::string const & k, std::string const & 
     if (CheckInt  (App::sim_replay_length,         k, v)) { return true; }
     if (CheckInt  (App::sim_replay_stepping,       k, v)) { return true; }
     if (CheckBool (App::sim_position_storage,      k, v)) { return true; }
+    if (CheckBool (App::sim_realistic_commands,    k, v)) { return true; }
     if (CheckBool (App::sim_races_enabled,         k, v)) { return true; }
     if (CheckBool (App::sim_no_collisions,         k, v)) { return true; }
     if (CheckBool (App::sim_no_self_collisions,    k, v)) { return true; }
@@ -802,6 +803,7 @@ void Settings::SaveSettings()
     WritePod (f, App::sim_replay_length     );
     WritePod (f, App::sim_replay_stepping   );
     WriteYN  (f, App::sim_position_storage  );
+    WriteYN  (f, App::sim_realistic_commands);
     WriteYN  (f, App::sim_races_enabled     );
     WriteYN  (f, App::sim_no_collisions     );
     WriteYN  (f, App::sim_no_self_collisions);


### PR DESCRIPTION
New setting that allows you to disable the 'close proximity' forward command logic

Realistic Forward commands -> you can only 'remote control' trucks which are connected in some way