### PR TITLE
:bug: Fixed possible divison by zero

### DIFF
--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1009,6 +1009,11 @@ void ActorManager::UpdateActors(Actor* player_actor, float dt)
 
     dt += m_dt_remainder;
     m_physics_steps = dt / PHYSICS_DT;
+    if (m_physics_steps == 0)
+    {
+        return;
+    }
+
     m_dt_remainder = dt - (m_physics_steps * PHYSICS_DT);
     dt = PHYSICS_DT * m_physics_steps;
 


### PR DESCRIPTION
performing physics update with 0 steps makes no sense and causes division by zero in `Actor::ForceFeedbackStep()` (and likely other complications)

Found here: https://github.com/RigsOfRods/rigs-of-rods/pull/2434#issuecomment-529402927