### PR TITLE
Reduced selector combo box size

### DIFF
--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -343,6 +343,7 @@ void MainSelector::Draw()
         DisplayEntry& sd_entry = m_display_entries[m_selected_entry];
         if (sd_entry.sde_entry->sectionconfigs.size() > 0)
         {
+            ImGui::PushItemWidth(ImGui::GetWindowWidth() / 2);
             ImGui::Combo(_LC("MainSelector", "Configuration"), &m_selected_sectionconfig,
                     &MainSelector::ScComboItemGetter, sd_entry.sde_entry,
                     static_cast<int>(sd_entry.sde_entry->sectionconfigs.size()));


### PR DESCRIPTION
So it doesn't overlapped from new sized button

![kk](https://user-images.githubusercontent.com/2660424/108249296-93c52480-715d-11eb-9916-d72a06e3ed3f.png)
