### PR TITLE
Added setting to toggle keyboard hydro speed coupling

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -153,6 +153,7 @@ static TerrainManager*  g_sim_terrain;
  GVarPod_A<float>             io_ffb_stress_gain  ("io_ffb_stress_gain",      "Force Feedback Stress",     0.f);
  GVarEnum_AP<IoInputGrabMode> io_input_grab_mode  ("io_input_grab_mode",      "Input Grab",                IoInputGrabMode::ALL,   IoInputGrabMode::ALL);
  GVarPod_A<bool>              io_arcade_controls  ("io_arcade_controls",      "ArcadeControls",            false);
+ GVarPod_A<bool>              io_hydro_coupling  ("io_hydro_coupling",        "Keyboard Steering Speed Coupling",            true);
  GVarPod_A<int>           io_outgauge_mode        ("io_outgauge_mode",        "OutGauge Mode",             0); // 0 = disabled, 1 = enabled
  GVarStr_A<50>            io_outgauge_ip          ("io_outgauge_ip",          "OutGauge IP",               "192.168.1.100");
  GVarPod_A<int>           io_outgauge_port        ("io_outgauge_port",        "OutGauge Port",             1337);

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -748,6 +748,7 @@ extern GVarPod_A<float>        io_ffb_master_gain;
 extern GVarPod_A<float>             io_ffb_stress_gain;
 extern GVarEnum_AP<IoInputGrabMode> io_input_grab_mode;
 extern GVarPod_A<bool>              io_arcade_controls;
+extern GVarPod_A<bool>              io_hydro_coupling;
 extern GVarPod_A<int>          io_outgauge_mode;
 extern GVarStr_A<50>           io_outgauge_ip;
 extern GVarPod_A<int>          io_outgauge_port;

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -435,6 +435,12 @@ void RoR::GUI::TopMenubar::Update()
                 }
             }       
 #endif // USE_CAELUM
+            if (current_actor != nullptr)
+            {
+                ImGui::Separator();
+                ImGui::TextColored(GRAY_HINT_TEXT, "Vehicle control options:");
+                DrawGCheckbox(App::io_hydro_coupling, "Keyboard steering speed coupling");
+            }
             if (App::mp_state.GetActive() == MpState::CONNECTED)
             {
                 ImGui::Separator();

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -559,12 +559,23 @@ void Actor::CalcHydros()
         {
             if (ar_hydro_dir_command != 0)
             {
-                // minimum rate: 20% --> enables to steer high velocity vehicles
-                float rate = std::max(1.2f, 30.0f / (10.0f + std::abs(ar_wheel_speed / 2.0f)));
-                if (ar_hydro_dir_state > ar_hydro_dir_command)
-                    ar_hydro_dir_state -= PHYSICS_DT * rate;
+                if (!App::io_hydro_coupling.GetActive())
+                {
+                    float rate = std::max(1.2f, 30.0f / (10.0f));
+                    if (ar_hydro_dir_state > ar_hydro_dir_command)
+                        ar_hydro_dir_state -= PHYSICS_DT * rate;
+                    else
+                        ar_hydro_dir_state += PHYSICS_DT * rate;
+                }
                 else
-                    ar_hydro_dir_state += PHYSICS_DT * rate;
+                {
+                    // minimum rate: 20% --> enables to steer high velocity vehicles
+                    float rate = std::max(1.2f, 30.0f / (10.0f + std::abs(ar_wheel_speed / 2.0f)));
+                    if (ar_hydro_dir_state > ar_hydro_dir_command)
+                        ar_hydro_dir_state -= PHYSICS_DT * rate;
+                    else
+                        ar_hydro_dir_state += PHYSICS_DT * rate;
+                }
             }
             float dirdelta = PHYSICS_DT;
             if (ar_hydro_dir_state > dirdelta)

--- a/source/main/utils/Settings.cpp
+++ b/source/main/utils/Settings.cpp
@@ -550,6 +550,7 @@ bool Settings::ParseGlobalVarSetting(std::string const & k, std::string const & 
     if (CheckFloat(App::io_ffb_master_gain,        k, v)) { return true; }
     if (CheckFloat(App::io_ffb_stress_gain,        k, v)) { return true; }
     if (CheckBool (App::io_arcade_controls,        k, v)) { return true; }
+    if (CheckBool (App::io_hydro_coupling,        k, v)) { return true; }
     if (CheckInt  (App::io_outgauge_mode,          k, v)) { return true; }
     if (CheckStr  (App::io_outgauge_ip,            k, v)) { return true; }
     if (CheckInt  (App::io_outgauge_port,          k, v)) { return true; }
@@ -831,6 +832,7 @@ void Settings::SaveSettings()
     WritePod (f, App::io_ffb_master_gain);
     WritePod (f, App::io_ffb_stress_gain);
     WriteYN  (f, App::io_arcade_controls);
+    WriteYN  (f, App::io_hydro_coupling);
     WritePod (f, App::io_outgauge_mode);
     WriteStr (f, App::io_outgauge_ip);
     WritePod (f, App::io_outgauge_port);


### PR DESCRIPTION
Currently, steering on keyboard slows down when a vehicle is traveling at high speed. This adds the ability to toggle that limitation through the dropdown Settings menu, enabled by default for backwards compatibility.  Making it much easier for keyboard players to drift or race high-downforce vehicles like the MeanMachine. 

When disabled, hydros will always move at a constant rate, regardless of wheel speed.
 
Video demos:
https://streamable.com/5pd58t
https://streamable.com/9wpwhz