### PR TITLE
🔧 Fixed particle issue during truck reset

### DIFF
--- a/source/main/gfx/DustManager.cpp
+++ b/source/main/gfx/DustManager.cpp
@@ -93,6 +93,10 @@ void RoR::GfxScene::UpdateScene(float dt_sec)
     // Particles
     if (RoR::App::gfx_particles_mode.GetActive() == 1)
     {
+        for (GfxActor* gfx_actor: m_all_gfx_actors)
+        {
+            gfx_actor->UpdateParticles(m_simbuf.simbuf_sim_speed * dt_sec);
+        }
         for (auto itor : m_dustpools)
         {
             itor.second->update();

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1003,13 +1003,9 @@ void ActorManager::UpdateActors(Actor* player_actor, float dt)
         {
             actor->updateVisual(dt);
             actor->UpdateFlareStates(dt); // Only state, visuals done by GfxActor
-            if (dt > 0.0f && !actor->ar_replay_mode && !actor->ar_physics_paused)
+            if (actor->ar_update_physics && App::gfx_skidmarks_mode.GetActive() > 0)
             {
-                if (App::gfx_skidmarks_mode.GetActive() > 0)
-                {
-                    actor->updateSkidmarks();
-                }
-                actor->m_gfx_actor->UpdateParticles(dt); // TODO: move it to GfxActor ~ only_a_ptr, 06/2018
+                actor->updateSkidmarks();
             }
             if (actor->ar_sim_state == Actor::SimState::NETWORKED_OK)
             {


### PR DESCRIPTION
Fixes a small issue with: https://github.com/RigsOfRods/rigs-of-rods/pull/2115 (skidmarks were rendered during truck reset)