### PR TITLE
🐛 Fixed bad resource handling of subdirectories

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1017,11 +1017,8 @@ bool CacheSystem::ParseKnownFiles(Ogre::String group)
         auto files = ResourceGroupManager::getSingleton().findResourceFileInfo(group, "*." + ext);
         for (const auto& file : *files)
         {
-            if (file.path.empty())
-            {
-                this->AddFile(group, file, ext);
-                empty = false;
-            }
+            this->AddFile(group, file, ext);
+            empty = false;
         }
     }
     return empty;

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -248,18 +248,27 @@ void ContentManager::InitModCache()
     if (!App::app_extra_mod_path.IsActiveEmpty())
     {
         std::string extra_mod_path = App::app_extra_mod_path.GetActive();
-        ResourceGroupManager::getSingleton().addResourceLocation(extra_mod_path           , "FileSystem", RGN_CONTENT, true);
+        ResourceGroupManager::getSingleton().addResourceLocation(extra_mod_path           , "FileSystem", RGN_CONTENT);
     }
-    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "mods")    , "FileSystem", RGN_CONTENT, true);
-    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "packs")   , "FileSystem", RGN_CONTENT, true);
-    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "terrains"), "FileSystem", RGN_CONTENT, true);
-    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "vehicles"), "FileSystem", RGN_CONTENT, true);
-    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(base, "content") , "FileSystem", RGN_CONTENT, true);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "mods")    , "FileSystem", RGN_CONTENT);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "packs")   , "FileSystem", RGN_CONTENT);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "terrains"), "FileSystem", RGN_CONTENT);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "vehicles"), "FileSystem", RGN_CONTENT);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(base, "content") , "FileSystem", RGN_CONTENT);
     ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(base, objects)   , "Zip"       , RGN_CONTENT);
 
-
-    // Search for unzipped content
-    FileInfoListPtr files = ResourceGroupManager::getSingleton().findResourceFileInfo(RGN_CONTENT, "*", true);
+    ResourceGroupManager::getSingleton().createResourceGroup(RGN_TEMP, false);
+    if (!App::app_extra_mod_path.IsActiveEmpty())
+    {
+        std::string extra_mod_path = App::app_extra_mod_path.GetActive();
+        ResourceGroupManager::getSingleton().addResourceLocation(extra_mod_path           , "FileSystem", RGN_TEMP, true);
+    }
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "mods")    , "FileSystem", RGN_TEMP, true);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "packs")   , "FileSystem", RGN_TEMP, true);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "terrains"), "FileSystem", RGN_TEMP, true);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(user, "vehicles"), "FileSystem", RGN_TEMP, true);
+    ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(base, "content") , "FileSystem", RGN_TEMP, true);
+    FileInfoListPtr files = ResourceGroupManager::getSingleton().findResourceFileInfo(RGN_TEMP, "*", true);
     for (const auto& file : *files)
     {
         if (!file.archive)
@@ -267,6 +276,7 @@ void ContentManager::InitModCache()
         String fullpath = PathCombine(file.archive->getName(), file.filename);
         ResourceGroupManager::getSingleton().addResourceLocation(fullpath, "FileSystem", RGN_CONTENT);
     }
+    ResourceGroupManager::getSingleton().destroyResourceGroup(RGN_TEMP);
 
     // Search for skinzips
     FileInfoListPtr skinzips = ResourceGroupManager::getSingleton().findResourceFileInfo(RGN_CONTENT, "*.skinzip");


### PR DESCRIPTION
* Prevents duplicate cache entries when having zip archives in subdirectories
* Fixes support for content in subdirectories of zip archives

Closes: https://github.com/RigsOfRods/rigs-of-rods/pull/2225