### PR TITLE
Updated input maps

### DIFF
--- a/resources/skeleton/config/Bluetooth_XINPUT_compatible_input_device.map
+++ b/resources/skeleton/config/Bluetooth_XINPUT_compatible_input_device.map
@@ -1,0 +1,88 @@
+; -------------------------------------------
+; Xbox Controller (Bluetooth) Input Map
+; Created by CuriousMike
+; Version 1.3
+
+;Buttons:
+;A: Button 0
+;B: Button 1
+;X: Button 2
+;Y: Button 3
+;Left bumper: Button 4
+;Right bumper: Button 5
+;View: Button 6
+;Menu: Button 7
+;Left stick button: Button 8
+;Right stick button: Button 9
+
+;Axes:
+;Left Stick (Left/Right): Axis 1
+;Left Stick (Up/Down): Axis 0
+;Right Stick (Left/Right): Axis 3
+;Right Stick (Up/Down): Axis 2
+;Left/Right Trigger: Axis 4
+; -------------------------------------------
+
+
+
+
+; AIRPLANE
+AIRPLANE_ELEVATOR_DOWN         JoystickAxis         0 0 UPPER 
+AIRPLANE_ELEVATOR_UP           JoystickAxis         0 0 LOWER 
+AIRPLANE_PARKING_BRAKE         JoystickButton       0 5 
+AIRPLANE_REVERSE               JoystickButton       0 4 
+AIRPLANE_RUDDER_LEFT           JoystickAxis         0 4 UPPER 
+AIRPLANE_RUDDER_RIGHT          JoystickAxis         0 4 LOWER 
+AIRPLANE_STEER_LEFT            JoystickAxis         0 1 LOWER+DEADZONE=0.15 
+AIRPLANE_STEER_RIGHT           JoystickAxis         0 1 UPPER+DEADZONE=0.15 
+AIRPLANE_THROTTLE_AXIS         None                 
+AIRPLANE_THROTTLE_UP           JoystickPov          0 0 North
+AIRPLANE_THROTTLE_FULL         JoystickButton       0 2
+AIRPLANE_THROTTLE_NO           JoystickButton       0 1
+AIRPLANE_THROTTLE_DOWN         JoystickPov          0 0 South
+AIRPLANE_TOGGLE_ENGINES        JoystickButton       0 0 
+
+
+; BOAT
+BOAT_STEER_LEFT               JoystickAxis         0 1 LOWER+DEADZONE=0.25 
+BOAT_STEER_RIGHT              JoystickAxis         0 1 UPPER+DEADZONE=0.25 
+BOAT_THROTTLE_UP 			  JoystickAxis         0 4 LOWER
+BOAT_THROTTLE_DOWN 			  JoystickAxis         0 4 UPPER
+BOAT_REVERSE                  JoystickButton       0 1
+BOAT_CENTER_RUDDER            JoystickButton       0 2
+
+; CAMERA
+CAMERA_CHANGE                  JoystickButton       0 6 
+CAMERA_ROTATE_DOWN             JoystickAxis         0 2 UPPER 
+CAMERA_ROTATE_UP               JoystickAxis         0 2 LOWER 
+CAMERA_ROTATE_LEFT             JoystickAxis         0 3 LOWER 
+CAMERA_ROTATE_RIGHT            JoystickAxis         0 3 UPPER 
+
+; CHARACTER
+CHARACTER_BACKWARDS            JoystickAxis         0 0 UPPER 
+CHARACTER_FORWARD              JoystickAxis         0 0 LOWER 
+CHARACTER_JUMP                 JoystickButton       0 2 
+CHARACTER_LEFT                 JoystickAxis         0 1 LOWER 
+CHARACTER_RIGHT                JoystickAxis         0 1 UPPER 
+CHARACTER_RUN                  JoystickButton       0 0 
+
+; COMMON
+COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
+COMMON_LOCK                    JoystickPov          0 0 East
+COMMON_QUIT_GAME               JoystickButton       0 7 
+COMMON_TOGGLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+
+; TRUCK
+TRUCK_ACCELERATE               JoystickAxis         0 4 LOWER
+TRUCK_AUTOSHIFT_UP             JoystickPov          0 0 North 
+TRUCK_AUTOSHIFT_DOWN           JoystickPov          0 0 South
+TRUCK_BRAKE                    JoystickAxis         0 4 UPPER 
+TRUCK_HORN                     JoystickButton       0 8 
+TRUCK_PARKING_BRAKE            JoystickButton       0 5 
+TRUCK_SHIFT_DOWN               JoystickButton       0 1 
+TRUCK_SHIFT_UP                 JoystickButton       0 2 
+TRUCK_MANUAL_CLUTCH			   JoystickButton       0 4
+TRUCK_STARTER                  JoystickButton       0 0 
+TRUCK_STEER_LEFT               JoystickAxis         0 1 LOWER+DEADZONE=0.25 
+TRUCK_STEER_RIGHT              JoystickAxis         0 1 UPPER+DEADZONE=0.25 
+TRUCK_TOGGLE_CONTACT           JoystickButton       0 9 

--- a/resources/skeleton/config/Logitech_Formula_Force_EX_USB.map
+++ b/resources/skeleton/config/Logitech_Formula_Force_EX_USB.map
@@ -30,4 +30,4 @@ TRUCK_STEER_LEFT               JoystickAxis         0 0 LOWER+DEADZONE=0.00
 TRUCK_STEER_RIGHT              JoystickAxis         0 0 UPPER+DEADZONE=0.00 
 TRUCK_SWITCH_SHIFT_MODES       JoystickButton       0 2 
 TRUCK_TOGGLE_CONTACT           JoystickButton       0 9 
-TRUCK_TOGGLE_AXLE_LOCK         JoystickButton       0 6 
+TRUCK_TOGGLE_INTER_WHEEL_DIFF         JoystickButton       0 6 

--- a/resources/skeleton/config/Logitech_G27_Racing_Wheel_USB.map
+++ b/resources/skeleton/config/Logitech_G27_Racing_Wheel_USB.map
@@ -55,4 +55,4 @@ TRUCK_STEER_LEFT               JoystickAxis         0 0 LOWER+DEADZONE=0.00+LINE
 TRUCK_STEER_RIGHT              JoystickAxis         0 0 UPPER+DEADZONE=0.00+LINEARITY=0.70 
 TRUCK_SWITCH_SHIFT_MODES       JoystickButton       0 3 
 TRUCK_TOGGLE_CONTACT           JoystickButton       0 22 
-TRUCK_TOGGLE_AXLE_LOCK         JoystickButton       0 2 
+TRUCK_TOGGLE_INTER_WHEEL_DIFF         JoystickButton       0 2 

--- a/resources/skeleton/config/Logitech_G29_Driving_Force_Racing_Wheel_USB.map
+++ b/resources/skeleton/config/Logitech_G29_Driving_Force_Racing_Wheel_USB.map
@@ -43,6 +43,8 @@ TRUCK_BRAKE                    JoystickAxis         0 1 REVERSE+DEADZONE=0.00
 TRUCK_HORN                     JoystickButton       0 23 
 TRUCK_MANUAL_CLUTCH            JoystickSliderX      0 X 0 REVERSE 
 TRUCK_PARKING_BRAKE            JoystickButton       0 3 
+TRUCK_SHIFT_DOWN               JoystickButton       0 5 
+TRUCK_SHIFT_UP                 JoystickButton       0 4 
 TRUCK_SHIFT_GEAR_REVERSE       JoystickButton       0 18 
 TRUCK_SHIFT_GEAR1              JoystickButton       0 12 
 TRUCK_SHIFT_GEAR2              JoystickButton       0 13 
@@ -58,7 +60,7 @@ TRUCK_STEER_LEFT               JoystickAxis         0 0 LOWER+DEADZONE=0.00
 TRUCK_STEER_RIGHT              JoystickAxis         0 0 UPPER+DEADZONE=0.00 
 TRUCK_SWITCH_SHIFT_MODES       JoystickPov          0 0 East
 TRUCK_TOGGLE_CONTACT           JoystickButton       0 1 
-TRUCK_TOGGLE_AXLE_LOCK         JoystickButton       0 2 
+TRUCK_TOGGLE_INTER_WHEEL_DIFF  JoystickButton       0 2 
 TRUCK_TOGGLE_INTER_AXLE_DIFF   JoystickButton       0 8 
 TRUCK_TOGGLE_TCASE_4WD_MODE    JoystickButton       0 19 
 TRUCK_TOGGLE_TCASE_GEAR_RATIO  JoystickButton       0 20 

--- a/resources/skeleton/config/Logitech_G29_Driving_Force_Racing_Wheel_USB.txt
+++ b/resources/skeleton/config/Logitech_G29_Driving_Force_Racing_Wheel_USB.txt
@@ -1,5 +1,6 @@
 This is an input map for the Logitech G29 Driving Force Racing Wheel USB
 Created by Charger, May 2019
+Last updated: April 5, 2020
 
 Control overview:
 

--- a/resources/skeleton/config/RGT_Force_Feedback_Pro.map
+++ b/resources/skeleton/config/RGT_Force_Feedback_Pro.map
@@ -33,7 +33,7 @@ TRUCK_SHIFT_UP                 JoystickButton       0 1
 TRUCK_TOGGLE_CONTACT           JoystickButton       0 2
 TRUCK_BLINK_LEFT               JoystickButton       0 3
 TRUCK_BLINK_RIGHT              JoystickButton       0 4
-TRUCK_TOGGLE_AXLE_LOCK         JoystickButton       0 5
+TRUCK_TOGGLE_INTER_WHEEL_DIFF         JoystickButton       0 5
 TRUCK_SHIFT_NEUTRAL            JoystickButton       0 6
 TRUCK_PARKING_BRAKE            JoystickButton       0 7
 

--- a/resources/skeleton/config/Wireless_Controller.map
+++ b/resources/skeleton/config/Wireless_Controller.map
@@ -1,0 +1,88 @@
+; -------------------------------------------
+; PlayStation 4 (experimental) Controller Input Map
+; Created by CuriousMike
+; Version 1.3
+
+;Buttons:
+;A: Button 0
+;B: Button 1
+;X: Button 2
+;Y: Button 3
+;Left bumper: Button 4
+;Right bumper: Button 5
+;View: Button 6
+;Menu: Button 7
+;Left stick button: Button 8
+;Right stick button: Button 9
+
+;Axes:
+;Left Stick (Left/Right): Axis 1
+;Left Stick (Up/Down): Axis 0
+;Right Stick (Left/Right): Axis 3
+;Right Stick (Up/Down): Axis 2
+;Left/Right Trigger: Axis 4
+; -------------------------------------------
+
+
+
+
+; AIRPLANE
+AIRPLANE_ELEVATOR_DOWN         JoystickAxis         0 0 UPPER 
+AIRPLANE_ELEVATOR_UP           JoystickAxis         0 0 LOWER 
+AIRPLANE_PARKING_BRAKE         JoystickButton       0 5 
+AIRPLANE_REVERSE               JoystickButton       0 4 
+AIRPLANE_RUDDER_LEFT           JoystickAxis         0 4 UPPER 
+AIRPLANE_RUDDER_RIGHT          JoystickAxis         0 4 LOWER 
+AIRPLANE_STEER_LEFT            JoystickAxis         0 1 LOWER+DEADZONE=0.15 
+AIRPLANE_STEER_RIGHT           JoystickAxis         0 1 UPPER+DEADZONE=0.15 
+AIRPLANE_THROTTLE_AXIS         None                 
+AIRPLANE_THROTTLE_UP           JoystickPov          0 0 North
+AIRPLANE_THROTTLE_FULL         JoystickButton       0 2
+AIRPLANE_THROTTLE_NO           JoystickButton       0 1
+AIRPLANE_THROTTLE_DOWN         JoystickPov          0 0 South
+AIRPLANE_TOGGLE_ENGINES        JoystickButton       0 0 
+
+
+; BOAT
+BOAT_STEER_LEFT               JoystickAxis         0 1 LOWER+DEADZONE=0.25 
+BOAT_STEER_RIGHT              JoystickAxis         0 1 UPPER+DEADZONE=0.25 
+BOAT_THROTTLE_UP 			  JoystickAxis         0 4 LOWER
+BOAT_THROTTLE_DOWN 			  JoystickAxis         0 4 UPPER
+BOAT_REVERSE                  JoystickButton       0 1
+BOAT_CENTER_RUDDER            JoystickButton       0 2
+
+; CAMERA
+CAMERA_CHANGE                  JoystickButton       0 6 
+CAMERA_ROTATE_DOWN             JoystickAxis         0 2 UPPER 
+CAMERA_ROTATE_UP               JoystickAxis         0 2 LOWER 
+CAMERA_ROTATE_LEFT             JoystickAxis         0 3 LOWER 
+CAMERA_ROTATE_RIGHT            JoystickAxis         0 3 UPPER 
+
+; CHARACTER
+CHARACTER_BACKWARDS            JoystickAxis         0 0 UPPER 
+CHARACTER_FORWARD              JoystickAxis         0 0 LOWER 
+CHARACTER_JUMP                 JoystickButton       0 2 
+CHARACTER_LEFT                 JoystickAxis         0 1 LOWER 
+CHARACTER_RIGHT                JoystickAxis         0 1 UPPER 
+CHARACTER_RUN                  JoystickButton       0 0 
+
+; COMMON
+COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
+COMMON_LOCK                    JoystickPov          0 0 East
+COMMON_QUIT_GAME               JoystickButton       0 7 
+COMMON_TOGGLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+
+; TRUCK
+TRUCK_ACCELERATE               JoystickAxis         0 4 LOWER
+TRUCK_AUTOSHIFT_UP             JoystickPov          0 0 North 
+TRUCK_AUTOSHIFT_DOWN           JoystickPov          0 0 South
+TRUCK_BRAKE                    JoystickAxis         0 4 UPPER 
+TRUCK_HORN                     JoystickButton       0 8 
+TRUCK_PARKING_BRAKE            JoystickButton       0 5 
+TRUCK_SHIFT_DOWN               JoystickButton       0 1 
+TRUCK_SHIFT_UP                 JoystickButton       0 2 
+TRUCK_MANUAL_CLUTCH			   JoystickButton       0 4
+TRUCK_STARTER                  JoystickButton       0 0 
+TRUCK_STEER_LEFT               JoystickAxis         0 1 LOWER+DEADZONE=0.25 
+TRUCK_STEER_RIGHT              JoystickAxis         0 1 UPPER+DEADZONE=0.25 
+TRUCK_TOGGLE_CONTACT           JoystickButton       0 9 


### PR DESCRIPTION
- Updated Xbox and G29 input maps to latest version from https://forum.rigsofrods.org/resources/xbox-one-360-ps4-controller-input-map.146/ and https://forum.rigsofrods.org/resources/logitech-g29-input-map.516/
- Added wireless PS4 controller input map
- Fixed differential lock event name