### PR TITLE
📐 Loading window cleanup

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -103,7 +103,6 @@ SimController::SimController(RoR::ForceFeedback* ff, RoR::SkidmarkConfig* skid_c
     m_force_feedback(ff),
     m_skidmark_conf(skid_conf),
     m_hide_gui(false),
-    m_was_app_window_closed(false),
     m_is_pace_reset_pressed(false),
     m_last_cache_selection(nullptr),
     m_last_screenshot_date(""),
@@ -1877,23 +1876,8 @@ void SimController::windowResized(Ogre::RenderWindow* rw)
     m_actor_manager.NotifyActorsWindowResized();
 }
 
-//Unattach OIS before window shutdown (very important under Linux)
-void SimController::windowClosed(Ogre::RenderWindow* rw)
-{
-    // No on-screen rendering must be performed after window is closed -> crashes!
-    LOG("[RoR|Simulation] Received \"WindowClosed\" event. Stopping rendering.");
-    m_was_app_window_closed = true;
-}
-
-void SimController::windowMoved(Ogre::RenderWindow* rw)
-{
-    LOG("*** windowMoved");
-}
-
 void SimController::windowFocusChange(Ogre::RenderWindow* rw)
 {
-    // Too verbose
-    //LOG("*** windowFocusChange");
     RoR::App::GetInputEngine()->resetKeys();
 }
 
@@ -2289,7 +2273,7 @@ void SimController::EnterGameplayLoop()
 
     m_actor_manager.SyncWithSimThread(); // Wait for background tasks to finish
     App::sim_state.SetActive(SimState::OFF);
-    App::GetGuiManager()->GetLoadingWindow()->setProgress(50, _L("Unloading Terrain"), !m_was_app_window_closed); // Renders a frame
+    App::GetGuiManager()->GetLoadingWindow()->setProgress(50, _L("Unloading Terrain")); // Renders a frame
     this->CleanupAfterSimulation();
     OgreBites::WindowEventUtilities::removeWindowEventListener(App::GetOgreSubsystem()->GetRenderWindow(), this);
 }

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -120,8 +120,6 @@ public:
 private:
 
     // Ogre::WindowEventListener interface
-    void   windowMoved             (Ogre::RenderWindow* rw);
-    void   windowClosed            (Ogre::RenderWindow* rw);
     void   windowFocusChange       (Ogre::RenderWindow* rw);
     void   windowResized           (Ogre::RenderWindow* rw);
 
@@ -155,7 +153,6 @@ private:
     float                    m_time;
     RoR::ForceFeedback*      m_force_feedback;
     bool                     m_hide_gui;
-    bool                     m_was_app_window_closed;
     bool                     m_actor_info_gui_visible;
     bool                     m_pressure_pressed;
 

--- a/source/main/gui/panels/GUI_LoadingWindow.cpp
+++ b/source/main/gui/panels/GUI_LoadingWindow.cpp
@@ -36,17 +36,10 @@ LoadingWindow::LoadingWindow()
     MyGUI::IntSize gui_area = MyGUI::RenderManager::getInstance().getViewSize();
     mMainWidget->setPosition(gui_area.width / 2 - mMainWidget->getWidth() / 2, gui_area.height / 2 - mMainWidget->getHeight() / 2);
     ((MyGUI::Window*)mMainWidget)->setCaption(_L("Loading ..."));
-    t = new Ogre::Timer();
     mMainWidget->setVisible(false);
 }
 
-LoadingWindow::~LoadingWindow()
-{
-    delete(t);
-    t = NULL;
-}
-
-void LoadingWindow::setProgress(int _percent, const Ogre::UTFString& _text, bool _updateRenderFrame)
+void LoadingWindow::setProgress(int _percent, const Ogre::UTFString& _text)
 {
     mMainWidget->setVisible(true);
     mInfoStaticText->setCaption(convertToMyGUIString(_text));
@@ -54,34 +47,24 @@ void LoadingWindow::setProgress(int _percent, const Ogre::UTFString& _text, bool
     mBarProgress->setProgressAutoTrack(false);
     mBarProgress->setProgressPosition(_percent);
 
-    if (_updateRenderFrame)
-    {
-        renderOneFrame();
-    }
+    renderOneFrame();
 }
 
-void LoadingWindow::setAutotrack(const Ogre::UTFString& _text, bool _updateRenderFrame)
+void LoadingWindow::setAutotrack(const Ogre::UTFString& _text)
 {
     mMainWidget->setVisible(true);
     mInfoStaticText->setCaption(convertToMyGUIString(_text));
     mBarProgress->setProgressPosition(0);
     mBarProgress->setProgressAutoTrack(true);
 
-    if (_updateRenderFrame)
-    {
-        renderOneFrame(true);
-    }
+    renderOneFrame();
 }
 
-void LoadingWindow::renderOneFrame(bool force)
+void LoadingWindow::renderOneFrame()
 {
-    if (t->getMilliseconds() > 200 || force)
-    {
-        // we must pump the window messages, otherwise the window will get white on Vista ...
-        OgreBites::WindowEventUtilities::messagePump();
-        Ogre::Root::getSingleton().renderOneFrame();
-        t->reset();
-    }
+    // we must pump the window messages, otherwise the window will get white on Vista ...
+    OgreBites::WindowEventUtilities::messagePump();
+    Ogre::Root::getSingleton().renderOneFrame();
 }
 
 bool LoadingWindow::IsVisible() { return mMainWidget->getVisible(); }

--- a/source/main/gui/panels/GUI_LoadingWindow.h
+++ b/source/main/gui/panels/GUI_LoadingWindow.h
@@ -37,17 +37,16 @@ class LoadingWindow :
 public:
 
     LoadingWindow();
-    ~LoadingWindow();
 
-    void setProgress(int _percent, const Ogre::UTFString& _text = "", bool _updateRenderFrame = true);
-    void setAutotrack(const Ogre::UTFString& _text = "", bool _updateRenderFrame = true);
+    void setProgress(int _percent, const Ogre::UTFString& _text = "");
+    void setAutotrack(const Ogre::UTFString& _text = "");
 
     void SetVisible(bool v);
     bool IsVisible();
 
 private:
 
-    void renderOneFrame(bool force = false);
+    void renderOneFrame();
 
     ATTRIBUTE_FIELD_WIDGET_NAME(LoadingWindow, mBarProgress, "Bar");
 
@@ -55,8 +54,6 @@ private:
     ATTRIBUTE_FIELD_WIDGET_NAME(LoadingWindow, mInfoStaticText, "Info");
 
     MyGUI::TextBox* mInfoStaticText;
-
-    Ogre::Timer* t;
 };
 
 } // namespace GUI

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -315,15 +315,13 @@ bool TerrainGeometryManager::InitTerrain(std::string otc_filename)
 
     configureTerrainDefaults();
 
-    auto* loading_win = RoR::App::GetGuiManager()->GetLoadingWindow();
     for (OTCPage& page : m_spec->pages)
     {
-        loading_win->setProgress(43, _L("preparing terrain page ") + XZSTR(page.pos_x, page.pos_z));
         this->SetupGeometry(page, m_spec->is_flat);
     }
 
     // sync load since we want everything in place when we start
-    loading_win->setProgress(44, _L("loading terrain pages"));
+    App::GetGuiManager()->GetLoadingWindow()->setProgress(44, _L("Loading terrain pages ..."));
     m_ogre_terrain_group->loadAllTerrains(true);
 
     Terrain* terrain = m_ogre_terrain_group->getTerrain(0, 0);
@@ -350,9 +348,9 @@ bool TerrainGeometryManager::InitTerrain(std::string otc_filename)
     }
     mIsFlat = std::abs(mMaxHeight - mMinHeight) < std::numeric_limits<float>::epsilon();
 
-    // update the blend maps
     if (m_was_new_geometry_generated)
     {
+        // update the blend maps
         if (terrainManager->GetDef().custom_material_name.empty())
         {
             for (OTCPage& page : m_spec->pages)
@@ -361,9 +359,7 @@ bool TerrainGeometryManager::InitTerrain(std::string otc_filename)
 
                 if (terrain != nullptr)
                 {
-                    loading_win->setProgress(45, _L("loading terrain page layers ") + XZSTR(page.pos_x, page.pos_z));
                     this->SetupLayers(page, terrain);
-                    loading_win->setProgress(45, _L("loading terrain page blend maps ") + XZSTR(page.pos_x, page.pos_z));
                     this->SetupBlendMaps(page, terrain);
                 }
             }
@@ -372,7 +368,7 @@ bool TerrainGeometryManager::InitTerrain(std::string otc_filename)
         // always save the results when it was imported
         if (!m_spec->disable_cache)
         {
-            loading_win->setProgress(50, _L("saving all terrain pages ..."));
+            App::GetGuiManager()->GetLoadingWindow()->setProgress(50, _L("Saving all terrain pages ..."));
             m_ogre_terrain_group->saveAllTerrains(false);
         }
     }


### PR DESCRIPTION
Also removes the limit of having at most 5 loading window updates per second.