### PR TITLE
🐛 Fixed major flaw in the packet discard logic

### DIFF
--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -451,7 +451,7 @@ void Character::SendStreamData()
     strncpy(msg.anim_name, m_anim_name.c_str(), CHARACTER_ANIM_NAME_LEN);
     msg.anim_time = m_anim_time;
 
-    RoR::Networking::AddPacket(m_stream_id, RoRnet::MSG2_STREAM_DATA, sizeof(Networking::CharacterMsgPos), (char*)&msg);
+    RoR::Networking::AddPacket(m_stream_id, RoRnet::MSG2_STREAM_DATA, sizeof(Networking::CharacterMsgPos), (char*)&msg, true);
 #endif // USE_SOCKETW
 }
 

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -88,7 +88,7 @@ bool                 StartConnecting();             ///< Launches connecting on 
 ConnectState         CheckConnectingState();        ///< Reports state of background connecting and updates GVar 'mp_state'
 void                 Disconnect();
 
-void                 AddPacket(int streamid, int type, int len, char *content);
+void                 AddPacket(int streamid, int type, int len, char *content, bool discardable = false);
 void                 AddLocalStream(RoRnet::StreamRegister *reg, int size);
 
 std::vector<recv_packet_t> GetIncomingStreamData();

--- a/source/main/network/RoRnet.h
+++ b/source/main/network/RoRnet.h
@@ -28,7 +28,7 @@ namespace RoRnet {
 #define RORNET_LAN_BROADCAST_PORT   13000  //!< port used to send the broadcast announcement in LAN mode
 #define RORNET_MAX_USERNAME_LEN     40     //!< port used to send the broadcast announcement in LAN mode
 
-#define RORNET_VERSION              "RoRnet_2.40"
+#define RORNET_VERSION              "RoRnet_2.41"
 
 enum MessageType
 {
@@ -116,6 +116,7 @@ struct Header                      //!< Common header for every packet
     int32_t  source;               //!< source of this command: 0 = server
     uint32_t streamid;             //!< streamid for this command
     uint32_t size;                 //!< size of the attached data block
+    uint8_t discardable;           //!< allowed to be discarded?
 };
 
 struct StreamRegister              //!< Sent from the client to server and vice versa, to broadcast a new stream

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1900,7 +1900,7 @@ void Actor::sendStreamData()
         }
     }
 
-    RoR::Networking::AddPacket(ar_net_stream_id, MSG2_STREAM_DATA, packet_len, send_buffer);
+    RoR::Networking::AddPacket(ar_net_stream_id, MSG2_STREAM_DATA, packet_len, send_buffer, true);
 #endif //SOCKETW
 }
 


### PR DESCRIPTION
Not all `MSG2_STREAM_DATA` packets are allowed to be discarded.

This was the root of the first segfault in: https://github.com/RigsOfRods/rigs-of-rods/issues/2178

Requires: https://github.com/RigsOfRods/ror-server/pull/72