### PR TITLE
Removed dead hook flag 'lock nodes'

### DIFF
--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -225,7 +225,6 @@ struct hook_t
     int     hk_locked;
     int     hk_group;
     int     hk_lockgroup;
-    bool    hk_lock_nodes;
     bool    hk_selflock;
     bool    hk_autolock;
     bool    hk_nodisable;

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -5676,7 +5676,6 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
         hook.hk_locked            = UNLOCKED;
         hook.hk_lock_node         = nullptr;
         hook.hk_locked_actor      = nullptr;
-        hook.hk_lock_nodes        = true;
         hook.hk_lockgroup         = -1;
         hook.hk_beam              = & beam;
         hook.hk_maxforce          = HOOK_FORCE_DEFAULT;

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -2973,9 +2973,9 @@ void ActorSpawner::ProcessHook(RigDef::Hook & def)
     hook->hk_timer     = 0.f; // Hardcoded in BTS_HOOKS
     hook->hk_timer_preset = def.option_timer;
     hook->hk_min_length = def.option_min_range_meters;
-    hook->hk_selflock = BITMASK_IS_1(def.flags, RigDef::Hook::FLAG_SELF_LOCK);
-    hook->hk_nodisable = BITMASK_IS_1(def.flags, RigDef::Hook::FLAG_NO_DISABLE);
-    if (BITMASK_IS_1(def.flags, RigDef::Hook::FLAG_AUTO_LOCK))
+    hook->hk_selflock   = def.flag_self_lock;
+    hook->hk_nodisable  = def.flag_no_disable;
+    if (def.flag_auto_lock)
     {
         hook->hk_autolock = true;
         if (hook->hk_group == -1)
@@ -2983,11 +2983,11 @@ void ActorSpawner::ProcessHook(RigDef::Hook & def)
             hook->hk_group = -2; /* only overwrite hgroup when its still default (-1) */
         }
     }
-    if (BITMASK_IS_1(def.flags, RigDef::Hook::FLAG_NO_ROPE))
+    if (def.flag_no_rope)
     {
         hook->hk_beam->bounded = NOSHOCK;
     }
-    if (BITMASK_IS_0(def.flags, RigDef::Hook::FLAG_VISIBLE)) // NOTE: This flag can only hide a visible beam - it won't show a beam defined with 'invisible' flag.
+    if (!def.flag_visible) // NOTE: This flag can only hide a visible beam - it won't show a beam defined with 'invisible' flag.
     {
         // Find beam index
         int beam_index = -1;

--- a/source/main/resources/rig_def_fileformat/RigDef_File.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.cpp
@@ -129,12 +129,12 @@ Hook::Hook():
     flag_no_disable(false),
     flag_no_rope   (false),
     flag_visible   (false),
-    option_hook_range(0.4f),
+    option_hook_range(HOOK_RANGE_DEFAULT),
     option_speed_coef(1.0f),
-    option_max_force(10000000.f), // HOOK_FORCE_DEFAULT
+    option_max_force(HOOK_FORCE_DEFAULT),
     option_hookgroup(-1),
-    option_lockgroup(-1),
-    option_timer(5.f),
+    option_lockgroup(NODE_LOCKGROUP_DEFAULT),
+    option_timer(HOOK_LOCK_TIMER_DEFAULT),
     option_min_range_meters(0.f)
 {}
 

--- a/source/main/resources/rig_def_fileformat/RigDef_File.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.cpp
@@ -124,7 +124,11 @@ Fusedrag::Fusedrag():
 {}
 
 Hook::Hook():
-    flags(0),
+    flag_self_lock (false),
+    flag_auto_lock (false),
+    flag_no_disable(false),
+    flag_no_rope   (false),
+    flag_visible   (false),
     option_hook_range(0.4f),
     option_speed_coef(1.0f),
     option_max_force(10000000.f), // HOOK_FORCE_DEFAULT

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -2166,7 +2166,7 @@ struct File
         KEYWORD_GUISETTINGS,
         KEYWORD_HELP,
         KEYWORD_HIDE_IN_CHOOSER,
-        KEYWORD_HOOKGROUP,
+        KEYWORD_HOOKGROUP, // obsolete, ignored
         KEYWORD_HOOKS,
         KEYWORD_HYDROS,
         KEYWORD_IMPORTCOMMANDS,

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -1044,14 +1044,7 @@ struct Hook
 {
     Hook();
 
-    BITMASK_PROPERTY( flags, 1, FLAG_SELF_LOCK  , HasOptionSelfLock,  SetHasOptionSelfLock  )
-    BITMASK_PROPERTY( flags, 2, FLAG_AUTO_LOCK  , HasOptionAutoLock,  SetHasOptionAutoLock  )
-    BITMASK_PROPERTY( flags, 3, FLAG_NO_DISABLE , HasOptionNoDisable, SetHasOptionNoDisable )
-    BITMASK_PROPERTY( flags, 4, FLAG_NO_ROPE    , HasOptionNoRope,    SetHasOptionNoRope    )
-    BITMASK_PROPERTY( flags, 5, FLAG_VISIBLE    , HasOptionVisible,   SetHasOptionVisible   )
-
     Node::Ref node;
-    unsigned int flags;
     float option_hook_range;
     float option_speed_coef;
     float option_max_force;
@@ -1059,6 +1052,11 @@ struct Hook
     int option_lockgroup;
     float option_timer;
     float option_min_range_meters;
+    bool flag_self_lock :1;
+    bool flag_auto_lock :1;
+    bool flag_no_disable:1;
+    bool flag_no_rope   :1;
+    bool flag_visible   :1;
 };
 
 /* -------------------------------------------------------------------------- */

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -161,7 +161,7 @@ void Parser::ProcessCurrentLine()
         case File::KEYWORD_GUISETTINGS:              this->ChangeSection(File::SECTION_GUI_SETTINGS);     return;
         case File::KEYWORD_HELP:                     this->ChangeSection(File::SECTION_HELP);             return;
         case File::KEYWORD_HIDE_IN_CHOOSER:          this->ProcessGlobalDirective(keyword);               return;
-        case File::KEYWORD_HOOKGROUP:                /* Not supported yet, ignore */                      return;
+        case File::KEYWORD_HOOKGROUP:                /* Obsolete, ignored */                              return;
         case File::KEYWORD_HOOKS:                    this->ChangeSection(File::SECTION_HOOKS);            return;
         case File::KEYWORD_HYDROS:                   this->ChangeSection(File::SECTION_HYDROS);           return;
         case File::KEYWORD_IMPORTCOMMANDS:           m_definition->import_commands = true;                return;

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -863,11 +863,11 @@ void Parser::ParseHook()
         else if (has_value && (attr == "lockgroup"  || attr == "lgroup")     ) { hook.option_lockgroup        = this->GetArgInt  (++i); }
         else if (has_value && (attr == "shortlimit" || attr == "short_limit")) { hook.option_min_range_meters = this->GetArgFloat(++i); }
         // Flags
-        else if ((attr == "selflock") ||(attr == "self-lock") ||(attr == "self_lock") ) { BITMASK_SET_1(hook.flags, Hook::FLAG_SELF_LOCK);  }
-        else if ((attr == "autolock") ||(attr == "auto-lock") ||(attr == "auto_lock") ) { BITMASK_SET_1(hook.flags, Hook::FLAG_AUTO_LOCK);  }
-        else if ((attr == "nodisable")||(attr == "no-disable")||(attr == "no_disable")) { BITMASK_SET_1(hook.flags, Hook::FLAG_NO_DISABLE); }
-        else if ((attr == "norope")   ||(attr == "no-rope")   ||(attr == "no_rope")   ) { BITMASK_SET_1(hook.flags, Hook::FLAG_NO_ROPE);    }
-        else if ((attr == "visible")  ||(attr == "vis")                               ) { BITMASK_SET_1(hook.flags, Hook::FLAG_VISIBLE);    }
+        else if ((attr == "selflock") ||(attr == "self-lock") ||(attr == "self_lock") ) { hook.flag_self_lock  = true; }
+        else if ((attr == "autolock") ||(attr == "auto-lock") ||(attr == "auto_lock") ) { hook.flag_auto_lock  = true; }
+        else if ((attr == "nodisable")||(attr == "no-disable")||(attr == "no_disable")) { hook.flag_no_disable = true; }
+        else if ((attr == "norope")   ||(attr == "no-rope")   ||(attr == "no_rope")   ) { hook.flag_no_rope    = true; }
+        else if ((attr == "visible")  ||(attr == "vis")                               ) { hook.flag_visible    = true; }
         else
         {
             std::string msg = "Ignoring invalid option: " + attr;

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -1179,11 +1179,11 @@ void Serializer::ProcessHooks(File::Module* module)
         m_stream << "\n\t" << def.node.ToString();
 
         // Boolean options
-        if (def.HasOptionAutoLock())  { m_stream << ", auto-lock"; }
-        if (def.HasOptionNoDisable()) { m_stream << ", nodisable"; }
-        if (def.HasOptionNoRope())    { m_stream << ", norope";    }
-        if (def.HasOptionSelfLock())  { m_stream << ", self-lock"; }
-        if (def.HasOptionVisible())   { m_stream << ", visible";   }
+        if (def.flag_auto_lock)  { m_stream << ", auto-lock"; }
+        if (def.flag_no_disable) { m_stream << ", nodisable"; }
+        if (def.flag_no_rope)    { m_stream << ", norope";    }
+        if (def.flag_self_lock)  { m_stream << ", self-lock"; }
+        if (def.flag_visible)    { m_stream << ", visible";   }
 
         // Key-value options
         m_stream 


### PR DESCRIPTION
This flag makes hooks lock only to ropables instead of all nodes (default). It's been non-configurable for years and nobody noticed. Also, you can already define hook-able nodes using `lockgroups` and `lockgroup_default_nolock`

This is a diabolical PR to https://github.com/RigsOfRods/rigs-of-rods/pull/2421
