### PR TITLE
Fixed toggle physics and replay mode keys conflicting

### DIFF
--- a/resources/skeleton/config/input.map
+++ b/resources/skeleton/config/input.map
@@ -193,8 +193,8 @@ COMMON_TOGGLE_TERRAIN_EDITOR   Keyboard             EXPL+CTRL+Y
 COMMON_TOGGLE_CUSTOM_PARTICLES Keyboard             G 
 COMMON_TOGGLE_MAT_DEBUG        Keyboard             EXPL+CTRL+SHIFT+ALT+F 
 COMMON_TOGGLE_RENDER_MODE      Keyboard             E 
-COMMON_TOGGLE_REPLAY_MODE      Keyboard             EXPL+CTRL+J 
-COMMON_TOGGLE_PHYSICS          Keyboard             J 
+COMMON_TOGGLE_REPLAY_MODE      Keyboard             CTRL+J 
+COMMON_TOGGLE_PHYSICS          Keyboard             EXPL+J 
 COMMON_TOGGLE_STATS            Keyboard             EXPL+F 
 COMMON_TOGGLE_TRUCK_BEACONS    Keyboard             M 
 COMMON_TOGGLE_TRUCK_LIGHTS     Keyboard             N 

--- a/resources/skeleton/config/input.map
+++ b/resources/skeleton/config/input.map
@@ -1,3 +1,7 @@
+; Rigs of Rods keyboard input configuration file
+; DO NOT ADD OTHER DEVICE INPUTS IN THIS FILE! Create a separate `.map` file instead.
+; See https://docs.rigsofrods.org/gameplay/controls-config/#exporting-the-keymap for more info.
+; -------------------------------
 
 ; AIRPLANE
 AIRPLANE_AIRBRAKES_FULL        Keyboard             CTRL+4 


### PR DESCRIPTION
This fixes the toggle physics and replay mode keys conflicting. Also added a notice about adding other device inputs to input.map.
However, with this fix the physics paused notification shows EXPL:
![image](https://user-images.githubusercontent.com/46073351/73969054-abca5d00-48e8-11ea-9e3f-0ee8d12710f8.png)
The EXPL 'key' needs to be suppressed first before this can be merged.