### PR TITLE
🔧 Hide disabled hydros from skeleton view

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -753,7 +753,10 @@ void RoR::GfxActor::UpdateDebugView()
                 }
                 else if (beams[i].bm_type == BEAM_HYDRO)
                 {
-                    drawlist->AddLine(pos1xy, pos2xy, BEAM_HYDRO_COLOR, BEAM_HYDRO_THICKNESS);
+                    if (!beams[i].bm_disabled)
+                    {
+                        drawlist->AddLine(pos1xy, pos2xy, BEAM_HYDRO_COLOR, BEAM_HYDRO_THICKNESS);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Mainly relevant for ties.