### PR TITLE
Removed broken texture shadows

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -420,7 +420,6 @@ const char* EnumToStr(GfxShadowType v)
     switch(v)
     {
     case GfxShadowType::NONE   : return "NONE";
-    case GfxShadowType::TEXTURE: return "TEXTURE";
     case GfxShadowType::PSSM   : return "PSSM";
     default                    : return "~invalid~";
     }

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -80,7 +80,6 @@ const char* EnumToStr(SimGearboxMode v);
 enum class GfxShadowType
 {
     NONE,
-    TEXTURE,
     PSSM
 };
 const char* EnumToStr(GfxShadowType v);

--- a/source/main/gfx/ShadowManager.cpp
+++ b/source/main/gfx/ShadowManager.cpp
@@ -54,12 +54,7 @@ int ShadowManager::updateShadowTechnique()
 
     RoR::GfxShadowType type = RoR::App::gfx_shadow_type.GetActive();
 
-    if (type == RoR::GfxShadowType::TEXTURE)
-    {
-        gEnv->sceneManager->setShadowFarDistance(RoR::App::gfx_sight_range.GetActive());
-        processTextureShadows();
-    }
-    else if (type == RoR::GfxShadowType::PSSM)
+    if (type == RoR::GfxShadowType::PSSM)
     {
         processPSSM();
         if (gEnv->sceneManager->getShowDebugShadows())
@@ -90,12 +85,6 @@ int ShadowManager::updateShadowTechnique()
         }
     }
     return 0;
-}
-
-void ShadowManager::processTextureShadows()
-{
-    gEnv->sceneManager->setShadowTechnique(Ogre::SHADOWTYPE_TEXTURE_MODULATIVE);
-    gEnv->sceneManager->setShadowTextureSettings(2048, 2);
 }
 
 void ShadowManager::processPSSM()

--- a/source/main/gfx/ShadowManager.h
+++ b/source/main/gfx/ShadowManager.h
@@ -58,8 +58,6 @@ public:
 
 protected:
 
-    void processTextureShadows();
-
     void processPSSM();
     void setManagedMaterialSplitPoints(Ogre::PSSMShadowCameraSetup::SplitPointList splitPointList);
 

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -29,7 +29,7 @@ void RoR::GUI::GameSettings::Draw()
 {
     bool is_visible = true;
     const int flags = ImGuiWindowFlags_NoCollapse;
-    ImGui::SetNextWindowSize(ImVec2(600.f, 400.f), ImGuiSetCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(640.f, 400.f), ImGuiSetCond_FirstUseEver);
     ImGui::SetNextWindowPosCenter(ImGuiSetCond_Appearing);
     ImGui::Begin(_LC("GameSettings", "Game settings"), &is_visible, flags);
     if (! is_visible)
@@ -258,9 +258,8 @@ void RoR::GUI::GameSettings::Draw()
             "All vehicles, main lights\0"
             "All vehicles, all lights\0\0");
 
-        DrawGCombo(App::gfx_shadow_type, _LC("GameSettings", "Shadow type"),
+        DrawGCombo(App::gfx_shadow_type, _LC("GameSettings", "Shadow type (requires restart)"),
             "Disabled\0"
-            "Texture\0"
             "PSSM\0\0");
 
         if (App::gfx_shadow_type.GetActive() != GfxShadowType::NONE)

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -205,7 +205,6 @@ void Settings::ProcessCommandLine(int argc, char *argv[])
     }
 }
 
-const char* CONF_GFX_SHADOW_TEX     = "Texture shadows";
 const char* CONF_GFX_SHADOW_PSSM    = "Parallel-split Shadow Maps";
 const char* CONF_GFX_SHADOW_NONE    = "No shadows (fastest)";
 
@@ -267,7 +266,6 @@ inline bool CheckShadowTech(std::string const & key, std::string const & s)
     if (key != App::gfx_shadow_type.conf_name)
         return false;
 
-    if (s == CONF_GFX_SHADOW_TEX)     { App::gfx_shadow_type.SetActive(GfxShadowType::TEXTURE); return true; }
     if (s == CONF_GFX_SHADOW_PSSM)    { App::gfx_shadow_type.SetActive(GfxShadowType::PSSM   ); return true; }
     else                              { App::gfx_shadow_type.SetActive(GfxShadowType::NONE   ); return true; }
 }
@@ -673,7 +671,6 @@ inline const char* GfxShadowTechToStr(GfxShadowType v)
 {
     switch (v)
     {
-    case GfxShadowType::TEXTURE: return CONF_GFX_SHADOW_TEX;
     case GfxShadowType::PSSM   : return CONF_GFX_SHADOW_PSSM;
     case GfxShadowType::NONE   : return CONF_GFX_SHADOW_NONE;
     default                    : return "";

--- a/source/main/utils/Settings.h
+++ b/source/main/utils/Settings.h
@@ -46,7 +46,6 @@ void ShowVersion();
 // ---------------------
 // Config value strings
 
-extern const char* CONF_GFX_SHADOW_TEX;
 extern const char* CONF_GFX_SHADOW_PSSM;
 extern const char* CONF_GFX_SHADOW_NONE;
 


### PR DESCRIPTION
- Removed texture shadows. They are broken since 0.3x and they make the game crash or glitch
- Added `requires restart` info in the Shadow type selector

Fixes #2390 
Closes #2355 
Closes #84

Don't see a reason of keeping a broken feature for years. We should keep only PSSM and improve it.

@only-a-ptr thoughts?