### PR TITLE
Allow mods to use "dashtexture" (from "renderdash")

### DIFF
--- a/source/main/gfx/Renderdash.h
+++ b/source/main/gfx/Renderdash.h
@@ -34,6 +34,7 @@ public:
     ~Renderdash();
 
     void setEnable(bool en);
+    Ogre::TexturePtr getTexture() { return m_texture; }
 
     // Ogre::RenderTargetListener
     void preRenderTargetUpdate(const Ogre::RenderTargetEvent& evt) override;


### PR DESCRIPTION
The texture-substitution used for .skin files was extended to also use 'builtins'

Fixes #2346