### PR TITLE
Truckfile: improved minimass handling

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -724,9 +724,9 @@ void Actor::RecalculateNodeMasses(Real total)
     //update mass
     for (int i = 0; i < ar_num_nodes; i++)
     {
-        //LOG("Nodemass "+TOSTRING(i)+"-"+TOSTRING(ar_nodes[i].mass));
-        //for stability
-        if (!ar_nodes[i].nd_tyre_node && ar_nodes[i].mass < ar_minimass[i])
+        if (!ar_nodes[i].nd_tyre_node &&
+            !(m_definition->minimass_skip_loaded_nodes && ar_nodes[i].nd_loaded_mass) &&
+            ar_nodes[i].mass < ar_minimass[i])
         {
             if (App::diag_truck_mass.GetActive())
             {

--- a/source/main/resources/rig_def_fileformat/RigDef_File.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.cpp
@@ -658,6 +658,7 @@ File::File():
     disable_default_sounds(false),
     slide_nodes_connect_instantly(false),
     collision_range(DEFAULT_COLLISION_RANGE),
+    minimass_skip_loaded_nodes(false),
     report_num_errors(0),
     report_num_warnings(0),
     report_num_other(0)

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -175,9 +175,8 @@ struct MinimassPreset
 {
     enum Option
     {
-        OPTION_n_FILLER  = 'n',     //!< Updates the global minimass (classic behavior)
-        OPTION_d_DEFAULT = 'd',     //!< Sets new default (like `set_beam_defaults`)
-        OPTION_l_SKIP_LOADED = 'l'  //!< Only apply minimum mass to nodes without "L" option. Global effect.
+        OPTION_n_FILLER  = 'n',     //!< Updates the global minimass
+        OPTION_l_SKIP_LOADED = 'l'  //!< Only apply minimum mass to nodes without "L" option.
     };
 
     MinimassPreset(): min_mass(DEFAULT_MINIMASS), is_global(true)
@@ -2201,6 +2200,7 @@ struct File
         KEYWORD_SET_BEAM_DEFAULTS,
         KEYWORD_SET_BEAM_DEFAULTS_SCALE,
         KEYWORD_SET_COLLISION_RANGE,
+        KEYWORD_SET_DEFAULT_MINIMASS,
         KEYWORD_SET_INERTIA_DEFAULTS,
         KEYWORD_SET_MANAGEDMATS_OPTIONS,
         KEYWORD_SET_NODE_DEFAULTS,

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -175,8 +175,9 @@ struct MinimassPreset
 {
     enum Option
     {
-        OPTION_n_FILLER  = 'n',   //!< Updates the global minimass (classic behavior)
-        OPTION_d_DEFAULT = 'd'    //!< Sets new default (like `set_beam_defaults`)
+        OPTION_n_FILLER  = 'n',     //!< Updates the global minimass (classic behavior)
+        OPTION_d_DEFAULT = 'd',     //!< Sets new default (like `set_beam_defaults`)
+        OPTION_l_SKIP_LOADED = 'l'  //!< Only apply minimum mass to nodes without "L" option. Global effect.
     };
 
     MinimassPreset(): min_mass(DEFAULT_MINIMASS), is_global(true)
@@ -2367,6 +2368,7 @@ struct File
     std::vector<Author> authors;
     std::shared_ptr<Fileinfo> file_info;
     std::shared_ptr<MinimassPreset> global_minimass;
+    bool minimass_skip_loaded_nodes; //!< Only apply minimum mass to nodes without "L" option. Global effect.
 };
 
 } // namespace RigDef

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -179,14 +179,13 @@ struct MinimassPreset
         OPTION_l_SKIP_LOADED = 'l'  //!< Only apply minimum mass to nodes without "L" option.
     };
 
-    MinimassPreset(): min_mass(DEFAULT_MINIMASS), is_global(true)
+    MinimassPreset(): min_mass(DEFAULT_MINIMASS)
     {}
 
-    explicit MinimassPreset(float m, bool g): min_mass(m), is_global(g)
+    explicit MinimassPreset(float m): min_mass(m)
     {}
 
     float min_mass; //!< minimum node mass in Kg
-    bool is_global;
 };
 
 /* -------------------------------------------------------------------------- */

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -194,6 +194,7 @@ void Parser::ProcessCurrentLine()
         case File::KEYWORD_SET_BEAM_DEFAULTS:        this->ParseDirectiveSetBeamDefaults();               return;
         case File::KEYWORD_SET_BEAM_DEFAULTS_SCALE:  this->ParseDirectiveSetBeamDefaultsScale();          return;
         case File::KEYWORD_SET_COLLISION_RANGE:      this->ParseSetCollisionRange();                      return;
+        case File::KEYWORD_SET_DEFAULT_MINIMASS:     this->ParseDirectiveSetDefaultMinimass();            return;
         case File::KEYWORD_SET_INERTIA_DEFAULTS:     this->ParseDirectiveSetInertiaDefaults();            return;
         case File::KEYWORD_SET_MANAGEDMATS_OPTIONS:  this->ParseDirectiveSetManagedMaterialsOptions();    return;
         case File::KEYWORD_SET_NODE_DEFAULTS:        this->ParseDirectiveSetNodeDefaults();               return;
@@ -2439,6 +2440,13 @@ Node::Ref Parser::_ParseNodeRef(std::string const & node_id_str)
     }
 }
 
+void Parser::ParseDirectiveSetDefaultMinimass()
+{
+    if (! this->CheckNumArguments(2)) { return; } // Directive name + parameter
+
+    m_user_minimass = std::shared_ptr<MinimassPreset>(new MinimassPreset(this->GetArgFloat(1), false));
+}
+
 void Parser::ParseDirectiveSetInertiaDefaults()
 {
     if (! this->CheckNumArguments(2)) { return; }
@@ -2816,7 +2824,6 @@ void Parser::ParseNodeCollision()
 void Parser::ParseMinimass()
 {
     const float minimass = this->GetArgFloat(0);
-    bool set_global = true;
     if (m_num_args > 1)
     {
         const std::string options_str = this->GetArgStr(1);
@@ -2826,10 +2833,6 @@ void Parser::ParseMinimass()
             {
             case '\0': // Terminator NULL character
             case (MinimassPreset::OPTION_n_FILLER):
-                break;
-
-            case (MinimassPreset::OPTION_d_DEFAULT):
-                set_global = false;
                 break;
 
             case (MinimassPreset::OPTION_l_SKIP_LOADED):
@@ -2843,14 +2846,7 @@ void Parser::ParseMinimass()
         }
     }
 
-    if (set_global)
-    {
-        m_ror_minimass->min_mass = minimass;
-    }
-    else
-    {
-        m_user_minimass = std::shared_ptr<MinimassPreset>(new MinimassPreset(minimass, false));
-    }
+    m_ror_minimass->min_mass = minimass;
 
     this->ChangeSection(File::SECTION_NONE);
 }

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -2832,6 +2832,10 @@ void Parser::ParseMinimass()
                 set_global = false;
                 break;
 
+            case (MinimassPreset::OPTION_l_SKIP_LOADED):
+                m_definition->minimass_skip_loaded_nodes = true;
+                break;
+
             default:
                 this->AddMessage(Message::TYPE_WARNING, std::string("Unknown option: ") + c);
                 break;

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -2444,7 +2444,7 @@ void Parser::ParseDirectiveSetDefaultMinimass()
 {
     if (! this->CheckNumArguments(2)) { return; } // Directive name + parameter
 
-    m_user_minimass = std::shared_ptr<MinimassPreset>(new MinimassPreset(this->GetArgFloat(1), false));
+    m_user_minimass = std::shared_ptr<MinimassPreset>(new MinimassPreset(this->GetArgFloat(1)));
 }
 
 void Parser::ParseDirectiveSetInertiaDefaults()

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.h
@@ -124,6 +124,7 @@ private:
     void ParseDirectivePropCameraMode();
     void ParseDirectiveSetBeamDefaults();
     void ParseDirectiveSetBeamDefaultsScale();
+    void ParseDirectiveSetDefaultMinimass();
     void ParseDirectiveSetInertiaDefaults();
     void ParseDirectiveSetManagedMaterialsOptions();
     void ParseDirectiveSetNodeDefaults();

--- a/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
@@ -268,6 +268,7 @@ namespace Regexes
     E_KEYWORD_INLINE("set_beam_defaults")                         \
     E_KEYWORD_INLINE("set_beam_defaults_scale")                   \
     E_KEYWORD_INLINE("set_collision_range")                       \
+    E_KEYWORD_INLINE("set_default_minimass")                      \
     E_KEYWORD_INLINE("set_inertia_defaults")                      \
     E_KEYWORD_INLINE("set_managedmaterials_options")              \
     E_KEYWORD_INLINE("set_node_defaults")                         \


### PR DESCRIPTION
* Added directive `set_default_minimass 1.23` which replaces `minimass` with `d` flag. The directive can be used in-between defining nodes, like `set_node_defaults`.
* Added `minimass` option `l` which will disable the minimass check for all nodes with 'l' (load weight) option. Suggested by @DODgecharger: https://github.com/RigsOfRods/rigs-of-rods/issues/2255#issue-410565608; https://github.com/RigsOfRods/rigs-of-rods/pull/2276#issuecomment-465442036 (at bottom)

[SetDefaultMinimass_TestLoad.zip](https://github.com/RigsOfRods/rigs-of-rods/files/2885636/SetDefaultMinimass_TestLoad.zip)
