### PR TITLE
Gracefully handle invalid materials with empty names

### DIFF
--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -145,6 +145,9 @@ void ContentManager::AddResourcePack(ResourcePack const& resource_pack, std::str
 
 void ContentManager::InitContentManager()
 {
+    Ogre::ScriptCompilerManager::getSingleton().setListener(this);
+    Ogre::ResourceGroupManager::getSingleton().addResourceGroupListener(this);
+
     // Initialize "managed materials" first
     //   These are base materials referenced by user content
     //   They must be initialized before any content is loaded,
@@ -307,6 +310,39 @@ bool ContentManager::resourceCollision(Ogre::Resource* resource, Ogre::ResourceM
     RoR::LogFormat("[RoR|ContentManager] Skipping resource with duplicate name: '%s' (origin: '%s')",
         resource->getName().c_str(), resource->getOrigin().c_str());
     return false; // Instruct OGRE to drop the new resource and keep the original.
+}
+
+void ContentManager::scriptParseStarted(const String& scriptName, bool& skipThisScript)
+{
+    assert(m_curr_parsed_script.empty());
+
+    m_curr_parsed_script = scriptName;
+}
+
+void ContentManager::scriptParseEnded(const String& scriptName, bool skipped)
+{
+    assert(scriptName == m_curr_parsed_script);
+
+    m_curr_parsed_script.clear();
+}
+
+/// Workaround for OGRE script compiler not properly checking that material name is not empty.
+/// See https://github.com/RigsOfRods/rigs-of-rods/issues/2349
+bool ContentManager::handleEvent(ScriptCompiler *compiler, ScriptCompilerEvent *evt, void *retval)
+{
+    if (evt->mType == CreateMaterialScriptCompilerEvent::eventType)
+    {
+        auto* matEvent = static_cast<CreateMaterialScriptCompilerEvent*>(evt);
+        if (matEvent->mName.empty())
+        {
+            RoR::LogFormat("[RoR] Got malformed material (empty name) from file: '%s' - forcing OGRE to fail loading.",
+                matEvent->mFile.c_str());
+            // Report "handled" but create nothing -> OGRE will interrupt the loading
+            //   with message "failed to find or create material" [in MaterialTranslator::translate()]
+            return true;
+        }
+    }
+    return false; // Report "not handled"
 }
 
 void ContentManager::InitManagedMaterials(std::string const & rg_name)

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -146,7 +146,6 @@ void ContentManager::AddResourcePack(ResourcePack const& resource_pack, std::str
 void ContentManager::InitContentManager()
 {
     Ogre::ScriptCompilerManager::getSingleton().setListener(this);
-    Ogre::ResourceGroupManager::getSingleton().addResourceGroupListener(this);
 
     // Initialize "managed materials" first
     //   These are base materials referenced by user content
@@ -310,20 +309,6 @@ bool ContentManager::resourceCollision(Ogre::Resource* resource, Ogre::ResourceM
     RoR::LogFormat("[RoR|ContentManager] Skipping resource with duplicate name: '%s' (origin: '%s')",
         resource->getName().c_str(), resource->getOrigin().c_str());
     return false; // Instruct OGRE to drop the new resource and keep the original.
-}
-
-void ContentManager::scriptParseStarted(const String& scriptName, bool& skipThisScript)
-{
-    assert(m_curr_parsed_script.empty());
-
-    m_curr_parsed_script = scriptName;
-}
-
-void ContentManager::scriptParseEnded(const String& scriptName, bool skipped)
-{
-    assert(scriptName == m_curr_parsed_script);
-
-    m_curr_parsed_script.clear();
 }
 
 /// Workaround for OGRE script compiler not properly checking that material name is not empty.

--- a/source/main/resources/ContentManager.h
+++ b/source/main/resources/ContentManager.h
@@ -27,6 +27,7 @@
 #include "RoRPrerequisites.h"
 
 #include <OgreResourceGroupManager.h>
+#include <OgreScriptCompiler.h>
 
 #define RGN_TEMP "Temp"
 #define RGN_CACHE "Cache"
@@ -35,7 +36,10 @@
 
 namespace RoR {
 
-class ContentManager : public Ogre::ResourceLoadingListener
+class ContentManager:
+    public Ogre::ResourceLoadingListener, // Ogre::ResourceGroupManager::getSingleton().setLoadingListener()
+    public Ogre::ResourceGroupListener,   // Ogre::ResourceGroupManager::getSingleton().addResourceGroupListener()
+    public Ogre::ScriptCompilerListener   // Ogre::ScriptCompilerManager::getSingleton().setListener()
 {
 public:
 
@@ -84,13 +88,21 @@ public:
 
 private:
 
+    // Ogre::ResourceGroupListener()
+    void scriptParseStarted(const Ogre::String& scriptName, bool& skipThisScript) override;
+    void scriptParseEnded(const Ogre::String& scriptName, bool skipped) override;
+
     // implementation for resource loading listener
-    Ogre::DataStreamPtr resourceLoading(const Ogre::String& name, const Ogre::String& group, Ogre::Resource* resource);
-    void resourceStreamOpened(const Ogre::String& name, const Ogre::String& group, Ogre::Resource* resource, Ogre::DataStreamPtr& dataStream);
-    bool resourceCollision(Ogre::Resource* resource, Ogre::ResourceManager* resourceManager);
+    Ogre::DataStreamPtr resourceLoading(const Ogre::String& name, const Ogre::String& group, Ogre::Resource* resource) override;
+    void resourceStreamOpened(const Ogre::String& name, const Ogre::String& group, Ogre::Resource* resource, Ogre::DataStreamPtr& dataStream) override;
+    bool resourceCollision(Ogre::Resource* resource, Ogre::ResourceManager* resourceManager) override;
+
+    // Ogre::ScriptCompilerListener
+    bool handleEvent(Ogre::ScriptCompiler *compiler, Ogre::ScriptCompilerEvent *evt, void *retval) override;
 
     CacheSystem       m_mod_cache; //!< Database of addon content
     bool              m_base_resource_loaded;
+    std::string       m_curr_parsed_script;
 };
 
 } // namespace RoR

--- a/source/main/resources/ContentManager.h
+++ b/source/main/resources/ContentManager.h
@@ -38,7 +38,6 @@ namespace RoR {
 
 class ContentManager:
     public Ogre::ResourceLoadingListener, // Ogre::ResourceGroupManager::getSingleton().setLoadingListener()
-    public Ogre::ResourceGroupListener,   // Ogre::ResourceGroupManager::getSingleton().addResourceGroupListener()
     public Ogre::ScriptCompilerListener   // Ogre::ScriptCompilerManager::getSingleton().setListener()
 {
 public:
@@ -88,11 +87,7 @@ public:
 
 private:
 
-    // Ogre::ResourceGroupListener()
-    void scriptParseStarted(const Ogre::String& scriptName, bool& skipThisScript) override;
-    void scriptParseEnded(const Ogre::String& scriptName, bool skipped) override;
-
-    // implementation for resource loading listener
+    // Ogre::ResourceLoadingListener
     Ogre::DataStreamPtr resourceLoading(const Ogre::String& name, const Ogre::String& group, Ogre::Resource* resource) override;
     void resourceStreamOpened(const Ogre::String& name, const Ogre::String& group, Ogre::Resource* resource, Ogre::DataStreamPtr& dataStream) override;
     bool resourceCollision(Ogre::Resource* resource, Ogre::ResourceManager* resourceManager) override;
@@ -102,7 +97,6 @@ private:
 
     CacheSystem       m_mod_cache; //!< Database of addon content
     bool              m_base_resource_loaded;
-    std::string       m_curr_parsed_script;
 };
 
 } // namespace RoR


### PR DESCRIPTION
Works around insufficient sanity checking in OGRE - OGRE docs say material name is required, but the script compiler only logs 'Error' but accepts the material anyway, causing OGRE to trigger an assertion when attempting to create the material.

Fixes  #2349