### PR TITLE
Version+current date now written to RoR.log

### DIFF
--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -41,6 +41,8 @@
 #include "SoundScriptManager.h"
 
 #include <Overlay/OgreOverlaySystem.h>
+#include <ctime>
+#include <iomanip>
 #include <string>
 
 #ifdef USE_CURL
@@ -117,7 +119,10 @@ int main(int argc, char *argv[])
 
         auto ogre_log_manager = OGRE_NEW Ogre::LogManager();
         std::string rorlog_path = PathCombine(logs_dir, "RoR.log");
-        ogre_log_manager->createLog(rorlog_path, true, true);
+        Ogre::Log* rorlog = ogre_log_manager->createLog(rorlog_path, true, true);
+        rorlog->stream() << "[RoR] Rigs of Rods (www.rigsofrods.org) version " << ROR_VERSION_STRING;
+        std::time_t t = std::time(nullptr);
+        rorlog->stream() << "[RoR] Current date: " << std::put_time(std::localtime(&t), "%Y-%m-%d");
         App::diag_trace_globals.SetActive(true); // We have logger -> we can trace.
 
         if (! Settings::SetupAllPaths()) // Updates globals


### PR DESCRIPTION
Top 2 lines are new - i felt the info was missing:
```
18:35:18: [RoR] Rigs of Rods (www.rigsofrods.org) version 0.4.8.0-dev-11e17a3b-dirty
18:35:18: [RoR] Current date: 2019-05-05
18:35:18: [RoR|GVar]        sys_config_dir:  SetActive(), new: "C:\Users\Petr\Documents\Rigs of Rods 0.4\config", old: ""
18:35:18: [RoR|GVar]         sys_cache_dir:  SetActive(), new: "C:\Users\Petr\Documents\Rigs of Rods 0.4\cache", old: ""
18:35:18: [RoR|GVar]     sys_savegames_dir:  SetActive(), new: "C:\Users\Petr\Documents\Rigs of Rods 0.4\savegames", old: ""
18:35:18: [RoR|GVar]    sys_screenshot_dir:  SetActive(), new: "C:\Users\Petr\Documents\Rigs of Rods 0.4\screenshots", old: ""
18:35:18: [RoR|GVar]     sys_resources_dir:  SetActive(), new: "D:\Build\rigs-of-rods-Debug\bin\resources", old: ""
```