### PR TITLE
Chat history and fixes

### DIFF
--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -62,7 +62,7 @@ void GUI::ConsoleView::DrawConsoleMessages()
     {
         // Draw from bottom, messages may be multiline
         ImVec2 cursor = ImGui::GetWindowPos() + ImVec2(0, ImGui::GetWindowHeight());
-        for (int i = m_display_messages.size() - 1; i > 0; --i)
+        for (int i = m_display_messages.size() - 1; i >= 0; --i)
         {
             Console::Message const& m = *m_display_messages[i];
             float msg_h = ImGui::CalcTextSize(m.cm_text.c_str()).y + (2 * cvw_background_padding.y) + cvw_line_spacing;
@@ -293,20 +293,6 @@ ImVec2 GUI::ConsoleView::DrawColorMarkedText(ImVec2 bg_cursor, Ogre::TexturePtr 
     drawlist->AddRectFilled(bg_cursor, bg_cursor + bg_rect_size,
         ImColor(cvw_background_color), ImGui::GetStyle().FrameRounding);
     return bg_rect_size;
-}
-
-bool GUI::ConsoleView::DrawIcon(Ogre::TexturePtr tex)
-{
-    if (!App::GetGuiManager()->IsVisible_Console())
-    {
-        ImGui::SetCursorPosX(10.f); // Give some room for icon
-        if (tex)
-        {
-            ImGui::Image(reinterpret_cast<ImTextureID>(tex->getHandle()), ImVec2(16, 16));
-        }
-        ImGui::SameLine(); // Keep icon and text in the same line
-    }
-    return NULL;
 }
 
 int GUI::ConsoleView::UpdateMessages()

--- a/source/main/gui/panels/GUI_ConsoleView.h
+++ b/source/main/gui/panels/GUI_ConsoleView.h
@@ -41,6 +41,7 @@ struct ConsoleView
 {
     void DrawConsoleMessages();
     void DrawFilteringOptions();
+    void RequestReloadMessages() {m_reload_messages=true;}
 
     // Filtering (true means allowed)
     bool  cvw_filter_type_notice = true;

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -32,7 +32,6 @@
 
 RoR::GUI::GameChatBox::GameChatBox()
 {
-    m_console_view.cvw_msg_duration_ms = 10000; // 10sec
     m_console_view.cvw_filter_area_actor = false; // Disable vehicle spawn warnings/errors
     m_console_view.cvw_filter_type_error = false; // Disable errors
     m_console_view.cvw_filter_type_cmd = false; // Disable commands
@@ -47,7 +46,7 @@ void RoR::GUI::GameChatBox::Draw()
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0,0));
 
     // Begin drawing the messages pane (no input)
-    ImGuiWindowFlags msg_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoInputs |
+    ImGuiWindowFlags msg_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
     const float width = ImGui::GetIO().DisplaySize.x - (2 * theme.screen_edge_padding.x);
     ImVec2 msg_size(width, (ImGui::GetIO().DisplaySize.y / 3.f) + (2*ImGui::GetStyle().WindowPadding.y));
@@ -68,8 +67,35 @@ void RoR::GUI::GameChatBox::Draw()
         initialized = false;
     }
 
+    if (m_is_visible)
+    {
+        m_console_view.cvw_enable_scrolling = true;
+        m_console_view.cvw_msg_duration_ms = 3600000; // 1hour
+        m_console_view.cvw_filter_type_notice = false;
+        m_console_view.cvw_filter_type_warning = false; 
+        m_console_view.cvw_filter_area_script = false; 
+        if (init_scroll == false) // Initialize auto scrolling
+        {
+            m_console_view.RequestReloadMessages();
+            ImGui::SetScrollFromPosY(9999); // Force to bottom once
+            init_scroll = true;
+        }
+    }
+    else
+    {
+        m_console_view.cvw_enable_scrolling = false;
+        m_console_view.cvw_filter_type_notice = true;
+        m_console_view.cvw_filter_type_warning = true; 
+        m_console_view.cvw_filter_area_script = true; 
+        m_console_view.cvw_msg_duration_ms = 10000; // 10sec
+        if (init_scroll == true) // Initialize auto scrolling
+        {
+            m_console_view.RequestReloadMessages();
+            init_scroll = false;
+        }
+    }
+
     m_console_view.DrawConsoleMessages();
-    ImGui::SetScrollFromPosY(9999); // Force to bottom
 
     ImGui::End();
 

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -59,7 +59,14 @@ void RoR::GUI::GameChatBox::Draw()
     }
     ImGui::SetNextWindowPos(msg_pos);
 
-    ImGui::Begin("ChatMessages", nullptr, msg_flags);
+    if (m_is_visible)
+    {
+        ImGui::Begin("ChatMessages", nullptr, msg_flags);
+    }
+    else
+    {
+        ImGui::Begin("ChatMessages", nullptr, msg_flags | ImGuiWindowFlags_NoInputs);
+    }
 
     if (initialized == true)
     {

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -50,7 +50,7 @@ void RoR::GUI::GameChatBox::Draw()
         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
     const float width = ImGui::GetIO().DisplaySize.x - (2 * theme.screen_edge_padding.x);
     ImVec2 msg_size(width, (ImGui::GetIO().DisplaySize.y / 3.f) + (2*ImGui::GetStyle().WindowPadding.y));
-    ImVec2 chat_size(width, ImGui::GetTextLineHeightWithSpacing());
+    ImVec2 chat_size(width, ImGui::GetTextLineHeightWithSpacing() + 20);
     ImGui::SetNextWindowSize(msg_size);
     ImVec2 msg_pos(theme.screen_edge_padding.x, ImGui::GetIO().DisplaySize.y - (msg_size.y + theme.screen_edge_padding.y));
     if (m_is_visible)
@@ -115,6 +115,7 @@ void RoR::GUI::GameChatBox::Draw()
 
     if (m_is_visible) // Full display?
     {
+        ImGui::Text(_L("Chat history (use mouse wheel to scroll)"));
         ImGui::Text(_L("Message"));
         ImGui::SameLine();
         if (!m_kb_focused)

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -88,7 +88,7 @@ void RoR::GUI::GameChatBox::Draw()
         m_console_view.cvw_filter_type_warning = true; 
         m_console_view.cvw_filter_area_script = true; 
         m_console_view.cvw_msg_duration_ms = 10000; // 10sec
-        if (init_scroll == true) // Initialize auto scrolling
+        if (init_scroll == true)
         {
             m_console_view.RequestReloadMessages();
             init_scroll = false;

--- a/source/main/gui/panels/GUI_GameChatBox.h
+++ b/source/main/gui/panels/GUI_GameChatBox.h
@@ -56,6 +56,7 @@ private:
     Str<400>                  m_msg_buffer;
     ConsoleView               m_console_view;
     bool                      initialized = true;
+    bool                      init_scroll = false;
 };
 
 } // namespace GUI


### PR DESCRIPTION
- Implemented chat history
By pressing Y now you can see and scroll through chat messages. It shows only chat messages for a cleaner output.
![kk](https://user-images.githubusercontent.com/2660424/80617723-1e138f00-8a4b-11ea-83a8-1f5bda0ad114.png)

- Fixes and cleanups suggested by Petr

