### PR TITLE
Fixed switching actors on multiplayer

### DIFF
--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -676,7 +676,7 @@ void RoR::GUI::TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
         if ((!actor->ar_hide_in_actor_list) && (actor->ar_net_source_id == user.uniqueid))
         {
             char actortext_buf[400];
-            snprintf(actortext_buf, 400, "  [%d:%d] %s (%s)", i++, user.uniqueid, actor->ar_design_name.c_str(), actor->ar_filename.c_str());
+            snprintf(actortext_buf, 400, "  + %s (%s) ##[%d:%d]", actor->ar_design_name.c_str(), actor->ar_filename.c_str(), i++, user.uniqueid);
             if (ImGui::Button(actortext_buf)) // Button clicked?
             {
                 App::GetSimController()->SetPendingPlayerActor(actor);

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -670,12 +670,13 @@ void RoR::GUI::TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
     ImGui::PopStyleColor();
 
     // Display actor list
+    int i = 0;
     for (auto actor : App::GetSimController()->GetActors())
     {
         if ((!actor->ar_hide_in_actor_list) && (actor->ar_net_source_id == user.uniqueid))
         {
             char actortext_buf[400];
-            snprintf(actortext_buf, 400, "  + %s (%s)", actor->ar_design_name.c_str(), actor->ar_filename.c_str());
+            snprintf(actortext_buf, 400, "  [%d:%d] %s (%s)", i++, user.uniqueid, actor->ar_design_name.c_str(), actor->ar_filename.c_str());
             if (ImGui::Button(actortext_buf)) // Button clicked?
             {
                 App::GetSimController()->SetPendingPlayerActor(actor);


### PR DESCRIPTION
**Issue**

Spawn the same vehicle twice or more in multiplayer, go to `Vehicles` drop down menu and try to switch between them by clicking on the entries. Only the first spawned vehicle works, others not.

**Problem**

Entries must have a unique name like in single player

**Solution**

Added hidden numbers and user uniqueid on MP actor list. Now each entry name is unique and you can switch between all actors.