### PR TITLE
Removed diag_physics_dt

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -144,7 +144,6 @@ CVar* diag_hide_beam_stress;
 CVar* diag_hide_wheel_info;
 CVar* diag_hide_wheels;
 CVar* diag_hide_nodes;
-CVar* diag_physics_dt;
 CVar* diag_terrn_log_roads;
 
 // System

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -317,7 +317,6 @@ extern CVar* diag_hide_beam_stress;
 extern CVar* diag_hide_wheel_info;
 extern CVar* diag_hide_wheels;
 extern CVar* diag_hide_nodes;
-extern CVar* diag_physics_dt;
 extern CVar* diag_terrn_log_roads;
 
 // System

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -410,14 +410,6 @@ void TopMenubar::Update()
             }
             DrawGIntSlider(App::gfx_fps_limit, _LC("TopMenubar", "Game"), 0, 240);
 
-            /*   //  Uncomment if you want to tweak the physics, it has no other use, really.
-                 //  Do not publish - players tend to max it out and then complain about performance. :|
-            int physics_fps = std::round(1.0f / App::diag_physics_dt->GetFloat());
-            if (ImGui::SliderInt("Physics", &physics_fps, 2000, 10000))
-            {
-                App::diag_physics_dt->SetVal(Ogre::Math::Clamp(1.0f / physics_fps, 0.0001f, 0.0005f));
-            }
-            */
             ImGui::Separator();
             ImGui::TextColored(GRAY_HINT_TEXT, _LC("TopMenubar", "Simulation:"));
             float slowmotion = std::min(App::GetGameContext()->GetActorManager()->GetSimulationSpeed(), 1.0f);

--- a/source/main/physics/ActorManager.h
+++ b/source/main/physics/ActorManager.h
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 
-#define PHYSICS_DT App::diag_physics_dt->GetFloat()
+#define PHYSICS_DT 0.0005f // fixed dt of 0.5 ms
 
 namespace RoR {
 

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -94,7 +94,6 @@ void Console::CVarSetupBuiltins()
     App::diag_hide_wheel_info    = this->CVarCreate("diag_hide_wheel_info",    "Hide wheel info",            CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
     App::diag_hide_wheels        = this->CVarCreate("diag_hide_wheels",        "Hide wheels",                CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::diag_hide_nodes         = this->CVarCreate("diag_hide_nodes",         "Hide nodes",                 CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
-    App::diag_physics_dt         = this->CVarCreate("diag_physics_dt",          "PhysicsTimeStep",           CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "0.0005");
     App::diag_terrn_log_roads    = this->CVarCreate("diag_terrn_log_roads",    "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
 
     App::sys_process_dir         = this->CVarCreate("sys_process_dir",         "",                           0);


### PR DESCRIPTION
The UI code was removed by Petr because big values could lead to bad performance (https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/gui/panels/GUI_TopMenubar.cpp#L413-L420)

Still `diag_physics_dt` could be read from RoR.cfg (`PhysicsTimeStep`), so if a big value was set from a user with previous RoR version it could still lead to bad performance.

This completely removes `diag_physics_dt`, sets `PHYSICS_DT` at default 0.5 ms and eliminates user errors.