### PR TITLE
Fixed icon deformation

### DIFF
--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -245,7 +245,7 @@ bool GUI::ConsoleView::DrawIcon(Ogre::TexturePtr tex, ImVec2 reference_box)
         ImGui::SetCursorPosX(10.f); // Give some room for icon
         if (tex)
         {
-            ImGui::Image(reinterpret_cast<ImTextureID>(tex->getHandle()), ImVec2(tex->getWidth(), tex->getHeight()));
+            ImGui::Image(reinterpret_cast<ImTextureID>(tex->getHandle()), ImVec2(16, 16));
         }
         ImGui::SameLine(); // Keep icon and text in the same line
     }

--- a/source/main/gui/panels/GUI_MultiplayerClientList.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerClientList.cpp
@@ -225,7 +225,7 @@ bool MpClientList::DrawIcon(Ogre::TexturePtr tex, ImVec2 reference_box)
    // TODO: moving the cursor somehow deforms the image
    //     ImGui::SetCursorPosX(orig_pos.x + (reference_box.x - tex->getWidth()) / 2.f);
    //     ImGui::SetCursorPosY(orig_pos.y + (reference_box.y - tex->getHeight()) / 2.f);
-        ImGui::Image(reinterpret_cast<ImTextureID>(tex->getHandle()), ImVec2(tex->getWidth(), tex->getHeight()));
+        ImGui::Image(reinterpret_cast<ImTextureID>(tex->getHandle()), ImVec2(16, 16));
         hovered = ImGui::IsItemHovered();
     }
     ImGui::SetCursorPosX(orig_pos.x + reference_box.x + ImGui::GetStyle().ItemSpacing.x);


### PR DESCRIPTION
Fixes issue where icons in chat/notifications and client list got deformed/oversized:

![kk](https://user-images.githubusercontent.com/2660424/77361325-c0a76680-6d57-11ea-8497-bb91c3fa0cdf.png)

![kk](https://user-images.githubusercontent.com/2660424/77361444-f4828c00-6d57-11ea-8bcb-8e3678cdfc60.png)


Apparently we need to set size manually.