### PR TITLE
Fixed custom particle name conflicts between actors

### DIFF
--- a/source/main/physics/RigSpawner.h
+++ b/source/main/physics/RigSpawner.h
@@ -940,6 +940,8 @@ private:
 
     Ogre::MaterialPtr CreateSimpleMaterial(Ogre::ColourValue color);
 
+    Ogre::ParticleSystem* CreateParticleSystem(std::string const & name, std::string const & template_name);
+
     RigDef::MaterialFlareBinding* FindFlareBindingForMaterial(std::string const & material_name); ///< Returns NULL if none found
 
     RigDef::VideoCamera* FindVideoCameraByMaterial(std::string const & material_name); ///< Returns NULL if none found


### PR DESCRIPTION
Turns out I already resolved the same issue for 'exhausts', but I didn't for 'particles'. Now I unified the setup for both, always using correct (actor-specific) OGRE resource group.

I'm not sure how to test, though. The [DAF-semi-air](https://github.com/RigsOfRods/rigs-of-rods/issues/2344#issue-430077406) trucks don't use 'particles' keyword, only 'exhausts'. The [PittsSpecial](https://github.com/RigsOfRods/rigs-of-rods/issues/2344#issuecomment-489357708) does use 'particles', but those don't seem to show up when toggled.