### PR TITLE
Fixed double cursor on Windows

### DIFF
--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -1925,6 +1925,13 @@ bool InputEngine::setup(String hwnd, bool capture, bool capturemouse, bool captu
 #endif // LINUX
         }
 
+#if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+        if (RoR::App::io_input_grab_mode.GetActive() != RoR::IoInputGrabMode::ALL)
+        {
+            ShowCursor(FALSE);
+        }
+#endif
+
 #ifndef NOOGRE
         LOG("*** OIS WINDOW: "+hwnd);
 #endif //NOOGRE


### PR DESCRIPTION
This hides the Windows cursor when input grabbing is set to None or Dynamic. (both appear to be identical..)

Was fixed on Linux in https://github.com/RigsOfRods/rigs-of-rods/commit/d027ad1ed7a992f35b901e3d2e4f3e3ce3f44d44