### PR TITLE
Terrain editor fixes

### DIFF
--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -725,6 +725,7 @@ int main(int argc, char *argv[])
                     App::GetOverlayWrapper()->update(dt);
                     if (App::sim_state->GetEnum<SimState>() == SimState::EDITOR_MODE)
                     {
+                        App::GetGameContext()->UpdateSimInputEvents(dt);
                         App::GetSimTerrain()->GetTerrainEditor()->UpdateInputEvents(dt);
                     }
                     else if (App::sim_state->GetEnum<SimState>() == SimState::RUNNING)

--- a/source/main/terrain/TerrainEditor.cpp
+++ b/source/main/terrain/TerrainEditor.cpp
@@ -41,7 +41,7 @@ void TerrainEditor::UpdateInputEvents(float dt)
     auto& object_list = App::GetSimTerrain()->getObjectManager()->GetEditorObjects();
     bool update = false;
 
-    if (ImGui::IsMouseClicked(1)) // Middle button
+    if (ImGui::IsMouseClicked(2)) // Middle button
     {
         ImVec2 mouse_screen = ImGui::GetIO().MousePos / ImGui::GetIO().DisplaySize;
         Ogre::Ray terrain_editor_mouse_ray = App::GetCameraManager()->GetCamera()->getCameraToViewportRay(mouse_screen.x, mouse_screen.y);


### PR DESCRIPTION
Reported from discord

- Fixed ImGui mouse index (middle button -> 2)
- Fixed closing editor (`UpdateSimInputEvents` was running only in `RUNNING` state)