### PR TITLE
(Hotfix) 2 less crashes when loading terrains.

### DIFF
--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -32,6 +32,7 @@
 #include "Str.h"
 #include "ZeroedMemoryAllocator.h" // Legacy
 
+#include <fmt/format.h>
 #include <OgreStringConverter.h>
 
 #include <assert.h>

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -657,6 +657,14 @@ void TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
 
     for (ODefCollisionMesh& cmesh : odef->collision_meshes)
     {
+        if (cmesh.mesh_name == "")
+        {
+            App::GetConsole()->putMessage(
+                Console::CONSOLE_MSGTYPE_TERRN, Console::CONSOLE_SYSTEM_WARNING,
+                "ODEF: Skipping collision mesh with empty name");
+            continue;
+        }
+
         auto gm = terrainManager->GetCollisions()->getGroundModelByString(cmesh.groundmodel_name);
         terrainManager->GetCollisions()->addCollisionMesh(
             cmesh.mesh_name, pos, tenode->getOrientation(),

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -579,8 +579,17 @@ void TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
     {
         Str<100> ebuf; ebuf << m_entity_counter++ << "-" << odef->header.mesh_name;
         mo = new MeshObject(odef->header.mesh_name, m_resource_group, ebuf.ToCStr(), tenode);
-        mo->getEntity()->setCastShadows(odef->header.cast_shadows);
-        m_mesh_objects.push_back(mo);
+        if (mo->getEntity())
+        {
+            mo->getEntity()->setCastShadows(odef->header.cast_shadows);
+            m_mesh_objects.push_back(mo);
+        }
+        else
+        {
+            delete mo;
+            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_TERRN, Console::CONSOLE_SYSTEM_WARNING,
+                fmt::format("ODEF: Could not load mesh {}", odef->header.mesh_name));
+        }
     }
 
     tenode->setScale(odef->header.scale);


### PR DESCRIPTION
ODEF collmesh with empty name is now non-fatal:
![image](https://user-images.githubusercontent.com/491088/114080867-28214d00-98ac-11eb-80d9-6e0053ed35fe.png)
Same thing if mesh isn't found:
![screenshot_2021-04-08_21-04-46_1](https://user-images.githubusercontent.com/491088/114082834-86e7c600-98ae-11eb-91c8-c2dd0e56bfaa.png)


