### PR TITLE
🔧 Minor python plugin improvements

### DIFF
--- a/tools/blender/ror_export.py
+++ b/tools/blender/ror_export.py
@@ -47,6 +47,7 @@ class ror_export(bpy.types.Operator, ExportHelper):
             if obj.type != 'MESH':
                 continue
 
+            bpy.ops.object.mode_set(mode="OBJECT")
             bpy.ops.object.mode_set(mode="EDIT")
             bm = bmesh.from_edit_mesh(obj.data)
 

--- a/tools/blender/ror_import.py
+++ b/tools/blender/ror_import.py
@@ -55,9 +55,12 @@ class ror_import(bpy.types.Operator, ImportHelper):
             for line in f:
                 line = line.strip()
                 if not line or line[0] == ';':
-                    truckfile.append(line)
                     if mode == 'nodes' and line[:5] == ';grp:':
                         groups = [g.strip() for g in line[5:].split(',')]
+                    elif mode == 'beams' and line[:5] == ';grp:':
+                        pass
+                    else:
+                        truckfile.append(line)
                     continue
 
                 args = line.replace(',', ' ').split()


### PR DESCRIPTION
- Fixes the `set_beam_defaults` formatting during export (after edge deletion)
- Removes duplicate `;grp:` lines after the node / beam sections