### PR TITLE
Fixed crash with SkipMainMenu

### DIFF
--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -72,8 +72,8 @@ void MainSelector::Draw()
     GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse;
-    ImGui::SetNextWindowPosCenter(ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize(ImVec2((ImGui::GetIO().DisplaySize.x / 1.4), (ImGui::GetIO().DisplaySize.y / 1.2)), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowPosCenter(ImGuiCond_Appearing);
+    ImGui::SetNextWindowSize(ImVec2((ImGui::GetIO().DisplaySize.x / 1.4), (ImGui::GetIO().DisplaySize.y / 1.2)), ImGuiCond_Appearing);
     bool keep_open = true;
     if (!ImGui::Begin(_LC("MainSelector", "Loader"), &keep_open, win_flags))
     {

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -72,8 +72,18 @@ void MainSelector::Draw()
     GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse;
-    ImGui::SetNextWindowPosCenter(ImGuiCond_Appearing);
-    ImGui::SetNextWindowSize(ImVec2((ImGui::GetIO().DisplaySize.x / 1.4), (ImGui::GetIO().DisplaySize.y / 1.2)), ImGuiCond_Appearing);
+
+    if (initialized == true)
+    {
+        cond_flags = ImGuiCond_Appearing; // forces correct size/position when SkipMainMenu is enabled
+    }
+    else
+    {
+        cond_flags = ImGuiCond_FirstUseEver;
+    }
+
+    ImGui::SetNextWindowPosCenter(cond_flags);
+    ImGui::SetNextWindowSize(ImVec2((ImGui::GetIO().DisplaySize.x / 1.4), (ImGui::GetIO().DisplaySize.y / 1.2)), cond_flags);
     bool keep_open = true;
     if (!ImGui::Begin(_LC("MainSelector", "Loader"), &keep_open, win_flags))
     {
@@ -561,6 +571,7 @@ void MainSelector::Close()
     m_searchbox_was_active = false;
     m_loader_type = LT_None; // Hide window
     m_kb_focused = true;
+    initialized = false;
 }
 
 void MainSelector::Cancel()

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -100,6 +100,9 @@ private:
 
     std::map<LoaderType, int> m_last_selected_category; //!< Stores the last manually selected category index for each loader type
     std::map<LoaderType, int> m_last_selected_entry;    //!< Stores the last manually selected entry index for each loader type
+
+    bool               initialized = true;
+    int                cond_flags = 0;
 };
 
 } // namespace GUI

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -247,6 +247,7 @@ int main(int argc, char *argv[])
                 {
                     // MainMenu disabled (singleplayer mode) -> go directly to map selector (traditional behavior)
                     App::GetGuiManager()->SetVisible_GameMainMenu(false);
+                    App::GetContentManager()->InitModCache(CacheSystem::CacheValidityState::CACHE_STATE_UNKNOWN);
                     App::GetGuiManager()->GetMainSelector()->Show(LT_Terrain);
                 }
             }


### PR DESCRIPTION
Reported from discord

Fixes segfault when SkipMainMenu option is enabled

PS: The only way to make it set correct window position and size was `ImGuiCond_Appearing`, @only-a-ptr  is there a better way?

PS2: I think i got it