### PR TITLE
✨ Soft truck reset & per truck pause mode

### DIFF
--- a/resources/skeleton/config/input.map
+++ b/resources/skeleton/config/input.map
@@ -182,6 +182,7 @@ COMMON_REPLAY_FAST_FORWARD     Keyboard             EXPL+SHIFT+RIGHT
 COMMON_REPLAY_FORWARD          Keyboard             EXPL+RIGHT 
 COMMON_RESCUE_TRUCK            Keyboard             EXPL+R 
 COMMON_RESET_TRUCK             Keyboard             EXPL+I 
+COMMON_TOGGLE_RESET_MODE       Keyboard             EXPL+APOSTROPHE 
 COMMON_SCREENSHOT              Keyboard             SYSRQ 
 COMMON_SECURE_LOAD             Keyboard             O 
 COMMON_TOGGLE_DEBUG_VIEW       Keyboard             EXPL+K 
@@ -262,6 +263,7 @@ TRUCK_TOGGLE_FORWARDCOMMANDS   Keyboard             EXPL+CTRL+SHIFT+F
 TRUCK_TOGGLE_IMPORTCOMMANDS    Keyboard             EXPL+CTRL+SHIFT+I 
 TRUCK_TOGGLE_INTER_AXLE_DIFF   Keyboard             EXPL+CTRL+W 
 TRUCK_TOGGLE_INTER_WHEEL_DIFF  Keyboard             EXPL+W 
+TRUCK_TOGGLE_PHYSICS           Keyboard             END 
 TRUCK_TOGGLE_TCASE_4WD_MODE    Keyboard             EXPL+SHIFT+W 
 TRUCK_TOGGLE_TCASE_GEAR_RATIO  Keyboard             EXPL+ALT+W 
 TRUCK_TOGGLE_VIDEOCAMERA       Keyboard             EXPL+CTRL+V 

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -163,6 +163,7 @@ private:
     float                    m_race_start_time;
     float                    m_race_bestlap_time;
 
+    bool                     m_soft_reset_mode;
     bool                     m_advanced_vehicle_repair;
     float                    m_advanced_vehicle_repair_timer;
 

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -655,7 +655,7 @@ const float NODE_IMMOVABLE_RADIUS    (2.8f);
 
 void RoR::GfxActor::UpdateDebugView()
 {
-    if (m_debug_view == DebugViewType::DEBUGVIEW_NONE)
+    if (m_debug_view == DebugViewType::DEBUGVIEW_NONE && !m_actor->ar_physics_paused)
     {
         return; // Nothing to do
     }
@@ -699,6 +699,24 @@ void RoR::GfxActor::UpdateDebugView()
     ImGui::Begin(("RoR-SoftBodyView-" + TOSTRING(m_actor->ar_instance_id)).c_str(), NULL, screen_size, 0, window_flags);
     ImDrawList* drawlist = ImGui::GetWindowDrawList();
     ImGui::End();
+
+    if (m_actor->ar_physics_paused)
+    {
+        // Should we replace this circle with a proper bounding box?
+        Ogre::Vector3 pos_xyz = world2screen.Convert(m_actor->getPosition());
+        if (pos_xyz.z < 0.f)
+        {
+            ImVec2 pos(pos_xyz.x, pos_xyz.y);
+
+            float radius = 0.0f;
+            for (int i = 0; i < m_actor->ar_num_nodes; ++i)
+            {
+                radius = std::max(radius, pos_xyz.distance(world2screen.Convert(m_actor->ar_nodes[i].AbsPosition)));
+            }
+
+            drawlist->AddCircleFilled(pos, radius * 1.05f, 0x22222222, 36);
+        }
+    }
 
     // Skeleton display. NOTE: Order matters, it determines Z-ordering on render
     if ((m_debug_view == DebugViewType::DEBUGVIEW_SKELETON) ||

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -77,12 +77,14 @@ public:
     /// @param setInitPosition Set initial positions of nodes to current position?
     void              ResetPosition(Ogre::Vector3 translation, bool setInitPosition);
     void              ResetPosition(float px, float pz, bool setInitPosition, float miny);
-    void              RequestRotation(float rotation) { m_rotation_request += rotation; };
+    void              RequestRotation(float rotation, Ogre::Vector3 center) { m_rotation_request += rotation; m_rotation_request_center = center; };
     void              RequestAngleSnap(int division) { m_anglesnap_request = division; };
     void              RequestTranslation(Ogre::Vector3 translation) { m_translation_request += translation; };
     Ogre::Vector3     GetRotationCenter();
     float             GetMinHeight(bool skip_virtual_nodes=true);
+    float             GetMaxHeight(bool skip_virtual_nodes=true);
     float             GetHeightAboveGround(bool skip_virtual_nodes=true);
+    float             GetHeightAboveGroundBelow(float height, bool skip_virtual_nodes=true);
     bool              ReplayStep();
     void              ForceFeedbackStep(int steps);
     void              HandleInputEvents(float dt);
@@ -161,6 +163,7 @@ public:
     void              UpdateBoundingBoxes();
     void              calculateAveragePosition();
     void              UpdatePhysicsOrigin();
+    void              SoftReset();
     void              SyncReset(bool reset_position);      //!< this one should be called only synchronously (without physics running in background)
     blinktype         getBlinkType();
     std::vector<authorinfo_t>     getAuthors();
@@ -361,6 +364,7 @@ public:
     bool ar_import_commands:1;  //!< Sim state
     bool ar_toggle_ropes:1;     //!< Sim state
     bool ar_toggle_ties:1;      //!< Sim state
+    bool ar_physics_paused:1;   //!< Sim state
 
 private:
 
@@ -459,6 +463,7 @@ private:
     Ogre::String      m_net_username;
     Ogre::Timer       m_reset_timer;
     float             m_custom_light_toggle_countdown; //!< Input system helper status
+    Ogre::Vector3     m_rotation_request_center;
     float             m_rotation_request;         //!< Accumulator
     int               m_anglesnap_request;        //!< Accumulator
     Ogre::Vector3     m_translation_request;      //!< Accumulator

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -571,7 +571,8 @@ struct ActorModifyRequest
         INVALID,
         RELOAD,               //!< Full reload from filesystem, requested by user
         RESET_ON_INIT_POS,
-        RESET_ON_SPOT
+        RESET_ON_SPOT,
+        SOFT_RESET
     };
 
     Actor* amr_actor;

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1119,6 +1119,8 @@ bool Actor::CalcForcesEulerPrepare(bool doUpdate)
 {
     if (m_ongoing_reset)
         return false;
+    if (ar_physics_paused)
+        return false;
     if (ar_sim_state != Actor::SimState::LOCAL_SIMULATED)
         return false;
 

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -735,7 +735,7 @@ float Collisions::getSurfaceHeightBelow(float x, float z, float height)
         {
             collision_box_t* cbox = &m_collision_boxes[hashtable[hash][k].element_index];
 
-            if (!cbox->virt)
+            if (!cbox->virt && surface_height < cbox->hi.y)
             {
                 if (x > cbox->lo.x && z > cbox->lo.z && x < cbox->hi.x && z < cbox->hi.z)
                 {
@@ -781,6 +781,8 @@ float Collisions::getSurfaceHeightBelow(float x, float z, float height)
 
             auto lo = ctri->aab.getMinimum();
             auto hi = ctri->aab.getMaximum();
+            if (surface_height >= hi.y)
+                continue;
             if (x < lo.x || z < lo.z || x > hi.x || z > hi.z)
                 continue;
 
@@ -795,7 +797,7 @@ float Collisions::getSurfaceHeightBelow(float x, float z, float height)
         }
     }
 
-    return std::min(surface_height, height);
+    return surface_height;
 }
 
 bool Collisions::collisionCorrect(Vector3 *refpos, bool envokeScriptCallbacks)

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -992,6 +992,12 @@ eventInfo_t eventInfo[] = {
         _L("reset truck to original starting position")
     },
     {
+        "COMMON_TOGGLE_RESET_MODE",
+        EV_COMMON_TOGGLE_RESET_MODE,
+        "Keyboard EXPL+APOSTROPHE",
+        _L("toggle reset mode")
+    },
+    {
         "COMMON_SCREENSHOT",
         EV_COMMON_SCREENSHOT,
         "Keyboard EXPL+SYSRQ",
@@ -1567,6 +1573,12 @@ eventInfo_t eventInfo[] = {
         EV_TRUCK_TOGGLE_INTER_WHEEL_DIFF,
         "Keyboard EXPL+W",
         _L("cycle between available inter wheel differential modes")
+    },
+    {
+        "TRUCK_TOGGLE_PHYSICS",
+        EV_TRUCK_TOGGLE_PHYSICS,
+        "Keyboard END",
+        _L("toggle physics")
     },
     {
         "TRUCK_TOGGLE_TCASE_4WD_MODE",

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -240,6 +240,7 @@ enum events
     EV_COMMON_REPLAY_FORWARD,
     EV_COMMON_RESCUE_TRUCK, //!< teleport to rescue truck
     EV_COMMON_RESET_TRUCK, //!< reset truck to original starting position
+    EV_COMMON_TOGGLE_RESET_MODE, //!< toggle truck reset truck mode (soft vs. hard)
     EV_COMMON_ROPELOCK, //!< connect hook node to a node in close proximity
     EV_COMMON_SAVE_TERRAIN, //!< save terrain mesh to file
     EV_COMMON_SCREENSHOT, //!< take a screenshot
@@ -342,6 +343,7 @@ enum events
     EV_TRUCK_TOGGLE_IMPORTCOMMANDS, //!< toggle importcommands
     EV_TRUCK_TOGGLE_INTER_AXLE_DIFF, //!< toggle the inter axle differential mode
     EV_TRUCK_TOGGLE_INTER_WHEEL_DIFF, //!< toggle the inter wheel differential mode
+    EV_TRUCK_TOGGLE_PHYSICS, //!< toggle physics simulation
     EV_TRUCK_TOGGLE_TCASE_4WD_MODE, //!< toggle the transfer case 4wd mode
     EV_TRUCK_TOGGLE_TCASE_GEAR_RATIO, //!< toggle the transfer case gear ratio
     EV_TRUCK_TOGGLE_VIDEOCAMERA, //!< toggle videocamera update


### PR DESCRIPTION
The new soft reset allows you to translate and rotate entire groups of actors without doing an actual reset.

The new pause mode allows you to 'freeze / unfreeze' the physics of individual actors and fits the new save games feature perfectly.

Shortcuts:

- `TRUCK_TOGGLE_PHYSICS` (Default: 'END')
- `COMMON_TOGGLE_RESET_MODE` (Default: 'EXPL+APOSTROPHE')