### PR TITLE
✨ Much faster cache generation

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -766,6 +766,7 @@ void CacheSystem::fillTruckDetailInfo(CacheEntry& entry, Ogre::DataStreamPtr str
     RigDef::Parser parser;
     parser.Prepare();
     parser.ProcessOgreStream(stream.getPointer(), group);
+    parser.GetSequentialImporter()->Disable();
     parser.Finalize();
 
     /* Report messages */


### PR DESCRIPTION
Skip the sequential importer and gain a 2.4x increase in cache generation speed.