### PR TITLE
🐛 Fixed array index issue in GfxActor

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1801,7 +1801,11 @@ void RoR::GfxActor::UpdateSimDataBuffer()
         auto node = m_actor->ar_nodes[i];
         m_simbuf.simbuf_nodes.get()[i].AbsPosition = node.AbsPosition;
         m_simbuf.simbuf_nodes.get()[i].nd_has_contact = node.nd_has_ground_contact || node.nd_has_mesh_contact;
-        m_simbuf.simbuf_nodes.get()[i].nd_is_wet = (m_gfx_nodes[i].nx_wet_time_sec != -1.f);
+    }
+
+    for (NodeGfx& nx: m_gfx_nodes)
+    {
+        m_simbuf.simbuf_nodes.get()[nx.nx_node_idx].nd_is_wet = (nx.nx_wet_time_sec != -1.f);
     }
 
     // beams


### PR DESCRIPTION
Minor glitch in code, discovered by Debug mode in Visual Studio.

~I need a vehicle to test texture blending w/water.~

Update: tested with http://www.austingratzer.com/rigs/downloads.php?do=file&id=146, working