### PR TITLE
Survey map and MP client list window fixes

### DIFF
--- a/source/main/gui/panels/GUI_MultiplayerClientList.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerClientList.cpp
@@ -46,17 +46,25 @@ void MpClientList::Draw()
     GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse |
-        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar;
+        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
     const float content_width = 200.f;
     ImGui::SetNextWindowContentWidth(content_width);
     ImGui::SetNextWindowPos(ImVec2(
         ImGui::GetIO().DisplaySize.x - (content_width + (2*ImGui::GetStyle().WindowPadding.x) + theme.screen_edge_padding.x),
         theme.screen_edge_padding.y));
+
+    int y = 20;
+    std::vector<RoRnet::UserInfo> users = RoR::Networking::GetUserInfos();
+    users.insert(users.begin(), RoR::Networking::GetLocalUserData());
+    for (RoRnet::UserInfo const& user: users)
+    {
+       y += 20;
+    }
+
+    ImGui::SetNextWindowSize(ImVec2((content_width + (2*ImGui::GetStyle().WindowPadding.x)), y));
     ImGui::PushStyleColor(ImGuiCol_WindowBg, theme.semitransparent_window_bg);
     ImGui::Begin("Peers", nullptr, flags);
 
-    std::vector<RoRnet::UserInfo> users = RoR::Networking::GetUserInfos();
-    users.insert(users.begin(), RoR::Networking::GetLocalUserData());
     for (RoRnet::UserInfo const& user: users)
     {
         // Icon sizes: flag(16x11), auth(16x16), up(16x16), down(16x16)

--- a/source/main/gui/panels/GUI_MultiplayerClientList.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerClientList.cpp
@@ -58,7 +58,7 @@ void MpClientList::Draw()
     users.insert(users.begin(), RoR::Networking::GetLocalUserData());
     for (RoRnet::UserInfo const& user: users)
     {
-       y += 20;
+       y += ImGui::GetTextLineHeightWithSpacing();
     }
 
     ImGui::SetNextWindowSize(ImVec2((content_width + (2*ImGui::GetStyle().WindowPadding.x)), y));

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -81,9 +81,11 @@ void RoR::GUI::SurveyMap::Draw()
     }
 
     // Open window
-    ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize;
+    ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoScrollbar;
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(WINDOW_PADDING, WINDOW_PADDING));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, WINDOW_ROUNDING);
+    ImGui::SetNextWindowSize(ImVec2((view_size.x + 8), (view_size.y + 8)));
+
     if (mMapMode == SurveyMapMode::BIG)
     {
         ImGui::SetNextWindowPosCenter();


### PR DESCRIPTION
- Fixes black "artifact" when opening survey map
- Sets correct multiplayer client list initial window size and fixes same "artifact" when new clients added/removed

~~@only-a-ptr i know this will make you 🤢, i'm sure there is better way :smiley:~~

I think its ok now