### PR TITLE
Fixed black username color on black background

### DIFF
--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -95,7 +95,7 @@ Ogre::ColourValue Network::GetPlayerColor(int color_num)
 {
     int numColours = sizeof(MP_COLORS) / sizeof(Ogre::ColourValue);
     if (color_num < 0 || color_num >= numColours)
-        return Ogre::ColourValue::ZERO;
+        return Ogre::ColourValue::White;
 
     return MP_COLORS[color_num];
 }


### PR DESCRIPTION
Reported from discord.

Happened when online players are more than our colors (25) https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/network/Network.cpp#L98

Before
![bef](https://user-images.githubusercontent.com/2660424/109378209-5ee16c00-78d9-11eb-9d37-8df634b59677.png)
After
![after](https://user-images.githubusercontent.com/2660424/109378211-630d8980-78d9-11eb-937b-873cf9a6d7d0.png)

`ZERO` worked when client list panel/chat was an overlay and had white background
