### PR TITLE
Prevent partially visible chat history messages

### DIFF
--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -107,7 +107,10 @@ void ConsoleView::DrawConsoleMessages()
                                  (int)m_display_messages.size() - msg_start);
 
             const float line_offset = scroll_offset/line_h;
-            cursor -= ImVec2(0, (line_offset - (float)(int)line_offset)*line_h);
+            if (cvw_smooth_scrolling)
+            {
+                cursor -= ImVec2(0, (line_offset - (float)(int)line_offset)*line_h);
+            }
         }
 
         // Horizontal scrolling

--- a/source/main/gui/panels/GUI_ConsoleView.h
+++ b/source/main/gui/panels/GUI_ConsoleView.h
@@ -52,6 +52,7 @@ struct ConsoleView
     bool  cvw_filter_area_script = true;
     bool  cvw_filter_area_actor = true;
     bool  cvw_filter_area_terrn = true;
+    bool  cvw_smooth_scrolling = true;
 
     // Misc options
     size_t cvw_msg_duration_ms = 0u; //!< Message expiration; 0 means unlimited

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -54,7 +54,7 @@ void GameChatBox::Draw()
     const float width = ImGui::GetIO().DisplaySize.x - (2 * theme.screen_edge_padding.x);
     ImVec2 msg_size(width, (ImGui::GetIO().DisplaySize.y / 3.f) + (2*ImGui::GetStyle().WindowPadding.y));
     ImVec2 chat_size(width, ImGui::GetTextLineHeightWithSpacing() + 20);
-    ImGui::SetNextWindowSize(msg_size);
+    ImGui::SetNextWindowSize(ImVec2(msg_size.x, msg_size.y - 6.f));
     ImVec2 msg_pos(theme.screen_edge_padding.x, ImGui::GetIO().DisplaySize.y - (msg_size.y + theme.screen_edge_padding.y));
     if (m_is_visible)
     {
@@ -80,6 +80,7 @@ void GameChatBox::Draw()
     if (m_is_visible)
     {
         m_console_view.cvw_enable_scrolling = true;
+        m_console_view.cvw_smooth_scrolling = false;
         m_console_view.cvw_msg_duration_ms = 3600000; // 1hour
         m_console_view.cvw_filter_type_notice = false;
         m_console_view.cvw_filter_type_warning = false; 
@@ -94,6 +95,7 @@ void GameChatBox::Draw()
     else
     {
         m_console_view.cvw_enable_scrolling = false;
+        m_console_view.cvw_smooth_scrolling = true;
         m_console_view.cvw_filter_type_notice = true;
         m_console_view.cvw_filter_type_warning = true; 
         m_console_view.cvw_filter_area_script = true; 

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -114,7 +114,7 @@ void GameChatBox::Draw()
 
     // Draw chat box
     ImGuiWindowFlags chat_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
-        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;
+        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
 
     ImGui::SetNextWindowSize(chat_size);
     ImGui::SetNextWindowPos(ImVec2(theme.screen_edge_padding.x, ImGui::GetIO().DisplaySize.y - (chat_size.y + theme.screen_edge_padding.y)));

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -54,13 +54,14 @@ void GameChatBox::Draw()
     const float width = ImGui::GetIO().DisplaySize.x - (2 * theme.screen_edge_padding.x);
     ImVec2 msg_size(width, (ImGui::GetIO().DisplaySize.y / 3.f) + (2*ImGui::GetStyle().WindowPadding.y));
     ImVec2 chat_size(width, ImGui::GetTextLineHeightWithSpacing() + 20);
-    ImGui::SetNextWindowSize(ImVec2(msg_size.x, msg_size.y - 6.f));
     ImVec2 msg_pos(theme.screen_edge_padding.x, ImGui::GetIO().DisplaySize.y - (msg_size.y + theme.screen_edge_padding.y));
     if (m_is_visible)
     {
         msg_pos.y -= chat_size.y;
+        msg_size.y -= 6.f; // prevents partially bottom chat messages
     }
     ImGui::SetNextWindowPos(msg_pos);
+    ImGui::SetNextWindowSize(msg_size);
 
     if (m_is_visible)
     {


### PR DESCRIPTION
When chat input box is visible resize the window a bit to match line height. Works with scrolling also.

Also disables scrolling in chat input box window.