### PR TITLE
🔧 Network fixes

### DIFF
--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -152,7 +152,6 @@ private:
     float                    m_physics_simulation_time; //!< Amount of time the physics simulation is going to be advanced
     bool                     m_physics_simulation_paused;
     int                      m_stats_on;
-    float                    m_netcheck_gui_timer;
     float                    m_time;
     RoR::ForceFeedback*      m_force_feedback;
     bool                     m_hide_gui;


### PR DESCRIPTION
- Update the player list each frame (smoother frametimes)
- Keep the simulation running when the selector window is open (prevents network desync)