### PR TITLE
[WIP] Implemented chat history

### DIFF
--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -83,9 +83,13 @@ void GUI::ConsoleView::DrawConsoleMessages()
         {
             DrawIcon(Ogre::static_pointer_cast<Ogre::Texture>(Ogre::TextureManager::getSingleton().createOrRetrieve("error.png", "IconsRG").first));
         }
-        else if (dm->cm_type == Console::CONSOLE_SYSTEM_NETCHAT)
+        else if ((dm->cm_type == Console::CONSOLE_SYSTEM_NETCHAT) && (!App::GetGuiManager()->IsVisible_ChatBox()))
         {
             DrawIcon(Ogre::static_pointer_cast<Ogre::Texture>(Ogre::TextureManager::getSingleton().createOrRetrieve("comment.png", "IconsRG").first));
+        }
+        else if ((dm->cm_type == Console::CONSOLE_SYSTEM_NETCHAT) && (App::GetGuiManager()->IsVisible_ChatBox()))
+        {
+            DrawIcon(Ogre::static_pointer_cast<Ogre::Texture>(Ogre::TextureManager::getSingleton().createOrRetrieve("comment_add.png", "IconsRG").first));
         }
 
         std::string line = dm->cm_text;

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -34,7 +34,6 @@ RoR::GUI::GameChatBox::GameChatBox()
 {
     m_console_view.cvw_align_bottom = true;
     m_console_view.cvw_max_lines = 15u;
-    m_console_view.cvw_filter_duration_ms = 10000; // 10sec
     m_console_view.cvw_filter_area_actor = false; // Disable vehicle spawn warnings/errors
     m_console_view.cvw_filter_type_error = false; // Disable errors
     m_console_view.cvw_filter_type_cmd = false; // Disable commands
@@ -43,7 +42,7 @@ RoR::GUI::GameChatBox::GameChatBox()
 void RoR::GUI::GameChatBox::Draw()
 {
     // Begin drawing the messages pane (no input)
-    ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoInputs |
+    ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
     ImVec2 size(
         ImGui::GetIO().DisplaySize.x - (2 * ImGui::GetStyle().WindowPadding.x),
@@ -55,7 +54,7 @@ void RoR::GUI::GameChatBox::Draw()
     ImGui::SetNextWindowSize(size);
     if (m_is_visible) // Full display?
     {
-        size.y +=  35;
+        size.y +=  55;
     }
     ImGui::SetNextWindowPos(ImVec2(0, ImGui::GetIO().DisplaySize.y - size.y));
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0,0,0,0)); // Fully transparent background!
@@ -68,8 +67,29 @@ void RoR::GUI::GameChatBox::Draw()
         initialized = false;
     }
 
+    if (m_is_visible)
+    {
+        m_console_view.cvw_filter_duration_ms = 3600000; // 1hour
+        m_console_view.cvw_filter_type_notice = false;
+        m_console_view.cvw_filter_type_warning = false; 
+        m_console_view.cvw_filter_area_script = false; 
+        if (init_scroll == false) // Initialize auto scrolling
+        {
+            ImGui::SetScrollFromPosY(9999); // Force to bottom
+            init_scroll = true;
+        }
+    }
+    else
+    {
+        m_console_view.cvw_filter_type_notice = true;
+        m_console_view.cvw_filter_type_warning = true; 
+        m_console_view.cvw_filter_area_script = true; 
+        init_scroll = false;
+        m_console_view.cvw_filter_duration_ms = 10000; // 10sec
+        ImGui::SetScrollFromPosY(9999); // Force to bottom
+    }
+
     m_console_view.DrawConsoleMessages();
-    ImGui::SetScrollFromPosY(9999); // Force to bottom
 
     ImGui::End();
 
@@ -78,7 +98,7 @@ void RoR::GUI::GameChatBox::Draw()
         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
     ImVec2 bbar_size(
         ImGui::GetIO().DisplaySize.x - (2 * ImGui::GetStyle().WindowPadding.x),
-        ImGui::GetTextLineHeightWithSpacing() + (2 * ImGui::GetStyle().WindowPadding.x));
+        ImGui::GetTextLineHeightWithSpacing() + (4 * ImGui::GetStyle().WindowPadding.x));
     ImGui::SetNextWindowSize(bbar_size);
     ImGui::SetNextWindowPos(ImVec2(0, ImGui::GetIO().DisplaySize.y - bbar_size.y));
     ImGui::Begin("ChatBottomBar", nullptr, bbar_flags);
@@ -90,6 +110,7 @@ void RoR::GUI::GameChatBox::Draw()
 
     if (m_is_visible) // Full display?
     {
+        ImGui::Text(_L("Chat history (use mouse wheel to scroll)"));
         ImGui::Text(_L("Message"));
         ImGui::SameLine();
         if (!m_kb_focused)

--- a/source/main/gui/panels/GUI_GameChatBox.h
+++ b/source/main/gui/panels/GUI_GameChatBox.h
@@ -55,6 +55,7 @@ private:
     Str<400>                  m_msg_buffer;
     ConsoleView               m_console_view;
     bool                      initialized = true;
+    bool                      init_scroll = false;
 };
 
 } // namespace GUI


### PR DESCRIPTION
By pressing `Y` now you can see and scroll through chat messages. It shows only chat messages for a cleaner output, different icon also.

Normal chat/notifications
![kk](https://user-images.githubusercontent.com/2660424/77929249-1af17b80-72b2-11ea-8ade-64afe06fe2d8.png)
Pressing `Y` 
![kkk](https://user-images.githubusercontent.com/2660424/77929283-25137a00-72b2-11ea-8c22-046c060f7ffa.png)

For this to work as it should [this](https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/system/Console.cpp#L112) must not happen. But if is not, the console window will cause fps drop when visible with many lines (mostly spawner errors/warnings)

@only-a-ptr must do this https://github.com/RigsOfRods/rigs-of-rods/pull/2488#issuecomment-594464050 before this can be merged