### PR TITLE
Added "reload/activate last spawned vehicle" to TopMenubar/Simulation menu.

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -270,6 +270,12 @@ void GameContext::ModifyActor(ActorModifyRequest& rq)
     {
         m_actor_manager.RestoreSavedState(rq.amr_actor, *rq.amr_saved_state.get());
     }
+    if (rq.amr_type == ActorModifyRequest::Type::WAKE_UP &&
+        rq.amr_actor->ar_sim_state == Actor::SimState::LOCAL_SLEEPING)
+    {
+        rq.amr_actor->ar_sim_state = Actor::SimState::LOCAL_SIMULATED;
+        rq.amr_actor->ar_sleep_counter = 0.0f;
+    }
     if (rq.amr_type == ActorModifyRequest::Type::RELOAD)
     {
         CacheEntry* entry = App::GetCacheSystem()->FindEntryByFilename(LT_AllBeam, /*partial=*/false, rq.amr_actor->ar_filename);

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -261,22 +261,25 @@ void GameContext::ModifyActor(ActorModifyRequest& rq)
     {
         rq.amr_actor->SoftReset();
     }
-    if ((rq.amr_type == ActorModifyRequest::Type::RESET_ON_SPOT) ||
-        (rq.amr_type == ActorModifyRequest::Type::RESET_ON_INIT_POS))
+    else if (rq.amr_type == ActorModifyRequest::Type::RESET_ON_SPOT)
     {
-        rq.amr_actor->SyncReset(rq.amr_type == ActorModifyRequest::Type::RESET_ON_INIT_POS);
+        rq.amr_actor->SyncReset(/*reset_position:*/false);
     }
-    if (rq.amr_type == ActorModifyRequest::Type::RESTORE_SAVED)
+    else if (rq.amr_type == ActorModifyRequest::Type::RESET_ON_INIT_POS)
+    {
+        rq.amr_actor->SyncReset(/*reset_position:*/true);
+    }
+    else if (rq.amr_type == ActorModifyRequest::Type::RESTORE_SAVED)
     {
         m_actor_manager.RestoreSavedState(rq.amr_actor, *rq.amr_saved_state.get());
     }
-    if (rq.amr_type == ActorModifyRequest::Type::WAKE_UP &&
+    else if (rq.amr_type == ActorModifyRequest::Type::WAKE_UP &&
         rq.amr_actor->ar_sim_state == Actor::SimState::LOCAL_SLEEPING)
     {
         rq.amr_actor->ar_sim_state = Actor::SimState::LOCAL_SIMULATED;
         rq.amr_actor->ar_sleep_counter = 0.0f;
     }
-    if (rq.amr_type == ActorModifyRequest::Type::RELOAD)
+    else if (rq.amr_type == ActorModifyRequest::Type::RELOAD)
     {
         CacheEntry* entry = App::GetCacheSystem()->FindEntryByFilename(LT_AllBeam, /*partial=*/false, rq.amr_actor->ar_filename);
         if (!entry)

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -200,6 +200,7 @@ Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
 
     if (rq.asr_origin == ActorSpawnRequest::Origin::USER)
     {
+        m_last_spawned_actor = fresh_actor;
         if (fresh_actor->ar_driveable != NOT_DRIVEABLE)
         {
             this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)fresh_actor));
@@ -309,6 +310,11 @@ void GameContext::DeleteActor(Actor* actor)
     if (actor == m_prev_player_actor)
     {
         m_prev_player_actor = nullptr;
+    }
+
+    if (actor == m_last_spawned_actor)
+    {
+        m_last_spawned_actor = nullptr;
     }
 
     // Find linked actors and un-tie if tied

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -97,6 +97,7 @@ public:
 
     Actor*              GetPlayerActor() { return m_player_actor; }
     Actor*              GetPrevPlayerActor() { return m_prev_player_actor; }
+    Actor*              GetLastSpawnedActor() { return m_last_spawned_actor; } //!< Last actor spawned by user and still alive.
     void                SetPrevPlayerActor(Actor* actor) { m_prev_player_actor = actor; }
     void                ChangePlayerActor(Actor* actor);
 
@@ -145,6 +146,7 @@ private:
     ActorManager        m_actor_manager;
     Actor*              m_player_actor = nullptr;           //!< Actor (vehicle or machine) mounted and controlled by player
     Actor*              m_prev_player_actor = nullptr;      //!< Previous actor (vehicle or machine) mounted and controlled by player
+    Actor*              m_last_spawned_actor = nullptr;     //!< Last actor spawned by user and still alive.
     
     CacheEntry*         m_last_cache_selection = nullptr;   //!< Vehicle/load
     CacheEntry*         m_last_skin_selection = nullptr;

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -213,6 +213,14 @@ void TopMenubar::Update()
                     rq->amr_actor = App::GetGameContext()->GetLastSpawnedActor();
                     App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
                 }
+
+                if (ImGui::Button(_LC("TopMenubar", "Activate last spawned vehicle")))
+                {
+                    ActorModifyRequest* rq = new ActorModifyRequest;
+                    rq->amr_type = ActorModifyRequest::Type::WAKE_UP;
+                    rq->amr_actor = App::GetGameContext()->GetLastSpawnedActor();
+                    App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
+                }
             }
 
             if (!App::GetGameContext()->GetActorManager()->GetLocalActors().empty())

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -203,8 +203,7 @@ void TopMenubar::Update()
                     }
                 }
             }
-
-            if (App::GetGameContext()->GetLastSpawnedActor())
+            else if (App::GetGameContext()->GetLastSpawnedActor())
             {
                 if (ImGui::Button(_LC("TopMenubar", "Reload last spawned vehicle")))
                 {

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -206,6 +206,17 @@ void TopMenubar::Update()
                 }
             }
 
+            if (App::GetGameContext()->GetLastSpawnedActor())
+            {
+                if (ImGui::Button(_LC("TopMenubar", "Reload last spawned vehicle")))
+                {
+                    ActorModifyRequest* rq = new ActorModifyRequest;
+                    rq->amr_type = ActorModifyRequest::Type::RELOAD;
+                    rq->amr_actor = App::GetGameContext()->GetLastSpawnedActor();
+                    App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
+                }
+            }
+
             if (!App::GetGameContext()->GetActorManager()->GetLocalActors().empty())
             {
                 if (ImGui::Button(_LC("TopMenubar", "Remove all vehicles")))

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -191,12 +191,10 @@ void TopMenubar::Update()
                 {
                     if (ImGui::Button(_LC("TopMenubar", "Reload current vehicle")))
                     {
-                        {
-                            ActorModifyRequest* rq = new ActorModifyRequest;
-                            rq->amr_type = ActorModifyRequest::Type::RELOAD;
-                            rq->amr_actor = current_actor;
-                            App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
-                        }
+                        ActorModifyRequest* rq = new ActorModifyRequest;
+                        rq->amr_type = ActorModifyRequest::Type::RELOAD;
+                        rq->amr_actor = current_actor;
+                        App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
                     }
 
                     if (ImGui::Button(_LC("TopMenubar", "Remove current vehicle")))

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -205,6 +205,14 @@ void TopMenubar::Update()
             }
             else if (App::GetGameContext()->GetLastSpawnedActor())
             {
+                if (ImGui::Button(_LC("TopMenubar", "Activate last spawned vehicle")))
+                {
+                    ActorModifyRequest* rq = new ActorModifyRequest;
+                    rq->amr_type = ActorModifyRequest::Type::WAKE_UP;
+                    rq->amr_actor = App::GetGameContext()->GetLastSpawnedActor();
+                    App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
+                }
+
                 if (ImGui::Button(_LC("TopMenubar", "Reload last spawned vehicle")))
                 {
                     ActorModifyRequest* rq = new ActorModifyRequest;
@@ -213,12 +221,10 @@ void TopMenubar::Update()
                     App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
                 }
 
-                if (ImGui::Button(_LC("TopMenubar", "Activate last spawned vehicle")))
+                if (ImGui::Button(_LC("TopMenubar", "Remove last spawned vehicle")))
                 {
-                    ActorModifyRequest* rq = new ActorModifyRequest;
-                    rq->amr_type = ActorModifyRequest::Type::WAKE_UP;
-                    rq->amr_actor = App::GetGameContext()->GetLastSpawnedActor();
-                    App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
+                    App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED,
+                        (void*)App::GetGameContext()->GetLastSpawnedActor()));
                 }
             }
 

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -679,7 +679,8 @@ struct ActorModifyRequest
         RESET_ON_INIT_POS,
         RESET_ON_SPOT,
         SOFT_RESET,
-        RESTORE_SAVED
+        RESTORE_SAVED,
+        WAKE_UP
     };
 
     Actor*              amr_actor;


### PR DESCRIPTION
There are 3 new menu items in the Simulation menu of top menubar. Both are only visible when not in vehicle.
* **Reload last spawned vehicle** - Works much like trusty old "Reload current vehicle", but it doesn't require you to drive the vehicle. Useful for modding loads which aren't automatically entered on spawn.
* **Activate last spawned vehicle** - Wakes up the vehicle. Again, useful for loads which are spawned sleeping and not auto-entered.
* **Remove last spawned vehicle** - Works like good old "Remove current vehicle" but operates on the last one spawned.


![image](https://user-images.githubusercontent.com/491088/113430504-982a6180-93da-11eb-8060-be95e42ece55.png)

