### PR TITLE
Fixed incorrect reverse light sound updating over network

### DIFF
--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -618,7 +618,7 @@ void Actor::CalcNetwork()
     else
         SOUND_STOP(ar_instance_id, SS_TRIG_HORN);
 
-    if (m_net_reverse_light)
+    if (m_net_reverse_light && ar_engine->IsRunning())
         SOUND_START(ar_instance_id, SS_TRIG_REVERSE_GEAR);
     else
         SOUND_STOP(ar_instance_id, SS_TRIG_REVERSE_GEAR);


### PR DESCRIPTION
Reported from discord:

> there’s this bug with the reverse beep being triggered every frame when the remote vehicle engine is not running