### PR TITLE
Update cache when content changes

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -174,6 +174,7 @@ CacheEntry* CacheSystem::FindEntryByFilename(LoaderType type, bool partial, std:
 CacheSystem::CacheValidityState CacheSystem::EvaluateCacheValidity()
 {
     this->GenerateHashFromFilenames();
+    this->LoadCacheFileJson();
 
     // First, open cache file and get hash for quick update check
     rapidjson::Document j_doc;
@@ -193,6 +194,20 @@ CacheSystem::CacheValidityState CacheSystem::EvaluateCacheValidity()
     {
         RoR::Log("[RoR|ModCache] Cache file out of date");
         return CACHE_NEEDS_UPDATE;
+    }
+
+    for (auto& entry : m_entries)
+    {
+        std::string fn = entry.resource_bundle_path;
+        if (entry.resource_bundle_type == "FileSystem")
+        {
+            fn = PathCombine(fn, entry.fname);
+        }
+
+        if ((entry.filetime != RoR::GetFileLastModifiedTime(fn)))
+        {
+            return CACHE_NEEDS_UPDATE;
+        }
     }
 
     RoR::Log("[RoR|ModCache] Cache valid");


### PR DESCRIPTION
Reported from discord

Till now RoR updated the cache when content added/removed.

With this PR it also checks the `filetime` for every entry and if is different from the last time it was modified it sets `validity` to `CACHE_NEEDS_UPDATE`.

Means any change inside content (zip. skinzip ...) will now trigger cache update.

Don't know if this is the right way to do it but it works.