### PR TITLE
Check CacheEntry validity when spawning

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -2520,6 +2520,25 @@ Actor* SimController::SpawnActorDirectly(RoR::ActorSpawnRequest rq)
 
     if (rq.asr_cache_entry != nullptr)
     {
+        if (rq.asr_cache_entry->fname.empty())
+        {
+            RoR::LogFormat(
+                "[RoR] Error: Cannot spawn actor, corrupted modcache entry - empty filename (field 'fname')"
+                "\nDetails: number=%d, fpath='%s', dname='%s', resource_bundle_type='%s', resource_bundle_path='%s', deleted=%d",
+                rq.asr_cache_entry->number, rq.asr_cache_entry->fpath.c_str(), rq.asr_cache_entry->dname.c_str(),
+                rq.asr_cache_entry->resource_bundle_type.c_str(), rq.asr_cache_entry->resource_bundle_path.c_str(),
+                (int)rq.asr_cache_entry->deleted);
+
+            App::GetGuiManager()->ShowMessageBox(
+                _LC("Sim", "Error"),
+                _LC("Sim", "ModCache is corrupted. Please open Settings and press [Update cache]"));
+
+            App::GetCacheSystem()->ClearCache();
+            App::app_state.SetPending(AppState::MAIN_MENU);
+
+            return nullptr;
+        }
+
         rq.asr_filename = rq.asr_cache_entry->fname;
     }
 

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -146,6 +146,7 @@ public:
     CacheEntry*           FetchSkinByName(std::string const & skin_name);
     void                  UnloadActorFromMemory(std::string filename);
     CacheValidityState    EvaluateCacheValidity();
+    void                  ClearCache(); // removes all files from the cache
 
     void LoadResource(CacheEntry& t); //!< Loads the associated resource bundle if not already done.
     bool CheckResourceLoaded(Ogre::String &in_out_filename); //!< Finds + loads the associated resource bundle if not already done.
@@ -178,7 +179,6 @@ private:
     bool ParseKnownFiles(Ogre::String group); // returns true if no known files are found
     void ParseSingleZip(Ogre::String path);
 
-    void ClearCache(); // removes                   all files from the cache
     void PruneCache(); // removes modified (or deleted) files from the cache
 
     void AddFile(Ogre::String group, Ogre::FileInfo f, Ogre::String ext);


### PR DESCRIPTION
I found one possible cause of #2410 and RigsOfRods/ror-server#96 - when spawning actor using selector, the truckfile filename is taken from modcache entry which *might* become corrupted and contain empty filename.

I added a quick check - if it happens, RoR will clear the cache, return to main menu and instruct user to rebuild cache:
![image](https://user-images.githubusercontent.com/491088/66311146-1608cc00-e90e-11e9-87fe-581fce39d78c.png)


