### PR TITLE
Fixed segfault with remote locked actors and reverse

### DIFF
--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -618,7 +618,7 @@ void Actor::CalcNetwork()
     else
         SOUND_STOP(ar_instance_id, SS_TRIG_HORN);
 
-    if (m_net_reverse_light && ar_engine->IsRunning())
+    if (m_net_reverse_light && ar_engine && ar_engine->IsRunning())
         SOUND_START(ar_instance_id, SS_TRIG_REVERSE_GEAR);
     else
         SOUND_STOP(ar_instance_id, SS_TRIG_REVERSE_GEAR);


### PR DESCRIPTION
Player A: Spawn sisu and trailer, lock them and wait
Player B: Spawn sisu and trailer, lock them and put reverse
Player A segfaults:
```
Thread 1 "RoR" received signal SIGSEGV, Segmentation fault.
0x00005555558160f4 in RoR::Actor::CalcNetwork (this=this@entry=0x5555611245f0)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/physics/Actor.cpp:621
621        if (m_net_reverse_light && ar_engine->IsRunning())
(gdb) bt
#0  0x00005555558160f4 in RoR::Actor::CalcNetwork (this=this@entry=0x5555611245f0)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/physics/Actor.cpp:621
#1  0x0000555555832e16 in RoR::ActorManager::UpdateActors (this=0x555555be3e40 <RoR::App::g_game_context+64>, player_actor=0x55555df12190)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/physics/ActorManager.cpp:1037
#2  0x0000555555617ce0 in RoR::GameContext::UpdateActors (this=<optimized out>)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/GameContext.cpp:461
#3  0x00005555555ea592 in main (argc=<optimized out>, argv=<optimized out>)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/main.cpp:843
```

introduced in https://github.com/RigsOfRods/rigs-of-rods/pull/2692

> makes sense because ar_engine may be nullptr for loads and stuff.