### PR TITLE
ScriptEngine: Added missing safety checks

### DIFF
--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -375,7 +375,12 @@ public:
     float getFPS();
     float getAvgFPS();
 
-protected:
+private:
+
+    bool HaveSimController(const char* func_name); //!< Helper; Check if SimController instance exists, log warning if not.
+    bool HaveSimTerrain(const char* func_name); //!< Helper; Check if SimController instance exists, log warning if not.
+    bool HavePlayerAvatar(const char* func_name); //!< Helper; Check if local Character instance exists, log warning if not.
+    bool HaveMainCamera(const char* func_name); //!< Helper; Check if main camera exists, log warning if not.
 
     ScriptEngine* mse; //!< local script engine pointer, used as proxy mostly
 };


### PR DESCRIPTION
Fixes many possible crashes if multiplayer server uses script functions in inappropriate time (i.e. getting simulation time in main menu)