### PR TITLE
Truck file format: added animator option 'aeroreverse#'

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1816,15 +1816,15 @@ void RoR::GfxActor::UpdateSimDataBuffer()
         AeroEngine* src = m_actor->ar_aeroengines[i];
         SimBuffer::AeroEngineSB& dst = m_simbuf.simbuf_aeroengines[i];
 
+        dst.simbuf_ae_type       = src->getType();
         dst.simbuf_ae_throttle   = src->getThrottle();
         dst.simbuf_ae_rpm        = src->getRPM();
         dst.simbuf_ae_rpmpc      = src->getRPMpc();
         dst.simbuf_ae_rpm        = src->getRPM();
-        dst.simbuf_ae_turboprop  = (src->getType() == AeroEngine::AEROENGINE_TYPE_TURBOPROP);
         dst.simbuf_ae_ignition   = src->getIgnition();
         dst.simbuf_ae_failed     = src->isFailed();
 
-        if (dst.simbuf_ae_turboprop)
+        if (dst.simbuf_ae_type == AeroEngineType::AEROENGINE_TURBOPROP_PISTONPROP)
         {
             Turboprop* tp = static_cast<Turboprop*>(src);
             dst.simbuf_tp_aetorque = (100.0 * tp->indicated_torque / tp->max_torque); // TODO: Code ported as-is from calcAnimators(); what does it do? ~ only_a_ptr, 06/2018
@@ -2722,7 +2722,7 @@ void RoR::GfxActor::CalcPropAnimation(const int flag_state, float& cstate, int& 
             div++;
         }
 
-        if (m_simbuf.simbuf_aeroengines[aenum].simbuf_ae_turboprop) // If it's a turboprop or pistonprop...
+        if (m_simbuf.simbuf_aeroengines[aenum].simbuf_ae_type == AEROENGINE_TURBOPROP_PISTONPROP)
         {
             if (flag_state & PROP_ANIM_FLAG_AETORQUE)
             {

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -93,6 +93,7 @@ public:
 
         struct AeroEngineSB
         {
+            AeroEngineType simbuf_ae_type;
             float simbuf_ae_rpm;
             float simbuf_ae_rpmpc;
             float simbuf_ae_throttle;
@@ -100,7 +101,6 @@ public:
             float simbuf_tp_aepitch;  //!< Turboprop pitch, used by animation "aepitch"
             float simbuf_tj_ab_thrust; //! Turbojet afterburner
             float simbuf_tj_exhaust_velo; //! Turbojet
-            bool  simbuf_ae_turboprop:1; //!< This is a TurboProp/PistonProp
             bool  simbuf_ae_ignition:1;
             bool  simbuf_ae_failed:1;
             bool  simbuf_tj_afterburn:1; //! Turbojet afterburner

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -868,6 +868,8 @@ void OverlayWrapper::UpdateAerialHUD(RoR::GfxActor* gfx_actor)
         angle = -105.75;
     m_aerial_dashboard.vvitexture->setTextureRotate(Degree(-angle + 90.0));
 
+    const bool is_prop = simbuf_ae[0].simbuf_ae_type == AEROENGINE_TURBOPROP_PISTONPROP;
+
     //rpm
     m_aerial_dashboard.SetEngineRpm(0, simbuf_ae[0].simbuf_ae_rpmpc);
     m_aerial_dashboard.SetEngineRpm(1, (num_ae > 1) ? simbuf_ae[1].simbuf_ae_rpmpc : 0.f);
@@ -875,16 +877,16 @@ void OverlayWrapper::UpdateAerialHUD(RoR::GfxActor* gfx_actor)
     m_aerial_dashboard.SetEngineRpm(3, (num_ae > 3) ? simbuf_ae[3].simbuf_ae_rpmpc : 0.f);
 
     //turboprops - pitch
-    m_aerial_dashboard.SetEnginePitch(0, (simbuf_ae[0].simbuf_ae_turboprop) ? simbuf_ae[0].simbuf_tp_aepitch : 0.f);
-    m_aerial_dashboard.SetEnginePitch(1, (num_ae > 1 && simbuf_ae[1].simbuf_ae_turboprop) ? simbuf_ae[1].simbuf_tp_aepitch : 0.f);
-    m_aerial_dashboard.SetEnginePitch(2, (num_ae > 2 && simbuf_ae[2].simbuf_ae_turboprop) ? simbuf_ae[2].simbuf_tp_aepitch : 0.f);
-    m_aerial_dashboard.SetEnginePitch(3, (num_ae > 3 && simbuf_ae[3].simbuf_ae_turboprop) ? simbuf_ae[3].simbuf_tp_aepitch : 0.f);
+    m_aerial_dashboard.SetEnginePitch(0, (is_prop) ? simbuf_ae[0].simbuf_tp_aepitch : 0.f);
+    m_aerial_dashboard.SetEnginePitch(1, (num_ae > 1 && is_prop) ? simbuf_ae[1].simbuf_tp_aepitch : 0.f);
+    m_aerial_dashboard.SetEnginePitch(2, (num_ae > 2 && is_prop) ? simbuf_ae[2].simbuf_tp_aepitch : 0.f);
+    m_aerial_dashboard.SetEnginePitch(3, (num_ae > 3 && is_prop) ? simbuf_ae[3].simbuf_tp_aepitch : 0.f);
 
     //turboprops - torque
-    m_aerial_dashboard.SetEngineTorque(0, (simbuf_ae[0].simbuf_ae_turboprop) ? simbuf_ae[0].simbuf_tp_aetorque : 0.f);
-    m_aerial_dashboard.SetEngineTorque(1, (num_ae > 1 && simbuf_ae[1].simbuf_ae_turboprop) ? simbuf_ae[1].simbuf_tp_aetorque : 0.f);
-    m_aerial_dashboard.SetEngineTorque(2, (num_ae > 2 && simbuf_ae[2].simbuf_ae_turboprop) ? simbuf_ae[2].simbuf_tp_aetorque : 0.f);
-    m_aerial_dashboard.SetEngineTorque(3, (num_ae > 3 && simbuf_ae[3].simbuf_ae_turboprop) ? simbuf_ae[3].simbuf_tp_aetorque : 0.f);
+    m_aerial_dashboard.SetEngineTorque(0, (is_prop) ? simbuf_ae[0].simbuf_tp_aetorque : 0.f);
+    m_aerial_dashboard.SetEngineTorque(1, (num_ae > 1 && is_prop) ? simbuf_ae[1].simbuf_tp_aetorque : 0.f);
+    m_aerial_dashboard.SetEngineTorque(2, (num_ae > 2 && is_prop) ? simbuf_ae[2].simbuf_tp_aetorque : 0.f);
+    m_aerial_dashboard.SetEngineTorque(3, (num_ae > 3 && is_prop) ? simbuf_ae[3].simbuf_tp_aetorque : 0.f);
 
     //starters
     m_aerial_dashboard.SetIgnition(0, true, simbuf_ae[0].simbuf_ae_ignition);

--- a/source/main/gui/panels/GUI_SimActorStats.cpp
+++ b/source/main/gui/panels/GUI_SimActorStats.cpp
@@ -180,7 +180,7 @@ void SimActorStats::Draw(RoR::GfxActor* actorx)
             {
                 ImGui::TextColored(theme.value_blue_text_color, "%s #%d:", _LC("SimActorStats", "Engine "), engine_num);
                 ImGui::SameLine();
-                if (ae.simbuf_ae_turboprop) // Turboprop or pistonprop
+                if (ae.simbuf_ae_type == AEROENGINE_TURBOPROP_PISTONPROP)
                 {
                     ImGui::Text("%.2f RPM", ae.simbuf_ae_rpm);
                 }

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2282,7 +2282,7 @@ void Actor::CalcAnimators(const int flag_state, float& cstate, int& div, Real ti
         }
 
         if (flag_state & ANIM_FLAG_AETORQUE)
-            if (ar_aeroengines[aenum]->getType() == AeroEngine::AEROENGINE_TYPE_TURBOPROP)
+            if (ar_aeroengines[aenum]->getType() == AEROENGINE_TURBOPROP_PISTONPROP)
             {
                 Turboprop* tp = (Turboprop*)ar_aeroengines[aenum];
                 cstate = (100.0 * tp->indicated_torque / tp->max_torque) / 120.0f;
@@ -2290,7 +2290,7 @@ void Actor::CalcAnimators(const int flag_state, float& cstate, int& div, Real ti
             }
 
         if (flag_state & ANIM_FLAG_AEPITCH)
-            if (ar_aeroengines[aenum]->getType() == AeroEngine::AEROENGINE_TYPE_TURBOPROP)
+            if (ar_aeroengines[aenum]->getType() == AEROENGINE_TURBOPROP_PISTONPROP)
             {
                 Turboprop* tp = (Turboprop*)ar_aeroengines[aenum];
                 cstate = tp->pitch / 120.0f;
@@ -4210,7 +4210,7 @@ void Actor::updateDashBoards(float dt)
 	RoR::App::GetOverlayWrapper()->vvitexture->setTextureRotate(Degree(-angle+90.0));
 
 
-	if (curr_truck->aeroengines[0]->getType() == AeroEngine::AEROENGINE_TYPE_TURBOPROP)
+	if (curr_truck->aeroengines[0]->getType() == AEROENGINE_TURBOPROP_PISTONPROP)
 	{
 		Turboprop *tp=(Turboprop*)curr_truck->aeroengines[0];
     //pitch
@@ -4223,7 +4223,7 @@ void Actor::updateDashBoards(float dt)
 		RoR::App::GetOverlayWrapper()->airtorque1texture->setTextureRotate(Degree(-angle));
 	}
 
-	if (ftp>1 && curr_truck->aeroengines[1]->getType()==AeroEngine::AEROENGINE_TYPE_TURBOPROP)
+	if (ftp>1 && curr_truck->aeroengines[1]->getType()==AEROENGINE_TURBOPROP_PISTONPROP)
 	{
 		Turboprop *tp=(Turboprop*)curr_truck->aeroengines[1];
     //pitch
@@ -4236,7 +4236,7 @@ void Actor::updateDashBoards(float dt)
 		RoR::App::GetOverlayWrapper()->airtorque2texture->setTextureRotate(Degree(-angle));
 	}
 
-	if (ftp>2 && curr_truck->aeroengines[2]->getType()==AeroEngine::AEROENGINE_TYPE_TURBOPROP)
+	if (ftp>2 && curr_truck->aeroengines[2]->getType()==AEROENGINE_TURBOPROP_PISTONPROP)
 	{
 		Turboprop *tp=(Turboprop*)curr_truck->aeroengines[2];
     //pitch
@@ -4249,7 +4249,7 @@ void Actor::updateDashBoards(float dt)
 		RoR::App::GetOverlayWrapper()->airtorque3texture->setTextureRotate(Degree(-angle));
 	}
 
-	if (ftp>3 && curr_truck->aeroengines[3]->getType()==AeroEngine::AEROENGINE_TYPE_TURBOPROP)
+	if (ftp>3 && curr_truck->aeroengines[3]->getType()==AEROENGINE_TURBOPROP_PISTONPROP)
 	{
 		Turboprop *tp=(Turboprop*)curr_truck->aeroengines[3];
     //pitch

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -379,7 +379,7 @@ private:
     bool              CalcForcesEulerPrepare(bool doUpdate); 
     void              CalcAircraftForces(bool doUpdate);   
     void              CalcForcesEulerCompute(bool doUpdate, int num_steps); 
-    void              CalcAnimators(const int flag_state, float &cstate, int &div, float timer, const float lower_limit, const float upper_limit, const float option3); 
+    void              CalcAnimators(hydrobeam_t const& hydrobeam, float &cstate, int &div);
     void              CalcBeams(bool trigger_hooks);       
     void              CalcBeamsInterActor();               
     void              CalcBuoyance(bool doUpdate);         

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -697,26 +697,27 @@ void Actor::CalcHydros()
             cstate = 1.0;
         if (cstate < -1.0)
             cstate = -1.0;
-        // Animators following, if no animator, skip all the tests...
-        int flagstate = hydrobeam.hb_anim_flags;
-        if (flagstate)
+
+        // Animators
+        if (hydrobeam.hb_anim_flags)
         {
-            this->CalcAnimators(flagstate, cstate, div, PHYSICS_DT, 0.0f, 0.0f, hydrobeam.hb_anim_param);
+            this->CalcAnimators(hydrobeam, cstate, div);
         }
 
+        // Final composition
         if (div)
         {
             cstate /= (float)div;
 
             cstate = hydrobeam.hb_inertia.CalcCmdKeyDelay(cstate, PHYSICS_DT);
 
-            if (!(hydrobeam.hb_flags & HYDRO_FLAG_SPEED) && !flagstate)
+            if (!(hydrobeam.hb_flags & HYDRO_FLAG_SPEED) && !hydrobeam.hb_anim_flags)
                 ar_hydro_dir_wheel_display = cstate;
 
             float factor = 1.0 - cstate * hydrobeam.hb_speed;
 
             // check and apply animators limits if set
-            if (flagstate)
+            if (hydrobeam.hb_anim_flags)
             {
                 if (factor < 1.0f - ar_beams[beam_idx].shortbound)
                     factor = 1.0f - ar_beams[beam_idx].shortbound;

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -3500,23 +3500,23 @@ void ActorSpawner::ProcessAnimator(RigDef::Animator & def)
     /* Aerial */
     if (BITMASK_IS_1(def.aero_animator.flags, RigDef::AeroAnimator::OPTION_THROTTLE)) {
         BITMASK_SET_1(anim_flags, ANIM_FLAG_THROTTLE);
-        anim_option = static_cast<float>(def.aero_animator.motor);
+        anim_option = static_cast<float>(def.aero_animator.engine_idx);
     }
     if (BITMASK_IS_1(def.aero_animator.flags, RigDef::AeroAnimator::OPTION_RPM)) {
         BITMASK_SET_1(anim_flags, ANIM_FLAG_RPM);
-        anim_option = static_cast<float>(def.aero_animator.motor);
+        anim_option = static_cast<float>(def.aero_animator.engine_idx);
     }
     if (BITMASK_IS_1(def.aero_animator.flags, RigDef::AeroAnimator::OPTION_TORQUE)) {
         BITMASK_SET_1(anim_flags, ANIM_FLAG_AETORQUE);
-        anim_option = static_cast<float>(def.aero_animator.motor);
+        anim_option = static_cast<float>(def.aero_animator.engine_idx);
     }
     if (BITMASK_IS_1(def.aero_animator.flags, RigDef::AeroAnimator::OPTION_PITCH)) {
         BITMASK_SET_1(anim_flags, ANIM_FLAG_AEPITCH);
-        anim_option = static_cast<float>(def.aero_animator.motor);
+        anim_option = static_cast<float>(def.aero_animator.engine_idx);
     }
     if (BITMASK_IS_1(def.aero_animator.flags, RigDef::AeroAnimator::OPTION_STATUS)) {
         BITMASK_SET_1(anim_flags, ANIM_FLAG_AESTATUS);
-        anim_option = static_cast<float>(def.aero_animator.motor);
+        anim_option = static_cast<float>(def.aero_animator.engine_idx);
     }
 
     unsigned int beam_index = m_actor->ar_num_beams;

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -6139,7 +6139,7 @@ void ActorSpawner::SetupDefaultSoundSources(Actor *vehicle)
         int turbojet_node = vehicle->ar_aeroengines[i]->getNoderef();
         Ogre::String index_str = TOSTRING(i+1);
 
-        if (vehicle->ar_aeroengines[i]->getType()==AeroEngine::AEROENGINE_TYPE_TURBOJET)
+        if (vehicle->ar_aeroengines[i]->getType()==AEROENGINE_TURBOJET)
         {
             AddSoundSourceInstance(vehicle, "tracks/default_turbojet_start" + index_str, turbojet_node);
             AddSoundSourceInstance(vehicle, "tracks/default_turbojet_lopower" + index_str, turbojet_node);
@@ -6149,7 +6149,7 @@ void ActorSpawner::SetupDefaultSoundSources(Actor *vehicle)
                 AddSoundSourceInstance(vehicle, "tracks/default_turbojet_afterburner" + index_str, turbojet_node);
             }
         }
-        else if (vehicle->ar_aeroengines[i]->getType()==AeroEngine::AEROENGINE_TYPE_TURBOPROP)
+        else if (vehicle->ar_aeroengines[i]->getType()==AEROENGINE_TURBOPROP_PISTONPROP)
         {
             if (((Turboprop*)vehicle->ar_aeroengines[i])->is_piston)
             {

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -210,6 +210,12 @@ enum LocalizerType
     LOCALIZER_VOR
 };
 
+enum AeroEngineType
+{
+    AEROENGINE_UNKNOWN,
+    AEROENGINE_TURBOPROP_PISTONPROP,
+    AEROENGINE_TURBOJET,
+};
 
 // --------------------------------
 // Soft body physics

--- a/source/main/physics/air/AeroEngine.h
+++ b/source/main/physics/air/AeroEngine.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "Application.h"
+#include "SimData.h"
 
 #include <Ogre.h>
 
@@ -29,12 +30,6 @@ namespace RoR {
 class AeroEngine
 {
 public:
-    enum
-    {
-        AEROENGINE_TYPE_TURBOPROP,
-        AEROENGINE_TYPE_TURBOJET
-    };
-
     virtual ~AeroEngine() {}
 
     virtual void updateVisuals(RoR::GfxActor* gfx_actor) =0;
@@ -59,7 +54,7 @@ public:
     virtual float getpropwash() =0;
     virtual Ogre::Vector3 getAxis() =0;
     virtual bool isFailed() =0;
-    virtual int getType() =0;
+    virtual AeroEngineType getType() =0;
     virtual bool getIgnition() =0;
     virtual void setIgnition(bool val) =0;
     virtual int getNoderef() =0;

--- a/source/main/physics/air/TurboJet.h
+++ b/source/main/physics/air/TurboJet.h
@@ -82,7 +82,7 @@ public:
     float getThrottle();
     float getpropwash() { return m_propwash; };
     int getNoderef() { return m_node_back; };
-    int getType() { return AEROENGINE_TYPE_TURBOJET; };
+    AeroEngineType getType() { return AEROENGINE_TURBOJET; };
 
     bool tjet_afterburnable;
     TurbojetVisual tjet_visual;

--- a/source/main/physics/air/TurboProp.h
+++ b/source/main/physics/air/TurboProp.h
@@ -76,7 +76,7 @@ public:
     float getpropwash() { return propwash; };
     Ogre::Vector3 getAxis() { return axis; };
     bool isFailed() { return failed; };
-    int getType() { return AEROENGINE_TYPE_TURBOPROP; };
+    AeroEngineType getType() { return AEROENGINE_TURBOPROP_PISTONPROP; };
     bool getIgnition() { return ignition; };
     void setIgnition(bool val) { ignition = val; };
     int getNoderef() { return noderef; };

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -1225,19 +1225,14 @@ struct Hydro
 
 struct AeroAnimator
 {
-    AeroAnimator():
-        flags(0),
-        motor(0)
-    {}
-
     static const unsigned int OPTION_THROTTLE = BITMASK(1);
     static const unsigned int OPTION_RPM      = BITMASK(2);
     static const unsigned int OPTION_TORQUE   = BITMASK(3);
     static const unsigned int OPTION_PITCH    = BITMASK(4);
     static const unsigned int OPTION_STATUS   = BITMASK(5);
 
-    unsigned int flags;
-    unsigned int motor;
+    unsigned int flags      = 0u;
+    unsigned int engine_idx = 0u;
 };
 
 struct Animator

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -3084,7 +3084,7 @@ void Parser::ParseAnimator()
             else if (results[1] == "aeropit")    animator.aero_animator.flags |= AeroAnimator::OPTION_PITCH;
             else if (results[1] == "aerostatus") animator.aero_animator.flags |= AeroAnimator::OPTION_STATUS;
 
-            animator.aero_animator.motor = this->ParseArgInt(results[2].str().c_str());
+            animator.aero_animator.engine_idx = this->ParseArgUint(results[2].str().c_str()) - 1;
         }
         else if ((is_shortlimit = (token.compare(0, 10, "shortlimit") == 0)) || (token.compare(0, 9, "longlimit") == 0))
         {

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -1268,7 +1268,7 @@ void Serializer::ProcessTriggers(File::Module* module)
     if (AND_VAR) { m_stream << " | "; } \
     if (BITMASK_IS_1((DEF_VAR).aero_animator.flags, RigDef::AeroAnimator::BITMASK_CONST)) { \
         AND_VAR = true; \
-        m_stream << NAME_STR << DEF_VAR.aero_animator.motor; \
+        m_stream << NAME_STR << DEF_VAR.aero_animator.engine_idx + 1; \
     }
 
 #define ANIMATOR_ADD_LIMIT(DEF_VAR, AND_VAR, BITMASK_CONST, NAME_STR, VALUE) \

--- a/source/main/resources/rig_def_fileformat/RigDef_Validator.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Validator.cpp
@@ -437,15 +437,21 @@ bool Validator::CheckShock3(RigDef::Shock3 & shock3)
 
 bool Validator::CheckAnimator(RigDef::Animator & def)
 {
+    // Ignore non-source flags
     unsigned int source_check = def.flags;
     BITMASK_SET_0(source_check, RigDef::Animator::OPTION_SHORT_LIMIT);
     BITMASK_SET_0(source_check, RigDef::Animator::OPTION_LONG_LIMIT);
-    if (source_check == 0)
+    BITMASK_SET_0(source_check, RigDef::Animator::OPTION_VISIBLE);
+    BITMASK_SET_0(source_check, RigDef::Animator::OPTION_INVISIBLE);
+    if (source_check != 0 || def.aero_animator.flags != 0)
     {
-        AddMessage(Message::TYPE_ERROR, "Failed to identify animator source");
+        return true;
+    }
+    else
+    {
+        AddMessage(Message::TYPE_ERROR, "Animator: No animator source defined");
         return false;
     }
-    return true;
 }
 
 bool Validator::CheckCommand(RigDef::Command2 & def)

--- a/source/main/utils/BitFlags.h
+++ b/source/main/utils/BitFlags.h
@@ -6,7 +6,8 @@
 
 // BITMASK(1) = 0x00000001 = 0b00....0001
 // BITMASK(2) = 0x00000002 = 0b00....0010
-#define BITMASK( OFFSET )           (1 << ( (OFFSET) - 1))
+#define BITMASK( OFFSET )           (          1  << ((OFFSET) - 1) )
+#define BITMASK_64( OFFSET )        ( uint64_t(1) << ((OFFSET) - 1) )
 
 #define BITMASK_SET_0( VAR, FLAGS ) ( (VAR) &= ~ (FLAGS) )
 
@@ -41,24 +42,3 @@ template<typename var_T, typename flags_T> void Bitmask_SetBool(bool val, var_T 
 	BITMASK_PROPERTY_GET((VAR), (BIT_INDEX), FLAG_NAME, GETTER_NAME) \
 	inline void SETTER_NAME(bool value) { Bitmask_SetBool(value, (VAR), FLAG_NAME); }
 
-// --------------------------------------------------------------------------------
-
-#define BITMASK_64( OFFSET )           ( uint64_t(1) << ((OFFSET) - 1) )
-
-#define BITMASK_64_SET_0               BITMASK_SET_0
-
-#define BITMASK_64_SET_1               BITMASK_SET_1
-
-#define BITMASK_64_IS_0( VAR, FLAGS )  ( ((VAR) & (FLAGS)) == uint64_t(0) )
-
-#define BITMASK_64_IS_1                BITMASK_IS_1
-
-/// Defines a 64bit bitmask constant with given bit index (1-indexed) and a getter function. 
-#define BITMASK_64_PROPERTY_GET(VAR, BIT_INDEX, FLAG_NAME, GETTER_NAME) \
-	static const unsigned int FLAG_NAME = BITMASK_64((BIT_INDEX)); \
-	inline bool GETTER_NAME() const { return BITMASK_64_IS_1((VAR), FLAG_NAME); }
-
-/// Defines a 64bit bitmask constant with given bit index (1-indexed) and a getter/setter functions.
-#define BITMASK_64_PROPERTY(VAR, BIT_INDEX, FLAG_NAME, GETTER_NAME, SETTER_NAME) \
-	BITMASK_PROPERTY_GET((VAR), (BIT_INDEX), FLAG_NAME, GETTER_NAME) \
-	inline void SETTER_NAME(bool value) { Bitmask_SetBool(value, (VAR), FLAG_NAME); }


### PR DESCRIPTION
Suggested by PM at Discord. Currently not implemented.

How it should work:
See https://docs.rigsofrods.org/vehicle-creation/fileformat-truck/#animators
'aeroreverse#' applies only to turbojets - outputs 1.0 if the turbojet is in reverse mode, otherwise 0.0