### PR TITLE
[WIP] Added notification/chat icons and other improvements

### DIFF
--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -251,3 +251,4 @@ bool GUI::ConsoleView::DrawIcon(Ogre::TexturePtr tex, ImVec2 reference_box)
     }
     return NULL;
 }
+

--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -93,6 +93,7 @@ void GUI::ConsoleView::DrawConsoleMessages()
             break;
 
         case Console::CONSOLE_SYSTEM_WARNING:
+            this->DrawIcon(FetchIcon("error.png"), ImVec2(0.f, ImGui::GetTextLineHeight()));
             this->DrawColorMarkedText(theme.warning_text_color, line);
             break;
 
@@ -250,4 +251,3 @@ bool GUI::ConsoleView::DrawIcon(Ogre::TexturePtr tex, ImVec2 reference_box)
     }
     return NULL;
 }
-

--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -68,6 +68,7 @@ void GUI::ConsoleView::DrawConsoleMessages()
     }
 
     GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+
     for (const Console::Message* dm: m_display_list)
     {
         std::string line = dm->cm_text;
@@ -102,6 +103,16 @@ void GUI::ConsoleView::DrawConsoleMessages()
 
         case Console::Console::CONSOLE_HELP:
             this->DrawColorMarkedText(theme.help_text_color, line);
+            break;
+
+        case Console::Console::CONSOLE_SYSTEM_NOTICE:
+            this->DrawIcon(FetchIcon("information.png"), ImVec2(0.f, ImGui::GetTextLineHeight()));
+            this->DrawColorMarkedText(ImGui::GetStyle().Colors[ImGuiCol_Text], line);
+            break;
+
+        case Console::Console::CONSOLE_SYSTEM_NETCHAT:
+            this->DrawIcon(FetchIcon("comments.png"), ImVec2(0.f, ImGui::GetTextLineHeight()));
+            this->DrawColorMarkedText(ImGui::GetStyle().Colors[ImGuiCol_Text], line);
             break;
 
         default:
@@ -174,7 +185,7 @@ void GUI::ConsoleView::DrawColorMarkedText(ImVec4 default_color, std::string con
         if (seg_start != seg_end)
         {
             std::string text(seg_start, seg_end); // TODO: optimize!
-            ImVec2 text_size = ImGui::CalcTextSize(text.c_str());            
+            ImVec2 text_size = ImGui::CalcTextSize(text.c_str());           
             drawlist->AddText(text_cursor, ImColor(r,g,b), text.c_str());
             total_text_size.x += text_size.x;
             total_text_size.y = std::max(total_text_size.y, text_size.y);
@@ -215,3 +226,28 @@ void GUI::ConsoleView::NewLine(ImVec2 text_size)
     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (text_size + (cvw_background_padding * 2)).y + cvw_line_spacing);
 }
 
+Ogre::TexturePtr GUI::ConsoleView::FetchIcon(const char* name)
+{
+    try
+    {
+        return Ogre::static_pointer_cast<Ogre::Texture>(
+            Ogre::TextureManager::getSingleton().createOrRetrieve(name, "IconsRG").first);
+    }
+    catch (...) {}
+
+    return Ogre::TexturePtr(); // null
+}
+
+bool GUI::ConsoleView::DrawIcon(Ogre::TexturePtr tex, ImVec2 reference_box)
+{
+    if (!App::GetGuiManager()->IsVisible_Console())
+    {
+        ImGui::SetCursorPosX(10.f); // Give some room for icon
+        if (tex)
+        {
+            ImGui::Image(reinterpret_cast<ImTextureID>(tex->getHandle()), ImVec2(tex->getWidth(), tex->getHeight()));
+        }
+        ImGui::SameLine(); // Keep icon and text in the same line
+    }
+    return NULL;
+}

--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -68,7 +68,6 @@ void GUI::ConsoleView::DrawConsoleMessages()
     }
 
     GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
-
     for (const Console::Message* dm: m_display_list)
     {
         std::string line = dm->cm_text;

--- a/source/main/gui/panels/GUI_ConsoleView.h
+++ b/source/main/gui/panels/GUI_ConsoleView.h
@@ -71,6 +71,9 @@ private:
     DisplayMsgVec    m_display_list;
     unsigned long    m_newest_msg_time = 0;      // Updated by `DrawConsoleMessages()`
     std::regex       m_text_color_regex = std::regex(R"(#[a-fA-F\d]{6})");
+
+    Ogre::TexturePtr FetchIcon(const char* name);
+    bool DrawIcon(Ogre::TexturePtr tex, ImVec2 reference_box);
 };
 
 } // namespace GUI

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -33,7 +33,7 @@
 RoR::GUI::GameChatBox::GameChatBox()
 {
     m_console_view.cvw_align_bottom = true;
-    m_console_view.cvw_max_lines = 20u;
+    m_console_view.cvw_max_lines = 15u;
     m_console_view.cvw_filter_duration_ms = 10000; // 10sec
     m_console_view.cvw_filter_area_actor = false; // Disable vehicle spawn warnings/errors
     m_console_view.cvw_filter_type_error = false; // Disable errors
@@ -53,10 +53,20 @@ void RoR::GUI::GameChatBox::Draw()
         size.y += ImGui::GetTextLineHeightWithSpacing() + (2 * ImGui::GetStyle().WindowPadding.x); // reserve space for input window
     }
     ImGui::SetNextWindowSize(size);
+    if (m_is_visible) // Full display?
+    {
+        size.y +=  35;
+    }
     ImGui::SetNextWindowPos(ImVec2(0, ImGui::GetIO().DisplaySize.y - size.y));
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0,0,0,0)); // Fully transparent background!
     ImGui::PushStyleColor(ImGuiCol_ChildWindowBg, ImVec4(0,0,0,0)); // Fully transparent background!
     ImGui::Begin("ChatMessages", nullptr, win_flags);
+
+    if (initialized == true)
+    {
+        RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, "Welcome to Rigs of Rods!", "", 10000, false);
+        initialized = false;
+    }
 
     m_console_view.DrawConsoleMessages();
     ImGui::SetScrollFromPosY(9999); // Force to bottom
@@ -75,17 +85,7 @@ void RoR::GUI::GameChatBox::Draw()
 
     if (m_is_visible) // Full display?
     {
-        const char* name = "chatbox-filtering";
-        // Draw filter button and input box in one line
-        if (ImGui::Button(_LC("Console", "Filter options")))
-        {
-            ImGui::OpenPopup(name);
-        }
-        if (ImGui::BeginPopup(name))
-        {
-            m_console_view.DrawFilteringOptions();
-            ImGui::EndPopup();
-        }
+        ImGui::Text(_L("Message"));
         ImGui::SameLine();
         if (!m_kb_focused)
         {
@@ -93,7 +93,7 @@ void RoR::GUI::GameChatBox::Draw()
             m_kb_focused = true;
         }
         const ImGuiInputTextFlags cmd_flags = ImGuiInputTextFlags_EnterReturnsTrue;
-        if (ImGui::InputText(_L("Message"), m_msg_buffer.GetBuffer(), m_msg_buffer.GetCapacity(), cmd_flags))
+        if (ImGui::InputText("", m_msg_buffer.GetBuffer(), m_msg_buffer.GetCapacity(), cmd_flags))
         {
             if (RoR::App::mp_state.GetActive() == RoR::MpState::CONNECTED)
             {

--- a/source/main/gui/panels/GUI_GameChatBox.h
+++ b/source/main/gui/panels/GUI_GameChatBox.h
@@ -54,6 +54,7 @@ private:
     bool                      m_kb_focused = false;
     Str<400>                  m_msg_buffer;
     ConsoleView               m_console_view;
+    bool                      initialized = true;
 };
 
 } // namespace GUI


### PR DESCRIPTION
- Added notices/chat/warning icons
Logic already used in `GUI_MultiplayerClientList`, but here uses filters to fetch and draw icons.
Icons draw only for default enabled chat filters (notices/chat/warnings) and disabled in console, so we don't hurt performance.
![kkkk](https://user-images.githubusercontent.com/2660424/76762427-f36ebf00-6799-11ea-9bf3-b9b722ef1185.png)

- Added a nice initial message when you load a terrain for first time
![kk](https://user-images.githubusercontent.com/2660424/76746928-f5785400-6780-11ea-881f-876c9010edcb.png)

- Removed chat filtering options: It was available only in multiplayer and enabling extra filters causes too much spam unlike in console where they make total sense. Currently default enabled filters are all we need.

![kk](https://user-images.githubusercontent.com/2660424/76747409-c0203600-6781-11ea-9a25-b5392f909ecb.png)

- Reduced max chat/notification lines to 15

- Added an extra space between chat message input box and messages draw area to prevent overlapping when messages go to full bottom
