### PR TITLE
Hide character netlabel when entering a vehicle with seat prop

### DIFF
--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -638,6 +638,10 @@ void RoR::GfxCharacter::UpdateCharacterInScene()
     {
         if (xc_simbuf.simbuf_actor_coupling->GetGfxActor()->HasDriverSeatProp())
         {
+            if (xc_movable_text != nullptr)
+            {
+                xc_movable_text->setVisible(false);
+            }
             Ogre::Vector3 pos;
             Ogre::Quaternion rot;
             xc_simbuf.simbuf_actor_coupling->GetGfxActor()->CalculateDriverPos(pos, rot);


### PR DESCRIPTION
Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/2326

Before:
![bef](https://user-images.githubusercontent.com/2660424/56512896-61cee100-6539-11e9-86ad-18a9585406d1.png)
After:
![after](https://user-images.githubusercontent.com/2660424/56512904-65fafe80-6539-11e9-83ff-c732a5847e20.png)
