### PR TITLE
Terrain editor fixes

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -914,7 +914,7 @@ void GameContext::UpdateSimInputEvents(float dt)
     }
 
     // terrain editor toggle
-    if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TERRAIN_EDITOR))
+    if (!App::GetGameContext()->GetPlayerActor() && App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TERRAIN_EDITOR))
     {
         App::GetGameContext()->PushMessage(MSG_EDI_ENTER_TERRN_EDITOR_REQUESTED);
     }

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -914,13 +914,9 @@ void GameContext::UpdateSimInputEvents(float dt)
     }
 
     // terrain editor toggle
-    bool toggle_editor = (App::GetGameContext()->GetPlayerActor() && App::sim_state->GetEnum<SimState>() == SimState::EDITOR_MODE) ||
-        (!App::GetGameContext()->GetPlayerActor() && RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TERRAIN_EDITOR));
-    if (toggle_editor)
+    if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TERRAIN_EDITOR))
     {
-        Message m(App::sim_state->GetEnum<SimState>() == SimState::EDITOR_MODE ?
-                    MSG_EDI_LEAVE_TERRN_EDITOR_REQUESTED : MSG_EDI_ENTER_TERRN_EDITOR_REQUESTED);
-        App::GetGameContext()->PushMessage(m);
+        App::GetGameContext()->PushMessage(MSG_EDI_ENTER_TERRN_EDITOR_REQUESTED);
     }
 
     // forward commands from character

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -870,7 +870,8 @@ int main(int argc, char *argv[])
             }
 
             // Create snapshot of simulation state for Gfx/GUI updates
-            if (App::sim_state->GetEnum<SimState>() == SimState::RUNNING)
+            if (App::sim_state->GetEnum<SimState>() == SimState::RUNNING ||   // Obviously
+                App::sim_state->GetEnum<SimState>() == SimState::EDITOR_MODE) // Needed for character movement
             {
                 App::GetGfxScene()->BufferSimulationData();
             }

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -774,7 +774,6 @@ int main(int argc, char *argv[])
                     App::GetOverlayWrapper()->update(dt);
                     if (App::sim_state->GetEnum<SimState>() == SimState::EDITOR_MODE)
                     {
-                        App::GetGameContext()->UpdateSimInputEvents(dt);
                         App::GetGameContext()->UpdateSkyInputEvents(dt);
                         App::GetSimTerrain()->GetTerrainEditor()->UpdateInputEvents(dt);
                     }

--- a/source/main/terrain/TerrainEditor.cpp
+++ b/source/main/terrain/TerrainEditor.cpp
@@ -237,6 +237,11 @@ void TerrainEditor::UpdateInputEvents(float dt)
     {
         App::GetGameContext()->GetCharacterFactory()->Update(dt);
     }    
+
+    if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TERRAIN_EDITOR))
+    {
+        App::GetGameContext()->PushMessage(MSG_EDI_LEAVE_TERRN_EDITOR_REQUESTED);
+    }
 }
 
 void TerrainEditor::WriteOutputFile()


### PR DESCRIPTION
Reported from discord.

Keyboard shortcuts (ENTER, CTRL [ ] etc...) work again.