### PR TITLE
🐛 Fixed the texture tool

### DIFF
--- a/source/main/gui/panels/GUI_TextureToolWindow.h
+++ b/source/main/gui/panels/GUI_TextureToolWindow.h
@@ -34,10 +34,6 @@ class TextureToolWindow : public wraps::BaseLayout, public ZeroedMemoryAllocator
 public:
 
     TextureToolWindow();
-    ~TextureToolWindow();
-
-    void show();
-    void hide();
 
     bool IsVisible();
     void SetVisible(bool value);

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -99,7 +99,7 @@ UTFString formatBytes(double bytes)
     wchar_t tmp[128] = L"";
     const wchar_t* si_prefix[] = {L"B", L"KB", L"MB", L"GB", L"TB", L"EB", L"ZB", L"YB"};
     int base = 1024;
-    int c = std::min((int)(log(bytes) / log((float)base)), (int)sizeof(si_prefix) - 1);
+    int c = bytes > 0 ? std::min((int)(log(bytes) / log((float)base)), (int)sizeof(si_prefix) - 1) : 0;
     swprintf(tmp, 128, L"%1.2f %ls", bytes / pow((float)base, c), si_prefix[c]);
     return UTFString(tmp);
 }


### PR DESCRIPTION
- Fixes crash with textures of size 0
- Preselects the 'Dynamic Textures only' checkbock
- Preselects the 'MapRttTex' texture, if it exists
- Lists all textures when you open the window
- Sorts the textures by name