### PR TITLE
Full support for Unicode file paths

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -140,13 +140,6 @@ void CacheSystem::LoadModCache(CacheValidityState validity)
 
     this->LoadCacheFileJson();
 
-    // show error on zero content
-    if (m_entries.empty())
-    {
-        ErrorUtils::ShowError(_L("No content found"), _L("Failed to generate list of installed content"));
-        exit(1);
-    }
-
     App::app_force_cache_purge.SetActive(false);
     App::app_force_cache_udpate.SetActive(false);
 

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -169,8 +169,6 @@ private:
     void LoadCacheFileJson();
     void ImportEntryFromJson(rapidjson::Value& j_entry, CacheEntry & out_entry);
 
-    Ogre::String GetCacheConfigFilename(); // returns absolute path of the cache file
-
     static Ogre::String StripUIDfromString(Ogre::String uidstr); 
     static Ogre::String StripSHA1fromString(Ogre::String sha1str);
 

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -243,7 +243,10 @@ void ContentManager::InitContentManager()
 
 void ContentManager::InitModCache()
 {
-    ResourceGroupManager::getSingleton().addResourceLocation(App::sys_cache_dir.GetActive(), "FileSystem", RGN_CACHE, false, false);
+    ResourceGroupManager::getSingleton().addResourceLocation(
+        App::sys_cache_dir.GetActive(), "FileSystem", RGN_CACHE, /*recursive=*/false, /*readOnly=*/false);
+    ResourceGroupManager::getSingleton().addResourceLocation(
+        App::sys_savegames_dir.GetActive(), "FileSystem", RGN_SAVEGAMES, /*recursive=*/false, /*readOnly=*/false);
 
     std::string user = App::sys_user_dir.GetActive();
     std::string base = App::sys_process_dir.GetActive();

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -434,9 +434,7 @@ bool ContentManager::LoadAndParseJson(std::string const& filename, std::string c
     }
     catch (Ogre::FileNotFoundException)
     {
-        RoR::LogFormat("[RoR] File '%s' (resource group '%s') not found",
-                       filename.c_str(), rg_name.c_str());
-        return false;
+        return false; // Error already logged by OGRE
     }
     catch (std::exception& e)
     {

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -145,6 +145,11 @@ void ContentManager::AddResourcePack(ResourcePack const& resource_pack, std::str
 
 void ContentManager::InitContentManager()
 {
+    ResourceGroupManager::getSingleton().addResourceLocation(
+        App::sys_config_dir.GetActive(), "FileSystem", RGN_CONFIG, /*recursive=*/false, /*readOnly=*/false);
+    ResourceGroupManager::getSingleton().addResourceLocation(
+        App::sys_savegames_dir.GetActive(), "FileSystem", RGN_SAVEGAMES, /*recursive=*/false, /*readOnly=*/false);
+
     Ogre::ScriptCompilerManager::getSingleton().setListener(this);
 
     // Initialize "managed materials" first
@@ -200,10 +205,6 @@ void ContentManager::InitContentManager()
     // streams path, to be processed later by the cache system
     LOG("RoR|ContentManager: Loading filesystems");
 
-    // config, flat
-    ResourceGroupManager::getSingleton().addResourceLocation(std::string(RoR::App::sys_config_dir.GetActive()), "FileSystem", ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    // packs, to be processed later by the cache system
-
     // add scripts folder
     ResourceGroupManager::getSingleton().addResourceLocation(std::string(App::sys_user_dir.GetActive()) + PATH_SLASH + "scripts", "FileSystem", "Scripts");
 
@@ -245,9 +246,6 @@ void ContentManager::InitModCache()
 {
     ResourceGroupManager::getSingleton().addResourceLocation(
         App::sys_cache_dir.GetActive(), "FileSystem", RGN_CACHE, /*recursive=*/false, /*readOnly=*/false);
-    ResourceGroupManager::getSingleton().addResourceLocation(
-        App::sys_savegames_dir.GetActive(), "FileSystem", RGN_SAVEGAMES, /*recursive=*/false, /*readOnly=*/false);
-
     std::string user = App::sys_user_dir.GetActive();
     std::string base = App::sys_process_dir.GetActive();
     std::string objects = PathCombine("resources", "beamobjects.zip");

--- a/source/main/resources/ContentManager.h
+++ b/source/main/resources/ContentManager.h
@@ -32,6 +32,7 @@
 
 #define RGN_TEMP "Temp"
 #define RGN_CACHE "Cache"
+#define RGN_CONFIG "Config"
 #define RGN_CONTENT "Content"
 #define RGN_SAVEGAMES "Savegames"
 #define RGN_MANAGED_MATS "ManagedMaterials"

--- a/source/main/resources/ContentManager.h
+++ b/source/main/resources/ContentManager.h
@@ -28,6 +28,7 @@
 
 #include <OgreResourceGroupManager.h>
 #include <OgreScriptCompiler.h>
+#include <rapidjson/document.h>
 
 #define RGN_TEMP "Temp"
 #define RGN_CACHE "Cache"
@@ -84,6 +85,11 @@ public:
     void               InitModCache();
     void               LoadGameplayResources();  //!< Checks GVar settings and loads required resources.
     std::string        ListAllUserContent(); //!< Used by ModCache for quick detection of added/removed content
+    bool               DeleteDiskFile(std::string const& filename, std::string const& rg_name);
+
+    // JSON:
+    bool               LoadAndParseJson(std::string const& filename, std::string const& rg_name, rapidjson::Document& j_doc);
+    bool               SerializeAndWriteJson(std::string const& filename, std::string const& rg_name, rapidjson::Document& j_doc);
 
 private:
 

--- a/source/main/resources/ContentManager.h
+++ b/source/main/resources/ContentManager.h
@@ -33,6 +33,7 @@
 #define RGN_TEMP "Temp"
 #define RGN_CACHE "Cache"
 #define RGN_CONTENT "Content"
+#define RGN_SAVEGAMES "Savegames"
 #define RGN_MANAGED_MATS "ManagedMaterials"
 
 namespace RoR {

--- a/source/main/scripting/LocalStorage.h
+++ b/source/main/scripting/LocalStorage.h
@@ -2,7 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
-    Copyright 2013-2017 Petr Ohlidal & contributors
+    Copyright 2013-2020 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -99,7 +99,7 @@ public:
     std::string getSection() { return sectionName; }
 
 protected:
-    bool saved;
+    bool saved; //!< Inverted 'dirty flag'
     std::string sectionName;
 
     // Our properties

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -481,8 +481,6 @@ public:
     int getJoyComponentCount(OIS::ComponentType type, int joystickNumber);
     std::string getJoyVendor(int joystickNumber);
     void smoothValue(float& ref, float value, float rate);
-    bool saveMapping(std::string outfile = CONFIGFILENAME, Ogre::String hwnd = 0, int joyNum = -10);
-    bool appendLineToConfig(std::string line, std::string outfile = CONFIGFILENAME);
     bool loadMapping(std::string outfile = CONFIGFILENAME, bool append = false, int deviceID = -1);
 
     void destroy();

--- a/source/main/utils/SHA1.cpp
+++ b/source/main/utils/SHA1.cpp
@@ -159,52 +159,6 @@ void CSHA1::UpdateHash(uint8_t *data, uint32_t len)
     memcpy(&m_buffer[j], &data[i], len - i);
 }
 
-#ifdef SHA1_UTILITY_FUNCTIONS
-// Hash in file contents
-bool CSHA1::HashFile(char *szFileName)
-{
-    unsigned long ulFileSize, ulRest, ulBlocks;
-    unsigned long i;
-    uint8_t uData[SHA1_MAX_FILE_BUFFER];
-    FILE *fIn;
-
-    if (szFileName == NULL) return false;
-
-    fIn = fopen(szFileName, "rb");
-    if (fIn == NULL) return false;
-
-    fseek(fIn, 0, SEEK_END);
-    ulFileSize = (unsigned long)ftell(fIn);
-    fseek(fIn, 0, SEEK_SET);
-
-    if (ulFileSize != 0)
-    {
-        ulBlocks = ulFileSize / SHA1_MAX_FILE_BUFFER;
-        ulRest = ulFileSize % SHA1_MAX_FILE_BUFFER;
-    }
-    else
-    {
-        ulBlocks = 0;
-        ulRest = 0;
-    }
-
-    for (i = 0; i < ulBlocks; i++)
-    {
-        size_t result = fread(uData, 1, SHA1_MAX_FILE_BUFFER, fIn);
-        UpdateHash((uint8_t *)uData, SHA1_MAX_FILE_BUFFER);
-    }
-
-    if (ulRest != 0)
-    {
-        size_t result = fread(uData, 1, ulRest, fIn);
-        UpdateHash((uint8_t *)uData, ulRest);
-    }
-
-    fclose(fIn); fIn = NULL;
-    return true;
-}
-#endif
-
 void CSHA1::Final()
 {
     uint32_t i;

--- a/source/main/utils/SHA1.h
+++ b/source/main/utils/SHA1.h
@@ -100,9 +100,6 @@ public:
 
     // Update the hash value
     void UpdateHash(uint8_t* data, uint32_t len);
-#ifdef SHA1_UTILITY_FUNCTIONS
-    bool HashFile(char* szFileName);
-#endif
 
     // Finalize hash and report
     void Final();

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -122,51 +122,6 @@ String HashData(const char *key, int len)
     return result.str();
 }
 
-String HashFile(const char *szFileName)
-{
-    unsigned long ulFileSize, ulRest, ulBlocks;
-    std::vector<char> uData(2097152);
-
-    if (szFileName == NULL) return "";
-
-    FILE *fIn = fopen(szFileName, "rb");
-    if (fIn == NULL) return "";
-
-    fseek(fIn, 0, SEEK_END);
-    ulFileSize = (unsigned long)ftell(fIn);
-    fseek(fIn, 0, SEEK_SET);
-
-    if (ulFileSize != 0)
-    {
-        ulBlocks = ulFileSize / static_cast<unsigned long>(uData.size());
-        ulRest = ulFileSize % uData.size();
-    }
-    else
-    {
-        ulBlocks = 0;
-        ulRest = 0;
-    }
-
-    uint32_t hash = 0;
-    for (unsigned long i = 0; i < ulBlocks; i++)
-    {
-        size_t result = fread(uData.data(), 1, uData.size(), fIn);
-        hash = FastHash(uData.data(), uData.size(), hash);
-    }
-
-    if (ulRest != 0)
-    {
-        size_t result = fread(uData.data(), 1, ulRest, fIn);
-        hash = FastHash(uData.data(), ulRest, hash);
-    }
-
-    fclose(fIn); fIn = NULL;
-
-    std::stringstream result;
-    result << std::hex << hash;
-    return result.str();
-}
-
 UTFString tryConvertUTF(const char* buffer)
 {
     std::string str_in(buffer);

--- a/source/main/utils/Utils.h
+++ b/source/main/utils/Utils.h
@@ -44,8 +44,6 @@ Ogre::String sha1sum(const char *key, int len);
 
 Ogre::String HashData(const char *key, int len);
 
-Ogre::String HashFile(const char* szFileName);
-
 Ogre::UTFString tryConvertUTF(const char* buffer);
 
 Ogre::UTFString formatBytes(double bytes);


### PR DESCRIPTION
See #2353

## Update 2020-01-27

I removed the TODO items, most of them were long obsolete, also I fixed several other things not even listed.

The coverage is still not 100% (for example Flexbody cache may still cause issues), but the rest is important enough to merge now.

## How to test

1. Set up Conan, see https://github.com/RigsOfRods/rigs-of-rods/wiki/Compile-(Linux)#installing-the-dependencies
2. Clone https://github.com/AnotherFoxGuy/conan-OGRE and modify it by adding `cmake.definitions['CMAKE_CXX_FLAGS'] = '-D_OGRE_FILESYSTEM_ARCHIVE_UNICODE'`
3. Create the modified package `conan create . demo/testing`
4. Edit RoR's conanfile.txt: change OGRE reference to `OGRE/1.11.6@demo/testing` 
5. Use CMake to configure RoR, it will invoke Conan to fetch dependencies