### PR TITLE
🔧 Improved 'setwaterlevel' console command

### DIFF
--- a/source/main/gui/panels/GUI_GameConsole.cpp
+++ b/source/main/gui/panels/GUI_GameConsole.cpp
@@ -256,7 +256,7 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
         putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("gravity <real> or <text string> - changes gravity constant. Outputs current value if no argument is given"), "script_go.png");
         putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("Possible values: \n earth \n moon \n jupiter \n A random number (use negative)"), "script_go.png");
 
-        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("setwaterlevel <real> - changes water's level"), "script_go.png");
+        putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("setwaterlevel <real> or default - changes water's level"), "script_go.png");
 
         putMessage(CONSOLE_MSGTYPE_INFO, CONSOLE_HELP, _L("spawnobject <odef name> - spawn a object at the player position"), "script_go.png");
 
@@ -296,8 +296,9 @@ void Console::eventCommandAccept(MyGUI::Edit* _sender)
             IWater* water = App::GetSimTerrain()->getWater();
             if (water != nullptr)
             {
+                float height = (args[1] == "default") ? App::GetSimTerrain()->getWaterHeight() : PARSEREAL(args[1]);
                 water->WaterSetCamera(gEnv->mainCamera);
-                water->SetStaticWaterHeight(PARSEREAL(args[1]));
+                water->SetStaticWaterHeight(height);
                 water->UpdateWater();
                 putMessage (CONSOLE_MSGTYPE_INFO, CONSOLE_SYSTEM_REPLY, _L ("Water level set to: ") + StringConverter::toString (water->GetStaticWaterHeight ()), "information.png");
             }

--- a/source/main/terrain/TerrainManager.h
+++ b/source/main/terrain/TerrainManager.h
@@ -46,6 +46,7 @@ public:
     int                getVersion() const            { return m_def.version; };
     int                getFarClip() const            { return m_sight_range; }
     float              getPagedDetailFactor() const  { return m_paged_detail_factor; };
+    float              getWaterHeight() const        { return m_def.water_height; };
     Ogre::Vector3      getMaxTerrainSize();
     Collisions*        getCollisions()               { return m_collisions; };
     IWater*            getWater()                    { return m_water.get(); };


### PR DESCRIPTION
`setwaterlevel default` allows you to reset the water level back to the default height.