### PR TITLE
Added flare type 'd' (dashboard indicator)

### DIFF
--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -113,6 +113,7 @@ DashBoardManager::DashBoardManager(void) : visible(true), free_dashboard(0)
 
     INITDATA(DD_SIGNAL_TURNLEFT         , DC_BOOL, "signal_turnleft");
     INITDATA(DD_SIGNAL_TURNRIGHT        , DC_BOOL, "signal_turnright");
+    INITDATA(DD_SIGNAL_WARNING          , DC_BOOL, "signal_warning");
     // load dash fonts
     MyGUI::ResourceManager::getInstance().load("MyGUI_FontsDash.xml");
 }

--- a/source/main/gui/DashBoardManager.h
+++ b/source/main/gui/DashBoardManager.h
@@ -175,8 +175,9 @@ enum
     DD_ODOMETER_TOTAL,
     DD_ODOMETER_USER,
 
-    DD_SIGNAL_TURNLEFT,
-    DD_SIGNAL_TURNRIGHT,
+    DD_SIGNAL_TURNLEFT,  //!< Left blinker is lit.
+    DD_SIGNAL_TURNRIGHT, //!< Right blinker is lit.
+    DD_SIGNAL_WARNING,   //!< The warning-blink indicator is lit.
 
     DD_MAX
 };

--- a/source/main/gui/DashBoardManager.h
+++ b/source/main/gui/DashBoardManager.h
@@ -189,21 +189,21 @@ public:
     ~DashBoardManager(void);
 
     // Getter / Setter
-    inline bool _getBool(size_t key) { return data[key].data.value_bool; };
-    inline int _getInt(size_t key) { return data[key].data.value_int; };
-    inline float _getFloat(size_t key) { return data[key].data.value_float; };
-    inline float getNumeric(size_t key);
-    inline char* getChar(size_t key) { return data[key].data.value_char; };
-    inline bool getEnabled(size_t key) { return data[key].enabled; };
+    bool _getBool(size_t key) { return data[key].data.value_bool; };
+    int _getInt(size_t key) { return data[key].data.value_int; };
+    float _getFloat(size_t key) { return data[key].data.value_float; };
+    float getNumeric(size_t key);
+    char* getChar(size_t key) { return data[key].data.value_char; };
+    bool getEnabled(size_t key) { return data[key].enabled; };
 
-    inline void setBool(size_t key, bool& val) { data[key].data.value_bool = val; };
-    inline void setInt(size_t key, int& val) { data[key].data.value_int = val; };
-    inline void setFloat(size_t key, float& val) { data[key].data.value_float = val; };
-    inline void setChar(size_t key, const char* val) { strncpy(data[key].data.value_char, val, DD_MAXCHAR); };
+    void setBool(size_t key, bool val) { data[key].data.value_bool = val; };
+    void setInt(size_t key, int val) { data[key].data.value_int = val; };
+    void setFloat(size_t key, float val) { data[key].data.value_float = val; };
+    void setChar(size_t key, const char* val) { strncpy(data[key].data.value_char, val, DD_MAXCHAR); };
 
-    inline void setEnabled(size_t key, bool val) { data[key].enabled = val; };
+    void setEnabled(size_t key, bool val) { data[key].enabled = val; };
 
-    inline int getDataType(size_t key) { return data[key].type; };
+    int getDataType(size_t key) { return data[key].type; };
 
     int getLinkIDForName(Ogre::String& str);
 

--- a/source/main/network/OutGauge.cpp
+++ b/source/main/network/OutGauge.cpp
@@ -24,6 +24,7 @@
 #include "Application.h"
 #include "Actor.h"
 #include "ActorManager.h"
+#include "DashBoardManager.h"
 #include "EngineSim.h"
 #include "RoRVersion.h"
 
@@ -170,11 +171,11 @@ bool OutGauge::Update(float dt, Actor* truck)
             gd.ShowLights |= DL_FULLBEAM;
         if (truck->ar_engine->HasStarterContact() && !truck->ar_engine->IsRunning())
             gd.ShowLights |= DL_BATTERY;
-        if (truck->m_left_blink_lit)
+        if (truck->ar_dashboard->_getBool(DD_SIGNAL_TURNLEFT))
             gd.ShowLights |= DL_SIGNAL_L;
-        if (truck->m_right_blink_lit)
+        if (truck->ar_dashboard->_getBool(DD_SIGNAL_TURNRIGHT))
             gd.ShowLights |= DL_SIGNAL_R;
-        if (truck->m_warn_blink_lit)
+        if (truck->ar_dashboard->_getBool(DD_SIGNAL_WARNING))
             gd.ShowLights |= DL_SIGNAL_ANY;
         if (truck->tc_mode)
             gd.ShowLights |= DL_TC;

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3025,6 +3025,10 @@ void Actor::updateFlareStates(float dt)
         {
             isvisible = this->getCustomLightVisible(ar_flares[i].controlnumber);
         }
+        else if (ar_flares[i].fl_type == FlareType::DASHBOARD)
+        {
+            isvisible = ar_dashboard->_getBool(ar_flares[i].dashboard_link);
+        }
         else if (ar_flares[i].fl_type == FlareType::BLINKER_LEFT)
         {
             isvisible = (m_blink_type == BLINK_LEFT || m_blink_type == BLINK_WARN);

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -116,7 +116,7 @@ public:
     void              resolveCollisions(float max_distance, bool consider_up);
     void              updateSkidmarks();                   //!< Creates or updates skidmarks. No side effects.
     void              prepareInside(bool inside);          //!< Prepares vehicle for in-cabin camera use.
-    void              UpdateFlareStates(float dt_sec);
+    void              updateFlareStates(float dt);
     void              updateVisual(float dt=0);
     void              ScaleActor(float value);
     Ogre::Vector3     GetGForcesCur() { return m_camera_local_gforces_cur; };
@@ -504,11 +504,7 @@ private:
     bool              m_extern_reverse_light_on = false;         //!< For trailers and such - imported state.
     bool              m_beacon_light_on = false;
     bool              m_custom_lights_on[MAX_CLIGHTS] = {false}; //!< 'u' flares control number on/off states.
-
     BlinkType         m_blink_type = BLINK_NONE;                 //!< Current turn/warn signal mode.
-    bool              m_left_blink_lit = false;                  //!< Blinking state - is currently lit?
-    bool              m_right_blink_lit = false;                 //!< Blinking state - is currently lit?
-    bool              m_warn_blink_lit = false;                  //!< Blinking state - is currently lit?
     bool              m_blinker_autoreset = false;               //!< When true, we're steering and blinker will turn off automatically.
 
     bool m_hud_features_ok:1;      //!< Gfx state; Are HUD features matching actor's capabilities?

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -1024,6 +1024,9 @@ void ActorManager::UpdateActors(Actor* player_actor)
             actor->ar_engine->UpdateEngineAudio();
         }
 
+        // Always update indicator states - used by 'u' type flares.
+        actor->updateDashBoards(dt);
+
         // Blinkers (turn signals) must always be updated
         actor->updateFlareStates(dt);
 
@@ -1057,7 +1060,7 @@ void ActorManager::UpdateActors(Actor* player_actor)
             player_actor->ToggleRopes(-1);
             player_actor->ar_toggle_ropes = false;
         }
-        player_actor->updateDashBoards(dt);
+
         player_actor->ForceFeedbackStep(m_physics_steps);
 
         if (player_actor->ar_sim_state == Actor::SimState::LOCAL_REPLAY)

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -1025,7 +1025,7 @@ void ActorManager::UpdateActors(Actor* player_actor)
         }
 
         // Blinkers (turn signals) must always be updated
-        actor->UpdateFlareStates(dt);
+        actor->updateFlareStates(dt);
 
         if (actor->ar_sim_state != Actor::SimState::LOCAL_SLEEPING)
         {

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2064,6 +2064,17 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
         }
     }
 
+    if (def.type == FlareType::DASHBOARD)
+    {
+        flare.dashboard_link = m_actor->ar_dashboard->getLinkIDForName(def.dashboard_link);
+        if (flare.dashboard_link == -1)
+        {
+            this->AddMessage(Message::TYPE_WARNING,
+                fmt::format("Skipping 'd' flare, invalid input link '{}'", def.dashboard_link));
+            return;
+        }
+    }
+
     /* Visuals */
     flare.snode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
     std::string flare_name = this->ComposeName("Flare", static_cast<int>(m_actor->ar_flares.size()));
@@ -2088,6 +2099,10 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
             else if (def.type == FlareType::BLINKER_LEFT || (def.type == FlareType::BLINKER_RIGHT))
             {
                 material_name = "tracks/blinkflare";
+            }
+            else if (def.type == FlareType::DASHBOARD)
+            {
+                material_name = "tracks/greenflare";
             }
             else
             {

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2044,7 +2044,12 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
     if (def.type == FlareType::USER)
     {
         // control number: convert from 1-10 to 0-9
-        if (def.control_number < 1)
+        if (def.control_number == 12) // Special case - legacy parking brake indicator
+        {
+            flare.fl_type = FlareType::DASHBOARD;
+            flare.dashboard_link = DD_PARKINGBRAKE;
+        }
+        else if (def.control_number < 1)
         {
             this->AddMessage(Message::TYPE_WARNING,
                 fmt::format("Bad flare control num {}, must be 1-{}, using 1.",
@@ -2092,15 +2097,15 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
         using_default_material = (material_name.length() == 0 || material_name == "default");
         if (using_default_material)
         {
-            if (def.type == FlareType::BRAKE_LIGHT)
+            if (flare.fl_type == FlareType::BRAKE_LIGHT)
             {
                 material_name = "tracks/brakeflare";
             }
-            else if (def.type == FlareType::BLINKER_LEFT || (def.type == FlareType::BLINKER_RIGHT))
+            else if (flare.fl_type == FlareType::BLINKER_LEFT || (flare.fl_type == FlareType::BLINKER_RIGHT))
             {
                 material_name = "tracks/blinkflare";
             }
-            else if (def.type == FlareType::DASHBOARD)
+            else if (flare.fl_type == FlareType::DASHBOARD)
             {
                 material_name = "tracks/greenflare";
             }
@@ -2122,7 +2127,7 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
     if ((App::gfx_flares_mode->GetEnum<GfxFlaresMode>() >= GfxFlaresMode::CURR_VEHICLE_HEAD_ONLY) && size > 0.001)
     {
         //if (type == 'f' && usingDefaultMaterial && flaresMode >=2 && size > 0.001)
-        if (def.type == FlareType::HEADLIGHT && using_default_material )
+        if (flare.fl_type == FlareType::HEADLIGHT && using_default_material )
         {
             /* front light */
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
@@ -2136,7 +2141,7 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
     }
     if ((App::gfx_flares_mode->GetEnum<GfxFlaresMode>() >= GfxFlaresMode::ALL_VEHICLES_ALL_LIGHTS) && size > 0.001)
     {
-        if (def.type == FlareType::HEADLIGHT && ! using_default_material)
+        if (flare.fl_type == FlareType::HEADLIGHT && ! using_default_material)
         {
             /* this is a quick fix for the red backlight when frontlight is switched on */
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
@@ -2144,28 +2149,28 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
             flare.light->setSpecularColour( Ogre::ColourValue(1.0, 0, 0));
             flare.light->setAttenuation(10.0, 1.0, 0, 0);
         }
-        else if (def.type == FlareType::REVERSE_LIGHT)
+        else if (flare.fl_type == FlareType::REVERSE_LIGHT)
         {
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
             flare.light->setDiffuseColour(Ogre::ColourValue(1, 1, 1));
             flare.light->setSpecularColour(Ogre::ColourValue(1, 1, 1));
             flare.light->setAttenuation(20.0, 1, 0, 0);
         }
-        else if (def.type == FlareType::BRAKE_LIGHT)
+        else if (flare.fl_type == FlareType::BRAKE_LIGHT)
         {
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
             flare.light->setDiffuseColour( Ogre::ColourValue(1.0, 0, 0));
             flare.light->setSpecularColour( Ogre::ColourValue(1.0, 0, 0));
             flare.light->setAttenuation(10.0, 1.0, 0, 0);
         }
-        else if (def.type == FlareType::BLINKER_LEFT || (def.type == FlareType::BLINKER_RIGHT))
+        else if (flare.fl_type == FlareType::BLINKER_LEFT || (flare.fl_type == FlareType::BLINKER_RIGHT))
         {
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
             flare.light->setDiffuseColour( Ogre::ColourValue(1, 1, 0));
             flare.light->setSpecularColour( Ogre::ColourValue(1, 1, 0));
             flare.light->setAttenuation(10.0, 1, 1, 0);
         }
-        else if (def.type == FlareType::USER)
+        else if (flare.fl_type == FlareType::USER)
         {
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
             flare.light->setDiffuseColour( Ogre::ColourValue(1, 1, 1));

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2008,7 +2008,7 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
     /* Backwards compatibility */
     if (blink_delay == -2) 
     {
-        if (def.type == RigDef::Flare2::TYPE_l_LEFT_BLINKER || def.type == RigDef::Flare2::TYPE_r_RIGHT_BLINKER)
+        if (def.type == FlareType::BLINKER_LEFT || def.type == FlareType::BLINKER_RIGHT)
         {
             blink_delay = -1; /* Default blink */
         }
@@ -2018,17 +2018,17 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
         }
     }
     
-    if (size == -2.f && def.type == RigDef::Flare2::TYPE_f_HEADLIGHT)
+    if (size == -2.f && def.type == FlareType::HEADLIGHT)
     {
         size = 1.f;
     }
-    else if ((size == -2.f && def.type != RigDef::Flare2::TYPE_f_HEADLIGHT) || size == -1.f)
+    else if ((size == -2.f && def.type != FlareType::HEADLIGHT) || size == -1.f)
     {
         size = 0.5f;
     }
 
     flare_t flare;
-    flare.fl_type              = static_cast<FlareType>(def.type);
+    flare.fl_type              = def.type;
     flare.controlnumber        = -1;
     flare.blinkdelay           = (blink_delay == -1) ? 0.5f : blink_delay / 1000.f;
     flare.blinkdelay_curr      = 0.f;
@@ -2041,7 +2041,7 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
     flare.offsetz              = def.offset.z;
     flare.size                 = size;
 
-    if (def.type == RigDef::Flare2::TYPE_u_USER)
+    if (def.type == FlareType::USER)
     {
         // control number: convert from 1-10 to 0-9
         if (def.control_number < 1)
@@ -2081,11 +2081,11 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
         using_default_material = (material_name.length() == 0 || material_name == "default");
         if (using_default_material)
         {
-            if (def.type == RigDef::Flare2::TYPE_b_BRAKELIGHT)
+            if (def.type == FlareType::BRAKE_LIGHT)
             {
                 material_name = "tracks/brakeflare";
             }
-            else if (def.type == RigDef::Flare2::TYPE_l_LEFT_BLINKER || (def.type == RigDef::Flare2::TYPE_r_RIGHT_BLINKER))
+            else if (def.type == FlareType::BLINKER_LEFT || (def.type == FlareType::BLINKER_RIGHT))
             {
                 material_name = "tracks/blinkflare";
             }
@@ -2107,7 +2107,7 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
     if ((App::gfx_flares_mode->GetEnum<GfxFlaresMode>() >= GfxFlaresMode::CURR_VEHICLE_HEAD_ONLY) && size > 0.001)
     {
         //if (type == 'f' && usingDefaultMaterial && flaresMode >=2 && size > 0.001)
-        if (def.type == RigDef::Flare2::TYPE_f_HEADLIGHT && using_default_material )
+        if (def.type == FlareType::HEADLIGHT && using_default_material )
         {
             /* front light */
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
@@ -2121,7 +2121,7 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
     }
     if ((App::gfx_flares_mode->GetEnum<GfxFlaresMode>() >= GfxFlaresMode::ALL_VEHICLES_ALL_LIGHTS) && size > 0.001)
     {
-        if (def.type == RigDef::Flare2::TYPE_f_HEADLIGHT && ! using_default_material)
+        if (def.type == FlareType::HEADLIGHT && ! using_default_material)
         {
             /* this is a quick fix for the red backlight when frontlight is switched on */
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
@@ -2129,28 +2129,28 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
             flare.light->setSpecularColour( Ogre::ColourValue(1.0, 0, 0));
             flare.light->setAttenuation(10.0, 1.0, 0, 0);
         }
-        else if (def.type == RigDef::Flare2::TYPE_R_REVERSE_LIGHT)
+        else if (def.type == FlareType::REVERSE_LIGHT)
         {
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
             flare.light->setDiffuseColour(Ogre::ColourValue(1, 1, 1));
             flare.light->setSpecularColour(Ogre::ColourValue(1, 1, 1));
             flare.light->setAttenuation(20.0, 1, 0, 0);
         }
-        else if (def.type == RigDef::Flare2::TYPE_b_BRAKELIGHT)
+        else if (def.type == FlareType::BRAKE_LIGHT)
         {
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
             flare.light->setDiffuseColour( Ogre::ColourValue(1.0, 0, 0));
             flare.light->setSpecularColour( Ogre::ColourValue(1.0, 0, 0));
             flare.light->setAttenuation(10.0, 1.0, 0, 0);
         }
-        else if (def.type == RigDef::Flare2::TYPE_l_LEFT_BLINKER || (def.type == RigDef::Flare2::TYPE_r_RIGHT_BLINKER))
+        else if (def.type == FlareType::BLINKER_LEFT || (def.type == FlareType::BLINKER_RIGHT))
         {
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
             flare.light->setDiffuseColour( Ogre::ColourValue(1, 1, 0));
             flare.light->setSpecularColour( Ogre::ColourValue(1, 1, 0));
             flare.light->setAttenuation(10.0, 1, 1, 0);
         }
-        else if (def.type == RigDef::Flare2::TYPE_u_USER)
+        else if (def.type == FlareType::USER)
         {
             flare.light=App::GetGfxScene()->GetSceneManager()->createLight(flare_name);
             flare.light->setDiffuseColour( Ogre::ColourValue(1, 1, 1));

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -201,7 +201,8 @@ enum class FlareType: char
     REVERSE_LIGHT  = 'R',
     BLINKER_LEFT   = 'l',
     BLINKER_RIGHT  = 'r',
-    USER           = 'u'
+    USER           = 'u',
+    DASHBOARD      = 'd'
 };
 
 enum LocalizerType
@@ -540,6 +541,7 @@ struct flare_t
     Ogre::Light *light;
     FlareType fl_type;
     int controlnumber; //!< Only 'u' type flares, valid values 0-9, maps to EV_TRUCK_LIGHTTOGGLE01 to 10.
+    int dashboard_link; //!< Only 'd' type flares, valid values are DD_*
     float blinkdelay;
     float blinkdelay_curr;
     bool blinkdelay_state;

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -44,6 +44,7 @@
 #include "BitFlags.h"
 #include "RigDef_Node.h"
 #include "SimConstants.h"
+#include "SimData.h"
 
 #include <list>
 #include <memory>
@@ -947,29 +948,17 @@ struct Flare2
 {
     Flare2():
         offset(0, 0, 1), /* Section 'flares(1)' has offset.z hardcoded to 1 */
-        type(TYPE_f_HEADLIGHT),
+        type(RoR::FlareType::HEADLIGHT),
         control_number(-1),
         blink_delay_milis(-2),
         size(-1)
     {}
 
-    enum Type
-    {
-        TYPE_f_HEADLIGHT     = 'f',
-        TYPE_b_BRAKELIGHT    = 'b',
-        TYPE_l_LEFT_BLINKER  = 'l',
-        TYPE_r_RIGHT_BLINKER = 'r',
-        TYPE_R_REVERSE_LIGHT = 'R',
-        TYPE_u_USER          = 'u',
-
-        TYPE_INVALID         = 0xFFFFFFFF
-    };
-
     Node::Ref reference_node;
     Node::Ref node_axis_x;
     Node::Ref node_axis_y;
     Ogre::Vector3 offset;
-    Type type;
+    RoR::FlareType type;
     int control_number;
     int blink_delay_milis;
     float size;

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -959,7 +959,8 @@ struct Flare2
     Node::Ref node_axis_y;
     Ogre::Vector3 offset;
     RoR::FlareType type;
-    int control_number;
+    int control_number; //!< Only 'u' type flares.
+    std::string dashboard_link; //!< Only 'd' type flares.
     int blink_delay_milis;
     float size;
     Ogre::String material_name;

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -3515,18 +3515,24 @@ unsigned Parser::GetArgUint(int index)
     return static_cast<unsigned>(this->GetArgLong(index));
 }
 
-Flare2::Type Parser::GetArgFlareType(int index)
+FlareType Parser::GetArgFlareType(int index)
 {
     char in = this->GetArgChar(index);
-    if (in != 'f' && in != 'b' && in != 'l' && in != 'r' && in != 'R' && in != 'u')
+    switch (in)
     {
-        char msg[100];
-        snprintf(msg, 100, "Invalid flare type '%c', falling back to type 'f' (front light)...", in);
-        AddMessage(Message::TYPE_WARNING, msg);
+        case (char)FlareType::HEADLIGHT:
+        case (char)FlareType::BRAKE_LIGHT:
+        case (char)FlareType::BLINKER_LEFT:
+        case (char)FlareType::BLINKER_RIGHT:
+        case (char)FlareType::REVERSE_LIGHT:
+        case (char)FlareType::USER:
+            return FlareType(in);
 
-        in = 'f';
+        default:
+            this->AddMessage(Message::TYPE_WARNING,
+                fmt::format("Invalid flare type '{}', falling back to type 'f' (front light)...", in));
+            return FlareType::NONE;
     }
-    return Flare2::Type(in);
 }
 
 float Parser::GetArgFloat(int index)

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -3543,7 +3543,7 @@ FlareType Parser::GetArgFlareType(int index)
         default:
             this->AddMessage(Message::TYPE_WARNING,
                 fmt::format("Invalid flare type '{}', falling back to type 'f' (front light)...", in));
-            return FlareType::NONE;
+            return FlareType::HEADLIGHT;
     }
 }
 

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -1175,8 +1175,19 @@ void Parser::ParseFlaresUnified()
         flare2.offset.z = this->GetArgFloat(pos++);
     }
 
-    if (m_num_args > pos) { flare2.type              = this->GetArgFlareType(pos++); }
-    if (m_num_args > pos) { flare2.control_number    = this->GetArgInt      (pos++); }
+    if (m_num_args > pos) { flare2.type = this->GetArgFlareType(pos++); }
+
+    if (m_num_args > pos)
+    {
+        switch (flare2.type)
+        {
+            case FlareType::USER:      flare2.control_number = this->GetArgInt(pos); break;
+            case FlareType::DASHBOARD: flare2.dashboard_link = this->GetArgStr(pos); break;
+            default: break;
+        }
+        pos++;
+    }
+
     if (m_num_args > pos) { flare2.blink_delay_milis = this->GetArgInt      (pos++); }
     if (m_num_args > pos) { flare2.size              = this->GetArgFloat    (pos++); }
     if (m_num_args > pos) { flare2.material_name     = this->GetArgStr      (pos++); }
@@ -3526,6 +3537,7 @@ FlareType Parser::GetArgFlareType(int index)
         case (char)FlareType::BLINKER_RIGHT:
         case (char)FlareType::REVERSE_LIGHT:
         case (char)FlareType::USER:
+        case (char)FlareType::DASHBOARD:
             return FlareType(in);
 
         default:

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.h
@@ -215,7 +215,7 @@ private:
     Node::Ref          GetArgNullableNode (int index);
     MeshWheel::Side    GetArgWheelSide    (int index);
     Wing::Control      GetArgWingSurface  (int index);
-    Flare2::Type       GetArgFlareType    (int index);
+    RoR::FlareType     GetArgFlareType    (int index);
     std::string        GetArgManagedTex   (int index);
 
     float              ParseArgFloat      (const char* str);

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -770,7 +770,7 @@ void Serializer::ProcessFlares2(File::Module* module)
             << ", " << def.node_axis_y.ToString()
             << ", " << def.offset.x
             << ", " << def.offset.y
-            << ", " << def.type
+            << ", " << (char)def.type
             << ", " << def.control_number
             << ", " << def.blink_delay_milis
             << ", " << def.size


### PR DESCRIPTION
**Changes**:
* Added new type flag for flares, 'd' (dashboard indicator) - instead of a control number, you enter an input source from our dashboard system: https://docs.rigsofrods.org/vehicle-creation/making-custom-hud/#input-sources
* Restored support for special control number '12' which represents parking brake.

**Example**:
```
flares
7,3,6,   0.12, 0.3,       d, engine_ignition
7,3,6,   0.45, 0.3,       d, engine_battery
7,3,6,   0.72, 0.3,       d, engine_clutch_warning

7,3,6,   0.12, 0.15,      d, parkingbrake
7,3,6,   0.28, 0.15,      d, locked
7,3,6,   0.45, 0.15,      d, low_pressure
7,3,6,   0.68, 0.15,      d, signal_warning
```

**Demonstration**:
Test vehicle: [flareboard.zip](https://github.com/RigsOfRods/rigs-of-rods/files/6308858/flareboard.zip)
![image](https://user-images.githubusercontent.com/491088/114613490-b0846100-9ca3-11eb-8f49-67b9f8a36339.png)

