### PR TITLE
Hotfix: make "resource name is empty string" non-fatal

### DIFF
--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -330,7 +330,7 @@ public:
     std::string       ar_filename;                    //!< Attribute; filled at spawn
     std::string       ar_filehash;                    //!< Attribute; filled at spawn
     int               ar_airbrake_intensity;          //!< Physics state; values 0-5
-    int               ar_net_source_id;
+    int               ar_net_source_id;               //!< Unique ID of remote player who spawned this actor
     int               ar_net_stream_id;
     std::map<int,int> ar_net_stream_results;
     Ogre::Timer       ar_net_timer;

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1071,30 +1071,34 @@ bool CacheSystem::CheckResourceLoaded(Ogre::String & filename)
 
 bool CacheSystem::CheckResourceLoaded(Ogre::String & filename, Ogre::String& group)
 {
-    // check if we already loaded it via ogre ...
-    if (ResourceGroupManager::getSingleton().resourceExistsInAnyGroup(filename))
+    try
     {
-        group = ResourceGroupManager::getSingleton().findGroupContainingResource(filename);
-        return true;
-    }
-
-    for (auto& entry : m_entries)
-    {
-        // case insensitive comparison
-        String fname = entry.fname;
-        String fname_without_uid = entry.fname_without_uid;
-        StringUtil::toLowerCase(fname);
-        StringUtil::toLowerCase(filename);
-        StringUtil::toLowerCase(fname_without_uid);
-        if (fname == filename || fname_without_uid == filename)
+        // check if we already loaded it via ogre ...
+        if (ResourceGroupManager::getSingleton().resourceExistsInAnyGroup(filename))
         {
-            // we found the file, load it
-            LoadResource(entry);
-            filename = entry.fname;
-            group = entry.resource_group;
-            return !group.empty() && ResourceGroupManager::getSingleton().resourceExists(group, filename);
+            group = ResourceGroupManager::getSingleton().findGroupContainingResource(filename);
+            return true;
+        }
+
+        for (auto& entry : m_entries)
+        {
+            // case insensitive comparison
+            String fname = entry.fname;
+            String fname_without_uid = entry.fname_without_uid;
+            StringUtil::toLowerCase(fname);
+            StringUtil::toLowerCase(filename);
+            StringUtil::toLowerCase(fname_without_uid);
+            if (fname == filename || fname_without_uid == filename)
+            {
+                // we found the file, load it
+                LoadResource(entry);
+                filename = entry.fname;
+                group = entry.resource_group;
+                return !group.empty() && ResourceGroupManager::getSingleton().resourceExists(group, filename);
+            }
         }
     }
+    catch (Ogre::Exception& oex) {} // Already logged by OGRE
 
     return false;
 }


### PR DESCRIPTION
This prevents an unhandled exception (aka "crash" because it terminates RoR) when an invalid spawn request is received in multiplayer, see #2410