### PR TITLE
🔧 Update PMM to 1.6.0

### DIFF
--- a/cmake/3rdparty/pmm.cmake
+++ b/cmake/3rdparty/pmm.cmake
@@ -1,6 +1,7 @@
 ## MIT License
 ##
 ## Copyright (c) 2018 vector-of-bool
+## Copyright (c) 2019 Edgar (Edgar@AnotherFoxGuy.com)
 ##
 ## Permission is hereby granted, free of charge, to any person obtaining a copy
 ## of this software and associated documentation files (the "Software"), to deal
@@ -21,13 +22,13 @@
 ## SOFTWARE.
 
 # Bump this version to change what PMM version is downloaded
-set(PMM_VERSION_INIT 1.5.1)
+set(PMM_VERSION_INIT 1.6.0)
 
 # Helpful macro to set a variable if it isn't already set
 macro(_pmm_set_if_undef varname)
-    if(NOT DEFINED "${varname}")
+    if (NOT DEFINED "${varname}")
         set("${varname}" "${ARGN}")
-    endif()
+    endif ()
 endmacro()
 
 ## Variables used by this script
@@ -44,19 +45,19 @@ _pmm_set_if_undef(PMM_DIR "${PMM_DIR_BASE}/${PMM_VERSION}")
 # The file that we first download
 set(_PMM_ENTRY_FILE "${PMM_DIR}/entry.cmake")
 
-if(NOT EXISTS "${_PMM_ENTRY_FILE}" OR PMM_ALWAYS_DOWNLOAD)
+if (NOT EXISTS "${_PMM_ENTRY_FILE}" OR PMM_ALWAYS_DOWNLOAD)
     file(
-        DOWNLOAD "${PMM_URL}/entry.cmake"
-        "${_PMM_ENTRY_FILE}.tmp"
-        STATUS pair
-        )
+            DOWNLOAD "${PMM_URL}/entry.cmake"
+            "${_PMM_ENTRY_FILE}.tmp"
+            STATUS pair
+    )
     list(GET pair 0 rc)
     list(GET pair 1 msg)
-    if(rc)
+    if (rc)
         message(FATAL_ERROR "Failed to download PMM entry file")
-    endif()
+    endif ()
     file(RENAME "${_PMM_ENTRY_FILE}.tmp" "${_PMM_ENTRY_FILE}")
-endif()
+endif ()
 
 # ^^^ DO NOT CHANGE THIS LINE vvv
 set(_PMM_BOOTSTRAP_VERSION 1)


### PR DESCRIPTION
This fixes a bug in PMM that when one of the cmake_multi builds failed, it would continue instead of reporting the error 