### PR TITLE
🔧 Simplified invalid actor logic and revamped actor spawn info

### DIFF
--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -170,8 +170,7 @@ void RoR::GUI::TopMenubar::Update()
                     App::GetGuiManager()->SetVisible_VehicleDescription(true);
                 }
 
-                if (current_actor->ar_sim_state != Actor::SimState::NETWORKED_OK &&
-                        current_actor->ar_sim_state != Actor::SimState::INVALID)
+                if (current_actor->ar_sim_state != Actor::SimState::NETWORKED_OK)
                 {
                     if (ImGui::Button("Reload current vehicle"))
                     {

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -46,7 +46,6 @@ public:
         LOCAL_SIMULATED,  //!< simulated (local) actor
         NETWORKED_OK,     //!< not simulated (remote) actor
         LOCAL_SLEEPING,   //!< sleeping (local) actor
-        INVALID           //!< not simulated and not updated via the network (e.g. size differs from expected)
     };
 
     Actor(

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -59,6 +59,7 @@ public:
     unsigned long  GetNetTime()                            { return m_net_timer.getMilliseconds(); };
     int            GetNetTimeOffset(int sourceid);
     void           UpdateNetTimeOffset(int sourceid, int offset);
+    void           AddStreamMismatch(int sourceid, int streamid) { m_stream_mismatches[sourceid].insert(streamid); };
     int            CheckNetworkStreamsOk(int sourceid);
     int            CheckNetRemoteStreamsOk(int sourceid);
     void           NotifyActorsWindowResized();

--- a/source/main/utils/Utils.h
+++ b/source/main/utils/Utils.h
@@ -102,6 +102,7 @@ std::string SanitizeUtf8CString(const char* start, const char* end = nullptr);
 
 namespace Color {
 const Ogre::UTFString CommandColour = Ogre::UTFString("#00FF00");
+const Ogre::UTFString WarningColour = Ogre::UTFString("#FF0000");
 const Ogre::UTFString NormalColour = Ogre::UTFString("#FFFFFF");
 const Ogre::UTFString WhisperColour = Ogre::UTFString("#FFCC00");
 const Ogre::UTFString ScriptCommandColour = Ogre::UTFString("#0099FF");


### PR DESCRIPTION
We can just delete remote trucks the moment we detect that they're no compatible with what we have installed locally.

| Missing content | Content mismatch |
| :-: | :-: |
| ![temp2](https://user-images.githubusercontent.com/9437207/52974353-81bf1880-33c1-11e9-82a4-fa485bc4f754.png) | ![temp1](https://user-images.githubusercontent.com/9437207/52974352-81bf1880-33c1-11e9-8bd7-f4690441f5c5.png) |
