### PR TITLE
Fixed reflection settings

### DIFF
--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -205,7 +205,13 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, boo
 {
     // how many of the 6 render planes to update at once? Use cvar 'gfx_envmap_rate', unless instructed to do full render.
     const int update_rate = full ? NUM_FACES : App::gfx_envmap_rate->GetInt();
-    if (!full && (!App::gfx_envmap_enabled->GetBool() || update_rate == 0))
+
+    if (!App::gfx_envmap_enabled->GetBool())
+    {
+        return;
+    }
+
+    if (!full && update_rate == 0)
     {
         return;
     }


### PR DESCRIPTION
Fixed the `Reflections=Yes/No` setting not being respected

Now it works exactly like in 2020.01:

Reflections=No:
![1](https://user-images.githubusercontent.com/2660424/113232910-be4ee500-92a6-11eb-92fa-b09093a9a9f1.png)
Reflections=Yes, ReflectionUpdateRate=0:
![2](https://user-images.githubusercontent.com/2660424/113233113-2ac9e400-92a7-11eb-8888-d5ddc9416478.png)
Reflections=Yes, ReflectionUpdateRate=1:
![3](https://user-images.githubusercontent.com/2660424/113233152-3cab8700-92a7-11eb-8d2b-2adaa3109c2e.png)
Reflections=Yes, ReflectionUpdateRate=2:
![4](https://user-images.githubusercontent.com/2660424/113233163-43d29500-92a7-11eb-81d4-132f7b817b99.png)

etc...


