### PR TITLE
Hotfix: restored 'nocast' keyword in ODEF fileformat - resolves PSSM issues

### DIFF
--- a/source/main/resources/odef_fileformat/ODefFileFormat.cpp
+++ b/source/main/resources/odef_fileformat/ODefFileFormat.cpp
@@ -291,6 +291,11 @@ bool ODefParser::ProcessCurrentLine()
         m_def->collision_meshes.emplace_back(
             m_ctx.cbox_mesh_name, m_ctx.header_scale, m_ctx.cbox_groundmodel_name);
     }
+    else if (line_str == "nocast")
+    {
+        m_def->header.cast_shadows = false;
+    }
+
     return true;
 }
 

--- a/source/main/resources/odef_fileformat/ODefFileFormat.h
+++ b/source/main/resources/odef_fileformat/ODefFileFormat.h
@@ -121,6 +121,7 @@ struct ODefFile
     {
         std::string   mesh_name;
         Ogre::Vector3 scale;
+        bool          cast_shadows = true;
     }                             header;
 
     bool                          mode_standard = false;

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -579,6 +579,7 @@ void TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
     {
         Str<100> ebuf; ebuf << m_entity_counter++ << "-" << odef->header.mesh_name;
         mo = new MeshObject(odef->header.mesh_name, m_resource_group, ebuf.ToCStr(), tenode);
+        mo->getEntity()->setCastShadows(odef->header.cast_shadows);
         m_mesh_objects.push_back(mo);
     }
 


### PR DESCRIPTION
Accidentally dropped while creating standalone ODEF parser, see https://github.com/RigsOfRods/rigs-of-rods/commit/2046c336068ffd0e024c6b5710fe2113c14cf559

Test map: https://sim-monsters.com/files/file/3309-tampa-2020-show-1/ - uses custom skybox ODEF, so without 'nocast' everything is shadowed.

Kudos @tritonas00 for discovering.