### PR TITLE
Enhanced console auto scrolling

### DIFF
--- a/source/main/gui/panels/GUI_ConsoleWindow.cpp
+++ b/source/main/gui/panels/GUI_ConsoleWindow.cpp
@@ -60,7 +60,7 @@ void GUI::ConsoleWindow::Draw()
 
     this->DrawConsoleMessages();
 
-    if (initialized == false) // Keep auto scrolling until we change scrollbar position
+    if (initialized == false) // Initialize auto scrolling
     {
         ImGui::SetScrollFromPosY(9999); // Force to bottom
         if (m_autoscroll_pos > 0.1f)

--- a/source/main/gui/panels/GUI_ConsoleWindow.cpp
+++ b/source/main/gui/panels/GUI_ConsoleWindow.cpp
@@ -60,11 +60,25 @@ void GUI::ConsoleWindow::Draw()
 
     this->DrawConsoleMessages();
 
+    if (initialized == false) // Keep auto scrolling until we change scrollbar position
+    {
+        ImGui::SetScrollFromPosY(9999); // Force to bottom
+        if (m_autoscroll_pos > 0.1f)
+        {
+            initialized = true;
+        }
+    }
+
     if (this->GetNewestMsgTime() > m_autoscroll_time) // New message arrived?
     {
         m_autoscroll_time = this->GetNewestMsgTime();
-        ImGui::SetScrollFromPosY(9999); // Force to bottom
+        if (m_autoscroll_pos >= 1.f) // Only autoscroll if previous position is rougly at bottom (imgui yields ~1.15 at full bottom)
+        {
+            ImGui::SetScrollFromPosY(9999); // Force to bottom
+        }
     }
+
+    m_autoscroll_pos = ImGui::GetScrollY() / ImGui::GetScrollMaxY();
 
     ImGui::EndChild();
     ImGui::Separator();

--- a/source/main/gui/panels/GUI_ConsoleWindow.h
+++ b/source/main/gui/panels/GUI_ConsoleWindow.h
@@ -57,6 +57,7 @@ private:
     bool                     m_is_visible = false;
     unsigned long            m_autoscroll_time = 0;
     float                    m_autoscroll_pos = 0.f;
+    bool                     initialized = false;
 };
 
 } // namespace GUI


### PR DESCRIPTION
Keep auto scrolling until we change scrollbar position (so we can see older messages undistracted), then continue auto scrolling when we move scrollbar at full bottom.

Restores @only-a-ptr original code, with some improvements:
In original code you had to move scrollbar at full bottom once to start auto scrolling. Now it happens automagically.
