### PR TITLE
Αdded 'commands' filter

### DIFF
--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -125,6 +125,7 @@ void GUI::ConsoleView::DrawFilteringOptions()
     ImGui::MenuItem(_LC("Console", "Warnings"), "", &cvw_filter_type_warning);
     ImGui::MenuItem(_LC("Console", "Errors"),   "", &cvw_filter_type_error);
     ImGui::MenuItem(_LC("Console", "Net chat"), "", &cvw_filter_type_chat);
+    ImGui::MenuItem(_LC("Console", "Commands"), "", &cvw_filter_type_cmd);
 }
 
 bool GUI::ConsoleView::MessageFilter(Console::Message const& m)
@@ -137,9 +138,9 @@ bool GUI::ConsoleView::MessageFilter(Console::Message const& m)
         (m.cm_area == Console::MessageArea::CONSOLE_MSGTYPE_SCRIPT && cvw_filter_area_script);
 
     const bool type_ok =
-        (m.cm_type == Console::CONSOLE_HELP) ||
-        (m.cm_type == Console::CONSOLE_TITLE) ||
-        (m.cm_type == Console::CONSOLE_SYSTEM_REPLY) ||
+        (m.cm_type == Console::CONSOLE_HELP) && cvw_filter_type_cmd ||
+        (m.cm_type == Console::CONSOLE_TITLE) && cvw_filter_type_cmd ||
+        (m.cm_type == Console::CONSOLE_SYSTEM_REPLY) && cvw_filter_type_cmd ||
         (m.cm_type == Console::CONSOLE_SYSTEM_ERROR   && cvw_filter_type_error) ||
         (m.cm_type == Console::CONSOLE_SYSTEM_WARNING && cvw_filter_type_warning) ||
         (m.cm_type == Console::CONSOLE_SYSTEM_NOTICE  && cvw_filter_type_notice) ||

--- a/source/main/gui/panels/GUI_ConsoleView.h
+++ b/source/main/gui/panels/GUI_ConsoleView.h
@@ -48,6 +48,7 @@ struct ConsoleView
     bool  cvw_filter_type_warning = true;
     bool  cvw_filter_type_error = true;
     bool  cvw_filter_type_chat = true;
+    bool  cvw_filter_type_cmd = true;
     bool  cvw_filter_area_echo = false; //!< Not the same thing as 'log' command!
     bool  cvw_filter_area_script = true;
     bool  cvw_filter_area_actor = true;

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -37,6 +37,7 @@ RoR::GUI::GameChatBox::GameChatBox()
     m_console_view.cvw_filter_duration_ms = 10000; // 10sec
     m_console_view.cvw_filter_area_actor = false; // Disable vehicle spawn warnings/errors
     m_console_view.cvw_filter_type_error = false; // Disable errors
+    m_console_view.cvw_filter_type_cmd = false; // Disable commands
 }
 
 void RoR::GUI::GameChatBox::Draw()


### PR DESCRIPTION
Added `cvw_filter_type_cmd`, enabled in console and disabled in chat/notifications so when you enter a command in console it will not printed as notification.