### PR TITLE
🎮 New trailer parking brake logic

### DIFF
--- a/resources/skeleton/config/input.map
+++ b/resources/skeleton/config/input.map
@@ -254,6 +254,7 @@ TRUCK_LIGHTTOGGLE9             Keyboard             EXPL+CTRL+9
 TRUCK_LIGHTTOGGLE10            Keyboard             EXPL+CTRL+0 
 TRUCK_MANUAL_CLUTCH            Keyboard             LSHIFT 
 TRUCK_PARKING_BRAKE            Keyboard             P 
+TRUCK_TRAILER_PARKING_BRAKE    Keyboard             V
 TRUCK_SHIFT_DOWN               Keyboard             Z 
 TRUCK_SHIFT_NEUTRAL            Keyboard             D 
 TRUCK_SHIFT_UP                 Keyboard             A 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1190,6 +1190,14 @@ void SimController::UpdateInputEvents(float dt)
                         }
                     }
 
+                    if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TRAILER_PARKING_BRAKE))
+                    {
+                        if (m_player_actor->ar_driveable == TRUCK)
+                            m_player_actor->ar_trailer_parking_brake = !m_player_actor->ar_trailer_parking_brake;
+                        else if (m_player_actor->ar_driveable == NOT_DRIVEABLE)
+                            m_player_actor->ToggleParkingBrake();
+                    }
+
                     if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_VIDEOCAMERA, 0.5f))
                     {
                         if (m_player_actor->GetGfxActor()->GetVideoCamState() == GfxActor::VideoCamState::VCSTATE_DISABLED)

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1472,6 +1472,7 @@ void Actor::SyncReset(bool reset_position)
     ar_fusedrag = Vector3::ZERO;
     m_blink_type = BLINK_NONE;
     ar_parking_brake = false;
+    ar_trailer_parking_brake = false;
     ar_avg_wheel_speed = 0.0f;
     ar_wheel_speed = 0.0f;
     ar_wheel_spin = 0.0f;
@@ -4387,6 +4388,7 @@ Actor::Actor(
     , m_net_reverse_light(false)
     , m_replay_pos_prev(-1)
     , ar_parking_brake(false)
+    , ar_trailer_parking_brake(false)
     , m_avg_node_position(rq.asr_position)
     , m_previous_gear(0)
     , m_ref_tyre_pressure(50.0)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -322,6 +322,7 @@ public:
     float             ar_sleep_counter;               //!< Sim state; idle time counter
     ground_model_t*   ar_submesh_ground_model;
     bool              ar_parking_brake;
+    bool              ar_trailer_parking_brake;
     int               ar_lights;                      //!< boolean 1/0
     float             ar_left_mirror_angle;           //!< Sim state; rear view mirror angle
     float             ar_right_mirror_angle;          //!< Sim state; rear view mirror angle

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -699,7 +699,10 @@ void ActorManager::ForwardCommands(Actor* source_actor)
 
             // forward brakes
             hook.hk_locked_actor->ar_brake = source_actor->ar_brake;
-            hook.hk_locked_actor->ar_parking_brake = source_actor->ar_parking_brake;
+            if (hook.hk_locked_actor->ar_parking_brake != source_actor->ar_trailer_parking_brake)
+            {
+                hook.hk_locked_actor->ToggleParkingBrake();
+            }
 
             // forward lights
             hook.hk_locked_actor->ar_lights = source_actor->ar_lights;

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -265,6 +265,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
         actor->ar_hydro_rudder_state = j_entry["hydro_rudder_state"].GetFloat();
         actor->ar_hydro_elevator_state = j_entry["hydro_elevator_state"].GetFloat();
         actor->ar_parking_brake = j_entry["parking_brake"].GetBool();
+        actor->ar_trailer_parking_brake = j_entry["trailer_parking_brake"].GetBool();
         actor->ar_avg_wheel_speed = j_entry["avg_wheel_speed"].GetFloat();
         actor->ar_wheel_speed = j_entry["wheel_speed"].GetFloat();
         actor->ar_wheel_spin = j_entry["wheel_spin"].GetFloat();
@@ -566,6 +567,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
         j_entry.AddMember("hydro_rudder_state", actor->ar_hydro_rudder_state, j_doc.GetAllocator());
         j_entry.AddMember("hydro_elevator_state", actor->ar_hydro_elevator_state, j_doc.GetAllocator());
         j_entry.AddMember("parking_brake", actor->ar_parking_brake, j_doc.GetAllocator());
+        j_entry.AddMember("trailer_parking_brake", actor->ar_trailer_parking_brake, j_doc.GetAllocator());
         j_entry.AddMember("avg_wheel_speed", actor->ar_avg_wheel_speed, j_doc.GetAllocator());
         j_entry.AddMember("wheel_speed", actor->ar_wheel_speed, j_doc.GetAllocator());
         j_entry.AddMember("wheel_spin", actor->ar_wheel_spin, j_doc.GetAllocator());

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -1364,6 +1364,12 @@ eventInfo_t eventInfo[] = {
         _L("toggle parking brake")
     },
     {
+        "TRUCK_TRAILER_PARKING_BRAKE",
+        EV_TRUCK_TRAILER_PARKING_BRAKE,
+        "Keyboard V",
+        _L("toggle trailer parking brake")
+    },
+    {
         "TRUCK_ANTILOCK_BRAKE",
         EV_TRUCK_ANTILOCK_BRAKE,
         "Keyboard EXPL+SHIFT+B",

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -310,6 +310,7 @@ enum events
     EV_TRUCK_LIGHTTOGGLE10, //!< toggle custom light 10
     EV_TRUCK_MANUAL_CLUTCH, //!< manual clutch (for manual transmission)
     EV_TRUCK_PARKING_BRAKE, //!< toggle parking brake
+    EV_TRUCK_TRAILER_PARKING_BRAKE, //!< toggle trailer parking brake
     EV_TRUCK_RIGHT_MIRROR_LEFT,
     EV_TRUCK_RIGHT_MIRROR_RIGHT,
     EV_TRUCK_SHIFT_DOWN, //!< shift one gear down in manual transmission mode


### PR DESCRIPTION
You can now toggle the trailer parking brake independently from the towing truck.
- Default keyboard shortcut: `V`

This also works with no towing truck connected, if you enter the trailer.