### PR TITLE
Multiplayer improvements

### DIFF
--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -89,6 +89,8 @@ enum MsgType
     MSG_SIM_DELETE_ACTOR_REQUESTED,        //!< Payload = Actor* (weak)
     MSG_SIM_SEAT_PLAYER_REQUESTED,         //!< Payload = Actor* (weak) | nullptr
     MSG_SIM_TELEPORT_PLAYER_REQUESTED,     //!< Payload = Ogre::Vector3* (owner)
+    MSG_SIM_HIDE_NET_ACTOR_REQUESTED,      //!< Payload = Actor* (weak)
+    MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED,    //!< Payload = Actor* (weak)
     // GUI
     MSG_GUI_OPEN_MENU_REQUESTED,
     MSG_GUI_CLOSE_MENU_REQUESTED,

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -291,9 +291,9 @@ void GameContext::ModifyActor(ActorModifyRequest& rq)
         m_actor_manager.RestoreSavedState(rq.amr_actor, *rq.amr_saved_state.get());
     }
     else if (rq.amr_type == ActorModifyRequest::Type::WAKE_UP &&
-        rq.amr_actor->ar_sim_state == Actor::SimState::LOCAL_SLEEPING)
+        rq.amr_actor->ar_state == ActorState::LOCAL_SLEEPING)
     {
-        rq.amr_actor->ar_sim_state = Actor::SimState::LOCAL_SIMULATED;
+        rq.amr_actor->ar_state = ActorState::LOCAL_SIMULATED;
         rq.amr_actor->ar_sleep_counter = 0.0f;
     }
     else if (rq.amr_type == ActorModifyRequest::Type::RELOAD)
@@ -886,7 +886,7 @@ void GameContext::UpdateSimInputEvents(float dt)
         else // We're in a vehicle -> If moving slowly enough, get out
         {
             if (this->GetPlayerActor()->ar_nodes[0].Velocity.squaredLength() < 1.0f ||
-                this->GetPlayerActor()->ar_sim_state == Actor::SimState::NETWORKED_OK)
+                this->GetPlayerActor()->ar_state == ActorState::NETWORKED_OK)
             {
                 this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, nullptr));
             }

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -738,19 +738,10 @@ void RoR::GfxCharacter::UpdateCharacterInScene()
             }
 
             float camDist = (xc_scenenode->getPosition() - App::GetCameraManager()->GetCameraNode()->getPosition()).length();
+            Ogre::Vector3 scene_pos = xc_scenenode->getPosition();
+            scene_pos.y += (1.9f + camDist / 100.0f);
 
-            xc_movable_text->setCaption(xc_simbuf.simbuf_net_username);
-            if (camDist > 1000.0f)
-                xc_movable_text->setCaption(xc_simbuf.simbuf_net_username + "  (" + TOSTRING((float)(ceil(camDist / 100) / 10.0f)) + " km)");
-            else if (camDist > 20.0f && camDist <= 1000.0f)
-                xc_movable_text->setCaption(xc_simbuf.simbuf_net_username + "  (" + TOSTRING((int)camDist) + " m)");
-            else
-                xc_movable_text->setCaption(xc_simbuf.simbuf_net_username);
-
-            float h = std::max(9.0f, camDist * 1.2f);
-            xc_movable_text->setAdditionalHeight(1.9f + camDist / 100.0f);
-            xc_movable_text->setCharacterHeight(h);
-            xc_movable_text->setVisible(true);
+            App::GetGfxScene()->DrawNetLabel(scene_pos, camDist, xc_simbuf.simbuf_net_username, xc_simbuf.simbuf_color_number);
         }
     }
 #endif // USE_SOCKETW

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -645,14 +645,14 @@ void RoR::GfxCharacter::UpdateCharacterInScene()
             entity->setVisible(false);
             break;
         case ActorState::NETWORKED_OK:
-            entity->setVisible(true);
+            entity->setVisible(gfx_actor->HasDriverSeatProp());
             break;
         default:
             break; // no change.
         }
 
         // If visible, update position
-        if (entity->isVisible() && gfx_actor->HasDriverSeatProp())
+        if (entity->isVisible())
         {
             if (xc_movable_text != nullptr)
             {

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -632,9 +632,27 @@ void RoR::GfxCharacter::UpdateCharacterInScene()
     }
 
     // Position + Orientation
+    Ogre::Entity* entity = static_cast<Ogre::Entity*>(xc_scenenode->getAttachedObject(0));
     if (xc_simbuf.simbuf_actor_coupling != nullptr)
     {
-        if (xc_simbuf.simbuf_actor_coupling->GetGfxActor()->HasDriverSeatProp())
+        // We're in vehicle
+        GfxActor* gfx_actor = xc_simbuf.simbuf_actor_coupling->GetGfxActor();
+
+        // Update character visibility first
+        switch (gfx_actor->GetSimDataBuffer().simbuf_actor_state)
+        {
+        case ActorState::NETWORKED_HIDDEN:
+            entity->setVisible(false);
+            break;
+        case ActorState::NETWORKED_OK:
+            entity->setVisible(true);
+            break;
+        default:
+            break; // no change.
+        }
+
+        // If visible, update position
+        if (entity->isVisible() && gfx_actor->HasDriverSeatProp())
         {
             if (xc_movable_text != nullptr)
             {
@@ -657,7 +675,6 @@ void RoR::GfxCharacter::UpdateCharacterInScene()
     }
 
     // Animation
-    Ogre::Entity* entity = static_cast<Ogre::Entity*>(xc_scenenode->getAttachedObject(0));
     if (xc_simbuf.simbuf_anim_name != xc_simbuf_prev.simbuf_anim_name)
     {
         // 'Classic' method - enable one anim, exterminate the others ~ only_a_ptr, 06/2018

--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -106,7 +106,6 @@ struct GfxCharacter
     void            UpdateCharacterInScene();
 
     Ogre::SceneNode*          xc_scenenode;
-    MovableText*              xc_movable_text; // TODO: Remake using GUI; the network labels shouldn't be part of scene. ~only_a_ptr, 05/2018
     SimBuffer                 xc_simbuf;
     SimBuffer                 xc_simbuf_prev;
     Character*                xc_character;

--- a/source/main/gameplay/RecoveryMode.cpp
+++ b/source/main/gameplay/RecoveryMode.cpp
@@ -30,8 +30,8 @@ void RecoveryMode::UpdateInputEvents(float dt)
 {
     if (App::sim_state->getEnum<SimState>() != SimState::RUNNING &&
         App::GetGameContext()->GetPlayerActor() &&
-        App::GetGameContext()->GetPlayerActor()->ar_sim_state != Actor::SimState::NETWORKED_OK &&
-        App::GetGameContext()->GetPlayerActor()->ar_sim_state != Actor::SimState::LOCAL_REPLAY)
+        App::GetGameContext()->GetPlayerActor()->ar_state != ActorState::NETWORKED_OK &&
+        App::GetGameContext()->GetPlayerActor()->ar_state != ActorState::LOCAL_REPLAY)
     {
         return;
     }

--- a/source/main/gameplay/Replay.cpp
+++ b/source/main/gameplay/Replay.cpp
@@ -250,13 +250,13 @@ void Replay::UpdateInputEvents()
 {
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_REPLAY_MODE))
     {
-        if (m_actor->ar_sim_state == Actor::SimState::LOCAL_REPLAY)
-            m_actor->ar_sim_state = Actor::SimState::LOCAL_SIMULATED;
+        if (m_actor->ar_state == ActorState::LOCAL_REPLAY)
+            m_actor->ar_state = ActorState::LOCAL_SIMULATED;
         else
-            m_actor->ar_sim_state = Actor::SimState::LOCAL_REPLAY;
+            m_actor->ar_state = ActorState::LOCAL_REPLAY;
     }
 
-    if (m_actor->ar_sim_state == Actor::SimState::LOCAL_REPLAY)
+    if (m_actor->ar_state == ActorState::LOCAL_REPLAY)
     {
         if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_REPLAY_FORWARD, 0.1f) && this->ar_replay_pos <= 0)
         {

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -127,7 +127,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
         grab_truck = NULL;
         for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
-            if (actor->ar_sim_state == Actor::SimState::LOCAL_SIMULATED)
+            if (actor->ar_state == ActorState::LOCAL_SIMULATED)
             {
                 // check if our ray intersects with the bounding box of the truck
                 std::pair<bool, Real> pair = mouseRay.intersects(actor->ar_bounding_box);

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -3317,14 +3317,25 @@ void RoR::GfxActor::SetWingsVisible(bool visible)
 {
     for (int i = 0; i < m_actor->ar_num_wings; ++i)
     {
-        wing_t& wing = m_actor->ar_wings[i];
         if (!visible)
         {
-            wing.cnode->setVisible(false);
+            m_actor->ar_wings[i].cnode->setVisible(false);
         }
         else
         {
-            wing.cnode->setVisible(true);
+            m_actor->ar_wings[i].cnode->setVisible(true);
+        }
+    }
+
+    for (size_t i=0; i< m_actor->ar_airbrakes.size(); ++i)
+    {
+        if (!visible)
+        {
+            m_gfx_airbrakes[i].abx_scenenode->setVisible(false);
+        }
+        else
+        {
+            m_gfx_airbrakes[i].abx_scenenode->setVisible(true);
         }
     }
 }

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1741,6 +1741,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
     m_simbuf.simbuf_top_speed = m_actor->ar_top_speed;
     m_simbuf.simbuf_node0_velo = m_actor->ar_nodes[0].Velocity;
     m_simbuf.simbuf_net_username = m_actor->m_net_username;
+    m_simbuf.simbuf_net_colornum = m_actor->m_net_color_num;
 
     // General info
     m_simbuf.simbuf_actor_state = m_actor->ar_state;
@@ -2059,40 +2060,7 @@ void RoR::GfxActor::UpdateNetLabels(float dt)
         float y_offset = (m_simbuf.simbuf_aabb.getMaximum().y - m_simbuf.simbuf_pos.y) + (vlen / 100.0);
         Ogre::Vector3 scene_pos = m_simbuf.simbuf_pos + Ogre::Vector3::UNIT_Y * y_offset;
 
-        // this ensures that the nickname is always in a readable size
-        float font_size = std::max(0.6, vlen / 40.0);
-        std::string caption;
-        if (vlen > 1000) // 1000 ... vlen
-        {
-            caption =
-                m_simbuf.simbuf_net_username + " (" + TOSTRING((float)(ceil(vlen / 100) / 10.0) ) + " km)";
-        }
-        else if (vlen > 20) // 20 ... vlen ... 1000
-        {
-            caption =
-                m_simbuf.simbuf_net_username + " (" + TOSTRING((int)vlen) + " m)";
-        }
-        else // 0 ... vlen ... 20
-        {
-            caption = m_simbuf.simbuf_net_username;
-        }
-
-        // draw with DearIMGUI
-
-    ImVec2 screen_size = ImGui::GetIO().DisplaySize;
-    World2ScreenConverter world2screen(
-        App::GetCameraManager()->GetCamera()->getViewMatrix(true), App::GetCameraManager()->GetCamera()->getProjectionMatrix(), Ogre::Vector2(screen_size.x, screen_size.y));
-
-    ImDrawList* drawlist = GetImDummyFullscreenWindow();
-    ImGuiContext* g = ImGui::GetCurrentContext();
-    Ogre::Vector3 pos = world2screen.Convert(scene_pos);
-
-    // only draw when in front of camera
-    if (pos.z < 0.f)
-    {
-        ImVec2 screen_pos(pos.x, pos.y);
-        drawlist->AddText(g->Font, g->FontSize, screen_pos, ImGui::GetColorU32(ImGuiCol_Text), caption.c_str());
-    }
+    App::GetGfxScene()->DrawNetLabel(scene_pos, vlen, m_simbuf.simbuf_net_username, m_simbuf.simbuf_net_colornum);
 
 }
 

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -3313,6 +3313,22 @@ void RoR::GfxActor::SetAllMeshesVisible(bool visible)
     this->SetFlexbodyVisible(visible);
 }
 
+void RoR::GfxActor::SetWingsVisible(bool visible)
+{
+    for (int i = 0; i < m_actor->ar_num_wings; ++i)
+    {
+        wing_t& wing = m_actor->ar_wings[i];
+        if (!visible)
+        {
+            wing.cnode->setVisible(false);
+        }
+        else
+        {
+            wing.cnode->setVisible(true);
+        }
+    }
+}
+
 void RoR::GfxActor::UpdateWingMeshes()
 {
     for (int i = 0; i < m_actor->ar_num_wings; ++i)

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -2351,6 +2351,17 @@ void RoR::GfxActor::SetPropsVisible(bool visible)
     }
 }
 
+void RoR::GfxActor::SetAeroEnginesVisible(bool visible)
+{
+    // For turbojets, this hides meshes (nozzle, abflame) and particles
+    // For turbo/piston-props, this only hides particles, meshes are in props.
+
+    for (int i = 0; i < m_actor->ar_num_aeroengines; i++)
+    {
+        m_actor->ar_aeroengines[i]->setVisible(visible);
+    }
+}
+
 void RoR::GfxActor::SetRenderdashActive(bool active)
 {
     if (m_renderdash != nullptr)
@@ -3287,6 +3298,7 @@ void RoR::GfxActor::SetAllMeshesVisible(bool visible)
     this->SetFlexbodyVisible(visible);
     this->SetWingsVisible(visible);
     this->SetRodsVisible(visible);
+    this->SetAeroEnginesVisible(visible);
 }
 
 void RoR::GfxActor::SetWingsVisible(bool visible)

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1726,7 +1726,7 @@ void RoR::GfxActor::SetRodsVisible(bool visible)
 
 void RoR::GfxActor::UpdateSimDataBuffer()
 {
-    m_simbuf.simbuf_live_local = (m_actor->ar_sim_state == Actor::SimState::LOCAL_SIMULATED);
+    m_simbuf.simbuf_live_local = (m_actor->ar_state == ActorState::LOCAL_SIMULATED);
     m_simbuf.simbuf_physics_paused = m_actor->ar_physics_paused;
     m_simbuf.simbuf_pos = m_actor->getRotationCenter();
     m_simbuf.simbuf_rotation = m_actor->getRotation();
@@ -1749,7 +1749,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
     m_simbuf.simbuf_top_speed = m_actor->ar_top_speed;
     m_simbuf.simbuf_node0_velo = m_actor->ar_nodes[0].Velocity;
     m_simbuf.simbuf_net_username = m_actor->m_net_username;
-    m_simbuf.simbuf_is_remote = m_actor->ar_sim_state == Actor::SimState::NETWORKED_OK;
+    m_simbuf.simbuf_is_remote = m_actor->ar_state == ActorState::NETWORKED_OK;
 
     // nodes
     const int num_nodes = m_actor->ar_num_nodes;
@@ -1875,7 +1875,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
 
 bool RoR::GfxActor::IsActorLive() const
 {
-    return (m_actor->ar_sim_state < Actor::SimState::LOCAL_SLEEPING);
+    return (m_actor->ar_state < ActorState::LOCAL_SLEEPING);
 }
 
 void RoR::GfxActor::UpdateCabMesh()
@@ -1953,7 +1953,7 @@ void RoR::GfxActor::SetWheelsVisible(bool value)
 
 
 int RoR::GfxActor::GetActorId          () const { return m_actor->ar_instance_id; }
-int RoR::GfxActor::GetActorState       () const { return static_cast<int>(m_actor->ar_sim_state); }
+int RoR::GfxActor::GetActorState       () const { return static_cast<int>(m_actor->ar_state); }
 
 ActorType RoR::GfxActor::GetActorDriveable() const
 {

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1742,6 +1742,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
     m_simbuf.simbuf_node0_velo = m_actor->ar_nodes[0].Velocity;
     m_simbuf.simbuf_net_username = m_actor->m_net_username;
     m_simbuf.simbuf_net_colornum = m_actor->m_net_color_num;
+    m_simbuf.simbuf_smoke_enabled = m_actor->getSmokeEnabled();
 
     // General info
     m_simbuf.simbuf_actor_state = m_actor->ar_state;

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1726,8 +1726,6 @@ void RoR::GfxActor::SetRodsVisible(bool visible)
 
 void RoR::GfxActor::UpdateSimDataBuffer()
 {
-    m_simbuf.simbuf_live_local = (m_actor->ar_state == ActorState::LOCAL_SIMULATED);
-    m_simbuf.simbuf_physics_paused = m_actor->ar_physics_paused;
     m_simbuf.simbuf_pos = m_actor->getRotationCenter();
     m_simbuf.simbuf_rotation = m_actor->getRotation();
     m_simbuf.simbuf_tyre_pressure = m_actor->getTyrePressure().GetCurPressure();
@@ -1749,7 +1747,10 @@ void RoR::GfxActor::UpdateSimDataBuffer()
     m_simbuf.simbuf_top_speed = m_actor->ar_top_speed;
     m_simbuf.simbuf_node0_velo = m_actor->ar_nodes[0].Velocity;
     m_simbuf.simbuf_net_username = m_actor->m_net_username;
-    m_simbuf.simbuf_is_remote = m_actor->ar_state == ActorState::NETWORKED_OK;
+
+    // General info
+    m_simbuf.simbuf_actor_state = m_actor->ar_state;
+    m_simbuf.simbuf_physics_paused = m_actor->ar_physics_paused;
 
     // nodes
     const int num_nodes = m_actor->ar_num_nodes;
@@ -2053,7 +2054,11 @@ void RoR::GfxActor::UpdateNetLabels(float dt)
     // TODO: Remake network player labels via GUI... they shouldn't be billboards inside the scene ~ only_a_ptr, 05/2018
     if (m_actor->m_net_label_node && m_actor->m_net_label_mt)
     {
-        if (App::mp_hide_net_labels->getBool() || (!m_simbuf.simbuf_is_remote && App::mp_hide_own_net_label->getBool()))
+        const bool is_remote = 
+            m_simbuf.simbuf_actor_state == ActorState::NETWORKED_OK ||
+            m_simbuf.simbuf_actor_state == ActorState::NETWORKED_HIDDEN;
+
+        if (App::mp_hide_net_labels->getBool() || (!is_remote && App::mp_hide_own_net_label->getBool()))
         {
             m_actor->m_net_label_mt->setVisible(false);
             return;

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -3285,32 +3285,20 @@ void RoR::GfxActor::SetAllMeshesVisible(bool visible)
     this->SetWheelsVisible(visible);
     this->SetPropsVisible(visible);
     this->SetFlexbodyVisible(visible);
+    this->SetWingsVisible(visible);
+    this->SetRodsVisible(visible);
 }
 
 void RoR::GfxActor::SetWingsVisible(bool visible)
 {
     for (int i = 0; i < m_actor->ar_num_wings; ++i)
     {
-        if (!visible)
-        {
-            m_actor->ar_wings[i].cnode->setVisible(false);
-        }
-        else
-        {
-            m_actor->ar_wings[i].cnode->setVisible(true);
-        }
+        m_actor->ar_wings[i].cnode->setVisible(visible);
     }
 
     for (size_t i=0; i< m_actor->ar_airbrakes.size(); ++i)
     {
-        if (!visible)
-        {
-            m_gfx_airbrakes[i].abx_scenenode->setVisible(false);
-        }
-        else
-        {
-            m_gfx_airbrakes[i].abx_scenenode->setVisible(true);
-        }
+        m_gfx_airbrakes[i].abx_scenenode->setVisible(visible);
     }
 }
 

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -212,6 +212,7 @@ public:
     void                      SetFlexbodyVisible (bool visible);
     void                      SetWheelsVisible   (bool value);
     void                      SetAllMeshesVisible(bool value);
+    void                      SetWingsVisible    (bool visible);
     void                      SetCastShadows     (bool value);
     void                      UpdateDebugView    ();
     void                      ToggleDebugView    ();

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -120,6 +120,7 @@ public:
         bool                        simbuf_tyre_pressurizing  = false;
         Ogre::AxisAlignedBox        simbuf_aabb               = Ogre::AxisAlignedBox::BOX_NULL;
         std::string                 simbuf_net_username;
+        int                         simbuf_net_colornum;
         int                         simbuf_gear               = 0;
         int                         simbuf_autoshift          = 0;
         float                       simbuf_wheel_speed        = 0;

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -223,6 +223,8 @@ public:
     void                 SetCastShadows(bool value);
     void                 SetFlexbodiesVisible(bool visible);
     void                 SetPropsVisible(bool visible);
+    void                 SetAeroEnginesVisible(bool visible);
+
 
     // Visual updates
 

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -188,76 +188,93 @@ public:
 
     ~GfxActor();
 
-    void                      AddMaterialFlare   (int flare_index, Ogre::MaterialPtr mat);
-    void                      SetMaterialFlareOn (int flare_index, bool state_on);
-    void                      RegisterCabMaterial(Ogre::MaterialPtr mat, Ogre::MaterialPtr mat_trans);
-    void                      RegisterCabMesh    (Ogre::Entity* ent, Ogre::SceneNode* snode, FlexObj* flexobj);
-    void                      SetCabLightsActive (bool state_on);
-    void                      SetVideoCamState   (VideoCamState state);
-    void                      UpdateVideoCameras (float dt_sec);
-    void                      UpdateParticles    (float dt_sec);
-    void                      AddRod             (int beam_index, int node1_index, int node2_index, const char* material_name, bool visible, float diameter_meters);
-    void                      UpdateRods         ();
-    void                      SetRodsVisible     (bool visible);
-    void                      ScaleActor         (Ogre::Vector3 relpos, float ratio);
-    bool                      IsActorLive        () const; //!< Should the visuals be updated for this actor?
-    bool                      IsActorInitialized () const  { return m_initialized; } //!< Temporary TODO: Remove once the spawn routine is fixed
-    void                      InitializeActor    ()        { m_initialized = true; } //!< Temporary TODO: Remove once the spawn routine is fixed
-    void                      UpdateSimDataBuffer(); //!< Copies sim. data from `Actor` to `GfxActor` for later update
-    void                      SetWheelVisuals    (uint16_t index, WheelGfx wheel_gfx);
-    void                      CalculateDriverPos (Ogre::Vector3& out_pos, Ogre::Quaternion& out_rot);
-    void                      UpdateWheelVisuals ();
-    void                      FinishWheelUpdates ();
-    void                      UpdateFlexbodies   ();
-    void                      FinishFlexbodyTasks();
-    void                      SetFlexbodyVisible (bool visible);
-    void                      SetWheelsVisible   (bool value);
-    void                      SetAllMeshesVisible(bool value);
-    void                      SetWingsVisible    (bool visible);
-    void                      SetCastShadows     (bool value);
-    void                      UpdateDebugView    ();
-    void                      ToggleDebugView    ();
-    void                      CycleDebugViews    ();
-    void                      UpdateCabMesh      ();
-    void                      UpdateWingMeshes   ();
-    int                       GetActorId         () const;
-    int                       GetActorState      () const;
-    int                       GetNumFlexbodies   () const { return static_cast<int>(m_flexbodies.size()); }
-    void                      ResetFlexbodies    ();
-    void                      SetFlexbodiesVisible(bool visible);
-    ActorType                 GetActorDriveable  () const;
-    void                      RegisterAirbrakes  ();
-    void                      RegisterProps      (std::vector<Prop> const& props, int driverseat_prop_idx);
-    void                      UpdateAirbrakes    ();
-    void                      UpdateCParticles   ();
-    void                      UpdateAeroEngines  ();
-    void                      UpdateNetLabels    (float dt);
-    void                      SetDebugView       (DebugViewType dv);
-    void                      SortFlexbodies     ();
-    void                      AddFlexbody        (FlexBody* fb)           { m_flexbodies.push_back(fb); }
-    Attributes&               GetAttributes      ()                       { return m_attr; }
-    inline Ogre::MaterialPtr& GetCabTransMaterial()                       { return m_cab_mat_visual_trans; }
-    inline VideoCamState      GetVideoCamState   () const                 { return m_vidcam_state; }
-    inline DebugViewType      GetDebugView       () const                 { return m_debug_view; }
-    SimBuffer &               GetSimDataBuffer   ()                       { return m_simbuf; }
-    SimBuffer::NodeSB*        GetSimNodeBuffer   ()                       { return m_simbuf.simbuf_nodes.get(); }
-    std::set<GfxActor*>       GetLinkedGfxActors ()                       { return m_linked_gfx_actors; }
-    Ogre::String              GetResourceGroup   ()                       { return m_custom_resource_group; }
-    Actor*                    GetActor           ()                       { return m_actor; } // Watch out for multithreading with this!
-    int                       FetchNumBeams      () const ;
-    int                       FetchNumNodes      () const ;
-    int                       FetchNumWheelNodes () const ;
-    bool                 HasDriverSeatProp   () const { return m_driverseat_prop_index != -1; }
-    void                 UpdateBeaconFlare   (Prop & prop, float dt, bool is_player_actor);
-    void                 UpdateProps         (float dt, bool is_player_actor);
+    // Adding elements
+
+    void                 AddMaterialFlare(int flare_index, Ogre::MaterialPtr mat);
+    void                 RegisterCabMaterial(Ogre::MaterialPtr mat, Ogre::MaterialPtr mat_trans);
+    void                 RegisterCabMesh(Ogre::Entity* ent, Ogre::SceneNode* snode, FlexObj* flexobj);
+    void                 AddRod(int beam_index, int node1_index, int node2_index, const char* material_name, bool visible, float diameter_meters);
+    void                 SetWheelVisuals(uint16_t index, WheelGfx wheel_gfx);
+    void                 RegisterAirbrakes();
+    void                 RegisterProps(std::vector<Prop> const& props, int driverseat_prop_idx);
+    void                 AddFlexbody(FlexBody* fb) { m_flexbodies.push_back(fb); }
+    void                 SortFlexbodies();
+
+    // Visual changes
+
+    void                 SetMaterialFlareOn(int flare_index, bool state_on);
+    void                 SetCabLightsActive(bool state_on);
+    void                 SetVideoCamState(VideoCamState state);
+    void                 ScaleActor(Ogre::Vector3 relpos, float ratio);
+    void                 ToggleDebugView();
+    void                 CycleDebugViews();
+    void                 ResetFlexbodies();
+    void                 SetRenderdashActive(bool active);
+    void                 SetBeaconsEnabled(bool beacon_light_is_active);
+    void                 SetDebugView(DebugViewType dv);
+
+    // Visibility
+
+    void                 SetRodsVisible(bool visible);
+    void                 SetFlexbodyVisible (bool visible);
+    void                 SetWheelsVisible(bool value);
+    void                 SetAllMeshesVisible(bool value);
+    void                 SetWingsVisible(bool visible);
+    void                 SetCastShadows(bool value);
+    void                 SetFlexbodiesVisible(bool visible);
+    void                 SetPropsVisible(bool visible);
+
+    // Visual updates
+
+    void                 UpdateVideoCameras(float dt_sec);
+    void                 UpdateParticles(float dt_sec);
+    void                 UpdateRods();
+    void                 UpdateWheelVisuals();
+    void                 UpdateFlexbodies();
+    void                 UpdateDebugView();
+    void                 UpdateCabMesh();
+    void                 UpdateWingMeshes();
+    void                 UpdateBeaconFlare(Prop & prop, float dt, bool is_player_actor);
+    void                 UpdateProps(float dt, bool is_player_actor);
     void                 UpdatePropAnimations(float dt, bool is_player_connected);
-    void                 SetPropsVisible     (bool visible);
-    void                 SetRenderdashActive (bool active);
+    void                 UpdateAirbrakes();
+    void                 UpdateCParticles();
+    void                 UpdateAeroEngines();
+    void                 UpdateNetLabels(float dt);
+    void                 UpdateFlares(float dt_sec, bool is_player);
     void                 UpdateRenderdashRTT ();
-    void                 SetBeaconsEnabled   (bool beacon_light_is_active);
-    void                 CalcPropAnimation   (const int flag_state, float& cstate, int& div, float timer,
+
+    // Internal updates
+
+    void                 UpdateSimDataBuffer(); //!< Copies sim. data from `Actor` to `GfxActor` for later update
+    void                 FinishWheelUpdates();
+    void                 FinishFlexbodyTasks();
+
+    // Helpers
+
+    bool                 IsActorLive() const; //!< Should the visuals be updated for this actor?
+    bool                 IsActorInitialized() const  { return m_initialized; } //!< Temporary TODO: Remove once the spawn routine is fixed
+    void                 InitializeActor() { m_initialized = true; } //!< Temporary TODO: Remove once the spawn routine is fixed
+    void                 CalculateDriverPos(Ogre::Vector3& out_pos, Ogre::Quaternion& out_rot);
+    int                  GetActorId() const;
+    int                  GetActorState() const;
+    int                  GetNumFlexbodies() const { return static_cast<int>(m_flexbodies.size()); }
+    ActorType            GetActorDriveable() const;
+    Attributes&          GetAttributes() { return m_attr; }
+    Ogre::MaterialPtr&   GetCabTransMaterial() { return m_cab_mat_visual_trans; }
+    VideoCamState        GetVideoCamState() const { return m_vidcam_state; }
+    DebugViewType        GetDebugView() const { return m_debug_view; }
+    SimBuffer &          GetSimDataBuffer() { return m_simbuf; }
+    SimBuffer::NodeSB*   GetSimNodeBuffer() { return m_simbuf.simbuf_nodes.get(); }
+    std::set<GfxActor*>  GetLinkedGfxActors() { return m_linked_gfx_actors; }
+    Ogre::String         GetResourceGroup() { return m_custom_resource_group; }
+    Actor*               GetActor() { return m_actor; } // Watch out for multithreading with this!
+    int                  FetchNumBeams() const ;
+    int                  FetchNumNodes() const ;
+    int                  FetchNumWheelNodes() const ;
+    bool                 HasDriverSeatProp() const { return m_driverseat_prop_index != -1; }
+    void                 CalcPropAnimation(const int flag_state, float& cstate, int& div, float timer,
                                               const float lower_limit, const float upper_limit, const float option3);
-    void                 UpdateFlares        (float dt_sec, bool is_player);
 
 private:
 

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -132,6 +132,7 @@ public:
         float                       simbuf_inputshaft_rpm     = 0;     // Land vehicle only
         float                       simbuf_drive_ratio        = 0;     // Land vehicle only
         bool                        simbuf_beaconlight_active = false;
+        bool                        simbuf_smoke_enabled      = false;
         float                       simbuf_hydro_dir_state    = 0;     // State of steering actuator ('hydro'), for steeringwheel display
         float                       simbuf_hydro_aileron_state = 0;
         float                       simbuf_hydro_elevator_state = 0;

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "Actor.h"
 #include "AutoPilot.h"
 #include "Differentials.h"
 #include "ForwardDeclarations.h"
@@ -114,14 +115,11 @@ public:
         std::unique_ptr<NodeSB>     simbuf_nodes;
         Ogre::Vector3               simbuf_pos                = Ogre::Vector3::ZERO;
         Ogre::Vector3               simbuf_node0_velo         = Ogre::Vector3::ZERO;
-        bool                        simbuf_live_local         = false;
-        bool                        simbuf_physics_paused     = false;
         float                       simbuf_rotation           = 0;
         float                       simbuf_tyre_pressure      = 0;
         bool                        simbuf_tyre_pressurizing  = false;
         Ogre::AxisAlignedBox        simbuf_aabb               = Ogre::AxisAlignedBox::BOX_NULL;
         std::string                 simbuf_net_username;
-        bool                        simbuf_is_remote          = false;
         int                         simbuf_gear               = 0;
         int                         simbuf_autoshift          = 0;
         float                       simbuf_wheel_speed        = 0;
@@ -152,6 +150,9 @@ public:
         bool                        simbuf_headlight_on       = 0;
         Ogre::Vector3               simbuf_direction          = Ogre::Vector3::ZERO;         //!< Output of `Actor::getDirection()`
         float                       simbuf_top_speed          = 0;
+        // Gameplay state
+        ActorState                  simbuf_actor_state        = ActorState::LOCAL_SLEEPING;
+        bool                        simbuf_physics_paused     = false;
         // Autopilot
         int                         simbuf_ap_heading_mode    = Autopilot::HEADING_NONE;
         int                         simbuf_ap_heading_value   = 0;

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -75,7 +75,7 @@ void GfxScene::ClearScene()
     App::GetGuiManager()->GetDirectionArrow()->CreateArrow();
 }
 
-void RoR::GfxScene::Init()
+void GfxScene::Init()
 {
     ROR_ASSERT(!m_scene_manager);
     m_scene_manager = App::GetAppContext()->GetOgreRoot()->createSceneManager(Ogre::ST_EXTERIOR_CLOSE, "main_scene_manager");
@@ -83,7 +83,7 @@ void RoR::GfxScene::Init()
     m_skidmark_conf.LoadDefaultSkidmarkDefs();
 }
 
-void RoR::GfxScene::UpdateScene(float dt_sec)
+void GfxScene::UpdateScene(float dt_sec)
 {
     // Actors - start threaded tasks
     for (GfxActor* gfx_actor: m_live_gfx_actors)
@@ -251,7 +251,7 @@ void RoR::GfxScene::UpdateScene(float dt_sec)
     }
 }
 
-void RoR::GfxScene::SetParticlesVisible(bool visible)
+void GfxScene::SetParticlesVisible(bool visible)
 {
     for (auto itor : m_dustpools)
     {
@@ -259,7 +259,7 @@ void RoR::GfxScene::SetParticlesVisible(bool visible)
     }
 }
 
-DustPool* RoR::GfxScene::GetDustPool(const char* name)
+DustPool* GfxScene::GetDustPool(const char* name)
 {
     auto found = m_dustpools.find(name);
     if (found != m_dustpools.end())
@@ -272,12 +272,12 @@ DustPool* RoR::GfxScene::GetDustPool(const char* name)
     }
 }
 
-void RoR::GfxScene::RegisterGfxActor(RoR::GfxActor* gfx_actor)
+void GfxScene::RegisterGfxActor(RoR::GfxActor* gfx_actor)
 {
     m_all_gfx_actors.push_back(gfx_actor);
 }
 
-void RoR::GfxScene::BufferSimulationData()
+void GfxScene::BufferSimulationData()
 {
     m_simbuf.simbuf_player_actor = App::GetGameContext()->GetPlayerActor();
     m_simbuf.simbuf_character_pos = App::GetGameContext()->GetPlayerCharacter()->getPosition();
@@ -312,18 +312,18 @@ void RoR::GfxScene::BufferSimulationData()
     }
 }
 
-void RoR::GfxScene::RemoveGfxActor(RoR::GfxActor* remove_me)
+void GfxScene::RemoveGfxActor(RoR::GfxActor* remove_me)
 {
     auto itor = std::remove(m_all_gfx_actors.begin(), m_all_gfx_actors.end(), remove_me);
     m_all_gfx_actors.erase(itor, m_all_gfx_actors.end());
 }
 
-void RoR::GfxScene::RegisterGfxCharacter(RoR::GfxCharacter* gfx_character)
+void GfxScene::RegisterGfxCharacter(RoR::GfxCharacter* gfx_character)
 {
     m_all_gfx_characters.push_back(gfx_character);
 }
 
-void RoR::GfxScene::RemoveGfxCharacter(RoR::GfxCharacter* remove_me)
+void GfxScene::RemoveGfxCharacter(RoR::GfxCharacter* remove_me)
 {
     auto itor = std::remove(m_all_gfx_characters.begin(), m_all_gfx_characters.end(), remove_me);
     m_all_gfx_characters.erase(itor, m_all_gfx_characters.end());

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -370,13 +370,9 @@ void GfxScene::DrawNetLabel(Ogre::Vector3 scene_pos, float cam_dist, std::string
         ImDrawList* drawlist = GetImDummyFullscreenWindow();
         ImGuiContext* g = ImGui::GetCurrentContext();
 
-        // Draw background quad
+        // Draw background rectangle
         ImVec2 screen_pos(pos.x, pos.y - (text_size.y/2));
-        const ImVec2 QUAD_PAD(4.f, 4.f); // pixels
-        ImVec2 quad_tl = screen_pos - QUAD_PAD;
-        ImVec2 quad_br = quad_tl + text_size + QUAD_PAD;
-        drawlist->AddQuadFilled(quad_tl, ImVec2(quad_tl.x, quad_br.y), quad_br, ImVec2(quad_br.x, quad_tl.y), // clockwise
-            ImColor(theme.semitransparent_window_bg));
+        drawlist->AddRectFilled(ImVec2(pos.x - 4.f, pos.y - text_size.y / 2), ImVec2(pos.x + text_size.x + 4.f, pos.y + text_size.y / 2), ImColor(theme.semitransparent_window_bg), 4.f);
 
         // draw colored text
         Ogre::ColourValue color = App::GetNetwork()->GetPlayerColor(colornum);

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -359,15 +359,29 @@ void GfxScene::DrawNetLabel(Ogre::Vector3 scene_pos, float cam_dist, std::string
     World2ScreenConverter world2screen(
         App::GetCameraManager()->GetCamera()->getViewMatrix(true), App::GetCameraManager()->GetCamera()->getProjectionMatrix(), Ogre::Vector2(screen_size.x, screen_size.y));
 
-    ImDrawList* drawlist = GetImDummyFullscreenWindow();
-    ImGuiContext* g = ImGui::GetCurrentContext();
     Ogre::Vector3 pos = world2screen.Convert(scene_pos);
 
     // only draw when in front of camera
     if (pos.z < 0.f)
     {
-        ImVec2 screen_pos(pos.x, pos.y);
-        drawlist->AddText(g->Font, g->FontSize, screen_pos, ImGui::GetColorU32(ImGuiCol_Text), caption.c_str());
+        ImVec2 text_size = ImGui::CalcTextSize(caption.c_str());
+        GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+
+        ImDrawList* drawlist = GetImDummyFullscreenWindow();
+        ImGuiContext* g = ImGui::GetCurrentContext();
+
+        // Draw background quad
+        ImVec2 screen_pos(pos.x, pos.y - (text_size.y/2));
+        const ImVec2 QUAD_PAD(4.f, 4.f); // pixels
+        ImVec2 quad_tl = screen_pos - QUAD_PAD;
+        ImVec2 quad_br = quad_tl + text_size + QUAD_PAD;
+        drawlist->AddQuadFilled(quad_tl, ImVec2(quad_tl.x, quad_br.y), quad_br, ImVec2(quad_br.x, quad_tl.y), // clockwise
+            ImColor(theme.semitransparent_window_bg));
+
+        // draw colored text
+        Ogre::ColourValue color = App::GetNetwork()->GetPlayerColor(colornum);
+        ImVec4 text_color(color.r, color.g, color.b, 1.f);
+        drawlist->AddText(g->Font, g->FontSize, screen_pos, ImColor(text_color), caption.c_str());
     }
 }
 

--- a/source/main/gfx/GfxScene.h
+++ b/source/main/gfx/GfxScene.h
@@ -66,6 +66,7 @@ public:
     void           CreateDustPools();
     DustPool*      GetDustPool(const char* name);
     void           SetParticlesVisible(bool visible);
+    void           DrawNetLabel(Ogre::Vector3 pos, float cam_dist, std::string const& nick, int colornum);
     void           UpdateScene(float dt_sec);
     void           ClearScene();
     void           RegisterGfxActor(RoR::GfxActor* gfx_actor);

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -718,7 +718,7 @@ void CameraManager::UpdateCameraBehaviorStatic()
         angle = (m_staticcam_look_at - m_staticcam_position).angleBetween(velocity);
         speed = velocity.normalise();
 
-        if (m_cct_player_actor->ar_sim_state == Actor::SimState::LOCAL_REPLAY)
+        if (m_cct_player_actor->ar_state == ActorState::LOCAL_REPLAY)
         {
             speed *= m_cct_player_actor->getReplay()->getPrecision();
         }
@@ -918,7 +918,7 @@ void CameraManager::CameraBehaviorOrbitUpdate()
     }
     else
     {
-        if (m_cct_player_actor && m_cct_player_actor->ar_sim_state == Actor::SimState::LOCAL_REPLAY && camDisplacement != Vector3::ZERO)
+        if (m_cct_player_actor && m_cct_player_actor->ar_state == ActorState::LOCAL_REPLAY && camDisplacement != Vector3::ZERO)
             this->GetCameraNode()->setPosition(desiredPosition);
         else
             this->GetCameraNode()->setPosition(camPosition);

--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -349,3 +349,21 @@ Ogre::TexturePtr RoR::FetchIcon(const char* name)
 
     return Ogre::TexturePtr(); // null
 }
+
+ImDrawList* RoR::GetImDummyFullscreenWindow()
+{
+    ImVec2 screen_size = ImGui::GetIO().DisplaySize;
+
+    // Dummy fullscreen window to draw to
+    int window_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar| ImGuiWindowFlags_NoInputs 
+                     | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus;
+    ImGui::SetNextWindowPos(ImVec2(0,0));
+    ImGui::SetNextWindowSize(screen_size);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0,0,0,0)); // Fully transparent background!
+    ImGui::Begin("RoR_TransparentFullscreenWindow", NULL, window_flags);
+    ImDrawList* drawlist = ImGui::GetWindowDrawList();
+    ImGui::End();
+    ImGui::PopStyleColor(1); // WindowBg
+
+    return drawlist;
+}

--- a/source/main/gui/GUIUtils.h
+++ b/source/main/gui/GUIUtils.h
@@ -74,4 +74,6 @@ void DrawGCombo(CVar* cvar, const char* label, const char* values);
 
 Ogre::TexturePtr FetchIcon(const char* name);
 
+ImDrawList* GetImDummyFullscreenWindow();
+
 } // namespace RoR

--- a/source/main/gui/panels/GUI_DirectionArrow.cpp
+++ b/source/main/gui/panels/GUI_DirectionArrow.cpp
@@ -22,6 +22,7 @@
 
 #include "GUI_DirectionArrow.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "GfxActor.h"
 #include "GfxScene.h"

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -201,9 +201,9 @@ void SurveyMap::Draw()
             int truckstate = gfx_actor->GetActorState();
             Str<100> fileName;
 
-            if (truckstate == static_cast<int>(Actor::SimState::LOCAL_SIMULATED))
+            if (truckstate == static_cast<int>(ActorState::LOCAL_SIMULATED))
                 fileName << "icon_" << type_str << "_activated.dds"; // green icon
-            else if (truckstate == static_cast<int>(Actor::SimState::NETWORKED_OK))
+            else if (truckstate == static_cast<int>(ActorState::NETWORKED_OK))
                 fileName << "icon_" << type_str << "_networked.dds"; // blue icon
             else
                 fileName << "icon_" << type_str << ".dds"; // gray icon

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -891,7 +891,7 @@ void TopMenubar::DrawSpecialStateBox(float top_offset)
         float distance = 0.0f;
         Actor* player_actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
         if (player_actor != nullptr && App::GetGameContext()->GetPlayerActor() &&
-            player_actor->GetGfxActor()->GetSimDataBuffer().simbuf_live_local)
+            player_actor->GetGfxActor()->GetSimDataBuffer().simbuf_actor_state == ActorState::LOCAL_SIMULATED)
         {
             distance = player_actor->GetGfxActor()->GetSimDataBuffer().simbuf_pos.distance(data.simbuf_dir_arrow_target);
         }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -745,7 +745,6 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
     // Display actor list
     Ogre::TexturePtr tex1 = FetchIcon("control_pause.png");
     Ogre::TexturePtr tex2 = FetchIcon("control_play.png");
-    Ogre::TexturePtr tex3 = FetchIcon("control_eject.png");
     int i = 0;
     for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
@@ -769,10 +768,13 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
             }
             else // Our actor(s)
             {
-                if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(tex3->getHandle()), ImVec2(16, 16)))
+                std::string text_buf_rem = fmt::format(" X ##[{}]", i);
+                ImGui::PushStyleColor(ImGuiCol_Text, RED_TEXT);
+                if (ImGui::Button(text_buf_rem.c_str()))
                 {
                    App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
                 }
+                ImGui::PopStyleColor();
             }
             ImGui::PopID();
             ImGui::SameLine();

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -189,7 +189,7 @@ void TopMenubar::Update()
                     App::GetGuiManager()->SetVisible_VehicleDescription(true);
                 }
 
-                if (current_actor->ar_sim_state != Actor::SimState::NETWORKED_OK)
+                if (current_actor->ar_state != ActorState::NETWORKED_OK)
                 {
                     if (ImGui::Button(_LC("TopMenubar", "Reload current vehicle")))
                     {
@@ -244,7 +244,7 @@ void TopMenubar::Update()
                         for (auto actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
                         {
                             if (!actor->ar_hide_in_actor_list && !actor->isPreloadedWithTerrain() && 
-                                    actor->ar_sim_state != Actor::SimState::NETWORKED_OK)
+                                    actor->ar_state != ActorState::NETWORKED_OK)
                             {
                                 App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
                             }
@@ -753,14 +753,14 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
         {
             std::string id = fmt::format("{}:{}", i++, user.uniqueid);
             ImGui::PushID(id.c_str());
-            if (actor->ar_sim_state == Actor::SimState::NETWORKED_OK)
+            if (actor->ar_state == ActorState::NETWORKED_OK)
             {
                 if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(tex1->getHandle()), ImVec2(16, 16)))
                 {
                    App::GetGameContext()->PushMessage(Message(MSG_SIM_HIDE_NET_ACTOR_REQUESTED, (void*)actor));
                 }
             }
-            else if (actor->ar_sim_state == Actor::SimState::NETWORKED_HIDDEN)
+            else if (actor->ar_state == ActorState::NETWORKED_HIDDEN)
             {
                 if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(tex2->getHandle()), ImVec2(16, 16)))
                 {
@@ -828,7 +828,7 @@ void TopMenubar::DrawActorListSinglePlayer()
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, ORANGE_TEXT);
             }
-            else if (actor->ar_sim_state == Actor::SimState::LOCAL_SIMULATED)
+            else if (actor->ar_state == ActorState::LOCAL_SIMULATED)
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, WHITE_TEXT);
             }
@@ -875,7 +875,7 @@ void TopMenubar::DrawSpecialStateBox(float top_offset)
         content_width = ImGui::CalcTextSize(special_text.c_str()).x;
     }
     else if (App::GetGameContext()->GetPlayerActor() &&
-            App::GetGameContext()->GetPlayerActor()->ar_sim_state == Actor::SimState::LOCAL_REPLAY)
+            App::GetGameContext()->GetPlayerActor()->ar_state == ActorState::LOCAL_REPLAY)
     {
         content_width = 300;
         replay_box = true;

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -743,12 +743,41 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
     ImGui::PopStyleColor();
 
     // Display actor list
+    Ogre::TexturePtr tex1 = FetchIcon("control_pause.png");
+    Ogre::TexturePtr tex2 = FetchIcon("control_play.png");
+    Ogre::TexturePtr tex3 = FetchIcon("delete.png");
     int i = 0;
     for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
         if ((!actor->ar_hide_in_actor_list) && (actor->ar_net_source_id == user.uniqueid))
         {
-            std::string actortext_buf = fmt::format("  + {} ({}) ##[{}:{}]", actor->ar_design_name.c_str(), actor->ar_filename.c_str(), i++, user.uniqueid);
+            std::string id = fmt::format("{}:{}", i++, user.uniqueid);
+            ImGui::PushID(id.c_str());
+            if (actor->ar_sim_state == Actor::SimState::NETWORKED_OK)
+            {
+                if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(tex1->getHandle()), ImVec2(16, 16)))
+                {
+                   App::GetGameContext()->PushMessage(Message(MSG_SIM_HIDE_NET_ACTOR_REQUESTED, (void*)actor));
+                }
+            }
+            else if (actor->ar_sim_state == Actor::SimState::NETWORKED_HIDDEN)
+            {
+                if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(tex2->getHandle()), ImVec2(16, 16)))
+                {
+                   App::GetGameContext()->PushMessage(Message(MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED, (void*)actor));
+                }
+            }
+            else // Our actor(s)
+            {
+                if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(tex3->getHandle()), ImVec2(16, 16)))
+                {
+                   App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
+                }
+            }
+            ImGui::PopID();
+            ImGui::SameLine();
+
+            std::string actortext_buf = fmt::format("{} ({}) ##[{}:{}]", actor->ar_design_name.c_str(), actor->ar_filename.c_str(), i++, user.uniqueid);
             if (ImGui::Button(actortext_buf.c_str())) // Button clicked?
             {
                 App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)actor));

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -745,7 +745,7 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
     // Display actor list
     Ogre::TexturePtr tex1 = FetchIcon("control_pause.png");
     Ogre::TexturePtr tex2 = FetchIcon("control_play.png");
-    Ogre::TexturePtr tex3 = FetchIcon("delete.png");
+    Ogre::TexturePtr tex3 = FetchIcon("control_eject.png");
     int i = 0;
     for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
     {

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -642,6 +642,7 @@ int main(int argc, char *argv[])
                         actor->GetGfxActor()->SetAllMeshesVisible(false);
                         actor->GetGfxActor()->SetCastShadows(false);
                         actor->GetGfxActor()->SetRodsVisible(false);
+                        actor->muteAllSounds(); // Stop sounds
                     }
                     break;
 
@@ -657,6 +658,7 @@ int main(int argc, char *argv[])
                         actor->GetGfxActor()->SetAllMeshesVisible(true);
                         actor->GetGfxActor()->SetCastShadows(true);
                         actor->GetGfxActor()->SetRodsVisible(true);
+                        actor->unmuteAllSounds(); // Unmute sounds
                     }
                     break;
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -629,6 +629,36 @@ int main(int argc, char *argv[])
                     }
                     break;
 
+                case MSG_SIM_HIDE_NET_ACTOR_REQUESTED:
+                    if (App::mp_state->GetEnum<MpState>() == MpState::CONNECTED &&
+                        ((Actor*)m.payload)->ar_sim_state == Actor::SimState::NETWORKED_OK)
+                    {
+                        Actor* actor = (Actor*)m.payload;
+                        actor->ar_sim_state = Actor::SimState::NETWORKED_HIDDEN; // Stop net. updates
+                        App::GetGfxScene()->RemoveGfxActor(actor->GetGfxActor()); // Remove visuals
+                        actor->GetGfxActor()->SetFlexbodyVisible(false);
+                        actor->GetGfxActor()->SetWheelsVisible(false);
+                        actor->GetGfxActor()->SetAllMeshesVisible(false);
+                        actor->GetGfxActor()->SetCastShadows(false);
+                        actor->GetGfxActor()->SetRodsVisible(false);
+                    }
+                    break;
+
+                case MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED:
+                    if (App::mp_state->GetEnum<MpState>() == MpState::CONNECTED &&
+                        ((Actor*)m.payload)->ar_sim_state == Actor::SimState::NETWORKED_HIDDEN)
+                    {
+                        Actor* actor = (Actor*)m.payload;
+                        actor->ar_sim_state = Actor::SimState::NETWORKED_OK; // Resume net. updates
+                        App::GetGfxScene()->RegisterGfxActor(actor->GetGfxActor()); // Restore visuals
+                        actor->GetGfxActor()->SetFlexbodyVisible(true);
+                        actor->GetGfxActor()->SetWheelsVisible(true);
+                        actor->GetGfxActor()->SetAllMeshesVisible(true);
+                        actor->GetGfxActor()->SetCastShadows(true);
+                        actor->GetGfxActor()->SetRodsVisible(true);
+                    }
+                    break;
+
                 // -- GUI events ---
 
                 case MSG_GUI_OPEN_MENU_REQUESTED:

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -645,6 +645,7 @@ int main(int argc, char *argv[])
                         actor->GetGfxActor()->SetRodsVisible(false);
                         actor->muteAllSounds(); // Stop sounds
                         actor->setLightsOff(); // Turn all lights off
+                        
                     }
                     break;
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -630,11 +630,11 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_SIM_HIDE_NET_ACTOR_REQUESTED:
-                    if (App::mp_state->GetEnum<MpState>() == MpState::CONNECTED &&
-                        ((Actor*)m.payload)->ar_sim_state == Actor::SimState::NETWORKED_OK)
+                    if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED &&
+                        ((Actor*)m.payload)->ar_state == ActorState::NETWORKED_OK)
                     {
                         Actor* actor = (Actor*)m.payload;
-                        actor->ar_sim_state = Actor::SimState::NETWORKED_HIDDEN; // Stop net. updates
+                        actor->ar_state = ActorState::NETWORKED_HIDDEN; // Stop net. updates
                         App::GetGfxScene()->RemoveGfxActor(actor->GetGfxActor()); // Remove visuals
                         actor->GetGfxActor()->SetFlexbodyVisible(false);
                         actor->GetGfxActor()->SetWheelsVisible(false);
@@ -645,11 +645,11 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED:
-                    if (App::mp_state->GetEnum<MpState>() == MpState::CONNECTED &&
-                        ((Actor*)m.payload)->ar_sim_state == Actor::SimState::NETWORKED_HIDDEN)
+                    if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED &&
+                        ((Actor*)m.payload)->ar_state == ActorState::NETWORKED_HIDDEN)
                     {
                         Actor* actor = (Actor*)m.payload;
-                        actor->ar_sim_state = Actor::SimState::NETWORKED_OK; // Resume net. updates
+                        actor->ar_state = ActorState::NETWORKED_OK; // Resume net. updates
                         App::GetGfxScene()->RegisterGfxActor(actor->GetGfxActor()); // Restore visuals
                         actor->GetGfxActor()->SetFlexbodyVisible(true);
                         actor->GetGfxActor()->SetWheelsVisible(true);
@@ -818,10 +818,10 @@ int main(int argc, char *argv[])
                             App::GetGameContext()->UpdateSimInputEvents(dt);
                             App::GetGameContext()->UpdateSkyInputEvents(dt);
                             if (App::GetGameContext()->GetPlayerActor() &&
-                                App::GetGameContext()->GetPlayerActor()->ar_sim_state != Actor::SimState::NETWORKED_OK) // we are in a vehicle
+                                App::GetGameContext()->GetPlayerActor()->ar_state != ActorState::NETWORKED_OK) // we are in a vehicle
                             {
                                 App::GetGameContext()->UpdateCommonInputEvents(dt);
-                                if (App::GetGameContext()->GetPlayerActor()->ar_sim_state != Actor::SimState::LOCAL_REPLAY)
+                                if (App::GetGameContext()->GetPlayerActor()->ar_state != ActorState::LOCAL_REPLAY)
                                 {
                                     if (App::GetGameContext()->GetPlayerActor()->ar_driveable == TRUCK)
                                     {

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -638,9 +638,7 @@ int main(int argc, char *argv[])
                         App::GetGfxScene()->RemoveGfxActor(actor->GetGfxActor()); // Remove visuals (also stops updating SimBuffer)
                         actor->GetGfxActor()->GetSimDataBuffer().simbuf_actor_state = ActorState::NETWORKED_HIDDEN; // Hack - manually propagate the new state to SimBuffer so Character can reflect it.
                         actor->GetGfxActor()->SetAllMeshesVisible(false);
-                        actor->GetGfxActor()->SetWingsVisible(false);
                         actor->GetGfxActor()->SetCastShadows(false);
-                        actor->GetGfxActor()->SetRodsVisible(false);
                         actor->muteAllSounds(); // Stop sounds
                         actor->setLightsOff(); // Turn all lights off
                         
@@ -655,9 +653,7 @@ int main(int argc, char *argv[])
                         actor->ar_state = ActorState::NETWORKED_OK; // Resume net. updates
                         App::GetGfxScene()->RegisterGfxActor(actor->GetGfxActor()); // Restore visuals (also resumes updating SimBuffer)
                         actor->GetGfxActor()->SetAllMeshesVisible(true);
-                        actor->GetGfxActor()->SetWingsVisible(true);
                         actor->GetGfxActor()->SetCastShadows(true);
-                        actor->GetGfxActor()->SetRodsVisible(true);
                         actor->unmuteAllSounds(); // Unmute sounds
                     }
                     break;

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -640,6 +640,7 @@ int main(int argc, char *argv[])
                         actor->GetGfxActor()->SetFlexbodyVisible(false);
                         actor->GetGfxActor()->SetWheelsVisible(false);
                         actor->GetGfxActor()->SetAllMeshesVisible(false);
+                        actor->GetGfxActor()->SetWingsVisible(false);
                         actor->GetGfxActor()->SetCastShadows(false);
                         actor->GetGfxActor()->SetRodsVisible(false);
                         actor->muteAllSounds(); // Stop sounds
@@ -657,6 +658,7 @@ int main(int argc, char *argv[])
                         actor->GetGfxActor()->SetFlexbodyVisible(true);
                         actor->GetGfxActor()->SetWheelsVisible(true);
                         actor->GetGfxActor()->SetAllMeshesVisible(true);
+                        actor->GetGfxActor()->SetWingsVisible(true);
                         actor->GetGfxActor()->SetCastShadows(true);
                         actor->GetGfxActor()->SetRodsVisible(true);
                         actor->unmuteAllSounds(); // Unmute sounds

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -635,7 +635,8 @@ int main(int argc, char *argv[])
                     {
                         Actor* actor = (Actor*)m.payload;
                         actor->ar_state = ActorState::NETWORKED_HIDDEN; // Stop net. updates
-                        App::GetGfxScene()->RemoveGfxActor(actor->GetGfxActor()); // Remove visuals
+                        App::GetGfxScene()->RemoveGfxActor(actor->GetGfxActor()); // Remove visuals (also stops updating SimBuffer)
+                        actor->GetGfxActor()->GetSimDataBuffer().simbuf_actor_state = ActorState::NETWORKED_HIDDEN; // Hack - manually propagate the new state to SimBuffer so Character can reflect it.
                         actor->GetGfxActor()->SetFlexbodyVisible(false);
                         actor->GetGfxActor()->SetWheelsVisible(false);
                         actor->GetGfxActor()->SetAllMeshesVisible(false);
@@ -650,7 +651,7 @@ int main(int argc, char *argv[])
                     {
                         Actor* actor = (Actor*)m.payload;
                         actor->ar_state = ActorState::NETWORKED_OK; // Resume net. updates
-                        App::GetGfxScene()->RegisterGfxActor(actor->GetGfxActor()); // Restore visuals
+                        App::GetGfxScene()->RegisterGfxActor(actor->GetGfxActor()); // Restore visuals (also resumes updating SimBuffer)
                         actor->GetGfxActor()->SetFlexbodyVisible(true);
                         actor->GetGfxActor()->SetWheelsVisible(true);
                         actor->GetGfxActor()->SetAllMeshesVisible(true);

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -637,8 +637,6 @@ int main(int argc, char *argv[])
                         actor->ar_state = ActorState::NETWORKED_HIDDEN; // Stop net. updates
                         App::GetGfxScene()->RemoveGfxActor(actor->GetGfxActor()); // Remove visuals (also stops updating SimBuffer)
                         actor->GetGfxActor()->GetSimDataBuffer().simbuf_actor_state = ActorState::NETWORKED_HIDDEN; // Hack - manually propagate the new state to SimBuffer so Character can reflect it.
-                        actor->GetGfxActor()->SetFlexbodyVisible(false);
-                        actor->GetGfxActor()->SetWheelsVisible(false);
                         actor->GetGfxActor()->SetAllMeshesVisible(false);
                         actor->GetGfxActor()->SetWingsVisible(false);
                         actor->GetGfxActor()->SetCastShadows(false);
@@ -656,8 +654,6 @@ int main(int argc, char *argv[])
                         Actor* actor = (Actor*)m.payload;
                         actor->ar_state = ActorState::NETWORKED_OK; // Resume net. updates
                         App::GetGfxScene()->RegisterGfxActor(actor->GetGfxActor()); // Restore visuals (also resumes updating SimBuffer)
-                        actor->GetGfxActor()->SetFlexbodyVisible(true);
-                        actor->GetGfxActor()->SetWheelsVisible(true);
                         actor->GetGfxActor()->SetAllMeshesVisible(true);
                         actor->GetGfxActor()->SetWingsVisible(true);
                         actor->GetGfxActor()->SetCastShadows(true);

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -643,6 +643,7 @@ int main(int argc, char *argv[])
                         actor->GetGfxActor()->SetCastShadows(false);
                         actor->GetGfxActor()->SetRodsVisible(false);
                         actor->muteAllSounds(); // Stop sounds
+                        actor->setLightsOff(); // Turn all lights off
                     }
                     break;
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -641,7 +641,7 @@ int main(int argc, char *argv[])
                         actor->GetGfxActor()->SetCastShadows(false);
                         actor->muteAllSounds(); // Stop sounds
                         actor->setLightsOff(); // Turn all lights off
-                        
+                        actor->setSmokeEnabled(false);
                     }
                     break;
 
@@ -655,6 +655,7 @@ int main(int argc, char *argv[])
                         actor->GetGfxActor()->SetAllMeshesVisible(true);
                         actor->GetGfxActor()->SetCastShadows(true);
                         actor->unmuteAllSounds(); // Unmute sounds
+                        actor->setSmokeEnabled(true);
                     }
                     break;
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3186,7 +3186,7 @@ void Actor::updateVisual(float dt)
 
     // update exhausts
     // TODO: Move to GfxActor, don't forget dt*m_simulation_speed
-    if (!m_disable_smoke && ar_engine && exhausts.size() > 0)
+    if (ar_engine && exhausts.size() > 0)
     {
         std::vector<exhaust_t>::iterator it;
         for (it = exhausts.begin(); it != exhausts.end(); it++)
@@ -3198,7 +3198,7 @@ void Actor::updateVisual(float dt)
             ParticleEmitter* emit = it->smoker->getEmitter(0);
             it->smokeNode->setPosition(ar_nodes[it->emitterNode].AbsPosition);
             emit->setDirection(dir);
-            if (ar_engine->GetSmoke() != -1.0)
+            if (!m_disable_smoke && ar_engine->GetSmoke() != -1.0)
             {
                 emit->setEnabled(true);
                 emit->setColour(ColourValue(0.0, 0.0, 0.0, 0.02 + ar_engine->GetSmoke() * 0.06));

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2992,6 +2992,14 @@ void Actor::lightsToggle()
     TRIGGER_EVENT(SE_TRUCK_LIGHT_TOGGLE, ar_instance_id);
 }
 
+void Actor::setLightsOff()
+{
+    for (size_t i = 0; i < ar_flares.size(); i++)
+    {
+        ar_flares[i].snode->setVisible(false);
+    }
+}
+
 void Actor::updateFlareStates(float dt)
 {
     if (m_flares_mode == GfxFlaresMode::NONE) { return; }

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2948,11 +2948,11 @@ void Actor::lightsToggle()
 {
     // export light command
     Actor* player_actor = App::GetGameContext()->GetPlayerActor();
-    if (ar_sim_state == Actor::SimState::LOCAL_SIMULATED && this == player_actor && ar_forward_commands)
+    if (ar_state == ActorState::LOCAL_SIMULATED && this == player_actor && ar_forward_commands)
     {
         for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
-            if (actor->ar_sim_state == Actor::SimState::LOCAL_SIMULATED && this != actor && actor->ar_import_commands)
+            if (actor->ar_state == ActorState::LOCAL_SIMULATED && this != actor && actor->ar_import_commands)
                 actor->lightsToggle();
         }
     }
@@ -3171,7 +3171,7 @@ void Actor::updateVisual(float dt)
 
 #ifdef USE_OPENAL
     //airplane radio chatter
-    if (ar_driveable == AIRPLANE && ar_sim_state != SimState::LOCAL_SLEEPING)
+    if (ar_driveable == AIRPLANE && ar_state != ActorState::LOCAL_SLEEPING)
     {
         // play random chatter at random time
         m_avionic_chatter_timer -= dt;
@@ -3420,7 +3420,7 @@ void Actor::tieToggle(int group)
                 // iterate over all actors
                 for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
                 {
-                    if (actor->ar_sim_state == SimState::LOCAL_SLEEPING ||
+                    if (actor->ar_state == ActorState::LOCAL_SLEEPING ||
                         (actor == this && it->ti_no_self_lock))
                     {
                         continue;
@@ -3549,7 +3549,7 @@ void Actor::ropeToggle(int group)
             // iterate over all actor_slots
             for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
-                if (actor->ar_sim_state == SimState::LOCAL_SLEEPING)
+                if (actor->ar_state == ActorState::LOCAL_SLEEPING)
                     continue;
                 // and their ropables
                 for (std::vector<ropable_t>::iterator itr = actor->ar_ropables.begin(); itr != actor->ar_ropables.end(); itr++)
@@ -3658,7 +3658,7 @@ void Actor::hookToggle(int group, HookAction mode, int node_number)
             // iterate over all actor_slots
             for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
-                if (actor->ar_sim_state == SimState::LOCAL_SLEEPING)
+                if (actor->ar_state == ActorState::LOCAL_SLEEPING)
                     continue;
                 if (this == actor && !it->hk_selflock)
                     continue; // don't lock to self
@@ -3780,7 +3780,7 @@ void Actor::beaconsToggle()
 
 bool Actor::getReverseLightVisible()
 {
-    if (ar_sim_state == SimState::NETWORKED_OK)
+    if (ar_state == ActorState::NETWORKED_OK)
         return m_net_reverse_light_on;
 
     if (ar_engine)
@@ -4496,7 +4496,7 @@ void Actor::setMass(float m)
 
 bool Actor::getBrakeLightVisible()
 {
-    if (ar_sim_state == SimState::NETWORKED_OK)
+    if (ar_state == ActorState::NETWORKED_OK)
         return m_net_brake_light_on;
 
     return (ar_brake > 0.01f && !ar_parking_brake);

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -245,13 +245,6 @@ Actor::~Actor()
         delete (*it);
     }
 
-    if (m_net_label_mt)
-    {
-        m_net_label_mt->setVisible(false);
-        delete m_net_label_mt;
-        m_net_label_mt = nullptr;
-    }
-
     if (m_intra_point_col_detector)
     {
         delete m_intra_point_col_detector;
@@ -4417,8 +4410,6 @@ Actor::Actor(
     , m_mouse_grab_node(-1)
     , m_mouse_grab_pos(Ogre::Vector3::ZERO)
     , m_net_initialized(false)
-    , m_net_label_node(0)
-    , m_net_label_mt(0)
     , ar_initial_total_mass(0)
     , ar_parking_brake(false)
     , ar_trailer_parking_brake(false)

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -123,6 +123,8 @@ public:
     Ogre::String      getTransferCaseName();               //! Gets the current transfer case mode name (4WD Hi, ...)
     void              displayTransferCaseMode();           //! Writes info to console/notify area
     void              toggleCustomParticles();
+    void              setSmokeEnabled(bool enabled) { m_disable_smoke = !enabled; }
+    bool              getSmokeEnabled() const { return !m_disable_smoke; }
     bool              getCustomParticleMode();
     void              beaconsToggle();
     bool              getBrakeLightVisible();
@@ -534,7 +536,7 @@ private:
     bool m_beam_deform_debug_enabled:1; //!< Logging state
     bool m_trigger_debug_enabled:1;     //!< Logging state
     bool m_disable_default_sounds:1;    //!< Spawner context; TODO: remove
-    bool m_disable_smoke:1;             //!< Gfx state
+    bool m_disable_smoke:1;             //!< Stops/starts smoke particles (i.e. exhausts, turbojets).
 
     struct VehicleForceSensors
     {

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -48,6 +48,7 @@ public:
     {
         LOCAL_SIMULATED,  //!< simulated (local) actor
         NETWORKED_OK,     //!< not simulated (remote) actor
+        NETWORKED_HIDDEN, //!< not simulated, not updated (remote)
         LOCAL_REPLAY,
         LOCAL_SLEEPING,   //!< sleeping (local) actor
     };

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -470,6 +470,7 @@ private:
     MovableText*      m_net_label_mt;
     Ogre::SceneNode*  m_net_label_node;
     Ogre::UTFString   m_net_username;
+    int               m_net_color_num;
     Ogre::Timer       m_reset_timer;
     Ogre::Vector3     m_rotation_request_center;
     float             m_rotation_request;         //!< Accumulator

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -103,6 +103,7 @@ public:
     //! @{ User interaction functions
     void              mouseMove(int node, Ogre::Vector3 pos, float force);
     void              lightsToggle();
+    void              setLightsOff();
     void              tieToggle(int group=-1);
     bool              isTied();
     void              hookToggle(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1);

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -25,7 +25,6 @@
 #include "CmdKeyInertia.h"
 #include "Differentials.h"
 #include "GfxActor.h"
-#include "MovableText.h"
 #include "PerVehicleCameraContext.h"
 #include "RigDef_Prerequisites.h"
 #include "SimData.h"
@@ -467,8 +466,6 @@ private:
     Ogre::Vector3     m_mouse_grab_pos;
     float             m_mouse_grab_move_force;
     float             m_spawn_rotation;
-    MovableText*      m_net_label_mt;
-    Ogre::SceneNode*  m_net_label_node;
     Ogre::UTFString   m_net_username;
     int               m_net_color_num;
     Ogre::Timer       m_reset_timer;

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -22,12 +22,13 @@
 #pragma once
 
 #include "Application.h"
-#include "SimData.h"
 #include "CmdKeyInertia.h"
+#include "Differentials.h"
 #include "GfxActor.h"
 #include "MovableText.h"
 #include "PerVehicleCameraContext.h"
 #include "RigDef_Prerequisites.h"
+#include "SimData.h"
 #include "TyrePressure.h"
 
 #include <Ogre.h>
@@ -43,15 +44,6 @@ class Actor : public ZeroedMemoryAllocator
     friend class GfxActor; // Temporary until all visuals are moved there. ~ only_a_ptr, 2018
     friend class OutGauge;
 public:
-
-    enum class SimState
-    {
-        LOCAL_SIMULATED,  //!< simulated (local) actor
-        NETWORKED_OK,     //!< not simulated (remote) actor
-        NETWORKED_HIDDEN, //!< not simulated, not updated (remote)
-        LOCAL_REPLAY,
-        LOCAL_SLEEPING,   //!< sleeping (local) actor
-    };
 
     Actor(
           int actor_id
@@ -360,10 +352,12 @@ public:
     Ogre::Timer       ar_net_timer;
     unsigned long     ar_net_last_update_time;
     DashBoardManager* ar_dashboard;
-    SimState          ar_sim_state;                   //!< Sim state
     float             ar_collision_range;             //!< Physics attr
     float             ar_top_speed;                   //!< Sim state
     ground_model_t*   ar_last_fuzzy_ground_model;     //!< GUI state
+
+    // Gameplay state
+    ActorState        ar_state;
 
     // Realtime node/beam structure editing helpers
     bool                    ar_nb_initialized;

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -1098,7 +1098,7 @@ bool Actor::CalcForcesEulerPrepare(bool doUpdate)
         return false;
     if (ar_physics_paused)
         return false;
-    if (ar_sim_state != Actor::SimState::LOCAL_SIMULATED)
+    if (ar_state != ActorState::LOCAL_SIMULATED)
         return false;
 
     if (doUpdate)

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -483,9 +483,12 @@ void ActorManager::HandleActorStreamData(std::vector<RoR::NetRecvPacket> packet_
         else if (packet.header.command == RoRnet::MSG2_STREAM_UNREGISTER)
         {
             Actor* b = this->GetActorByNetworkLinks(packet.header.source, packet.header.streamid);
-            if (b && b->ar_state == ActorState::NETWORKED_OK)
+            if (b)
             {
-                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)b));
+                if (b->ar_state == ActorState::NETWORKED_OK || b->ar_state == ActorState::NETWORKED_HIDDEN)
+                {
+                    App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)b));
+                }
             }
             m_stream_mismatches[packet.header.source].erase(packet.header.streamid);
         }

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -314,6 +314,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
         }
 
         actor->m_net_username = rq.asr_net_username;
+        actor->m_net_color_num = rq.asr_net_color;
 
         RoR::Str<100> element_name;
         ActorSpawner::ComposeName(element_name, "NetLabel", 0, actor->ar_instance_id);

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -315,20 +315,6 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
 
         actor->m_net_username = rq.asr_net_username;
         actor->m_net_color_num = rq.asr_net_color;
-
-        RoR::Str<100> element_name;
-        ActorSpawner::ComposeName(element_name, "NetLabel", 0, actor->ar_instance_id);
-        actor->m_net_label_mt = new MovableText(element_name.ToCStr(), actor->m_net_username);
-        actor->m_net_label_mt->setTextAlignment(MovableText::H_CENTER, MovableText::V_ABOVE);
-#ifdef USE_SOCKETW
-        actor->m_net_label_mt->setColor(App::GetNetwork()->GetPlayerColor((rq.asr_net_color)));
-#endif // USE_SOCKETW
-        actor->m_net_label_mt->setVisible(true);
-
-        actor->m_net_label_node = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
-        actor->m_net_label_node->attachObject(actor->m_net_label_mt);
-        actor->m_net_label_node->setVisible(true);
-        actor->m_deletion_scene_nodes.emplace_back(actor->m_net_label_node);
     }
     else if (App::sim_replay_enabled->getBool())
     {

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -280,7 +280,7 @@ void ActorSpawner::InitializeRig()
     m_actor->ar_num_cinecams=0;
     m_actor->m_deletion_scene_nodes.clear();
 
-    m_actor->ar_sim_state = Actor::SimState::LOCAL_SLEEPING;
+    m_actor->ar_state = ActorState::LOCAL_SLEEPING;
     m_actor->m_fusealge_airfoil = nullptr;
     m_actor->m_fusealge_front = nullptr;
     m_actor->m_fusealge_back = nullptr;
@@ -660,7 +660,7 @@ void ActorSpawner::ProcessTurbojet(RigDef::Turbojet & def)
 
     m_actor->ar_aeroengines[m_actor->ar_num_aeroengines]=tj;
     m_actor->ar_driveable=AIRPLANE;
-    if (m_actor->ar_autopilot == nullptr && m_actor->ar_sim_state != Actor::SimState::NETWORKED_OK)
+    if (m_actor->ar_autopilot == nullptr && m_actor->ar_state != ActorState::NETWORKED_OK)
     {
         m_actor->ar_autopilot=new Autopilot(m_actor->ar_instance_id);
     }
@@ -783,7 +783,7 @@ void ActorSpawner::BuildAerialEngine(
     m_actor->ar_driveable = AIRPLANE;
 
     /* Autopilot */
-    if (m_actor->ar_autopilot == nullptr && m_actor->ar_sim_state != Actor::SimState::NETWORKED_OK)
+    if (m_actor->ar_autopilot == nullptr && m_actor->ar_state != ActorState::NETWORKED_OK)
     {
         m_actor->ar_autopilot = new Autopilot(m_actor->ar_instance_id);
     }
@@ -910,7 +910,7 @@ void ActorSpawner::ProcessWing(RigDef::Wing & def)
         def.max_deflection,
         def.airfoil,
         def.efficacy_coef,
-        m_actor->ar_sim_state != Actor::SimState::NETWORKED_OK
+        m_actor->ar_state != ActorState::NETWORKED_OK
     );
 
     Ogre::Entity* entity = nullptr;

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -656,7 +656,7 @@ void ActorSpawner::ProcessTurbojet(RigDef::Turbojet & def)
     std::string propname = this->ComposeName("Turbojet", m_actor->ar_num_aeroengines);
     tj->tjet_visual.SetNodes(front, back, ref);
     tj->tjet_visual.SetupVisuals(def, m_actor->ar_num_aeroengines,
-        propname, nozzle_ent, afterburn_ent, m_actor->m_disable_smoke);
+        propname, nozzle_ent, afterburn_ent);
 
     m_actor->ar_aeroengines[m_actor->ar_num_aeroengines]=tj;
     m_actor->ar_driveable=AIRPLANE;
@@ -5749,10 +5749,6 @@ void ActorSpawner::AddExhaust(
         unsigned int direction_node_idx
     )
 {
-    if (m_actor->m_disable_smoke)
-    {
-        return;
-    }
     exhaust_t exhaust;
     exhaust.emitterNode = emitter_node_idx;
     exhaust.directionNode = direction_node_idx;

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -657,6 +657,10 @@ void ActorSpawner::ProcessTurbojet(RigDef::Turbojet & def)
     tj->tjet_visual.SetNodes(front, back, ref);
     tj->tjet_visual.SetupVisuals(def, m_actor->ar_num_aeroengines,
         propname, nozzle_ent, afterburn_ent);
+    if (!m_actor->m_disable_smoke)
+    {
+        tj->tjet_visual.SetVisible(true);
+    }
 
     m_actor->ar_aeroengines[m_actor->ar_num_aeroengines]=tj;
     m_actor->ar_driveable=AIRPLANE;

--- a/source/main/physics/Differentials.cpp
+++ b/source/main/physics/Differentials.cpp
@@ -22,6 +22,8 @@
 #include "Differentials.h"
 #include "Language.h"
 
+using namespace RoR;
+
 void Differential::ToggleDifferentialMode()
 {
     if (m_available_diffs.size() > 1)

--- a/source/main/physics/Differentials.h
+++ b/source/main/physics/Differentials.h
@@ -23,6 +23,8 @@
 #include <vector>
 #include <OgreUTFString.h>
 
+namespace RoR {
+
 struct DifferentialData
 {
     float speed[2];
@@ -79,4 +81,6 @@ public:
 private:
     std::vector<DiffType> m_available_diffs;
 };
+
+} // namespace RoR
 

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -480,7 +480,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
         j_entry.AddMember("min_height", actor->getMinHeight(), j_doc.GetAllocator());
         j_entry.AddMember("spawn_rotation", actor->m_spawn_rotation, j_doc.GetAllocator());
         j_entry.AddMember("preloaded_with_terrain", actor->isPreloadedWithTerrain(), j_doc.GetAllocator());
-        j_entry.AddMember("sim_state", static_cast<int>(actor->ar_sim_state), j_doc.GetAllocator());
+        j_entry.AddMember("sim_state", static_cast<int>(actor->ar_state), j_doc.GetAllocator());
         j_entry.AddMember("physics_paused", actor->ar_physics_paused, j_doc.GetAllocator());
         j_entry.AddMember("player_actor", actor==App::GetGameContext()->GetPlayerActor(), j_doc.GetAllocator());
         j_entry.AddMember("prev_player_actor", actor==App::GetGameContext()->GetPrevPlayerActor(), j_doc.GetAllocator());
@@ -751,7 +751,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
 void ActorManager::RestoreSavedState(Actor* actor, rapidjson::Value const& j_entry)
 {
     actor->m_spawn_rotation = j_entry["spawn_rotation"].GetFloat();
-    actor->ar_sim_state = static_cast<Actor::SimState>(j_entry["sim_state"].GetInt());
+    actor->ar_state = static_cast<ActorState>(j_entry["sim_state"].GetInt());
     actor->ar_physics_paused = j_entry["physics_paused"].GetBool();
 
     if (j_entry["player_actor"].GetBool())

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -213,6 +213,14 @@ enum LocalizerType
     LOCALIZER_VOR
 };
 
+enum class ActorState
+{
+    LOCAL_SIMULATED,  //!< simulated (local) actor
+    NETWORKED_OK,     //!< not simulated (remote) actor
+    NETWORKED_HIDDEN, //!< not simulated, not updated (remote)
+    LOCAL_REPLAY,
+    LOCAL_SLEEPING,   //!< sleeping (local) actor
+};
 
 // --------------------------------
 // Soft body physics

--- a/source/main/physics/air/AeroEngine.h
+++ b/source/main/physics/air/AeroEngine.h
@@ -37,7 +37,6 @@ public:
 
     virtual ~AeroEngine() {}
 
-    virtual void updateVisuals(RoR::GfxActor* gfx_actor) =0;
     virtual void updateForces(float dt, int doUpdate) =0;
 
     virtual void setThrottle(float val) =0;
@@ -65,6 +64,10 @@ public:
     virtual int getNoderef() =0;
     virtual bool getWarmup() =0;
     virtual float getRadius() =0;
+
+    // Visuals
+    virtual void updateVisuals(RoR::GfxActor* gfx_actor) = 0;
+    virtual void setVisible(bool visible) = 0;
 };
 
 } // namespace RoR

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -144,7 +144,13 @@ TurbojetVisual::~TurbojetVisual()
 
 void Turbojet::updateVisuals(RoR::GfxActor* gfx_actor)
 {
-    this->tjet_visual.UpdateVisuals(gfx_actor);
+    if (this->tjet_visual.IsVisible())
+        this->tjet_visual.UpdateVisuals(gfx_actor);
+}
+
+void Turbojet::setVisible(bool visible)
+{
+    this->tjet_visual.SetVisible(visible);
 }
 
 void TurbojetVisual::UpdateVisuals(RoR::GfxActor* gfx_actor)
@@ -203,6 +209,18 @@ void TurbojetVisual::UpdateVisuals(RoR::GfxActor* gfx_actor)
             emit->setColour(ColourValue(0.0, 0.0, 0.0, 0.1));
             emit->setTimeToLive(0.1 / 0.1);
         }
+    }
+}
+
+void TurbojetVisual::SetVisible(bool visible)
+{
+    m_visible = visible;
+    m_smoke_particle->setVisible(visible);
+    m_nozzle_scenenode->setVisible(visible);
+    if (!visible)
+    {
+        // only hide, regular update will restore visibility if needed.
+        m_flame_scenenode->setVisible(false);
     }
 }
 

--- a/source/main/physics/air/TurboJet.h
+++ b/source/main/physics/air/TurboJet.h
@@ -33,6 +33,8 @@ public:
     void SetupVisuals(RigDef::Turbojet & def, int num, std::string const& propname, Ogre::Entity* nozzle, Ogre::Entity* afterburner_flame, bool disable_smoke);
     void SetNodes(int front, int back, int ref);
     void UpdateVisuals(RoR::GfxActor* gfx_actor);
+    void SetVisible(bool visible);
+    bool IsVisible() const { return m_visible; }
 
 private:
     Ogre::SceneNode*      m_smoke_scenenode;
@@ -42,6 +44,7 @@ private:
     Ogre::Entity*         m_nozzle_entity;
     Ogre::SceneNode*      m_nozzle_scenenode;
 
+    bool     m_visible = false; // Needed for flames which are hidden by default.
     int      m_number;
     float    m_radius;
     uint16_t m_node_back;
@@ -65,7 +68,6 @@ public:
     void setReverse(bool val);
     bool getReverse() { return m_reverse; };
     void updateForces(float dt, int doUpdate);
-    void updateVisuals(RoR::GfxActor* gfx_actor) override;
 
     Ogre::Vector3 getAxis() { return m_axis; };
 
@@ -83,6 +85,11 @@ public:
     float getpropwash() { return m_propwash; };
     int getNoderef() { return m_node_back; };
     int getType() { return AEROENGINE_TYPE_TURBOJET; };
+
+    // AeroEngine visuals
+
+    void updateVisuals(RoR::GfxActor* gfx_actor) override;
+    void setVisible(bool visible) override;
 
     bool tjet_afterburnable;
     TurbojetVisual tjet_visual;

--- a/source/main/physics/air/TurboJet.h
+++ b/source/main/physics/air/TurboJet.h
@@ -30,7 +30,7 @@ class TurbojetVisual
 {
 public:
     ~TurbojetVisual();
-    void SetupVisuals(RigDef::Turbojet & def, int num, std::string const& propname, Ogre::Entity* nozzle, Ogre::Entity* afterburner_flame, bool disable_smoke);
+    void SetupVisuals(RigDef::Turbojet & def, int num, std::string const& propname, Ogre::Entity* nozzle, Ogre::Entity* afterburner_flame);
     void SetNodes(int front, int back, int ref);
     void UpdateVisuals(RoR::GfxActor* gfx_actor);
     void SetVisible(bool visible);

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -208,6 +208,11 @@ void Turboprop::updateVisuals(RoR::GfxActor* gfx_actor)
 #endif
 }
 
+void Turboprop::setVisible(bool visible)
+{
+    smokePS->setVisible(visible);
+}
+
 void Turboprop::updateForces(float dt, int doUpdate)
 {
     if (doUpdate)

--- a/source/main/physics/air/TurboProp.h
+++ b/source/main/physics/air/TurboProp.h
@@ -55,7 +55,6 @@ public:
     );
     ~Turboprop();
 
-    void updateVisuals(RoR::GfxActor* gfx_actor) override;
     void updateForces(float dt, int doUpdate);
 
     void setThrottle(float val);
@@ -82,6 +81,10 @@ public:
     int getNoderef() { return noderef; };
     bool getWarmup() { return warmup; };
     float getRadius() { return radius; };
+
+    // Visuals
+    void updateVisuals(RoR::GfxActor* gfx_actor) override;
+    void setVisible(bool visible) override;
 
 private:
 

--- a/source/main/physics/collision/DynamicCollisions.cpp
+++ b/source/main/physics/collision/DynamicCollisions.cpp
@@ -176,7 +176,7 @@ void RoR::ResolveInterActorCollisions(const float dt, PointColDetector &interPoi
 
                     const auto penetration_depth = collrange - distance;
 
-                    const bool remote = (hit_actor->ar_sim_state == Actor::SimState::NETWORKED_OK);
+                    const bool remote = (hit_actor->ar_state == ActorState::NETWORKED_OK);
 
                     ResolveCollisionForces(penetration_depth, *hitnode, *na, *nb, *no, coord.alpha,
                             coord.beta, coord.gamma, normal, dt, remote, submesh_ground_model);

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -266,7 +266,7 @@ int GameScript::getNumTrucksByFlag(int flag)
     int result = 0;
     for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
-        if (!flag || static_cast<int>(actor->ar_sim_state) == flag)
+        if (!flag || static_cast<int>(actor->ar_state) == flag)
             result++;
     }
     return result;

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -377,9 +377,9 @@ void ScriptEngine::init()
     
     // enum truckStates
     result = engine->RegisterEnum("truckStates"); ROR_ASSERT(result>=0);
-    result = engine->RegisterEnumValue("truckStates", "TS_SIMULATED", static_cast<int>(Actor::SimState::LOCAL_SIMULATED)); ROR_ASSERT(result>=0);
-    result = engine->RegisterEnumValue("truckStates", "TS_SLEEPING",  static_cast<int>(Actor::SimState::LOCAL_SLEEPING)); ROR_ASSERT(result>=0);
-    result = engine->RegisterEnumValue("truckStates", "TS_NETWORKED", static_cast<int>(Actor::SimState::NETWORKED_OK)); ROR_ASSERT(result>=0);
+    result = engine->RegisterEnumValue("truckStates", "TS_SIMULATED", static_cast<int>(ActorState::LOCAL_SIMULATED)); ROR_ASSERT(result>=0);
+    result = engine->RegisterEnumValue("truckStates", "TS_SLEEPING",  static_cast<int>(ActorState::LOCAL_SLEEPING)); ROR_ASSERT(result>=0);
+    result = engine->RegisterEnumValue("truckStates", "TS_NETWORKED", static_cast<int>(ActorState::NETWORKED_OK)); ROR_ASSERT(result>=0);
 
     // enum truckTypes
     result = engine->RegisterEnum("truckTypes"); ROR_ASSERT(result>=0);


### PR DESCRIPTION
You can now remove your own actors and hide/unhide remote actors (useful if someone lags you) from top menu bar in multiplayer.

![kkk](https://user-images.githubusercontent.com/2660424/121780592-badeb080-cba9-11eb-804c-b39e27a2729d.png)

Also net labels remade using ImGui.

![kk](https://user-images.githubusercontent.com/2660424/123830036-9dc91200-d90b-11eb-9f3f-1bb92d57ef19.png)

Closes https://github.com/RigsOfRods/rigs-of-rods/issues/2497
Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/2622
Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/479

Thanks Petr for the help!