### PR TITLE
Nonsense issues with Renderdash

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -2384,9 +2384,7 @@ void RoR::GfxActor::UpdateRenderdashRTT()
 {
     if (m_renderdash != nullptr)
     {
-        App::GetGfxScene()->GetSceneManager()->removeRenderQueueListener(&App::GetGuiManager()->GetImGui()); // Hack to prevent DearIMGUI being drawn to renderdash
         m_renderdash->getRenderTarget()->update();
-        App::GetGfxScene()->GetSceneManager()->addRenderQueueListener(&App::GetGuiManager()->GetImGui()); // Resume DearIMGUI rendering
     }
 }
 

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -2384,7 +2384,9 @@ void RoR::GfxActor::UpdateRenderdashRTT()
 {
     if (m_renderdash != nullptr)
     {
+        App::GetGfxScene()->GetSceneManager()->removeRenderQueueListener(&App::GetGuiManager()->GetImGui()); // Hack to prevent DearIMGUI being drawn to renderdash
         m_renderdash->getRenderTarget()->update();
+        App::GetGfxScene()->GetSceneManager()->addRenderQueueListener(&App::GetGuiManager()->GetImGui()); // Resume DearIMGUI rendering
     }
 }
 

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -2380,6 +2380,14 @@ void RoR::GfxActor::SetRenderdashActive(bool active)
     }
 }
 
+void RoR::GfxActor::UpdateRenderdashRTT()
+{
+    if (m_renderdash != nullptr)
+    {
+        m_renderdash->getRenderTarget()->update();
+    }
+}
+
 void RoR::GfxActor::SetBeaconsEnabled(bool beacon_light_is_active)
 {
     const bool enableLight = (App::gfx_flares_mode->GetEnum<GfxFlaresMode>() != GfxFlaresMode::NO_LIGHTSOURCES);

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -250,6 +250,7 @@ public:
     void                 UpdatePropAnimations(float dt, bool is_player_connected);
     void                 SetPropsVisible     (bool visible);
     void                 SetRenderdashActive (bool active);
+    void                 UpdateRenderdashRTT ();
     void                 SetBeaconsEnabled   (bool beacon_light_is_active);
     void                 CalcPropAnimation   (const int flag_state, float& cstate, int& div, float timer,
                                               const float lower_limit, const float upper_limit, const float option3);

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -217,6 +217,7 @@ void RoR::GfxScene::UpdateScene(float dt_sec)
             gfx_actor->UpdateCParticles();
             gfx_actor->UpdateAeroEngines();
             gfx_actor->UpdatePropAnimations(dt_sec, (gfx_actor == player_gfx_actor) || is_player_connected);
+            gfx_actor->UpdateRenderdashRTT();
         }
         // Beacon flares must always be updated
         gfx_actor->UpdateProps(dt_sec, (gfx_actor == player_gfx_actor));

--- a/source/main/gfx/Renderdash.cpp
+++ b/source/main/gfx/Renderdash.cpp
@@ -22,6 +22,9 @@
 
 #include "Application.h"
 #include "GfxScene.h"
+#include "GUIManager.h"
+#include "GUI_DirectionArrow.h"
+#include "OverlayWrapper.h"
 
 #include <Overlay/OgreOverlayManager.h>
 #include <Overlay/OgreOverlay.h>
@@ -86,6 +89,13 @@ void RoR::Renderdash::preRenderTargetUpdate(const Ogre::RenderTargetEvent& evt)
     // hide everything
     App::GetGfxScene()->GetSceneManager()->setFindVisibleObjects(false);
 
+    // Disable DearIMGUI overlay
+    App::GetGfxScene()->GetSceneManager()->removeRenderQueueListener(&App::GetGuiManager()->GetImGui());
+
+    // Disable other overlays
+    App::GetOverlayWrapper()->HideRacingOverlay();
+    App::GetGuiManager()->GetDirectionArrow()->SetVisible(false);
+
     //show overlay
     m_dash_overlay->show();
     m_needles_overlay->show();
@@ -96,6 +106,11 @@ void RoR::Renderdash::postRenderTargetUpdate(const Ogre::RenderTargetEvent& evt)
 {
     // show everything
     App::GetGfxScene()->GetSceneManager()->setFindVisibleObjects(true);
+
+    // Enable DearIMGUI overlay
+    App::GetGfxScene()->GetSceneManager()->addRenderQueueListener(&App::GetGuiManager()->GetImGui());
+
+    // Overlays 'racing' and 'direction arrow' are re-enabled automatically if needed
 
     // hide overlay
     m_dash_overlay->hide();

--- a/source/main/gfx/Renderdash.cpp
+++ b/source/main/gfx/Renderdash.cpp
@@ -62,6 +62,10 @@ RoR::Renderdash::Renderdash(std::string const& rg_name, std::string const& tex_n
 
     m_rtt_tex->addListener(this);
     m_rtt_tex->setActive(false);
+
+    // IMPORTANT: Must be manually updated as a workaround
+    //  Under Windows with DirectX9 rendering, once auto-updated RTT is enabled, all DearIMGUI colors change: blue turns light orange, yellow turns light blue, red turns dark purple etc... looks like a hue shift but I haven't researched further. The moment the RTT is deactivated colors go back to normal.
+    m_rtt_tex->setAutoUpdated(false);
 }
 
 RoR::Renderdash::~Renderdash()

--- a/source/main/gfx/Renderdash.h
+++ b/source/main/gfx/Renderdash.h
@@ -36,6 +36,7 @@ public:
 
     void setEnable(bool en);
     Ogre::TexturePtr getTexture() { return m_texture; }
+    Ogre::RenderTarget* getRenderTarget() { return m_rtt_tex; }
 
     // Ogre::RenderTargetListener
     void preRenderTargetUpdate(const Ogre::RenderTargetEvent& evt) override;


### PR DESCRIPTION
Separated out from #2630

Original problem: Windows/Direct3D9 renderer: when player enters any vehicle, DearIMGUI colors temporarily change (looks like a hue shift). Leaving the vehicle restores them. Memory stays intact.

Orig. solution: make renderdash RTT manually updated, see commits below.

Consequence: some GUI indicators break for no apparent reason (both Windows/Linux). Code flow is unchanged. See https://github.com/RigsOfRods/rigs-of-rods/pull/2630#issuecomment-753672831