### PR TITLE
🐛 Fixed the vehicle implosion in multiplayer

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -1502,6 +1502,19 @@ void SimController::UpdateSimulation(float dt)
 {
     m_actor_manager.SyncWithSimThread();
 
+#ifdef USE_SOCKETW
+    if (App::mp_state.GetActive() == MpState::CONNECTED)
+    {
+        std::vector<Networking::recv_packet_t> packets = RoR::Networking::GetIncomingStreamData();
+        if (!packets.empty())
+        {
+            RoR::ChatSystem::HandleStreamData(packets);
+            m_actor_manager.HandleActorStreamData(packets);
+            m_character_factory.handleStreamData(packets); // Update characters last (or else beam coupling might fail)
+        }
+    }
+#endif //SOCKETW
+
     // ACTOR CHANGE REQUESTS - Handle early (so that other logic can reflect it)
     //   1. Removal requests - Done first; respective entries in 'modify' queue are erased.
     //   2. Modify requests - currently just reload, will be extended
@@ -1649,17 +1662,6 @@ void SimController::UpdateSimulation(float dt)
         }
     }
     m_actor_spawn_queue.clear();
-
-    // Retrieve stream data after creating new vehicles (which interrupts the simulation loop for up to a few seconds)
-#ifdef USE_SOCKETW
-    if (App::mp_state.GetActive() == MpState::CONNECTED)
-    {
-        std::vector<Networking::recv_packet_t> packets = RoR::Networking::GetIncomingStreamData();
-        RoR::ChatSystem::HandleStreamData(packets);
-        m_actor_manager.HandleActorStreamData(packets);
-        m_character_factory.handleStreamData(packets); // Update characters last (or else beam coupling might fail)
-    }
-#endif //SOCKETW
 
     if (App::sim_load_savegame.GetActive())
     {

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -432,16 +432,18 @@ void Actor::CalcNetwork()
 
     float tratio = (float)(rnow - oob1->time) / (float)(oob2->time - oob1->time);
 
-    if (App::GetSimController()->GetBeamFactory()->NetworkStreamsInSync(ar_net_source_id))
+    if (tratio > 4.0f)
     {
-        if (tratio > 1.0f)
-        {
-            App::GetSimController()->GetBeamFactory()->UpdateNetTimeOffset(ar_net_source_id, -std::pow(2, tratio));
-        }
-        else if (index_offset == 0 && (m_net_updates.size() > 5 || (tratio < 0.125f && m_net_updates.size() > 2)))
-        {
-            App::GetSimController()->GetBeamFactory()->UpdateNetTimeOffset(ar_net_source_id, +1);
-        }
+        m_net_updates.clear();
+        return; // Wait for new data
+    }
+    else if (tratio > 1.0f)
+    {
+        App::GetSimController()->GetBeamFactory()->UpdateNetTimeOffset(ar_net_source_id, -std::pow(2, tratio));
+    }
+    else if (index_offset == 0 && (m_net_updates.size() > 5 || (tratio < 0.125f && m_net_updates.size() > 2)))
+    {
+        App::GetSimController()->GetBeamFactory()->UpdateNetTimeOffset(ar_net_source_id, +1);
     }
 
     short* sp1 = (short*)(netb1 + sizeof(float) * 3);

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -59,7 +59,6 @@ public:
     unsigned long  GetNetTime()                            { return m_net_timer.getMilliseconds(); };
     int            GetNetTimeOffset(int sourceid);
     void           UpdateNetTimeOffset(int sourceid, int offset);
-    bool           NetworkStreamsInSync(int sourceid);
     int            CheckNetworkStreamsOk(int sourceid);
     int            CheckNetRemoteStreamsOk(int sourceid);
     void           NotifyActorsWindowResized();


### PR DESCRIPTION
The network buffer length calculation failed when some clients needed much longer than others to spawn a new actor.