### PR TITLE
CMake/MSVC: disable non-standard behavior

### DIFF
--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -387,6 +387,8 @@ IF (WIN32)
     # warning C4244: 'initializing' : conversion from 'const float' to 'int', possible loss of data
     # warning C4305: 'initializing' : truncation from 'double' to 'const float'
     add_definitions("/wd4305 /wd4244 /wd4193 -DNOMINMAX")
+    # Disable non-standard behavior
+    add_definitions("/permissive-")
 ELSEIF (UNIX)
     #  include_directories(${GTK_INCLUDE_DIRS})
     set(OS_LIBS "X11 -l${CMAKE_DL_LIBS} -lrt")

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -288,7 +288,7 @@ add_executable(${BINNAME} ${SOURCE_FILES} ${pagedgeometry_SOURCE_FILES})
 
 if (WIN32)
     set_target_properties(${BINNAME} PROPERTIES WIN32_EXECUTABLE YES)
-    add_definitions(-DWIN32_LEAN_AND_MEAN)
+    add_compile_definitions(WIN32_LEAN_AND_MEAN)
 endif ()
 
 ####################################################################################################
@@ -386,9 +386,9 @@ IF (WIN32)
     # disable some annoying VS warnings:
     # warning C4244: 'initializing' : conversion from 'const float' to 'int', possible loss of data
     # warning C4305: 'initializing' : truncation from 'double' to 'const float'
-    add_definitions("/wd4305 /wd4244 /wd4193 -DNOMINMAX")
+    add_compile_options("/wd4305 /wd4244 /wd4193 -DNOMINMAX")
     # Disable non-standard behavior
-    add_definitions("/permissive-")
+    add_compile_options("/permissive-")
 ELSEIF (UNIX)
     #  include_directories(${GTK_INCLUDE_DIRS})
     set(OS_LIBS "X11 -l${CMAKE_DL_LIBS} -lrt")
@@ -501,7 +501,7 @@ else (USE_PACKAGE_MANAGER)
         target_compile_definitions(${BINNAME} PRIVATE USE_CURL)
 
         if (WIN32)
-            add_definitions(-DWIN32_LEAN_AND_MEAN)
+            add_compile_definitions(WIN32_LEAN_AND_MEAN)
         endif ()
     endif ()
 


### PR DESCRIPTION
This hopefully reduces Windows/Linux discrepances.

Found thanks to: https://github.com/RigsOfRods/rigs-of-rods/issues/2565#issuecomment-717489222

```
// Example program
#include <iostream>
#include <string>
#include <vector>

struct Message
{
    Message(std::string const& _desc):  description(_desc) {}
    Message(void* _data):  payload(_data) {}

    std::string description;
    void*       payload      = nullptr;
};

int main()
{
  // Output:
    // 'desc:abcd, payload:0000000000000000' with /permissive-
    // 'desc:, payload:00007FF67BC932B0' without it.
  Message m("abcd");
  std::cout << "desc:" << m.description<<", payload:" << m.payload;
}
```