### PR TITLE
Dont load savegame with different terrain in MP

### DIFF
--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -546,6 +546,11 @@ int main(int argc, char *argv[])
                         {
                             App::GetGameContext()->LoadScene(m.description);
                         }
+                        else if (terrn_filename != App::sim_terrain_name->GetStr() && App::mp_state->GetEnum<MpState>() == MpState::CONNECTED)
+                        {
+                            Str<400> msg; msg << _L("Not loading different terrain while in Multiplayer");
+                            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING, msg.ToCStr());
+                        }
                         else
                         {
                             if (App::sim_terrain_name->GetStr() != "")


### PR DESCRIPTION
Reported from discord.

Loading a savegame with different terrain than the running one while on multiplayer causes unpredictable behavior (server will kick you for too many actors or if it loads other players can't see you)

With this PR it loads only the savegame which matches the running terrain or else:
![kk](https://user-images.githubusercontent.com/2660424/107871685-8cc3bb00-6eac-11eb-917f-837bdccaea84.png)
