### PR TITLE
🐛 Fixed 'Globals' section parsing logic

### DIFF
--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.h
@@ -217,7 +217,6 @@ private:
     int              TokenizeCurrentLine();
     bool             CheckNumArguments(int num_required_args);
     void             ChangeSection(RigDef::File::Section new_section);
-    void             ExitSections();
     void             ProcessChangeModuleLine(File::Keyword keyword);
 
     std::string        GetArgStr          (int index);


### PR DESCRIPTION
The old parser did exit the current section on the following keywords:
* author
* description
* fileformatversion
* fileinfo
* minimass
