### PR TITLE
Fixed pssm switching

### DIFF
--- a/source/main/gfx/ShadowManager.cpp
+++ b/source/main/gfx/ShadowManager.cpp
@@ -178,6 +178,9 @@ void ShadowManager::setManagedMaterialSplitPoints(Ogre::PSSMShadowCameraSetup::S
     for (int i = 0; i < 3; ++i)
         splitPoints[i] = splitPointList[i];
 
-    GpuSharedParametersPtr p = GpuProgramManager::getSingleton().getSharedParameters("pssm_params");
-    p->setNamedConstant("pssmSplitPoints", splitPoints);
+    if (App::gfx_shadow_type->GetActiveEnum<GfxShadowType>() == GfxShadowType::PSSM)
+    {
+        GpuSharedParametersPtr p = GpuProgramManager::getSingleton().getSharedParameters("pssm_params");
+        p->setNamedConstant("pssmSplitPoints", splitPoints);
+    }
 }

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -252,7 +252,7 @@ void RoR::GUI::GameSettings::Draw()
             "All vehicles, main lights\0"
             "All vehicles, all lights\0\0");
 
-        DrawGCombo(App::gfx_shadow_type, _LC("GameSettings", "Shadow type (requires restart)"),
+        DrawGCombo(App::gfx_shadow_type, _LC("GameSettings", "Shadow type"),
             "Disabled\0"
             "PSSM\0\0");
 


### PR DESCRIPTION
Enable/Disable pssm shadows without restarting the game. Fixes:

```
InvalidParametersException: No shared parameter set with name 'pssm_params'! in GpuProgramManager::getSharedParameters at /home/babis/Downloads/ror-dependencies/Source/ogre/OgreMain/src/OgreGpuProgramManager.cpp (line 199)
```