### PR TITLE
Fixed races stoppage logic

### DIFF
--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -330,8 +330,9 @@ int GameScript::GetPlayerActorId()
 
 void GameScript::registerForEvent(int eventValue)
 {
+    eventValue = -1;
+
     if (mse)
-        mse->eventMask = -1;
         mse->eventMask += eventValue;
 }
 

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -330,7 +330,7 @@ int GameScript::GetPlayerActorId()
 
 void GameScript::registerForEvent(int eventValue)
 {
-    eventValue = -1;
+    mse->eventMask = -1;
 
     if (mse)
         mse->eventMask += eventValue;

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -331,6 +331,7 @@ int GameScript::GetPlayerActorId()
 void GameScript::registerForEvent(int eventValue)
 {
     if (mse)
+        mse->eventMask = -1;
         mse->eventMask += eventValue;
 }
 


### PR DESCRIPTION
it seems ` mse->eventMask` needs reset everytime races are loaded
