### PR TITLE
Fixed FOV changes in Settings GUI not saved to RoR.cfg

### DIFF
--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -1,6 +1,6 @@
 /*
     This source file is part of Rigs of Rods
-    Copyright 2016-2017 Petr Ohlidal & contributors
+    Copyright 2013-2020 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -112,6 +112,16 @@ void RoR::DrawGIntSlider(GVarPod_A<int>& gvar, const char* label, int v_min, int
     if (ImGui::SliderInt(label, &val, v_min, v_max))
     {
         gvar.SetActive(val);
+    }
+}
+
+void RoR::DrawGIntSlider(GVarPod_APS<int>& gvar, const char* label, int v_min, int v_max)
+{
+    int val = gvar.GetActive();
+    if (ImGui::SliderInt(label, &val, v_min, v_max))
+    {
+        gvar.SetActive(val);
+        gvar.SetStored(val);
     }
 }
 

--- a/source/main/gui/GUIUtils.h
+++ b/source/main/gui/GUIUtils.h
@@ -1,6 +1,6 @@
 /*
     This source file is part of Rigs of Rods
-    Copyright 2016-2017 Petr Ohlidal & contributors
+    Copyright 2013-2020 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -30,7 +30,6 @@ void DrawImGuiSpinner(
     const float spacing = 2.f, const float step_sec = 0.15f);
 
 void DrawGCheckbox(GVarPod_A<bool>& gvar, const char* label);
-
 void DrawGCheckbox(GVarPod_APS<bool>& gvar, const char* label);
 
 void DrawGIntCheck(GVarPod_A<int>& gvar, const char* label);
@@ -38,11 +37,11 @@ void DrawGIntCheck(GVarPod_A<int>& gvar, const char* label);
 void DrawGIntBox(GVarPod_A<int>& gvar, const char* label);
 
 void DrawGIntSlider(GVarPod_A<int>& gvar, const char* label, int v_min, int v_max);
+void DrawGIntSlider(GVarPod_APS<int>& gvar, const char* label, int v_min, int v_max);
 
 void DrawGFloatSlider(GVarPod_A<float>& gvar, const char* label, float v_min, float v_max);
 
 void DrawGFloatBox(GVarPod_A<float>& gvar, const char* label);
-
 void DrawGFloatBox(GVarPod_APS<float>& gvar, const char* label);
 
 template <size_t Len>


### PR DESCRIPTION
Problem: The settings GUI was only updating 'Active' value, but the FOV settings were of type `GVar_APS`, meaning state 'Stored' needed to be updated separately.

Solution: added function overload which handles `GVar_APS` entries.

Fixes #2478