### PR TITLE
Removed extra username text from join/leave messages

### DIFF
--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -311,7 +311,7 @@ void Network::RecvThread()
                 {
                     // Console is now threadsafe, no need to send fake chatmessages to ourselves
                     Str<300> text;
-                    text << user->username << _L(" left the game");
+                    text << _L(" left the game");
                     App::GetConsole()->putNetMessage(user->uniqueid, Console::CONSOLE_SYSTEM_NOTICE, text.ToCStr());
                     LOG_THREAD(text);
 
@@ -337,7 +337,6 @@ void Network::RecvThread()
                 {
                     memcpy(&user_info, buffer, sizeof(RoRnet::UserInfo));
                     Str<300> text;
-                    text << user_info.username;
                     if (user_info.authstatus != 0) // Show nothing for guests (no special authorization)
                     {
                         text << " (" << UserAuthToStringShort(user_info) << ")";

--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -311,7 +311,7 @@ void Network::RecvThread()
                 {
                     // Console is now threadsafe, no need to send fake chatmessages to ourselves
                     Str<300> text;
-                    text << _L(" left the game");
+                    text << _L("left the game");
                     App::GetConsole()->putNetMessage(user->uniqueid, Console::CONSOLE_SYSTEM_NOTICE, text.ToCStr());
                     LOG_THREAD(text);
 
@@ -339,7 +339,7 @@ void Network::RecvThread()
                     Str<300> text;
                     if (user_info.authstatus != 0) // Show nothing for guests (no special authorization)
                     {
-                        text << " (" << UserAuthToStringShort(user_info) << ")";
+                        text << "(" << UserAuthToStringShort(user_info) << ")";
                     }
                     text << _L(" joined the game");
                     

--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -339,9 +339,9 @@ void Network::RecvThread()
                     Str<300> text;
                     if (user_info.authstatus != 0) // Show nothing for guests (no special authorization)
                     {
-                        text << "(" << UserAuthToStringShort(user_info) << ")";
+                        text << "(" << UserAuthToStringShort(user_info) << ") ";
                     }
-                    text << _L(" joined the game");
+                    text << _L("joined the game");
                     
                     // NB: Console is threadsafe
                     App::GetConsole()->putNetMessage(

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -403,7 +403,7 @@ void ActorManager::HandleActorStreamData(std::vector<RoR::NetRecvPacket> packet_
                 else
                 {
                     Str<200> text;
-                    text << _L(" spawned a new vehicle: ") << filename;
+                    text << _L("spawned a new vehicle: ") << filename;
                     App::GetConsole()->putNetMessage(
                         reg->origin_sourceid, Console::CONSOLE_SYSTEM_NOTICE, text.ToCStr());
 


### PR DESCRIPTION
Requested from discord

Before:
![kk](https://user-images.githubusercontent.com/2660424/107155180-9feffb80-697f-11eb-86f3-7bb8e82ef24a.png)
After:
![kk](https://user-images.githubusercontent.com/2660424/107174254-65fc1500-69d2-11eb-8dba-7bbf744ebede.png)

Also cleaned up extra leading spaces in `putNetMessage` messages since we already have the required space in https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/gui/panels/GUI_ConsoleView.cpp#L188

Now all `putNetMessage` messages are consistent