### PR TITLE
Moved direction arrow back to it's overlay

### DIFF
--- a/resources/materials/ror.material
+++ b/resources/materials/ror.material
@@ -2418,7 +2418,9 @@ material tracks/directionArrowNormal
     {
         pass
         {
-			lighting off
+            lighting off
+            depth_check on
+            cull_hardware none 
             scene_blend alpha_blend
             texture_unit
             {

--- a/resources/overlays/directionarrow.overlay
+++ b/resources/overlays/directionarrow.overlay
@@ -1,6 +1,6 @@
 overlay tracks/DirectionArrow
 {
-	zorder 12
+	zorder 600
 	overlay_element tracks/DirectionArrow/MainPanel Panel
 	{
 		transparent true

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -101,7 +101,6 @@ static TerrainManager*  g_sim_terrain;
  GVarPod_A<int>           sim_replay_stepping     ("sim_replay_stepping",     "Replay Steps per second",   1000);
  GVarPod_A<bool>          sim_realistic_commands  ("sim_realistic_commands",  "Realistic forward commands",false);
  GVarPod_A<bool>          sim_races_enabled       ("sim_races_enabled",       "Races",                     true);
- GVarPod_A<bool>          sim_direction_arrow     ("sim_direction_arrow",     "Direction Arrow",           true);
  GVarPod_A<bool>          sim_no_collisions       ("sim_no_collisions",       "DisableCollisions",         false);
  GVarPod_A<bool>          sim_no_self_collisions  ("sim_no_self_collisions",  "DisableSelfCollisions",     false);
  GVarEnum_AP<SimGearboxMode> sim_gearbox_mode     ("sim_gearbox_mode",        "GearboxMode",               SimGearboxMode::AUTO,    SimGearboxMode::AUTO);

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -675,7 +675,6 @@ extern GVarPod_A<int>          sim_replay_length;
 extern GVarPod_A<int>          sim_replay_stepping;
 extern GVarPod_A<bool>         sim_realistic_commands;
 extern GVarPod_A<bool>         sim_races_enabled;
-extern GVarPod_A<bool>         sim_direction_arrow;
 extern GVarPod_A<bool>         sim_no_collisions;
 extern GVarPod_A<bool>         sim_no_self_collisions;
 extern GVarEnum_AP<SimGearboxMode> sim_gearbox_mode;

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -727,36 +727,34 @@ void OverlayWrapper::SetupDirectionArrow()
     {
         // setup direction arrow
         Ogre::Entity* arrow_entity = gEnv->sceneManager->createEntity("arrow2.mesh");
+        arrow_entity->setRenderQueueGroup(Ogre::RENDER_QUEUE_OVERLAY);
 
         // Add entity to the scene node
-        m_direction_arrow_node = gEnv->sceneManager->getRootSceneNode()->createChildSceneNode();
+        m_direction_arrow_node = new SceneNode(gEnv->sceneManager);
         m_direction_arrow_node->attachObject(arrow_entity);
         m_direction_arrow_node->setVisible(false);
-        m_direction_arrow_node->setScale(0.3, 0.3, 0.3);
+        m_direction_arrow_node->setScale(0.1, 0.1, 0.1);
+        m_direction_arrow_node->setPosition(Vector3(-0.6, +0.4, -1));
         m_direction_arrow_node->setFixedYawAxis(true, Vector3::UNIT_Y);
+        m_direction_arrow_overlay->add3D(m_direction_arrow_node);
     }
 }
 
 void OverlayWrapper::UpdateDirectionArrowHud(RoR::GfxActor* player_vehicle, Ogre::Vector3 point_to, Ogre::Vector3 character_pos)
 {
-    Vector3 position = Vector3::ZERO;
+    m_direction_arrow_node->lookAt(point_to, Node::TS_WORLD, Vector3::UNIT_Y);
     Real distance = 0.0f;
     if (player_vehicle != nullptr && player_vehicle->GetSimDataBuffer().simbuf_live_local)
     {
-        position = player_vehicle->GetSimDataBuffer().simbuf_pos;
-        position.y = player_vehicle->GetSimDataBuffer().simbuf_aabb.getMaximum().y + 0.1f;
         distance = player_vehicle->GetSimDataBuffer().simbuf_pos.distance(point_to);
     }
     else if (gEnv->player)
     {
-        position = character_pos;;
-        position.y += 1.9f;
         distance = character_pos.distance(point_to);
     }
-    point_to.y = Math::Clamp(point_to.y, position.y - distance / 8.0f, position.y + distance / 8.0f);
-    m_direction_arrow_node->setPosition(position);
-    m_direction_arrow_node->lookAt(point_to, Node::TS_WORLD, Vector3::UNIT_Y);
-    this->directionArrowDistance->setCaption(StringUtil::format("%0.1f meter", distance));
+    char tmp[256];
+    sprintf(tmp, "%0.1f meter", distance);
+    this->directionArrowDistance->setCaption(tmp);
 }
 
 void OverlayWrapper::HideDirectionOverlay()
@@ -771,7 +769,7 @@ void OverlayWrapper::ShowDirectionOverlay(Ogre::String const& caption)
     m_direction_arrow_overlay->show();
     directionArrowText->setCaption(caption);
     directionArrowDistance->setCaption("");
-    m_direction_arrow_node->setVisible(RoR::App::sim_direction_arrow.GetActive());
+    m_direction_arrow_node->setVisible(true);
     BITMASK_SET_1(m_visible_overlays, VisibleOverlays::DIRECTION_ARROW);
 }
 

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -214,7 +214,6 @@ void RoR::GUI::GameSettings::Draw()
         DrawGCheckbox(App::sim_realistic_commands, _LC("GameSettings", "Realistic forward commands"));
 
         DrawGCheckbox(App::sim_races_enabled, _LC("GameSettings", "Enable races"));
-        DrawGCheckbox(App::sim_direction_arrow, _LC("GameSettings", "Direction arrow"));
 
         DrawGCheckbox(App::sim_no_self_collisions, _LC("GameSettings", "No intra truck collisions"));
         DrawGCheckbox(App::sim_no_collisions, _LC("GameSettings", "No inter truck collisions"));

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -624,7 +624,6 @@ bool Settings::ParseGlobalVarSetting(std::string const & k, std::string const & 
     if (CheckInt  (App::sim_replay_stepping,       k, v)) { return true; }
     if (CheckBool (App::sim_realistic_commands,    k, v)) { return true; }
     if (CheckBool (App::sim_races_enabled,         k, v)) { return true; }
-    if (CheckBool (App::sim_direction_arrow,       k, v)) { return true; }
     if (CheckBool (App::sim_no_collisions,         k, v)) { return true; }
     if (CheckBool (App::sim_no_self_collisions,    k, v)) { return true; }
 
@@ -823,7 +822,6 @@ void Settings::SaveSettings()
     WritePod (f, App::sim_replay_stepping   );
     WriteYN  (f, App::sim_realistic_commands);
     WriteYN  (f, App::sim_races_enabled     );
-    WriteYN  (f, App::sim_direction_arrow   );
     WriteYN  (f, App::sim_no_collisions     );
     WriteYN  (f, App::sim_no_self_collisions);
 


### PR DESCRIPTION
- Restores original direction arrow position
- Reverts https://github.com/RigsOfRods/rigs-of-rods/commit/6afaa854b99ab80b24dbc16e52e6bbd14a54ed62

Back then ulteq struggled to bring back the direction arrow in it's [overlay](https://github.com/RigsOfRods/rigs-of-rods/blob/master/resources/overlays/directionarrow.overlay) so he came up with an alternative way https://github.com/RigsOfRods/rigs-of-rods/commit/6afaa854b99ab80b24dbc16e52e6bbd14a54ed62 (attached directly to vehicle) which was a bit annoying sometimes so he also added a switch to turn it off.

The problem was wrong `zorder` value in the overlay