### PR TITLE
Fixed EV_COMMON_FOV_LESS not working

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -486,7 +486,7 @@ void SimController::UpdateInputEvents(float dt)
 
         int modifier = 0;
         modifier = (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_FOV_LESS, 0.1f)) ? -1 : 0;
-        modifier = (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_FOV_MORE, 0.1f)) ?  1 : 0;
+        modifier += (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_FOV_MORE, 0.1f)) ?  1 : 0;
         int fov = -1;
         if (modifier != 0)
         {


### PR DESCRIPTION
from discord:

>hm. it seems the lower FOV key (numpad 7) doesn't work now
ctrl+numpad7 to increase FOV works

Seems it was a typo