### PR TITLE
Fixes

### DIFF
--- a/source/main/gameplay/RecoveryMode.cpp
+++ b/source/main/gameplay/RecoveryMode.cpp
@@ -36,6 +36,13 @@ void RecoveryMode::UpdateInputEvents(float dt)
         return;
     }
 
+    if (!App::GetGameContext()->GetPlayerActor())
+    {
+        m_advanced_vehicle_repair = false;
+        m_advanced_vehicle_repair_timer = 0.0f;
+        return;
+    }
+
     if (!App::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
     {
         m_advanced_vehicle_repair_timer = 0.0f;

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -51,8 +51,7 @@
 #include <Ogre.h>
 
 RoR::GfxActor::GfxActor(Actor* actor, ActorSpawner* spawner, std::string ogre_resource_group,
-                        std::vector<NodeGfx>& gfx_nodes, std::vector<Prop>& props,
-                        int driverseat_prop_idx, RoR::Renderdash* renderdash):
+                        std::vector<NodeGfx>& gfx_nodes, RoR::Renderdash* renderdash):
     m_actor(actor),
     m_custom_resource_group(ogre_resource_group),
     m_vidcam_state(VideoCamState::VCSTATE_ENABLED_ONLINE),
@@ -60,11 +59,9 @@ RoR::GfxActor::GfxActor(Actor* actor, ActorSpawner* spawner, std::string ogre_re
     m_last_debug_view(DebugViewType::DEBUGVIEW_SKELETON),
     m_rods_parent_scenenode(nullptr),
     m_gfx_nodes(gfx_nodes),
-    m_props(props),
     m_cab_scene_node(nullptr),
     m_cab_mesh(nullptr),
     m_cab_entity(nullptr),
-    m_driverseat_prop_index(driverseat_prop_idx),
     m_renderdash(renderdash),
     m_prop_anim_crankfactor_prev(0.f),
     m_prop_anim_shift_timer(0.f),
@@ -1988,6 +1985,12 @@ void RoR::GfxActor::RegisterAirbrakes()
 
         m_gfx_airbrakes.push_back(abx);
     }
+}
+
+void RoR::GfxActor::RegisterProps(std::vector<Prop> const& props, int driverseat_prop_idx)
+{
+    m_props = props;
+    m_driverseat_prop_index = driverseat_prop_idx;
 }
 
 void RoR::GfxActor::UpdateAirbrakes()

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -182,7 +182,7 @@ public:
     };
 
     GfxActor(Actor* actor, ActorSpawner* spawner, std::string ogre_resource_group,
-        std::vector<NodeGfx>& gfx_nodes, std::vector<Prop>& props, int driverseat_prop_idx, RoR::Renderdash* renderdash);
+        std::vector<NodeGfx>& gfx_nodes, RoR::Renderdash* renderdash);
 
     ~GfxActor();
 
@@ -224,6 +224,7 @@ public:
     void                      SetFlexbodiesVisible(bool visible);
     ActorType                 GetActorDriveable  () const;
     void                      RegisterAirbrakes  ();
+    void                      RegisterProps      (std::vector<Prop> const& props, int driverseat_prop_idx);
     void                      UpdateAirbrakes    ();
     void                      UpdateCParticles   ();
     void                      UpdateAeroEngines  ();

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -217,10 +217,11 @@ void RoR::GfxScene::UpdateScene(float dt_sec)
             gfx_actor->UpdateCParticles();
             gfx_actor->UpdateAeroEngines();
             gfx_actor->UpdatePropAnimations(dt_sec, (gfx_actor == player_gfx_actor) || is_player_connected);
-            gfx_actor->UpdateFlares(dt_sec, (gfx_actor == player_gfx_actor));
         }
         // Beacon flares must always be updated
         gfx_actor->UpdateProps(dt_sec, (gfx_actor == player_gfx_actor));
+        // Blinkers (turn signals) must always be updated
+        gfx_actor->UpdateFlares(dt_sec, (gfx_actor == player_gfx_actor));
     }
     if (player_gfx_actor != nullptr)
     {

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -205,18 +205,22 @@ void RoR::GfxScene::UpdateScene(float dt_sec)
     }
 
     // Actors - update misc visuals
-    for (GfxActor* gfx_actor: m_live_gfx_actors)
+    for (GfxActor* gfx_actor: m_all_gfx_actors)
     {
         bool is_player_connected = (player_connected_gfx_actors.find(gfx_actor) != player_connected_gfx_actors.end());
-        gfx_actor->UpdateRods();
-        gfx_actor->UpdateCabMesh();
-        gfx_actor->UpdateWingMeshes();
-        gfx_actor->UpdateAirbrakes();
-        gfx_actor->UpdateCParticles();
-        gfx_actor->UpdateAeroEngines();
-        gfx_actor->UpdatePropAnimations(dt_sec, (gfx_actor == player_gfx_actor) || is_player_connected);
+        if (gfx_actor->IsActorLive())
+        {
+            gfx_actor->UpdateRods();
+            gfx_actor->UpdateCabMesh();
+            gfx_actor->UpdateWingMeshes();
+            gfx_actor->UpdateAirbrakes();
+            gfx_actor->UpdateCParticles();
+            gfx_actor->UpdateAeroEngines();
+            gfx_actor->UpdatePropAnimations(dt_sec, (gfx_actor == player_gfx_actor) || is_player_connected);
+            gfx_actor->UpdateFlares(dt_sec, (gfx_actor == player_gfx_actor));
+        }
+        // Beacon flares must always be updated
         gfx_actor->UpdateProps(dt_sec, (gfx_actor == player_gfx_actor));
-        gfx_actor->UpdateFlares(dt_sec, (gfx_actor == player_gfx_actor));
     }
     if (player_gfx_actor != nullptr)
     {

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3038,8 +3038,6 @@ void Actor::UpdateFlareStates(float dt)
 
             if (ar_left_blink_on)
                 SOUND_PLAY_ONCE(ar_instance_id, SS_TRIG_TURN_SIGNAL_TICK);
-
-            ar_dashboard->setBool(DD_SIGNAL_TURNLEFT, isvisible);
         }
         else if (ar_flares[i].fl_type == FlareType::BLINKER_RIGHT && m_blink_type == BLINK_RIGHT)
         {
@@ -3047,8 +3045,6 @@ void Actor::UpdateFlareStates(float dt)
 
             if (ar_right_blink_on)
                 SOUND_PLAY_ONCE(ar_instance_id, SS_TRIG_TURN_SIGNAL_TICK);
-
-            ar_dashboard->setBool(DD_SIGNAL_TURNRIGHT, isvisible);
         }
         else if (ar_flares[i].fl_type == FlareType::BLINKER_LEFT && m_blink_type == BLINK_WARN)
         {
@@ -3056,9 +3052,6 @@ void Actor::UpdateFlareStates(float dt)
 
             if (ar_warn_blink_on)
                 SOUND_PLAY_ONCE(ar_instance_id, SS_TRIG_TURN_SIGNAL_WARN_TICK);
-
-            ar_dashboard->setBool(DD_SIGNAL_TURNRIGHT, isvisible);
-            ar_dashboard->setBool(DD_SIGNAL_TURNLEFT, isvisible);
         }
 
         ar_flares[i].isVisible = isvisible; // 3D engine objects are updated in GfxActor
@@ -3995,6 +3988,12 @@ void Actor::updateDashBoards(float dt)
     // lights
     bool lightsOn = (ar_lights > 0);
     ar_dashboard->setBool(DD_LIGHTS, lightsOn);
+
+    // turn signals
+    bool rightTurnOn = ar_right_blink_on || ar_warn_blink_on;
+    bool leftTurnOn = ar_left_blink_on || ar_warn_blink_on;
+    ar_dashboard->setBool(DD_SIGNAL_TURNRIGHT, rightTurnOn);
+    ar_dashboard->setBool(DD_SIGNAL_TURNLEFT, leftTurnOn);
 
     // Traction Control
     if (!tc_nodash)

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -1020,10 +1020,12 @@ void ActorManager::UpdateActors(Actor* player_actor)
             actor->ar_engine->UpdateEngineAudio();
         }
 
+        // Blinkers (turn signals) must always be updated
+        actor->UpdateFlareStates(dt);
+
         if (actor->ar_sim_state != Actor::SimState::LOCAL_SLEEPING)
         {
             actor->updateVisual(dt);
-            actor->UpdateFlareStates(dt); // Only state, visuals done by GfxActor
             if (actor->ar_update_physics && App::gfx_skidmarks_mode->GetInt() > 0)
             {
                 actor->updateSkidmarks();

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -6483,7 +6483,7 @@ void ActorSpawner::CreateGfxActor()
 {
     // Create the actor
     m_actor->m_gfx_actor = std::unique_ptr<RoR::GfxActor>(
-        new RoR::GfxActor(m_actor, this, m_custom_resource_group, m_gfx_nodes, m_props, m_driverseat_prop_index, m_oldstyle_renderdash));
+        new RoR::GfxActor(m_actor, this, m_custom_resource_group, m_gfx_nodes, m_oldstyle_renderdash));
 
     m_actor->GetGfxActor()->UpdateSimDataBuffer(); // Initial fill (to setup flexing meshes)
 }
@@ -6820,6 +6820,8 @@ void ActorSpawner::FinalizeGfxSetup()
     }
 
     m_actor->GetGfxActor()->RegisterAirbrakes();
+
+    m_actor->GetGfxActor()->RegisterProps(m_props, m_driverseat_prop_index);
 
     if (!m_help_material_name.empty())
     {

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -64,9 +64,9 @@ void Console::CVarSetupBuiltins()
     App::mp_pseudo_collisions    = this->CVarCreate("mp_pseudo_collisions",    "Multiplayer collisions",     CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::mp_server_host          = this->CVarCreate("mp_server_host",          "Server name",                CVAR_ARCHIVE);
     App::mp_server_port          = this->CVarCreate("mp_server_port",          "Server port",                CVAR_ARCHIVE | CVAR_TYPE_INT);
-    App::mp_server_password      = this->CVarCreate("mp_server_password",      "Server password",            CVAR_ARCHIVE);
+    App::mp_server_password      = this->CVarCreate("mp_server_password",      "Server password",            CVAR_ARCHIVE | CVAR_NO_LOG);
     App::mp_player_name          = this->CVarCreate("mp_player_name",          "Nickname",                   CVAR_ARCHIVE,                     "Player");
-    App::mp_player_token         = this->CVarCreate("mp_player_token",         "User Token",                 CVAR_ARCHIVE);
+    App::mp_player_token         = this->CVarCreate("mp_player_token",         "User Token",                 CVAR_ARCHIVE | CVAR_NO_LOG);
     App::mp_api_url              = this->CVarCreate("mp_api_url",              "Online API URL",             CVAR_ARCHIVE,                     "http://api.rigsofrods.org");
 
     App::diag_auto_spawner_report= this->CVarCreate("diag_auto_spawner_report","AutoActorSpawnerReport",     CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");


### PR DESCRIPTION
Fixes #2430

Problem: Beacon props generated by `ActorSpawner::ProcessWings()` weren't passed on to GfxActor.
Reason: Props were passed on GfxActor creation which  happened  before   `ActorSpawner::ProcessWings()`
Solution: Added `GfxActor::RegisterProps()` which is invoked after `ActorSpawner::ProcessWings()`