### PR TITLE
🔧 Fixed some minor truck filename issues

### DIFF
--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1189,7 +1189,7 @@ std::shared_ptr<RigDef::File> ActorManager::FetchActorDef(std::string filename, 
             return nullptr;
         }
 
-        RoR::LogFormat("[RoR] Parsing truckfile '%s'", filename);
+        RoR::LogFormat("[RoR] Parsing truckfile '%s'", resource_filename.c_str());
         RigDef::Parser parser;
         parser.Prepare();
         parser.ProcessOgreStream(stream.getPointer(), resource_groupname);
@@ -1229,8 +1229,7 @@ std::shared_ptr<RigDef::File> ActorManager::FetchActorDef(std::string filename, 
             //     "soundloads" = play sound effect at certain spot
             //     "fixes"      = structures of N/B fixed to the ground
             // These files can have no beams. Possible extensions: .load or .fixed
-            std::string file_name(filename);
-            std::string file_extension = file_name.substr(file_name.find_last_of('.'));
+            std::string file_extension = filename.substr(filename.find_last_of('.'));
             Ogre::StringUtil::toLowerCase(file_extension);
             if ((file_extension == ".load") | (file_extension == ".fixed"))
             {

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -153,15 +153,12 @@ void CacheSystem::LoadModCache(CacheValidityState validity)
 
 CacheEntry* CacheSystem::FindEntryByFilename(std::string filename)
 {
-    CacheEntry* fallback = nullptr;
     for (CacheEntry& entry : m_entries)
     {
-        if (entry.fname == filename)
+        if (entry.fname == filename || entry.fname_without_uid == filename)
             return &entry;
-        else if (entry.fname_without_uid == filename)
-            fallback = &entry;
     }
-    return fallback;
+    return nullptr;
 }
 
 void CacheSystem::UnloadActorFromMemory(std::string filename)


### PR DESCRIPTION
It used to be `entry.fname == filename || entry.fname_without_uid == filename`, and we also do it like this here: https://github.com/RigsOfRods/rigs-of-rods/blob/54e81c4316dfbd821d94f1ccfbc65fbb37066d20/source/main/resources/CacheSystem.cpp#L1064