### PR TITLE
Fixed re-spawning last truck enables blinker

### DIFF
--- a/resources/skeleton/config/input.map
+++ b/resources/skeleton/config/input.map
@@ -235,9 +235,9 @@ TRUCK_ACCELERATE_MODIFIER_50   Keyboard             CTRL+UP
 TRUCK_ANTILOCK_BRAKE           Keyboard             EXPL+SHIFT+B 
 TRUCK_AUTOSHIFT_DOWN           Keyboard             PGDOWN 
 TRUCK_AUTOSHIFT_UP             Keyboard             PGUP 
-TRUCK_BLINK_LEFT               Keyboard             COMMA 
-TRUCK_BLINK_RIGHT              Keyboard             PERIOD 
-TRUCK_BLINK_WARN               Keyboard             MINUS 
+TRUCK_BLINK_LEFT               Keyboard             EXPL+COMMA 
+TRUCK_BLINK_RIGHT              Keyboard             EXPL+PERIOD 
+TRUCK_BLINK_WARN               Keyboard             EXPL+MINUS 
 TRUCK_BRAKE                    Keyboard             DOWN 
 TRUCK_BRAKE_MODIFIER_25        Keyboard             ALT+DOWN 
 TRUCK_BRAKE_MODIFIER_50        Keyboard             CTRL+DOWN 

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1003,17 +1003,14 @@ void GameContext::UpdateCommonInputEvents(float dt)
     }
 
     // blinkers
-    if (!RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_RESPAWN_LAST_TRUCK))
-    {
-        if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_LEFT))
-            m_player_actor->toggleBlinkType(BLINK_LEFT);
+    if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_LEFT))
+        m_player_actor->toggleBlinkType(BLINK_LEFT);
 
-        if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_RIGHT))
-            m_player_actor->toggleBlinkType(BLINK_RIGHT);
+    if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_RIGHT))
+        m_player_actor->toggleBlinkType(BLINK_RIGHT);
 
-        if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_WARN))
-            m_player_actor->toggleBlinkType(BLINK_WARN);
-    }
+    if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_WARN))
+        m_player_actor->toggleBlinkType(BLINK_WARN);
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TRUCK_REMOVE))
     {

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1003,14 +1003,17 @@ void GameContext::UpdateCommonInputEvents(float dt)
     }
 
     // blinkers
-    if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_LEFT))
-        m_player_actor->toggleBlinkType(BLINK_LEFT);
+    if (!RoR::App::GetInputEngine()->getEventBoolValue(EV_COMMON_RESPAWN_LAST_TRUCK))
+    {
+        if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_LEFT))
+            m_player_actor->toggleBlinkType(BLINK_LEFT);
 
-    if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_RIGHT))
-        m_player_actor->toggleBlinkType(BLINK_RIGHT);
+        if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_RIGHT))
+            m_player_actor->toggleBlinkType(BLINK_RIGHT);
 
-    if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_WARN))
-        m_player_actor->toggleBlinkType(BLINK_WARN);
+        if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_BLINK_WARN))
+            m_player_actor->toggleBlinkType(BLINK_WARN);
+    }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TRUCK_REMOVE))
     {


### PR DESCRIPTION
Spawn a truck and press `ctrl .` to respawn it -> right blinker turns on (assigned to `.`)

It was fixed before (https://github.com/RigsOfRods/rigs-of-rods/pull/2200) but it seems it re introduced with https://github.com/RigsOfRods/rigs-of-rods/pull/2563