### PR TITLE
 Added odef option to disable shadow casting

### DIFF
--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -1268,6 +1268,12 @@ void TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
             continue;
         }
 
+        if (!strncmp("nocast", ptline, 6))
+        {
+        	mo->getEntity()->setCastShadows(false);
+        	continue;
+        }
+
         LOG("ODEF: unknown command in "+odefname+" : "+String(ptline));
     }
 }


### PR DESCRIPTION
Currently, all objects cast shadows except for grass. When you try to enable shadows on a terrain that features a skybox, a shadow will cast across the entire terarin, thus preventing shadows from functioning.  

This fixes that by adding a new `nocast` option to the odef file format which disables casting of shadows for the object. Allows terrains to utilize a skybox or other large objects while retaining shadow support:
![screenshot_2019-12-03_13-59-49_1](https://user-images.githubusercontent.com/46073351/70102063-07385000-1605-11ea-8346-ab3f964b5fd1.png)
![screenshot_2019-12-03_14-14-13_1](https://user-images.githubusercontent.com/46073351/70102065-09021380-1605-11ea-9a93-636987b14059.png)
![screenshot_2019-12-03_19-17-49_1](https://user-images.githubusercontent.com/46073351/70102062-07385000-1605-11ea-8d03-99e0093bef47.png)
Example usage:
```
AHSkyBox.mesh
1.0, 1.0, 1.0

nocast

end
```
There's probably a better way, but this works. (my coding knowledge is extremely limited lol)