### PR TITLE
Added cache updated notice

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -941,6 +941,7 @@ void CacheSystem::ParseZipArchives(String group)
     }
 
     RoR::App::GetGuiManager()->SetVisible_LoadingWindow(false);
+    App::GetGuiManager()->ShowMessageBox(_L("Info"), "Cache updated");
 }
 
 void CacheSystem::ParseSingleZip(String path)


### PR DESCRIPTION
Requested from discord

Updating cache can be ultra fast, especially with little content, so the progress window will not even appear in that case (opens/closes ultra fast). This PR adds a notice every time cache is updated so the user knows that its done.

![kk](https://user-images.githubusercontent.com/2660424/112634762-a9f08f80-8e43-11eb-9055-ac7efc14677c.png)
