### PR TITLE
Don't check if chat window is mouse hovered

### DIFF
--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -156,7 +156,6 @@ void GameChatBox::Draw()
         }
     }
 
-    App::GetGuiManager()->RequestGuiCaptureKeyboard(ImGui::IsWindowHovered());
     ImGui::End();
 
     ImGui::PopStyleColor(2); // 2*WindowBg


### PR DESCRIPTION
Reported from forum:

> I can't steer, move around, change the view, or do any main command if my cursor is placed anywhere near the bottom part of my screen.

https://forum.rigsofrods.org/threads/2021-04-discussion-thread.3128/#post-14973