### PR TITLE
🐛 Fixed broken transmission labels in multiplayer

### DIFF
--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -584,20 +584,6 @@ GfxCharacter* Character::SetupGfx()
     m_gfx_character->xc_character = this;
     m_gfx_character->xc_instance_name = m_instance_name;
 
-#ifdef USE_SOCKETW
-    if (App::mp_state.GetActive() == MpState::CONNECTED)
-    {
-        m_gfx_character->xc_movable_text = new MovableText("netlabel-" + m_instance_name, "");
-        scenenode->attachObject(m_gfx_character->xc_movable_text);
-        m_gfx_character->xc_movable_text->setFontName("CyberbitEnglish");
-        m_gfx_character->xc_movable_text->setTextAlignment(MovableText::H_CENTER, MovableText::V_ABOVE);
-        m_gfx_character->xc_movable_text->setAdditionalHeight(2);
-        m_gfx_character->xc_movable_text->showOnTop(false);
-        m_gfx_character->xc_movable_text->setCharacterHeight(8);
-        m_gfx_character->xc_movable_text->setColor(ColourValue::Black);
-    }
-#endif //SOCKETW
-
     return m_gfx_character;
 }
 
@@ -719,6 +705,18 @@ void RoR::GfxCharacter::UpdateCharacterInScene()
 #ifdef USE_SOCKETW
     if (App::mp_state.GetActive() == MpState::CONNECTED && !xc_simbuf.simbuf_actor_coupling)
     {
+        if (xc_movable_text == nullptr)
+        {
+            xc_movable_text = new MovableText("netlabel-" + xc_instance_name, "");
+            xc_movable_text->setFontName("CyberbitEnglish");
+            xc_movable_text->setSpaceWidth(0.2f);
+            xc_movable_text->setTextAlignment(MovableText::H_CENTER, MovableText::V_ABOVE);
+            xc_movable_text->setAdditionalHeight(2);
+            xc_movable_text->showOnTop(false);
+            xc_movable_text->setColor(ColourValue::Black);
+            xc_scenenode->attachObject(xc_movable_text);
+        }
+
         // From 'updateCharacterNetworkColor()'
         const String materialName = "tracks/" + xc_instance_name;
         const int textureUnitStateNum = 2;


### PR DESCRIPTION
| Before | After |
| ------------- | ------------- |
| ![temp](https://user-images.githubusercontent.com/9437207/51805121-e5926d80-2269-11e9-8f02-167297582f79.png) | ![temp](https://user-images.githubusercontent.com/9437207/51805131-0ce93a80-226a-11e9-85e5-7ad29ebeda5c.png) |

But don't ask me why this is fixing it ...
