### PR TITLE
Fixed corrupted ground type entries on resume

### DIFF
--- a/source/main/gui/panels/GUI_FrictionSettings.cpp
+++ b/source/main/gui/panels/GUI_FrictionSettings.cpp
@@ -134,6 +134,7 @@ bool FrictionSettings::GmComboItemGetter(void* data, int idx, const char** out_t
 
 void FrictionSettings::AnalyzeTerrain()
 {
+    m_gm_entries.clear();
     auto itor = App::GetSimTerrain()->GetCollisions()->getGroundModels()->begin();
     auto endi = App::GetSimTerrain()->GetCollisions()->getGroundModels()->end();
     for (; itor != endi; ++itor)


### PR DESCRIPTION
Make sure the vector is empty before adding things in it

Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/2665