### PR TITLE
Re added 'Default' skin in selector

### DIFF
--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -67,11 +67,6 @@ void MainSelector::Show(LoaderType type, std::string const& filter_guid)
     {
         m_selected_entry = m_last_selected_entry[m_loader_type];
     }
-
-    if (type == LT_Skin)
-    {
-        m_selected_entry = m_selected_entry["Default"];
-    }
 }
 
 void MainSelector::Draw()
@@ -371,6 +366,13 @@ void MainSelector::UpdateDisplayLists()
     m_display_categories.clear();
     m_display_entries.clear();
 
+    if (m_loader_type == LT_Skin)
+    {
+        m_dummy_skin.dname = "Default skin";
+        m_dummy_skin.description = "Original, unmodified skin";
+        m_display_entries.push_back(&m_dummy_skin);
+    }
+
     // Find all relevant entries
     CacheQuery query;
     query.cqy_filter_type = m_loader_type;
@@ -555,6 +557,11 @@ void MainSelector::Apply()
             sectionconfig = sd_entry.sde_entry->sectionconfigs[m_selected_sectionconfig];
         }
         this->Close();
+
+        if (m_loader_type == LT_Skin && sd_entry.sde_entry == &m_dummy_skin)
+        {
+            sd_entry.sde_entry = nullptr;
+        }
 
         App::GetSimController()->OnLoaderGuiApply(type, sd_entry.sde_entry, sectionconfig);
     }

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -70,7 +70,7 @@ void MainSelector::Show(LoaderType type, std::string const& filter_guid)
 
     if (type == LT_Skin)
     {
-         m_selected_entry = m_selected_entry["Default"];
+        m_selected_entry = m_selected_entry["Default"];
     }
 }
 

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -67,6 +67,11 @@ void MainSelector::Show(LoaderType type, std::string const& filter_guid)
     {
         m_selected_entry = m_last_selected_entry[m_loader_type];
     }
+
+    if (type == LT_Skin)
+    {
+         m_selected_entry = m_selected_entry["Default"];
+    }
 }
 
 void MainSelector::Draw()

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -96,6 +96,7 @@ private:
     Str<500>           m_search_input;
     bool               m_show_details = false;
     bool               m_searchbox_was_active = false;
+    CacheEntry m_dummy_skin;
 
     int                m_selected_category = 0;
     int                m_selected_entry = -1;

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -96,7 +96,7 @@ private:
     Str<500>           m_search_input;
     bool               m_show_details = false;
     bool               m_searchbox_was_active = false;
-    CacheEntry m_dummy_skin;
+    CacheEntry         m_dummy_skin;
 
     int                m_selected_category = 0;
     int                m_selected_entry = -1;


### PR DESCRIPTION
This will select the default skin if no one is selected, but i don't know how to show it as an entry also.
It should always be available on top of the skinzips list.

(Example: 767 airplane)