### PR TITLE
Changed Source/Filename text color in selector

### DIFF
--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -302,14 +302,14 @@ void MainSelector::Draw()
             {
                 ImGui::Text("%s", _L("Source: "));
                 ImGui::SameLine();
-                ImGui::TextColored(App::GetGuiManager()->GetTheme().value_blue_text_color,
+                ImGui::TextColored(App::GetGuiManager()->GetTheme().highlight_text_color,
                     "%s", sd_entry.sde_entry->resource_bundle_path.c_str());
             }
             if (!sd_entry.sde_entry->fname.empty())
             {
                 ImGui::Text("%s", _L("Filename: "));
                 ImGui::SameLine();
-                ImGui::TextColored(App::GetGuiManager()->GetTheme().value_blue_text_color,
+                ImGui::TextColored(App::GetGuiManager()->GetTheme().highlight_text_color,
                     "%s", sd_entry.sde_entry->fname.c_str());
             }
         }


### PR DESCRIPTION
It was very hard to read

Before
![bef](https://user-images.githubusercontent.com/2660424/76249103-4f41c100-624b-11ea-9736-d6e72c3f84bb.png)
After
![after](https://user-images.githubusercontent.com/2660424/76249110-5537a200-624b-11ea-9577-108b3c199cd1.png)
