### PR TITLE
Fixed multiplayer kick handling

### DIFF
--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -53,6 +53,7 @@ const char* EnumToStr(AppState v);
 enum class MpState
 {
     DISABLED,  ///< Not connected for whatever reason.
+    CONNECTING,
     CONNECTED,
 };
 const char* EnumToStr(MpState v);

--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -2278,11 +2278,25 @@ void SimController::EnterGameplayLoop()
         }
 
 #ifdef USE_SOCKETW
-        if ((App::mp_state.GetActive() == MpState::CONNECTED) && RoR::Networking::CheckError())
+        if ((App::mp_state.GetActive() == MpState::CONNECTED))
         {
-            const char* text = RoR::Networking::GetErrorMessage().asUTF8_c_str();
-            App::GetGuiManager()->ShowMessageBox(_L("Network fatal error: "), text);
-            App::app_state.SetPending(AppState::MAIN_MENU);
+            Networking::ConnectState con_state = Networking::CheckConnectingState();
+            if (con_state == Networking::ConnectState::KICKED)
+            {
+                App::app_state.SetPending(AppState::MAIN_MENU); // Will perform `Networking::Disconnect()`
+                App::GetGuiManager()->ShowMessageBox(
+                    _LC("Network", "Multiplayer: disconnected"),
+                    Networking::GetStatusMessage().c_str());
+                RoR::Networking::ResetStatusMessage();
+            }
+            else if (con_state == Networking::ConnectState::RECV_ERROR)
+            {
+                App::app_state.SetPending(AppState::MAIN_MENU); // Will perform `Networking::Disconnect()`
+                App::GetGuiManager()->ShowMessageBox(
+                    _L("Network fatal error: "),
+                    Networking::GetStatusMessage().c_str());
+                RoR::Networking::ResetStatusMessage();
+            }
         }
 #endif
 

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -542,7 +542,7 @@ void GUIManager::DrawMpConnectingStatusBox()
     // HACK: The trailing space is a workaround for a scissoring issue in OGRE/DearIMGUI integration. ~ only_a_ptr, 10/2017
     ImGui::Text("Joining [%s:%d] ", App::mp_server_host.GetActive(), App::mp_server_port.GetActive());
 #ifdef USE_SOCKETW
-    ImGui::TextDisabled("%s", Networking::GetStatusMessage().GetBuffer());
+    ImGui::TextDisabled("%s", Networking::GetStatusMessage().c_str());
 #endif
     ImGui::End();
 }

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -505,7 +505,7 @@ void GUIManager::DrawMainMenuGui()
         m_impl->panel_GameMainMenu.Draw();
     }
 
-    if ((App::mp_state.GetActive() != MpState::CONNECTED) && (App::mp_state.GetPending() == MpState::CONNECTED))
+    if (App::mp_state.GetActive() == MpState::CONNECTING)
     {
         this->DrawMpConnectingStatusBox();
     }
@@ -542,7 +542,7 @@ void GUIManager::DrawMpConnectingStatusBox()
     // HACK: The trailing space is a workaround for a scissoring issue in OGRE/DearIMGUI integration. ~ only_a_ptr, 10/2017
     ImGui::Text("Joining [%s:%d] ", App::mp_server_host.GetActive(), App::mp_server_port.GetActive());
 #ifdef USE_SOCKETW
-    ImGui::TextDisabled("%s", Networking::GetStatusMessage().c_str());
+    ImGui::TextDisabled("%s", m_net_connect_status.c_str());
 #endif
     ImGui::End();
 }

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -125,6 +125,7 @@ public:
     void DrawMainMenuGui();
     void DrawSimulationGui(float dt);
 
+    void SetMpConnectingStatusMsg(std::string const & msg) { m_net_connect_status = msg; }
     void DrawMpConnectingStatusBox();
     void hideGUI(bool visible);
 
@@ -158,6 +159,7 @@ private:
     bool               m_renderwindow_closed;
     OgreImGui          m_imgui;
     GuiTheme           m_theme;
+    std::string        m_net_connect_status;
 };
 
 } // namespace RoR

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -79,10 +79,10 @@ enum class ConnectState
     IDLE,
     WORKING,
     SUCCESS,
-    FAILURE
+    FAILURE,
+    KICKED,
+    RECV_ERROR
 };
-
-typedef Str<100> StatusStr;
 
 bool                 StartConnecting();             ///< Launches connecting on background.
 ConnectState         CheckConnectingState();        ///< Reports state of background connecting and updates GVar 'mp_state'
@@ -105,9 +105,8 @@ std::vector<RoRnet::UserInfo> GetUserInfos();
 bool                 GetUserInfo(int uid, RoRnet::UserInfo &result);
 Ogre::ColourValue    GetPlayerColor(int color_num);
 
-Ogre::UTFString      GetErrorMessage();
-StatusStr            GetStatusMessage();
-bool                 CheckError();
+std::string          GetStatusMessage();
+void                 ResetStatusMessage();
 
 } // namespace Networking
 } // namespace RoR

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -27,6 +27,11 @@
 #include "RoRnet.h"
 #include "RoRPrerequisites.h"
 
+#include <list>
+#include <queue>
+#include <string>
+#include <vector>
+
 namespace RoR {
 namespace Networking {
 
@@ -74,18 +79,30 @@ struct recv_packet_t
 
 // ------------------------ End of network messages --------------------------
 
-enum class ConnectState
+struct NetEvent
 {
-    IDLE,
-    WORKING,
-    SUCCESS,
-    FAILURE,
-    KICKED,
-    RECV_ERROR
+    enum class Type
+    {
+        INVALID,
+        CONNECT_STARTED,
+        CONNECT_PROGRESS,
+        CONNECT_SUCCESS,
+        CONNECT_FAILURE,
+        SERVER_KICK,
+        USER_DISCONNECT,
+        RECV_ERROR,
+    };
+
+    NetEvent(Type t, std::string const& msg) :type(t), message(msg) {}
+
+    Type type;
+    std::string message;
 };
 
-bool                 StartConnecting();             ///< Launches connecting on background.
-ConnectState         CheckConnectingState();        ///< Reports state of background connecting and updates GVar 'mp_state'
+typedef std::queue < NetEvent, std::list<NetEvent>> NetEventQueue;
+
+bool                 StartConnecting();    ///< Launches connecting on background.
+NetEventQueue        CheckEvents();        ///< Processes and returns the event queue.
 void                 Disconnect();
 
 void                 AddPacket(int streamid, int type, int len, char *content);
@@ -104,9 +121,6 @@ RoRnet::UserInfo     GetLocalUserData();
 std::vector<RoRnet::UserInfo> GetUserInfos();
 bool                 GetUserInfo(int uid, RoRnet::UserInfo &result);
 Ogre::ColourValue    GetPlayerColor(int color_num);
-
-std::string          GetStatusMessage();
-void                 ResetStatusMessage();
 
 } // namespace Networking
 } // namespace RoR


### PR DESCRIPTION
@tritonas00 Thanks for bringing #2309 into my attention, I looked at it with fresh eyes and... 🤢

Status: on Win10 x64, with RoR & rorserver built as Debug/x64:
* Upon server kick, RoR returns to main menu and displays message from server.
* Reconnecting works cleanly
* Exiting game works cleanly

More work is needed, though: When server is abruptly terminated, RoR silently exits. Also `CheckConnectingState()` should not do destructive reading as it does now - there should be separate notification queue instead.