### PR TITLE
Fix stack buffer overrun in SHA1 hashing.

### DIFF
--- a/source/main/utils/SHA1.cpp
+++ b/source/main/utils/SHA1.cpp
@@ -239,37 +239,19 @@ void CSHA1::Final()
 
 #ifdef SHA1_UTILITY_FUNCTIONS
 // Get the final hash as a pre-formatted string
-void CSHA1::ReportHash(char *szReport, unsigned char uReportType)
+std::string CSHA1::ReportHash()
 {
     unsigned char i;
-    char szTemp[16];
+    char szTemp[16] = {};
+    char szReport[41] = {}; // 40 characters of hash + terminator NULL-character
 
-    if (szReport == NULL) return;
-
-    if (uReportType == REPORT_HEX || uReportType == REPORT_HEX_SHORT)
+    for (i = 0; i < 20; i++)
     {
-        bool shortreport = (uReportType == REPORT_HEX_SHORT);
-        sprintf(szTemp, "%02X", m_digest[0]);
-        strcat(szReport, szTemp);
-
-        for (i = 1; i < 20; i++)
-        {
-            sprintf(szTemp, shortreport?"%02X":" %02X", m_digest[i]);
-            strcat(szReport, szTemp);
-        }
+        sprintf(szTemp, "%02X", m_digest[i]);
+        strcat(szReport, szTemp); // Beware: strcat() adds NULL-character
     }
-    else if (uReportType == REPORT_DIGIT)
-    {
-        sprintf(szTemp, "%u", m_digest[0]);
-        strcat(szReport, szTemp);
 
-        for (i = 1; i < 20; i++)
-        {
-            sprintf(szTemp, " %u", m_digest[i]);
-            strcat(szReport, szTemp);
-        }
-    }
-    else strcpy(szReport, "Error: Unknown report type!");
+    return szReport;
 }
 #endif
 

--- a/source/main/utils/SHA1.h
+++ b/source/main/utils/SHA1.h
@@ -84,15 +84,6 @@ namespace RoR {
 class CSHA1 : public ZeroedMemoryAllocator
 {
 public:
-#ifdef SHA1_UTILITY_FUNCTIONS
-    // Two different formats for ReportHash(...)
-    enum
-    {
-        REPORT_HEX = 0,
-        REPORT_DIGIT = 1,
-        REPORT_HEX_SHORT = 2,
-    };
-#endif
 
     // Constructor and Destructor
     CSHA1();
@@ -118,7 +109,7 @@ public:
 
     // Report functions: as pre-formatted and raw data
 #ifdef SHA1_UTILITY_FUNCTIONS
-    void ReportHash(char* szReport, unsigned char uReportType = REPORT_HEX);
+    std::string ReportHash();
 #endif
     void GetHash(uint8_t* puDest);
 

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -42,9 +42,7 @@ String sha1sum(const char *key, int len)
     RoR::CSHA1 sha1;
     sha1.UpdateHash((uint8_t *)key, len);
     sha1.Final();
-    char buf[40] = "";
-    sha1.ReportHash(buf, RoR::CSHA1::REPORT_HEX_SHORT);
-    return String(buf, 40);
+    return sha1.ReportHash();
 }
 
 String HashData(const char *key, int len)


### PR DESCRIPTION
Detected by Visual Studio 2017. The output buffer was 1 NULL-character too short.
![image](https://user-images.githubusercontent.com/491088/52862723-3513dd00-3136-11e9-9ee4-84a5233c7255.png)

