### PR TITLE
🐛 Fixed the wheel node mass calculation

### DIFF
--- a/source/main/datatypes/node_t.h
+++ b/source/main/datatypes/node_t.h
@@ -46,19 +46,14 @@ struct node_t
     Ogre::Real surface_coef;
     Ogre::Real volume_coef;
 
-    int16_t iswheel;          //!< 0=NOWHEEL, 1=WHEEL_DEFAULT, 2=WHEEL_2  3=WHEEL_FLEXBODY
     int16_t pos;              //!< This node's index in Actor::ar_nodes array.
     int16_t nd_coll_bbox_id;  //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
     int16_t nd_lockgroup;     //!< Optional attribute (-1 = default, 9999 = deny lock) - used in the hook lock logic
 
-    Ogre::Real      nd_avg_collision_slip;   //!< Physics state; average slip velocity across the last few physics frames
-    Ogre::Vector3   nd_last_collision_slip;  //!< Physics state; last collision slip vector
-    Ogre::Vector3   nd_last_collision_force; //!< Physics state; last collision force
-    ground_model_t* nd_last_collision_gm;    //!< Physics state; last collision 'ground model' (surface definition)
-
     // Bit flags
     bool            nd_cab_node:1;           //!< Attr; This node is part of collision triangle
-    bool            nd_rim_node:1;           //!< Attr; This node is part of the rim
+    bool            nd_rim_node:1;           //!< Attr; This node is part of a rim
+    bool            nd_tyre_node:1;          //!< Attr; This node is part of a tyre
     bool            nd_contacter:1;          //!< Attr; User-defined
     bool            nd_contactable:1;        //!< Attr; This node will be treated as contacter on inter truck collisions
     bool            nd_has_ground_contact:1; //!< Physics state
@@ -69,4 +64,9 @@ struct node_t
     bool            nd_override_mass:1;      //!< User defined attr; mass is user-specified rather than calculated (override the calculation)
     bool            nd_under_water:1;        //!< State; GFX hint
     bool            nd_no_mouse_grab:1;      //!< Attr; User-defined
+
+    Ogre::Real      nd_avg_collision_slip;   //!< Physics state; average slip velocity across the last few physics frames
+    Ogre::Vector3   nd_last_collision_slip;  //!< Physics state; last collision slip vector
+    Ogre::Vector3   nd_last_collision_force; //!< Physics state; last collision force
+    ground_model_t* nd_last_collision_gm;    //!< Physics state; last collision 'ground model' (surface definition)
 };

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -603,7 +603,7 @@ void RoR::GfxActor::UpdateParticles(float dt_sec)
                 break;
 
             case Collisions::FX_HARD:
-                if (n.iswheel != NOWHEEL && !n.nd_rim_node) // This is a wheel => skidmarks and tyre smoke
+                if (n.nd_tyre_node) // skidmarks and tyre smoke
                 {
                     const float SMOKE_THRESHOLD = 8.f;
                     const float SCREECH_THRESHOLD = 5.f;

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -638,7 +638,7 @@ void Actor::RecalculateNodeMasses(Real total, bool reCalc)
     //reset
     for (int i = 0; i < ar_num_nodes; i++)
     {
-        if (!ar_nodes[i].iswheel || ar_nodes[i].nd_rim_node)
+        if (!ar_nodes[i].nd_tyre_node)
         {
             if (!ar_nodes[i].nd_loaded_mass)
             {
@@ -657,9 +657,9 @@ void Actor::RecalculateNodeMasses(Real total, bool reCalc)
         if (ar_beams[i].bm_type != BEAM_VIRTUAL)
         {
             Real half_newlen = ar_beams[i].L / 2.0;
-            if (!(ar_beams[i].p1->iswheel && !ar_nodes[i].nd_rim_node))
+            if (!ar_beams[i].p1->nd_tyre_node)
                 len += half_newlen;
-            if (!(ar_beams[i].p2->iswheel && !ar_nodes[i].nd_rim_node))
+            if (!ar_beams[i].p2->nd_tyre_node)
                 len += half_newlen;
         }
     }
@@ -671,9 +671,9 @@ void Actor::RecalculateNodeMasses(Real total, bool reCalc)
             if (ar_beams[i].bm_type != BEAM_VIRTUAL)
             {
                 Real half_mass = ar_beams[i].L * total / len / 2.0f;
-                if (!(ar_beams[i].p1->iswheel && !ar_nodes[i].nd_rim_node))
+                if (!ar_beams[i].p1->nd_tyre_node)
                     ar_beams[i].p1->mass += half_mass;
-                if (!(ar_beams[i].p2->iswheel && !ar_nodes[i].nd_rim_node))
+                if (!ar_beams[i].p2->nd_tyre_node)
                     ar_beams[i].p2->mass += half_mass;
             }
         }
@@ -696,7 +696,7 @@ void Actor::RecalculateNodeMasses(Real total, bool reCalc)
     {
         //LOG("Nodemass "+TOSTRING(i)+"-"+TOSTRING(ar_nodes[i].mass));
         //for stability
-        if ((!ar_nodes[i].iswheel || ar_nodes[i].nd_rim_node) && ar_nodes[i].mass < m_minimass)
+        if (!ar_nodes[i].nd_tyre_node && ar_nodes[i].mass < m_minimass)
         {
             if (App::diag_truck_mass.GetActive())
             {

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -183,13 +183,6 @@ enum {
     DEFAULT_DETACHER_GROUP  = 0, // default for detaching beam group
 };
 
-enum {
-    NOWHEEL,
-    WHEEL_DEFAULT,
-    WHEEL_2,
-    WHEEL_FLEXBODY
-};
-
 enum class FlareType: char
 {
     NONE           = 0,

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -246,7 +246,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
     actor->m_wheel_node_count = 0;
     for (int i = 0; i < actor->ar_num_nodes; i++)
     {
-        if (actor->ar_nodes[i].iswheel != NOWHEEL && !actor->ar_nodes[i].nd_rim_node)
+        if (actor->ar_nodes[i].nd_tyre_node)
             actor->m_wheel_node_count++;
     }
 
@@ -254,7 +254,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
     actor->m_net_first_wheel_node = actor->ar_num_nodes;
     for (int i = 0; i < actor->ar_num_nodes; i++)
     {
-        if (actor->ar_nodes[i].iswheel != NOWHEEL || actor->ar_nodes[i].nd_rim_node)
+        if (actor->ar_nodes[i].nd_tyre_node || actor->ar_nodes[i].nd_rim_node)
         {
             actor->m_net_first_wheel_node = i;
             break;

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -4013,7 +4013,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
 
         outer_node.mass          = node_mass;
         outer_node.friction_coef = def.node_defaults->friction;
-        outer_node.iswheel       = WHEEL_FLEXBODY;
         outer_node.nd_rim_node   = true;
         AdjustNodeBuoyancy(outer_node, def.node_defaults);
 
@@ -4028,7 +4027,6 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
 
         inner_node.mass          = node_mass;
         inner_node.friction_coef = def.node_defaults->friction;
-        inner_node.iswheel       = WHEEL_FLEXBODY;
         inner_node.nd_rim_node   = true;
         AdjustNodeBuoyancy(inner_node, def.node_defaults);
 
@@ -4057,8 +4055,8 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         outer_node.friction_coef = def.node_defaults->friction;
         outer_node.volume_coef   = def.node_defaults->volume;
         outer_node.surface_coef  = def.node_defaults->surface;
-        outer_node.iswheel       = WHEEL_FLEXBODY;
         outer_node.nd_contacter  = true;
+        outer_node.nd_tyre_node  = true;
         AdjustNodeBuoyancy(outer_node, def.node_defaults);
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
@@ -4073,8 +4071,8 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         inner_node.friction_coef = def.node_defaults->friction;
         inner_node.volume_coef   = def.node_defaults->volume;
         inner_node.surface_coef  = def.node_defaults->surface;
-        inner_node.iswheel       = WHEEL_FLEXBODY;
         inner_node.nd_contacter  = true;
+        inner_node.nd_tyre_node  = true;
         AdjustNodeBuoyancy(inner_node, def.node_defaults);
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
@@ -4459,8 +4457,8 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
         node_t & outer_node = GetFreeNode();
         InitNode(outer_node, ray_point, node_defaults);
         outer_node.mass          = wheel_mass / (2.f * num_rays);
-        outer_node.iswheel       = WHEEL_DEFAULT;
         outer_node.nd_contacter  = true;
+        outer_node.nd_tyre_node  = true;
         AdjustNodeBuoyancy(outer_node, node_defaults);
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
@@ -4472,8 +4470,8 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
         node_t & inner_node = GetFreeNode();
         InitNode(inner_node, ray_point, node_defaults);
         inner_node.mass          = wheel_mass / (2.f * num_rays);
-        inner_node.iswheel       = WHEEL_DEFAULT;
         inner_node.nd_contacter  = true;
+        inner_node.nd_tyre_node  = true;
         AdjustNodeBuoyancy(inner_node, node_defaults);
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
@@ -4485,9 +4483,9 @@ unsigned int ActorSpawner::BuildWheelObjectAndNodes(
 #ifdef DEBUG_TRUCKPARSER2013
         // TRUCK PARSER 2013 DEBUG
         int modifier = 0;
-        msg << "\nDBG\tN1: index=" << outer_node.pos + modifier << ", iswheel=" << outer_node.iswheel 
+        msg << "\nDBG\tN1: index=" << outer_node.pos + modifier << ", iswheel=" << WHEEL_DEFAULT 
             <<", X=" << outer_node.AbsPosition.x <<", Y=" << outer_node.AbsPosition.y <<", Z=" << outer_node.AbsPosition.z << std::endl
-            << "DBG\tN2: index=" << inner_node.pos + modifier << ", iswheel=" << inner_node.iswheel 
+            << "DBG\tN2: index=" << inner_node.pos + modifier << ", iswheel=" << WHEEL_DEFAULT 
             <<", X=" << inner_node.AbsPosition.x <<", Y=" << inner_node.AbsPosition.y <<", Z=" << inner_node.AbsPosition.z;
         // END
 #endif
@@ -4701,7 +4699,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         node_t & outer_node    = GetFreeNode();
         InitNode(outer_node, ray_point, wheel_2_def.node_defaults);
         outer_node.mass        = node_mass;
-        outer_node.iswheel     = WHEEL_2;
         outer_node.nd_rim_node = true;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
@@ -4712,7 +4709,6 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         node_t & inner_node    = GetFreeNode();
         InitNode(inner_node, ray_point, wheel_2_def.node_defaults);
         inner_node.mass        = node_mass;
-        inner_node.iswheel     = WHEEL_2;
         inner_node.nd_rim_node = true;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
@@ -4737,11 +4733,11 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         node_t & outer_node = GetFreeNode();
         InitNode(outer_node, ray_point);
         outer_node.mass          = (0.67f * wheel_2_def.mass) / (2.f * wheel_2_def.num_rays);
-        outer_node.iswheel       = WHEEL_2;
         outer_node.friction_coef = wheel.wh_width * WHEEL_FRICTION_COEF;
         outer_node.volume_coef   = wheel_2_def.node_defaults->volume;
         outer_node.surface_coef  = wheel_2_def.node_defaults->surface;
         outer_node.nd_contacter  = true;
+        outer_node.nd_tyre_node  = true;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
 
@@ -4751,11 +4747,11 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         node_t & inner_node = GetFreeNode();
         InitNode(inner_node, ray_point);
         inner_node.mass          = (0.33f * wheel_2_def.mass) / (2.f * wheel_2_def.num_rays);
-        inner_node.iswheel       = WHEEL_2;
         inner_node.friction_coef = wheel.wh_width * WHEEL_FRICTION_COEF;
         inner_node.volume_coef   = wheel_2_def.node_defaults->volume;
         inner_node.surface_coef  = wheel_2_def.node_defaults->surface;
         inner_node.nd_contacter  = true;
+        inner_node.nd_tyre_node  = true;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
 
@@ -5655,7 +5651,6 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
     node.AbsPosition = node_position; 
     node.RelPosition = node_position - m_actor->ar_origin;
 
-    node.iswheel = NOWHEEL;
     node.friction_coef = def.node_defaults->friction;
     node.volume_coef = def.node_defaults->volume;
     node.surface_coef = def.node_defaults->surface;

--- a/source/main/physics/collision/DynamicCollisions.cpp
+++ b/source/main/physics/collision/DynamicCollisions.cpp
@@ -232,7 +232,7 @@ void ResolveIntraActorCollisions(const float dt, PointColDetector &intraPointCD,
                 const auto hitnode = &nodes[h->node_id];
 
                 //ignore wheel/chassis self contact
-                if (hitnode->iswheel && !hitnode->nd_rim_node) continue;
+                if (hitnode->nd_tyre_node) continue;
                 if (no == hitnode || na == hitnode || nb == hitnode) continue;
 
                 // transform point to triangle local coordinates


### PR DESCRIPTION
The bug was introduced with: https://github.com/RigsOfRods/rigs-of-rods/pull/2078
- Also removes the now obsolete `iswheel` flag to avoid further confusion.