### PR TITLE
🐛 Fixed bug in the cache entry lookup

### DIFF
--- a/source/main/MainMenu.cpp
+++ b/source/main/MainMenu.cpp
@@ -27,7 +27,6 @@
 
 #include "MainMenu.h"
 
-#include "CacheSystem.h"
 #include "ChatSystem.h"
 #include "ContentManager.h"
 #include "GUIManager.h"
@@ -85,12 +84,10 @@ void MainMenu::EnterMainMenuLoop()
 
         if (RoR::App::GetGuiManager()->GetMainSelector()->IsFinishedSelecting())
         {
-            CacheEntry* selected_map = RoR::App::GetGuiManager()->GetMainSelector()->GetSelectedEntry();
-            if (selected_map != nullptr)
+            if (RoR::App::GetGuiManager()->GetMainSelector()->GetSelectedEntry() != nullptr)
             {
-                App::GetGuiManager()->GetMainSelector()->Reset(); // TODO: Eliminate this mechanism ~ only_a_ptr 09/2016
                 App::app_state.SetPending(AppState::SIMULATION);
-                App::sim_terrain_name.SetPending(selected_map->fname.c_str());
+                App::sim_terrain_name.SetPending("");
             }
         }
 

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -2014,17 +2014,29 @@ bool SimController::SetupGameplayLoop()
     // Terrain name lookup
     if (!App::sim_terrain_name.IsPendingEmpty())
     {
+        const CacheEntry* lookup = nullptr;
         String name = App::sim_terrain_name.GetPending();
         StringUtil::toLowerCase(name);
-        for (const auto& entry : *App::GetCacheSystem()->GetEntries())
+        for (const auto& entry : App::GetCacheSystem()->GetEntries())
         {
-            String fname = entry.fname_without_uid;
+            String fname = entry.fname;
             StringUtil::toLowerCase(fname);
             if (entry.fext == "terrn2" && fname.find(name) != std::string::npos) 
             {
-                App::sim_terrain_name.SetPending(entry.fname.c_str());
-                break;
+                if (fname == name)
+                {
+                    lookup = &entry;
+                    break;
+                }
+                else if (lookup == nullptr)
+                {
+                    lookup = &entry;
+                }
             }
+        }
+        if (lookup != nullptr)
+        {
+            App::sim_terrain_name.SetPending(lookup->fname.c_str());
         }
     }
 
@@ -2067,25 +2079,37 @@ bool SimController::SetupGameplayLoop()
     if (!App::diag_preset_vehicle.IsActiveEmpty())
     {
         // Vehicle name lookup
-        String name = App::diag_preset_vehicle.GetActive();
+        const CacheEntry* lookup = nullptr;
+        String name = App::diag_preset_vehicle.GetPending();
         StringUtil::toLowerCase(name);
-        for (const auto& entry : *App::GetCacheSystem()->GetEntries())
+        for (const auto& entry : App::GetCacheSystem()->GetEntries())
         {
-            String fname = entry.fname_without_uid;
+            String fname = entry.fname;
             StringUtil::toLowerCase(fname);
             if (entry.fext != "terrn2" && fname.find(name) != std::string::npos) 
             {
-                App::diag_preset_vehicle.SetActive(entry.fname.c_str());
-                // Section config lookup
-                if (!entry.sectionconfigs.empty())
+                if (fname == name)
                 {
-                    auto cfgs = entry.sectionconfigs;
-                    if (std::find(cfgs.begin(), cfgs.end(), App::diag_preset_veh_config.GetActive()) == cfgs.end())
-                    {
-                        App::diag_preset_veh_config.SetActive(cfgs[0].c_str());
-                    }
+                    lookup = &entry;
+                    break;
                 }
-                break;
+                else if (lookup == nullptr)
+                {
+                    lookup = &entry;
+                }
+            }
+        }
+        if (lookup != nullptr)
+        {
+            App::diag_preset_vehicle.SetActive(lookup->fname.c_str());
+            // Section config lookup
+            if (!lookup->sectionconfigs.empty())
+            {
+                auto cfgs = lookup->sectionconfigs;
+                if (std::find(cfgs.begin(), cfgs.end(), App::diag_preset_veh_config.GetActive()) == cfgs.end())
+                {
+                    App::diag_preset_veh_config.SetActive(cfgs[0].c_str());
+                }
             }
         }
 

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -386,9 +386,9 @@ void CLASS::UpdateGuiData()
     }
 
     std::vector<std::time_t> timestamps;
-    std::vector<CacheEntry>* entries = RoR::App::GetCacheSystem()->GetEntries();
-    std::sort(entries->begin(), entries->end(), sort_entries<CacheEntry>());
-    for (std::vector<CacheEntry>::iterator it = entries->begin(); it != entries->end(); it++)
+    std::vector<CacheEntry> entries = RoR::App::GetCacheSystem()->GetEntries();
+    std::sort(entries.begin(), entries.end(), sort_entries<CacheEntry>());
+    for (std::vector<CacheEntry>::iterator it = entries.begin(); it != entries.end(); it++)
     {
         bool add = false;
         if (it->fext == "terrn2")
@@ -440,8 +440,8 @@ void CLASS::UpdateGuiData()
     }
 
     int tally_categories = 0, current_category = 0;
-    std::map<int, Ogre::String>* cats = RoR::App::GetCacheSystem()->GetCategories();
-    std::vector<std::pair<int, Ogre::String>> sorted_cats(cats->begin(), cats->end());
+    std::map<int, Ogre::String> cats = RoR::App::GetCacheSystem()->GetCategories();
+    std::vector<std::pair<int, Ogre::String>> sorted_cats(cats.begin(), cats.end());
     std::sort(sorted_cats.begin(), sorted_cats.end(), sort_cats<int, Ogre::String>());
     for (const auto& cat : sorted_cats)
     {

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -156,9 +156,14 @@ void CacheSystem::LoadModCache(CacheValidityState validity)
 
 CacheEntry* CacheSystem::FindEntryByFilename(std::string filename)
 {
+    StringUtil::toLowerCase(filename);
     for (CacheEntry& entry : m_entries)
     {
-        if (entry.fname == filename || entry.fname_without_uid == filename)
+        String fname = entry.fname;
+        String fname_without_uid = entry.fname_without_uid;
+        StringUtil::toLowerCase(fname);
+        StringUtil::toLowerCase(fname_without_uid);
+        if (fname == filename || fname_without_uid == filename)
             return &entry;
     }
     return nullptr;

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -149,8 +149,8 @@ public:
     bool CheckResourceLoaded(Ogre::String &in_out_filename); //!< Finds + loads the associated resource bundle if not already done.
     bool CheckResourceLoaded(Ogre::String &in_out_filename, Ogre::String &out_group); //!< Finds given resource, outputs group name. Also loads the associated resource bundle if not already done.
 
-    std::map<int, Ogre::String> *GetCategories() { return &m_categories; }
-    std::vector<CacheEntry> *GetEntries()        { return &m_entries; }
+    const std::map<int, Ogre::String> &GetCategories() const { return m_categories; }
+    const std::vector<CacheEntry> &GetEntries()        const { return m_entries; }
 
     CacheEntry *GetEntry(int modid);
     Ogre::String GetPrettyName(Ogre::String fname);


### PR DESCRIPTION
* 'snow.terrn2' would have been looked up as '31-snow.terrn2' even though both exist.
* `FindEntryByFilename` must not be case sensitive for backwards compatibility.