### PR TITLE
Load 'inertia_models.cfg' just once.

### DIFF
--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1590,7 +1590,11 @@ void Actor::SyncReset(bool reset_on_init)
         this->ar_autopilot->reset();
     if (m_buoyance)
         m_buoyance->sink = false;
-    m_hydro_inertia.resetCmdKeyDelay();
+
+    for (hydrobeam_t hydrobeam: ar_hydros)
+    {
+        hydrobeam.hb_inertia.ResetCmdKeyDelay();
+    }
 
     this->GetGfxActor()->ResetFlexbodies();
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -263,13 +263,6 @@ Actor::~Actor()
         m_inter_point_col_detector = nullptr;
     }
 
-    if (m_command_inertia)
-        delete m_command_inertia;
-    if (m_hydro_inertia)
-        delete m_hydro_inertia;
-    if (m_rotator_inertia)
-        delete m_rotator_inertia;
-
     if (m_transfer_case)
         delete m_transfer_case;
 
@@ -1597,8 +1590,7 @@ void Actor::SyncReset(bool reset_on_init)
         this->ar_autopilot->reset();
     if (m_buoyance)
         m_buoyance->sink = false;
-    if (m_hydro_inertia)
-        m_hydro_inertia->resetCmdKeyDelay();
+    m_hydro_inertia.resetCmdKeyDelay();
 
     this->GetGfxActor()->ResetFlexbodies();
 

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -490,9 +490,6 @@ private:
     int               m_wheel_node_count;      //!< Static attr; filled at spawn
     int               m_replay_pos_prev;       //!< Sim state
     int               m_previous_gear;         //!< Sim state; land vehicle shifting
-    CmdKeyInertia     m_rotator_inertia;       //!< Physics
-    CmdKeyInertia     m_hydro_inertia;         //!< Physics
-    CmdKeyInertia     m_command_inertia;       //!< Physics
     float             m_handbrake_force;       //!< Physics attr; defined in truckfile
     Airfoil*          m_fusealge_airfoil;      //!< Physics attr; defined in truckfile
     node_t*           m_fusealge_front;        //!< Physics attr; defined in truckfile

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -25,6 +25,7 @@
 
 #include "Application.h"
 #include "BeamData.h"
+#include "CmdKeyInertia.h"
 #include "GfxActor.h"
 #include "PerVehicleCameraContext.h"
 #include "RigDef_Prerequisites.h"
@@ -489,9 +490,9 @@ private:
     int               m_wheel_node_count;      //!< Static attr; filled at spawn
     int               m_replay_pos_prev;       //!< Sim state
     int               m_previous_gear;         //!< Sim state; land vehicle shifting
-    CmdKeyInertia*    m_rotator_inertia;       //!< Physics
-    CmdKeyInertia*    m_hydro_inertia;         //!< Physics
-    CmdKeyInertia*    m_command_inertia;       //!< Physics
+    CmdKeyInertia     m_rotator_inertia;       //!< Physics
+    CmdKeyInertia     m_hydro_inertia;         //!< Physics
+    CmdKeyInertia     m_command_inertia;       //!< Physics
     float             m_handbrake_force;       //!< Physics attr; defined in truckfile
     Airfoil*          m_fusealge_airfoil;      //!< Physics attr; defined in truckfile
     node_t*           m_fusealge_front;        //!< Physics attr; defined in truckfile

--- a/source/main/physics/BeamData.h
+++ b/source/main/physics/BeamData.h
@@ -38,6 +38,7 @@
 #include "ForwardDeclarations.h"
 #include "BeamConstants.h"
 #include "BitFlags.h"
+#include "CmdKeyInertia.h"
 
 enum event_types {
     EVENT_NONE=0,
@@ -321,6 +322,8 @@ struct command_t
     std::vector<commandbeam_t> beams;
     std::vector<int> rotators;
     Ogre::String description;
+    RoR::CmdKeyInertia rotator_inertia;
+    RoR::CmdKeyInertia command_inertia;
 };
 
 struct hydrobeam_t
@@ -331,6 +334,7 @@ struct hydrobeam_t
     int      hb_flags;
     int      hb_anim_flags; //!< Animators (beams updating length based on simulation variables)
     float    hb_anim_param; //!< Animators (beams updating length based on simulation variables)
+    RoR::CmdKeyInertia  hb_inertia;
 };
 
 struct rotator_t

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -81,6 +81,9 @@ ActorManager::ActorManager()
 
     gEnv->threadPool = new ThreadPool(thread_pool_workers);
     LOG("BEAMFACTORY: Creating " + TOSTRING(thread_pool_workers) + " worker threads");
+
+    // Load inertia config file
+    m_inertia_config.LoadDefaultInertiaModels();
 }
 
 ActorManager::~ActorManager()

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -27,6 +27,7 @@
 #include "RoRPrerequisites.h"
 
 #include "BeamData.h"
+#include "CmdKeyInertia.h"
 #include "Network.h"
 #include "RigDef_Prerequisites.h"
 
@@ -69,6 +70,7 @@ public:
     bool           AreTrucksForcedAwake() const            { return m_forced_awake; }
     void           SetSimulationSpeed(float speed)         { m_simulation_speed = std::max(0.0f, speed); };
     float          GetSimulationSpeed() const              { return m_simulation_speed; };
+    RoR::CmdKeyInertiaConfig& GetInertiaConfig()           { return m_inertia_config; }
     Actor*         FetchNextVehicleOnList(Actor* player, Actor* prev_player);
     Actor*         FetchPreviousVehicleOnList(Actor* player, Actor* prev_player);
     Actor*         FetchRescueVehicle();
@@ -118,6 +120,7 @@ private:
     std::shared_ptr<Task>           m_sim_task;
     std::vector<Actor*>             m_actors;
     Ogre::Timer                     m_net_timer;
+    RoR::CmdKeyInertiaConfig        m_inertia_config;
     bool            m_forced_awake;      //!< disables sleep counters
     int             m_physics_steps;
     float           m_dt_remainder;     ///< Keeps track of the rounding error in the time step calculation

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -699,7 +699,7 @@ void Actor::CalcHydros()
         {
             cstate /= (float)div;
 
-            cstate = m_hydro_inertia.calcCmdKeyDelay(cstate, i, PHYSICS_DT);
+            cstate = hydrobeam.hb_inertia.CalcCmdKeyDelay(cstate, PHYSICS_DT);
 
             if (!(hydrobeam.hb_flags & HYDRO_FLAG_SPEED) && !flagstate)
                 ar_hydro_dir_wheel_display = cstate;
@@ -877,7 +877,7 @@ void Actor::CalcCommands(bool doUpdate)
                             }
                         }
 
-                        v = m_command_inertia.calcCmdKeyDelay(v, i, PHYSICS_DT);
+                        v = ar_command_key[i].command_inertia.CalcCmdKeyDelay(v, PHYSICS_DT);
 
                         if (bbeam_dir * cmd_beam.cmb_state->auto_moving_mode > 0)
                             v = 1;
@@ -945,7 +945,7 @@ void Actor::CalcCommands(bool doUpdate)
                 if (ar_rotators[rota].needs_engine && ((ar_engine && !ar_engine->IsRunning()) || !ar_engine_hydraulics_ready))
                     continue;
 
-                v = m_rotator_inertia.calcCmdKeyDelay(ar_command_key[i].commandValue, i, PHYSICS_DT);
+                v = ar_command_key[i].rotator_inertia.CalcCmdKeyDelay(ar_command_key[i].commandValue, PHYSICS_DT);
 
                 if (v > 0.0f && ar_rotators[rota].engine_coupling > 0.0f)
                     requestpower = true;

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -699,8 +699,7 @@ void Actor::CalcHydros()
         {
             cstate /= (float)div;
 
-            if (m_hydro_inertia)
-                cstate = m_hydro_inertia->calcCmdKeyDelay(cstate, i, PHYSICS_DT);
+            cstate = m_hydro_inertia.calcCmdKeyDelay(cstate, i, PHYSICS_DT);
 
             if (!(hydrobeam.hb_flags & HYDRO_FLAG_SPEED) && !flagstate)
                 ar_hydro_dir_wheel_display = cstate;
@@ -878,8 +877,7 @@ void Actor::CalcCommands(bool doUpdate)
                             }
                         }
 
-                        if (m_command_inertia)
-                            v = m_command_inertia->calcCmdKeyDelay(v, i, PHYSICS_DT);
+                        v = m_command_inertia.calcCmdKeyDelay(v, i, PHYSICS_DT);
 
                         if (bbeam_dir * cmd_beam.cmb_state->auto_moving_mode > 0)
                             v = 1;
@@ -947,13 +945,10 @@ void Actor::CalcCommands(bool doUpdate)
                 if (ar_rotators[rota].needs_engine && ((ar_engine && !ar_engine->IsRunning()) || !ar_engine_hydraulics_ready))
                     continue;
 
-                if (m_rotator_inertia)
-                {
-                    v = m_rotator_inertia->calcCmdKeyDelay(ar_command_key[i].commandValue, i, PHYSICS_DT);
+                v = m_rotator_inertia.calcCmdKeyDelay(ar_command_key[i].commandValue, i, PHYSICS_DT);
 
-                    if (v > 0.0f && ar_rotators[rota].engine_coupling > 0.0f)
-                        requestpower = true;
-                }
+                if (v > 0.0f && ar_rotators[rota].engine_coupling > 0.0f)
+                    requestpower = true;
 
                 float cf = 1.0f;
 

--- a/source/main/physics/CmdKeyInertia.h
+++ b/source/main/physics/CmdKeyInertia.h
@@ -20,7 +20,8 @@
 
 #pragma once
 
-#include "RoRPrerequisites.h"
+#include <OgreSimpleSpline.h>
+#include <OgreString.h>
 
 namespace RoR {
 
@@ -37,29 +38,24 @@ private:
     std::map<Ogre::String, Ogre::SimpleSpline> m_splines;
 };
 
-} // namespace RoR
-
 class CmdKeyInertia
 {
 public:
+    CmdKeyInertia();
 
-    Ogre::Real calcCmdKeyDelay(Ogre::Real cmdInput, int cmdKey, Ogre::Real dt);
-    int setCmdKeyDelay(RoR::CmdKeyInertiaConfig& cfg, int number, Ogre::Real startDelay, Ogre::Real stopDelay, Ogre::String startFunction, Ogre::String stopFunction);
-    void resetCmdKeyDelay();
+    Ogre::Real CalcCmdKeyDelay(Ogre::Real cmdInput, Ogre::Real dt);
+    int SetCmdKeyDelay(RoR::CmdKeyInertiaConfig& cfg, Ogre::Real startDelay, Ogre::Real stopDelay, Ogre::String startFunction, Ogre::String stopFunction);
+    void ResetCmdKeyDelay();
 
 protected:
+    Ogre::Real          m_lastOutput;
+    Ogre::Real          m_startDelay;
+    Ogre::Real          m_stopDelay;
+    Ogre::Real          m_time;
+    Ogre::SimpleSpline* m_startSpline;
+    Ogre::SimpleSpline* m_stopSpline;
 
-    struct cmdKeyInertia_s
-    {
-        Ogre::Real lastOutput;
-        Ogre::Real startDelay;
-        Ogre::Real stopDelay;
-        Ogre::Real time;
-        Ogre::SimpleSpline* startSpline;
-        Ogre::SimpleSpline* stopSpline;
-    };
-
-    Ogre::Real calculateCmdOutput(Ogre::Real time, Ogre::SimpleSpline* spline);
-
-    std::map<int, cmdKeyInertia_s> cmdKeyInertia;
+    Ogre::Real CalculateCmdOutput(Ogre::Real time, Ogre::SimpleSpline* spline);
 };
+
+} // namespace RoR

--- a/source/main/physics/CmdKeyInertia.h
+++ b/source/main/physics/CmdKeyInertia.h
@@ -22,14 +22,29 @@
 
 #include "RoRPrerequisites.h"
 
-class CmdKeyInertia : public ZeroedMemoryAllocator
+namespace RoR {
+
+/// Loads and manages 'inertia_models.cfg'
+class CmdKeyInertiaConfig
+{
+public:
+    int LoadDefaultInertiaModels();
+    Ogre::SimpleSpline* GetSplineByName(Ogre::String model);
+
+private:
+    int ProcessLine(Ogre::StringVector args, Ogre::String model);
+
+    std::map<Ogre::String, Ogre::SimpleSpline> m_splines;
+};
+
+} // namespace RoR
+
+class CmdKeyInertia
 {
 public:
 
-    CmdKeyInertia();
-
     Ogre::Real calcCmdKeyDelay(Ogre::Real cmdInput, int cmdKey, Ogre::Real dt);
-    int setCmdKeyDelay(int number, Ogre::Real startDelay, Ogre::Real stopDelay, Ogre::String startFunction, Ogre::String stopFunction);
+    int setCmdKeyDelay(RoR::CmdKeyInertiaConfig& cfg, int number, Ogre::Real startDelay, Ogre::Real stopDelay, Ogre::String startFunction, Ogre::String stopFunction);
     void resetCmdKeyDelay();
 
 protected:
@@ -45,9 +60,6 @@ protected:
     };
 
     Ogre::Real calculateCmdOutput(Ogre::Real time, Ogre::SimpleSpline* spline);
-    int processLine(Ogre::StringVector args, Ogre::String model);
 
     std::map<int, cmdKeyInertia_s> cmdKeyInertia;
-    std::map<Ogre::String, Ogre::SimpleSpline> splines;
-    int loadDefaultInertiaModels();
 };

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -3306,6 +3306,7 @@ void ActorSpawner::_ProcessKeyInertia(
         if (inertia.start_delay_factor != 0.f && inertia.stop_delay_factor != 0.f)
         {
             key_inertia->setCmdKeyDelay(
+                App::GetSimController()->GetBeamFactory()->GetInertiaConfig(),
                 contract_key,
                 inertia.start_delay_factor,
                 inertia.stop_delay_factor,
@@ -3314,6 +3315,7 @@ void ActorSpawner::_ProcessKeyInertia(
             );
 
             key_inertia->setCmdKeyDelay(
+                App::GetSimController()->GetBeamFactory()->GetInertiaConfig(),
                 extend_key,
                 inertia.start_delay_factor,
                 inertia.stop_delay_factor,
@@ -3324,6 +3326,7 @@ void ActorSpawner::_ProcessKeyInertia(
         else if (inertia_defaults.start_delay_factor > 0 || inertia_defaults.stop_delay_factor > 0)
         {
             key_inertia->setCmdKeyDelay(
+                App::GetSimController()->GetBeamFactory()->GetInertiaConfig(),
                 contract_key,
                 inertia_defaults.start_delay_factor,
                 inertia_defaults.stop_delay_factor,
@@ -3332,6 +3335,7 @@ void ActorSpawner::_ProcessKeyInertia(
             );
 
             key_inertia->setCmdKeyDelay(
+                App::GetSimController()->GetBeamFactory()->GetInertiaConfig(),
                 extend_key,
                 inertia_defaults.start_delay_factor,
                 inertia_defaults.stop_delay_factor,
@@ -3423,6 +3427,7 @@ void ActorSpawner::ProcessAnimator(RigDef::Animator & def)
         if (def.inertia_defaults->start_delay_factor > 0 && def.inertia_defaults->stop_delay_factor > 0)
         {
             m_actor->m_hydro_inertia->setCmdKeyDelay(
+                App::GetSimController()->GetBeamFactory()->GetInertiaConfig(),
                 static_cast<int>(m_actor->ar_hydros.size()),
                 def.inertia_defaults->start_delay_factor,
                 def.inertia_defaults->stop_delay_factor,

--- a/source/main/physics/RigSpawner.h
+++ b/source/main/physics/RigSpawner.h
@@ -1031,11 +1031,10 @@ private:
     );
 
     void _ProcessKeyInertia(
-        CmdKeyInertia * key_inertia,
         RigDef::Inertia & inertia, 
         RigDef::Inertia & inertia_defaults, 
-        int contract_key, 
-        int extend_key
+        RoR::CmdKeyInertia& contract_key, 
+        RoR::CmdKeyInertia& extend_key
     );
 
     /** 


### PR DESCRIPTION
I noticed we're loading and parsing it three times when spawning any actor - for no reason (it's not configurable per actor, there's only one global config file).

UPDATE: With the last commit there's also minor performance improvement:
![image](https://user-images.githubusercontent.com/491088/63751806-59ecc800-c8b0-11e9-965d-12cc5cac40a4.png)

