### PR TITLE
Fixed main menu not appearing after closing multiplayer selector using escape

### DIFF
--- a/source/main/gui/panels/GUI_MultiplayerSelector.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerSelector.cpp
@@ -335,10 +335,6 @@ void MultiplayerSelector::MultiplayerSelector::Draw()
     if (!keep_open)
     {
         this->SetVisible(false);
-        if (App::app_state->GetEnum<AppState>() == AppState::MAIN_MENU)
-        {
-            App::GetGuiManager()->SetVisible_GameMainMenu(true);
-        }
     }
 }
 
@@ -362,6 +358,10 @@ void MultiplayerSelector::SetVisible(bool visible)
     {
         this->StartAsyncRefresh();
         m_password_buf = App::mp_server_password->GetStr();
+    }
+    else if (!visible && App::app_state->GetEnum<AppState>() == AppState::MAIN_MENU)
+    {
+        App::GetGuiManager()->SetVisible_GameMainMenu(true);
     }
 }
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -362,6 +362,7 @@ int main(int argc, char *argv[])
                 case MSG_NET_CONNECT_STARTED:
                     App::GetGuiManager()->GetLoadingWindow()->SetProgressNetConnect(m.description);
                     App::GetGuiManager()->SetVisible_MultiplayerSelector(false);
+                    App::GetGuiManager()->SetVisible_GameMainMenu(false);
                     break;
 
                 case MSG_NET_CONNECT_PROGRESS:


### PR DESCRIPTION
Reported on discord. 

Reverts https://github.com/RigsOfRods/rigs-of-rods/pull/2608/commits/4c3b21a85bcbf8fb1f190c3fd4e5219b8efa3662 but this time hides main menu last, to prevent it appearing while connecting. It seems the order was just wrong.