### PR TITLE
Fixed static reflection map being black.

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -107,7 +107,7 @@ bool GameContext::LoadTerrain(std::string const& filename_part)
     // Initialize envmap textures by rendering center of map
     Ogre::Vector3 center = App::GetSimTerrain()->getMaxTerrainSize() / 2;
     center.y = App::GetSimTerrain()->GetHeightAt(center.x, center.z) + 1.0f;
-    App::GetGfxScene()->GetEnvMap().UpdateEnvMap(center, nullptr);
+    App::GetGfxScene()->GetEnvMap().UpdateEnvMap(center, /*gfx_actor:*/nullptr, /*full:*/true);
 
     // Scan groundmodels
     App::GetGuiManager()->GetFrictionSettings()->AnalyzeTerrain();

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -205,7 +205,7 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, boo
 {
     // how many of the 6 render planes to update at once? Use cvar 'gfx_envmap_rate', unless instructed to do full render.
     const int update_rate = full ? NUM_FACES : App::gfx_envmap_rate->GetInt();
-    if (!App::gfx_envmap_enabled->GetBool() || update_rate == 0)
+    if (!full && (!App::gfx_envmap_enabled->GetBool() || update_rate == 0))
     {
         return;
     }


### PR DESCRIPTION
Even if disabled in config, the realtime envmap is fully rendered once after loading terrain, to provide static reflections.

Kudos to NegativeIce for reporting!