### PR TITLE
Truckfile now supports multiple `minimass` sections.

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -726,15 +726,15 @@ void Actor::RecalculateNodeMasses(Real total)
     {
         //LOG("Nodemass "+TOSTRING(i)+"-"+TOSTRING(ar_nodes[i].mass));
         //for stability
-        if (!ar_nodes[i].nd_tyre_node && ar_nodes[i].mass < m_minimass)
+        if (!ar_nodes[i].nd_tyre_node && ar_nodes[i].mass < ar_minimass[i])
         {
             if (App::diag_truck_mass.GetActive())
             {
                 char buf[300];
-                snprintf(buf, 300, "Node '%d' mass (%f Kg) is too light. Resetting to 'minimass' (%f Kg)", i, ar_nodes[i].mass, m_minimass);
+                snprintf(buf, 300, "Node '%d' mass (%f Kg) is too light. Resetting to 'minimass' (%f Kg)", i, ar_nodes[i].mass, ar_minimass[i]);
                 LOG(buf);
             }
-            ar_nodes[i].mass = m_minimass;
+            ar_nodes[i].mass = ar_minimass[i];
         }
     }
 
@@ -4408,7 +4408,6 @@ Actor::Actor(
     , m_wheel_diffs{} // Init array to nullptr
     , m_has_command_beams(false)
     , m_num_command_beams(0)
-    , m_minimass(50.f)
     , m_load_mass(0.f)
     , m_dry_mass(0.f)
     , ar_gui_use_engine_max_rpm(false)

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -203,6 +203,7 @@ public:
     Ogre::AxisAlignedBox      ar_bounding_box;     //!< standard bounding box (surrounds all nodes of an actor)
     Ogre::AxisAlignedBox      ar_predicted_bounding_box;
     std::vector<Ogre::Vector3>     ar_initial_node_positions;
+    std::vector<float>             ar_minimass; //!< minimum node mass in Kg
     std::vector<std::vector<int>>  ar_node_to_node_connections;
     std::vector<std::vector<int>>  ar_node_to_beam_connections;
     std::vector<Ogre::AxisAlignedBox>  ar_collision_bounding_boxes; //!< smart bounding boxes, used for determining the state of an actor (every box surrounds only a subset of nodes)
@@ -478,7 +479,6 @@ private:
     float             m_odometer_total;        //!< GUI state
     float             m_odometer_user;         //!< GUI state
     int               m_num_command_beams;     //!< TODO: Remove! Spawner context only; likely unused feature
-    float             m_minimass;              //!< Physics attr; minimum node mass in Kg
     float             m_load_mass;             //!< Physics attr; predefined load mass in Kg
     int               m_masscount;             //!< Physics attr; Number of nodes loaded with l option
     float             m_dry_mass;              //!< Physics attr;

--- a/source/main/physics/BeamConstants.h
+++ b/source/main/physics/BeamConstants.h
@@ -47,6 +47,7 @@ static const float DEFAULT_GRAVITY              = -9.8f;         //!< earth grav
 static const float DEFAULT_DRAG                 = 0.05f;
 static const float DEFAULT_BEAM_DIAMETER        = 0.05f;         //!< 5 centimeters default beam width
 static const float DEFAULT_COLLISION_RANGE      = 0.02f;
+static const float DEFAULT_MINIMASS             = 50.0f;         //!< minimum node mass in Kg
 static const float MIN_BEAM_LENGTH              = 0.1f;          //!< minimum beam lenght is 10 centimeters
 static const float INVERTED_MIN_BEAM_LENGTH     = 1.0f / MIN_BEAM_LENGTH;
 static const float BEAM_SKELETON_DIAMETER       = 0.01f;

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -221,6 +221,8 @@ void ActorSpawner::InitializeRig()
     if (req.num_wings > 0)
         m_actor->ar_wings = new wing_t[req.num_wings];
 
+    m_actor->ar_minimass.resize(req.num_nodes);
+
     // TODO: Perform these inits in constructor instead! ~ only_a_ptr, 01/2018
 
     // commands contain complex data structures, do not memset them ...
@@ -4008,6 +4010,7 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         outer_node.friction_coef = def.node_defaults->friction;
         outer_node.nd_rim_node   = true;
         AdjustNodeBuoyancy(outer_node, def.node_defaults);
+        m_actor->ar_minimass[outer_node.pos] = m_file->global_minimass->min_mass;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
 
@@ -4022,6 +4025,7 @@ void ActorSpawner::ProcessFlexBodyWheel(RigDef::FlexBodyWheel & def)
         inner_node.friction_coef = def.node_defaults->friction;
         inner_node.nd_rim_node   = true;
         AdjustNodeBuoyancy(inner_node, def.node_defaults);
+        m_actor->ar_minimass[inner_node.pos] = m_file->global_minimass->min_mass;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
 
@@ -4694,6 +4698,8 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         outer_node.mass        = node_mass;
         outer_node.nd_rim_node = true;
 
+        m_actor->ar_minimass[outer_node.pos] = m_file->global_minimass->min_mass;
+
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(outer_node.pos)));
 
         /* Inner ring */
@@ -4703,6 +4709,8 @@ unsigned int ActorSpawner::AddWheel2(RigDef::Wheel2 & wheel_2_def)
         InitNode(inner_node, ray_point, wheel_2_def.node_defaults);
         inner_node.mass        = node_mass;
         inner_node.nd_rim_node = true;
+
+        m_actor->ar_minimass[inner_node.pos] = m_file->global_minimass->min_mass;
 
         m_gfx_nodes.push_back(GfxActor::NodeGfx(static_cast<uint16_t>(inner_node.pos)));
 
@@ -5649,6 +5657,8 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
     node.surface_coef = def.node_defaults->surface;
 
     /* Mass */
+    m_actor->ar_minimass[inserted_node.first] = def.node_minimass->min_mass;
+
     if (def.node_defaults->load_weight >= 0.f) // The >= operator is in orig.
     {
         // orig = further override of hardcoded default.
@@ -5827,6 +5837,8 @@ void ActorSpawner::ProcessCinecam(RigDef::Cinecam & def)
     camera_node.volume_coef   = def.node_defaults->volume;
     camera_node.surface_coef  = def.node_defaults->surface;
     // NOTE: Not applying the 'node_mass' value here for backwards compatibility - this node must go through initial `Actor::RecalculateNodeMasses()` pass with default weight.
+
+    m_actor->ar_minimass[camera_node.pos] = m_file->global_minimass->min_mass;
 
     m_actor->ar_cinecam_node[m_actor->ar_num_cinecams] = camera_node.pos;
     m_actor->ar_num_cinecams++;

--- a/source/main/physics/RigSpawner_ProcessControl.cpp
+++ b/source/main/physics/RigSpawner_ProcessControl.cpp
@@ -163,12 +163,6 @@ Actor *ActorSpawner::SpawnActor()
         this->AddMessage(Message::TYPE_WARNING, "vehicle uses no GUID, skinning will be impossible");
     }
 
-    // Section 'minimass' in root module
-    if (m_file->_minimum_mass_set)
-    {
-        m_actor->m_minimass = m_file->minimum_mass;
-    }
-
     // Section 'description'
     m_actor->description.assign(m_file->description.begin(), m_file->description.end());
 

--- a/source/main/resources/rig_def_fileformat/RigDef_File.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.cpp
@@ -658,8 +658,6 @@ File::File():
     disable_default_sounds(false),
     slide_nodes_connect_instantly(false),
     collision_range(DEFAULT_COLLISION_RANGE),
-    minimum_mass(0.f),
-    _minimum_mass_set(false),
     report_num_errors(0),
     report_num_warnings(0),
     report_num_other(0)

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -168,10 +168,26 @@ struct BeamDefaults
 };
 
 /* -------------------------------------------------------------------------- */
-/* Sections NODES, NODES_2                                                    */
+/* Hybrid section MINIMASS                                                    */
 /* -------------------------------------------------------------------------- */
 
+struct MinimassPreset
+{
+    enum Option
+    {
+        OPTION_n_FILLER  = 'n',   //!< Updates the global minimass (classic behavior)
+        OPTION_d_DEFAULT = 'd'    //!< Sets new default (like `set_beam_defaults`)
+    };
 
+    MinimassPreset(): min_mass(DEFAULT_MINIMASS), is_global(true)
+    {}
+
+    explicit MinimassPreset(float m, bool g): min_mass(m), is_global(g)
+    {}
+
+    float min_mass; //!< minimum node mass in Kg
+    bool is_global;
+};
 
 /* -------------------------------------------------------------------------- */
 /* Directive SET_DEFAULT_INERTIA                                              */
@@ -2333,8 +2349,6 @@ struct File
     bool disable_default_sounds;
     Ogre::String name;
     float collision_range;
-    float minimum_mass;
-    bool _minimum_mass_set;
 
     // Report
     std::string loading_report;
@@ -2352,6 +2366,7 @@ struct File
     // File sections
     std::vector<Author> authors;
     std::shared_ptr<Fileinfo> file_info;
+    std::shared_ptr<MinimassPreset> global_minimass;
 };
 
 } // namespace RigDef

--- a/source/main/resources/rig_def_fileformat/RigDef_Node.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Node.h
@@ -162,6 +162,7 @@ struct Node
     float load_weight_override;
     bool _has_load_weight_override;
     std::shared_ptr<NodeDefaults> node_defaults;
+    std::shared_ptr<MinimassPreset> node_minimass;
     std::shared_ptr<BeamDefaults> beam_defaults; /* Needed for hook */
     int detacher_group;
 };

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.h
@@ -282,12 +282,14 @@ private:
 
     std::shared_ptr<Inertia>             m_ror_default_inertia;
     std::shared_ptr<NodeDefaults>        m_ror_node_defaults;
+    std::shared_ptr<MinimassPreset>      m_ror_minimass;
 
     // Data from user directives
     // Each affected section-struct has a shared_ptr to it's respective defaults
     std::shared_ptr<Inertia>             m_user_default_inertia;
     std::shared_ptr<BeamDefaults>        m_user_beam_defaults;
     std::shared_ptr<NodeDefaults>        m_user_node_defaults;
+    std::shared_ptr<MinimassPreset>      m_user_minimass;
     int                                  m_current_detacher_group;
     ManagedMaterialsOptions              m_current_managed_material_options;
 

--- a/source/main/resources/rig_def_fileformat/RigDef_Prerequisites.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Prerequisites.h
@@ -67,6 +67,7 @@ struct Inertia;
 struct Lockgroup;
 struct ManagedMaterialsOptions;
 struct MeshWheel;
+struct MinimassPreset;
 struct Node;
 struct NodeDefaults;
 struct Particle;

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -79,12 +79,6 @@ void Serializer::Serialize()
     WriteFlags();
     ProcessManagedMaterialsAndOptions(source_module);
 
-    // Section 'minimass'
-    if (m_rig_def->_minimum_mass_set)
-    {
-        m_stream << "minimass" << endl << "\t" << m_rig_def->minimum_mass << endl << endl;
-    }
-
     // Structure
     ProcessNodes(source_module);
     ProcessBeams(source_module);
@@ -2350,6 +2344,7 @@ void Serializer::ProcessNodes(File::Module* module)
     }
 
     // Group nodes by presets + find node-zero
+    // TODO: Handle minimass presets!
     std::map< NodeDefaults*, std::vector<Node*> > nodes_by_presets;
     Node* node_zero = nullptr;
     auto itor_end = module->nodes.end(); 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/491088/52947860-32082f00-3378-11e9-9f85-64dddccabcb2.png)

Test load: 
[MultiMiniMass_Test_Load.zip](https://github.com/RigsOfRods/rigs-of-rods/files/2875354/MultiMiniMass_Test_Load.zip)

Section minimass got options:
```
; option n = filler, does nothing
minimass
10.0, n

; option d = sets new default value, like `set_node_defaults`
minimass
4.0, d
```