### PR TITLE
🔧 Migrate Conan packages to Cloudsmith

### DIFF
--- a/cmake/DependenciesConfig.cmake
+++ b/cmake/DependenciesConfig.cmake
@@ -16,7 +16,7 @@ if (USE_PACKAGE_MANAGER)
     set(ROR_USE_CURL TRUE)
 
     include(pmm)
-    pmm(CONAN REMOTES ror-dependencies https://api.bintray.com/conan/anotherfoxguy/ror-dependencies BINCRAFTERS)
+    pmm(CONAN REMOTES rigs-of-rods-deps https://conan.cloudsmith.io/rigs-of-rods/deps/ BINCRAFTERS)
 
 else (USE_PACKAGE_MANAGER)
     # components

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,11 +3,11 @@ cmake
 
 [requires]
 AngelScript/2.32@anotherfoxguy/stable
-MyGUI/3.4.0-OGRE-1.11.6-with-patches@anotherfoxguy/stable
-OGRE/1.11.6-with-patches@anotherfoxguy/stable
+MyGUI/3.4.0@anotherfoxguy/stable
+OGRE/1.11.6.1@anotherfoxguy/stable
 OGREdeps/20.19.4@anotherfoxguy/stable
 SocketW/3.10.36@anotherfoxguy/stable
-discord-rpc/3.4.0@AnotherFoxGuy/stable
+discord-rpc/3.4.0@anotherfoxguy/stable
 fmt/7.1.3
 libcurl/7.69.1
 ogre-caelum/0.6.3-p1@anotherfoxguy/stable


### PR DESCRIPTION
Closes #2667

----------------
Note: on windows the old discord-rpc needs to be removed with `conan remove discord-rpc`