### PR TITLE
Added remove button to Vehicles menu

### DIFF
--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -719,6 +719,16 @@ void RoR::GUI::TopMenubar::DrawActorListSinglePlayer()
         int x = 0;
         for (auto actor : actor_list)
         {
+            char text_buf_rem[200];
+            snprintf(text_buf_rem, 200, "X" "##[%d]", x++);
+            ImGui::PushStyleColor(ImGuiCol_Text, RED_TEXT);
+            if (ImGui::Button(text_buf_rem))
+            {
+                App::GetSimController()->QueueActorRemove(actor);
+            }
+            ImGui::PopStyleColor();
+            ImGui::SameLine();
+
             char text_buf[200];
             snprintf(text_buf, 200, "[%d] %s", i++, actor->ar_design_name.c_str());
             auto linked_actors = actor->GetAllLinkedActors();
@@ -738,13 +748,6 @@ void RoR::GUI::TopMenubar::DrawActorListSinglePlayer()
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, GRAY_HINT_TEXT);
             }
-            char text_buf_rem[200];
-            snprintf(text_buf_rem, 200, "X" "##[%d]", x++);
-            if (ImGui::Button(text_buf_rem))
-            {
-                App::GetSimController()->QueueActorRemove(actor);
-            }
-            ImGui::SameLine();
             if (ImGui::Button(text_buf)) // Button clicked?
             {
                 App::GetSimController()->SetPendingPlayerActor(actor);

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -716,11 +716,10 @@ void RoR::GUI::TopMenubar::DrawActorListSinglePlayer()
     {
         Actor* player_actor = App::GetSimController()->GetPlayerActor();
         int i = 0;
-        int x = 0;
         for (auto actor : actor_list)
         {
             char text_buf_rem[200];
-            snprintf(text_buf_rem, 200, "X" "##[%d]", x++);
+            snprintf(text_buf_rem, 200, "X" "##[%d]", i);
             ImGui::PushStyleColor(ImGuiCol_Text, RED_TEXT);
             if (ImGui::Button(text_buf_rem))
             {

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -716,6 +716,7 @@ void RoR::GUI::TopMenubar::DrawActorListSinglePlayer()
     {
         Actor* player_actor = App::GetSimController()->GetPlayerActor();
         int i = 0;
+        int x = 0;
         for (auto actor : actor_list)
         {
             char text_buf[200];
@@ -738,7 +739,7 @@ void RoR::GUI::TopMenubar::DrawActorListSinglePlayer()
                 ImGui::PushStyleColor(ImGuiCol_Text, GRAY_HINT_TEXT);
             }
             char text_buf_rem[200];
-            snprintf(text_buf_rem, 200, "X" "##[%d]", i++);
+            snprintf(text_buf_rem, 200, "X" "##[%d]", x++);
             if (ImGui::Button(text_buf_rem))
             {
                 App::GetSimController()->QueueActorRemove(actor);

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -737,6 +737,13 @@ void RoR::GUI::TopMenubar::DrawActorListSinglePlayer()
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, GRAY_HINT_TEXT);
             }
+            char text_buf_rem[200];
+            snprintf(text_buf_rem, 200, "X" "##[%d]", i++);
+            if (ImGui::Button(text_buf_rem))
+            {
+                App::GetSimController()->QueueActorRemove(actor);
+            }
+            ImGui::SameLine();
             if (ImGui::Button(text_buf)) // Button clicked?
             {
                 App::GetSimController()->SetPendingPlayerActor(actor);

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -41,6 +41,7 @@ public:
     const ImVec4  WHITE_TEXT            = ImVec4(0.9f, 0.9f, 0.9f, 1.f);
     const ImVec4  GREEN_TEXT            = ImVec4(0.0f, 0.9f, 0.0f, 1.f);
     const ImVec4  ORANGE_TEXT           = ImVec4(0.9f, 0.6f, 0.0f, 1.f);
+    const ImVec4  RED_TEXT              = ImVec4(1.00f, 0.00f, 0.00f, 1.f);
 
     enum class TopMenu { TOPMENU_NONE, TOPMENU_SIM, TOPMENU_ACTORS, TOPMENU_SAVEGAMES, TOPMENU_SETTINGS, TOPMENU_TOOLS };
 


### PR DESCRIPTION
In single player you can now remove individual actors via the vehicles menu by clicking the X button

![kkk](https://user-images.githubusercontent.com/2660424/79248042-000f3180-7e84-11ea-94b2-196f7334450f.png)

fixes https://github.com/RigsOfRods/rigs-of-rods/issues/1616