### PR TITLE
📐 Section config cleanup

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1293,7 +1293,7 @@ void SimController::UpdateInputEvents(float dt)
                 {
                     ActorSpawnRequest rq;
                     rq.asr_cache_entry     = m_last_cache_selection;
-                    rq.asr_config          = m_last_vehicle_configs;
+                    rq.asr_config          = m_last_section_config;
                     rq.asr_skin            = m_last_skin_selection;
                     rq.asr_origin          = ActorSpawnRequest::Origin::USER;
                     m_actor_spawn_queue.push_back(rq);
@@ -1582,7 +1582,7 @@ void SimController::UpdateSimulation(float dt)
                 auto reload_pos = m_player_actor->getPosition();
                 auto reload_dir = Quaternion(Degree(270) - Radian(m_player_actor->getRotation()), Vector3::UNIT_Y);
                 auto debug_view = m_player_actor->GetGfxActor()->GetDebugView();
-                auto asr_config = m_player_actor->getActorConfig();
+                auto asr_config = m_player_actor->GetSectionConfig();
 
                 reload_pos.y = m_player_actor->GetMinHeight();
 
@@ -1612,7 +1612,7 @@ void SimController::UpdateSimulation(float dt)
         {
             m_last_cache_selection = rq.asr_cache_entry;
             m_last_skin_selection  = rq.asr_skin;
-            m_last_vehicle_configs = rq.asr_config;
+            m_last_section_config  = rq.asr_config;
 
             if (rq.asr_spawnbox == nullptr)
             {
@@ -2115,7 +2115,7 @@ bool SimController::SetupGameplayLoop()
 
         ActorSpawnRequest rq;
         rq.asr_filename   = App::diag_preset_vehicle.GetActive();
-        rq.asr_config     = std::vector<Ogre::String>(1, App::diag_preset_veh_config.GetActive());
+        rq.asr_config     = App::diag_preset_veh_config.GetActive();
         rq.asr_position   = gEnv->player->getPosition();
         rq.asr_rotation   = Quaternion(Degree(180) - gEnv->player->getRotation(), Vector3::UNIT_Y);
         rq.asr_origin     = ActorSpawnRequest::Origin::CONFIG_FILE;

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -157,7 +157,7 @@ private:
 
     CacheEntry*              m_last_cache_selection;
     RoR::SkinDef*            m_last_skin_selection;
-    std::vector<std::string> m_last_vehicle_configs;
+    Ogre::String             m_last_section_config;
 
     Ogre::Vector3            m_dir_arrow_pointed;
 

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -309,9 +309,7 @@ void CLASS::EventComboAcceptConfigComboBox(MyGUI::ComboBoxPtr _sender, size_t _i
     if (_index < 0 || _index >= m_Config->getItemCount())
         return;
 
-    m_vehicle_configs.clear();
-    Ogre::String config = *m_Config->getItemDataAt<Ogre::String>(_index);
-    m_vehicle_configs.push_back(config);
+    m_vehicle_config = *m_Config->getItemDataAt<Ogre::String>(_index);
 }
 
 template <typename T1, typename T2>
@@ -727,7 +725,7 @@ void CLASS::OnSelectionDone()
         }
         rq.asr_skin           = m_selected_skin;
         rq.asr_cache_entry    = m_selected_entry;
-        rq.asr_config         = m_vehicle_configs;
+        rq.asr_config         = m_vehicle_config;
         rq.asr_origin         = ActorSpawnRequest::Origin::USER;
         App::GetSimController()->QueueActorSpawn(rq);
 
@@ -761,9 +759,7 @@ void CLASS::UpdateControls(CacheEntry* entry)
         }
         m_Config->setIndexSelected(0);
 
-        m_vehicle_configs.clear();
-        Ogre::String configstr = *m_Config->getItemDataAt<Ogre::String>(0);
-        m_vehicle_configs.push_back(configstr);
+        m_vehicle_config = *m_Config->getItemDataAt<Ogre::String>(0);
     }
     else
     {
@@ -995,10 +991,10 @@ void CLASS::Show(LoaderType type)
     m_selection_done = false;
 
     m_selected_skin = 0;
+    m_vehicle_config = "";
     m_SearchLine->setCaption("");
     RoR::App::GetInputEngine()->resetKeys();
     App::GetGuiManager()->SetVisible_LoadingWindow(false);
-    m_vehicle_configs.clear();
     //MyGUI::InputManager::getInstance().setKeyFocusWidget(mMainWidget);
     MyGUI::InputManager::getInstance().setKeyFocusWidget(m_SearchLine);
     mMainWidget->setEnabledSilent(true);

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -47,8 +47,6 @@ public:
     void Cancel();
 
     CacheEntry* GetSelectedEntry() { return m_selected_entry; }
-    RoR::SkinDef* GetSelectedSkin() { return m_selected_skin; }
-    std::vector<Ogre::String> GetVehicleConfigs() { return m_vehicle_configs; }
 
 private:
 
@@ -85,7 +83,7 @@ private:
     RoR::SkinDef* m_selected_skin;
     bool m_selection_done;
     std::vector<CacheEntry> m_entries;
-    std::vector<Ogre::String> m_vehicle_configs;
+    Ogre::String m_vehicle_config;
     std::vector<RoR::SkinDef *> m_current_skins;
     bool m_keys_bound;
     RoR::SkinManager* m_skin_manager;

--- a/source/main/network/RoRnet.h
+++ b/source/main/network/RoRnet.h
@@ -126,7 +126,7 @@ struct StreamRegister              //!< Sent from the client to server and vice 
     int32_t origin_sourceid;       //!< origin sourceid
     int32_t origin_streamid;       //!< origin streamid
     char    name[128];             //!< the actor filename
-    char    data[8000];            //!< data used for stream setup
+    char    data[64];              //!< data used for stream setup
 };
 
 struct ActorStreamRegister
@@ -137,7 +137,7 @@ struct ActorStreamRegister
     int32_t origin_streamid;       //!< origin streamid
     char    name[128];             //!< filename
     int32_t bufferSize;            //!< initial stream status
-    char    actorconfig[10][60];   //!< section configuration
+    char    sectionconfig[60];     //!< section configuration
 };
 
 struct StreamUnRegister            //< sent to remove a stream

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1736,13 +1736,8 @@ void Actor::sendStreamSetup()
     reg.status = 0;
     reg.type = 0;
     reg.bufferSize = m_net_buffer_size;
-    strncpy(reg.name, ar_filename.c_str(), 128);
-    if (!m_actor_config.empty())
-    {
-        // insert section config
-        for (int i = 0; i < std::min<int>((int)m_actor_config.size(), 10); i++)
-            strncpy(reg.actorconfig[i], m_actor_config[i].c_str(), 60);
-    }
+    strncpy(reg.name, ar_filename.c_str(), 127);
+    strncpy(reg.sectionconfig, m_section_config.c_str(), 59);
 
 #ifdef USE_SOCKETW
     RoR::Networking::AddLocalStream((RoRnet::StreamRegister *)&reg, sizeof(RoRnet::ActorStreamRegister));
@@ -4399,7 +4394,7 @@ Actor::Actor(
     , m_avg_proped_wheel_radius(0.2f)
     , m_used_skin(rq.asr_skin)
     , ar_filename(rq.asr_filename)
-    , m_actor_config(rq.asr_config)
+    , m_section_config(rq.asr_config)
     , m_ongoing_reset(false)
     , ar_top_speed(0.0f)
     , ar_last_fuzzy_ground_model(nullptr)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -49,12 +49,6 @@ public:
         INVALID           //!< not simulated and not updated via the network (e.g. size differs from expected)
     };
 
-    /// @param actor_id Unique ID (previously 'truck number' or 'trucknum')
-    /// @param pos
-    /// @param rot
-    /// @param fname Rig file name.
-    /// @param actor_config Networking related.
-    /// @param preloaded_with_terrain Is this rig being pre-loaded along with terrain?
     Actor(
           int actor_id
         , unsigned int vector_index
@@ -159,7 +153,7 @@ public:
     blinktype         getBlinkType();
     std::vector<authorinfo_t>     getAuthors();
     std::vector<std::string>      getDescription();
-    std::vector<Ogre::String>     getActorConfig()      { return m_actor_config; }
+    Ogre::String     GetSectionConfig()                 { return m_section_config; }
     RoR::PerVehicleCameraContext* GetCameraContext()    { return &m_camera_context; }
     std::vector<Actor*> GetAllLinkedActors()            { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
     Ogre::Vector3     GetCameraDir()                    { return (ar_nodes[ar_main_camera_node_pos].RelPosition - ar_nodes[ar_main_camera_node_dir].RelPosition).normalisedCopy(); }
@@ -418,7 +412,7 @@ private:
     std::shared_ptr<RigDef::File>      m_definition;
     std::unique_ptr<RoR::GfxActor>     m_gfx_actor;
     RoR::PerVehicleCameraContext       m_camera_context;
-    std::vector<Ogre::String>          m_actor_config;
+    Ogre::String                       m_section_config;
     std::vector<SlideNode>             m_slidenodes;       //!< all the SlideNodes available on this actor
     std::vector<RailGroup*>            m_railgroups;       //!< all the available RailGroups for this actor
     std::vector<Ogre::Entity*>         m_deletion_entities;    //!< For unloading vehicle; filled at spawn.

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -546,7 +546,7 @@ struct ActorSpawnRequest
 
     CacheEntry*       asr_cache_entry; //!< Optional, overrides 'asr_filename' and 'asr_cache_entry_num'
     std::string       asr_filename;
-    std::vector<Ogre::String> asr_config;
+    Ogre::String      asr_config;
     Ogre::Vector3     asr_position;
     Ogre::Quaternion  asr_rotation;
     collision_box_t*  asr_spawnbox;

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -109,14 +109,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
     spawner.Setup(actor, def, parent_scene_node);
     /* Setup modules */
     spawner.AddModule(def->root_module);
-    if (def->user_modules.size() > 0) /* The vehicle-selector may return selected modules even for vehicle with no modules defined! Hence this check. */
-    {
-        std::vector<Ogre::String>::iterator itor = actor->m_actor_config.begin();
-        for (; itor != actor->m_actor_config.end(); itor++)
-        {
-            spawner.AddModule(*itor);
-        }
-    }
+    spawner.AddModule(actor->m_section_config);
     spawner.SpawnActor();
     def->report_num_errors += spawner.GetMessagesNumErrors();
     def->report_num_warnings += spawner.GetMessagesNumWarnings();
@@ -423,12 +416,7 @@ void ActorManager::HandleActorStreamData(std::vector<RoR::Networking::recv_packe
                     ActorSpawnRequest rq;
                     rq.asr_origin = ActorSpawnRequest::Origin::NETWORK;
                     rq.asr_filename = filename;
-                    for (int t = 0; t < 10; t++)
-                    {
-                        if (!strnlen(actor_reg->actorconfig[t], 60))
-                            break;
-                        rq.asr_config.push_back(String(actor_reg->actorconfig[t]));
-                    }
+                    rq.asr_config = actor_reg->sectionconfig;
                     rq.asr_net_username = tryConvertUTF(info.username);
                     rq.asr_net_color    = info.colournum;
 

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -71,9 +71,9 @@ CSimpleOpt::SOption cmdline_options[] = {
     { OPT_POS,            ("-pos"),         SO_REQ_SEP },
     { OPT_ROT,            ("-rot"),         SO_REQ_SEP },
     { OPT_TRUCK,          ("-truck"),       SO_REQ_SEP },
+    { OPT_TRUCKCONFIG,    ("-truckconfig"), SO_REQ_SEP },
     { OPT_ENTERTRUCK,     ("-enter"),       SO_NONE    },
     { OPT_WDIR,           ("-wd"),          SO_REQ_SEP },
-    { OPT_TRUCKCONFIG,    ("-actorconfig"), SO_REQ_SEP },
     { OPT_HELP,           ("--help"),       SO_NONE    },
     { OPT_HELP,           ("-help"),        SO_NONE    },
     { OPT_RESUME,         ("-resume"),      SO_NONE    },
@@ -94,10 +94,11 @@ void ShowCommandLineUsage()
             "-pos <Vect> (overrides spawn position)"    "\n"
             "-rot <float> (overrides spawn rotation)"   "\n"
             "-truck <truck> (loads truck on startup)"   "\n"
+            "-truckconfig <section>"                    "\n"
+            "-enter (player enters the selected truck)" "\n"
             "-resume loads previous autosave"           "\n"
             "-checkcache forces cache update"           "\n"
             "-version shows the version information"    "\n"
-            "-enter enters the selected truck"          "\n"
             "For example: RoR.exe -map simple2 -pos '518 0 518' -rot 45 -truck semi.truck -enter"));
 }
 


### PR DESCRIPTION
* Renames actor config into section config (everywhere)
* Actor can have any amount of sections, but only one can be selected
* Requires slight changes to the savegame file format and the net protocol

We were sending 8000 bytes of data during actor stream setup for sth. that takes 64 bytes at most. The longest section name in my cache is 31 characters long.