### PR TITLE
Wheel can now have multiple detacher groups.

### DIFF
--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -215,6 +215,7 @@ public:
     std::vector<float>        ar_initial_node_masses;
     std::vector<Ogre::Vector3>     ar_initial_node_positions;
     std::vector<std::pair<float, float>> ar_initial_beam_defaults;
+    std::vector<wheeldetacher_t>   ar_wheeldetachers;
     std::vector<float>             ar_minimass; //!< minimum node mass in Kg
     std::vector<std::vector<int>>  ar_node_to_node_connections;
     std::vector<std::vector<int>>  ar_node_to_beam_connections;

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -28,6 +28,7 @@
 #include "Buoyance.h"
 #include "CmdKeyInertia.h"
 #include "Collisions.h"
+#include "Console.h"
 #include "Differentials.h"
 #include "EngineSim.h"
 #include "FlexAirfoil.h"
@@ -1211,7 +1212,7 @@ void Actor::CalcBeams(bool trigger_hooks)
                             msg << "[RoR|Diag] XXX Support-Beam " << i << " limit extended and broke. "
                                 << "Length: " << difftoBeamL << " / max. Length: " << (ar_beams[i].L*break_limit) << ". ";
                             LogBeamNodes(msg, ar_beams[i]);
-                            RoR::Log(msg.ToCStr());
+                            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_NOTICE, msg.ToCStr());
                         }
                     }
                 }
@@ -1317,7 +1318,7 @@ void Actor::CalcBeams(bool trigger_hooks)
                             RoR::Str<200> msg;
                             msg << "[RoR|Diag] XXX Beam " << i << " just broke with force " << len << " / " << ar_beams[i].strength << ". ";
                             LogBeamNodes(msg, ar_beams[i]);
-                            RoR::Log(msg.ToCStr());
+                            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_NOTICE, msg.ToCStr());
                         }
 
                         // detachergroup check: beam[i] is already broken, check detacher group# == 0/default skip the check ( performance bypass for beams with default setting )
@@ -1335,7 +1336,8 @@ void Actor::CalcBeams(bool trigger_hooks)
                                     ar_beams[j].bm_disabled = true;
                                     if (m_beam_break_debug_enabled)
                                     {
-                                        LOG("Deleting Detacher BeamID: " + TOSTRING(j) + ", Detacher Group: " + TOSTRING(ar_beams[i].detacher_group)+ ", actor ID: " + TOSTRING(ar_instance_id));
+                                        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_NOTICE,
+                                            "Deleting Detacher BeamID: " + TOSTRING(j) + ", Detacher Group: " + TOSTRING(ar_beams[i].detacher_group)+ ", actor ID: " + TOSTRING(ar_instance_id));
                                     }
                                 }
                             }
@@ -1345,6 +1347,11 @@ void Actor::CalcBeams(bool trigger_hooks)
                                 if (wheeldetacher.wd_detacher_group == ar_beams[i].detacher_group)
                                 {
                                     ar_wheels[wheeldetacher.wd_wheel_id].wh_is_detached = true;
+                                    if (m_beam_break_debug_enabled)
+                                    {
+                                        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_NOTICE,
+                                            "Detaching wheel ID: " + TOSTRING(wheeldetacher.wd_wheel_id) + ", Detacher Group: " + TOSTRING(ar_beams[i].detacher_group)+ ", actor ID: " + TOSTRING(ar_instance_id));
+                                    }
                                 }
                             }
                         }
@@ -1490,9 +1497,9 @@ void Actor::CalcBeamsInterActor()
                         if (m_beam_break_debug_enabled)
                         {
                             RoR::Str<200> msg;
-                            msg << "[RoR|Diag] XXX Beam " << i << " just broke with force " << len << " / " << ar_inter_beams[i]->strength << ". ";
+                            msg << "Beam " << i << " just broke with force " << len << " / " << ar_inter_beams[i]->strength << ". ";
                             LogBeamNodes(msg, (*ar_inter_beams[i]));
-                            RoR::Log(msg.ToCStr());
+                            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_NOTICE, msg.ToCStr());
                         }
                     }
                     else

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -1339,12 +1339,12 @@ void Actor::CalcBeams(bool trigger_hooks)
                                     }
                                 }
                             }
-                            // cycle once through all wheels
-                            for (int j = 0; j < ar_num_wheels; j++)
+                            // cycle once through all wheeldetachers
+                            for (wheeldetacher_t const& wheeldetacher: ar_wheeldetachers)
                             {
-                                if (ar_wheels[j].wh_detacher_group == ar_beams[i].detacher_group)
+                                if (wheeldetacher.wd_detacher_group == ar_beams[i].detacher_group)
                                 {
-                                    ar_wheels[j].wh_is_detached = true;
+                                    ar_wheels[wheeldetacher.wd_wheel_id].wh_is_detached = true;
                                 }
                             }
                         }

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -4983,7 +4983,10 @@ void ActorSpawner::ProcessWheelDetacher(RigDef::WheelDetacher & def)
         return;
     }
 
-    m_actor->ar_wheels[def.wheel_id].wh_detacher_group = def.detacher_group;
+    wheeldetacher_t obj;
+    obj.wd_wheel_id = def.wheel_id;
+    obj.wd_detacher_group = def.detacher_group;
+    m_actor->ar_wheeldetachers.push_back(obj);
 };
 
 void ActorSpawner::ProcessTractionControl(RigDef::TractionControl & def)

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -384,7 +384,6 @@ struct wheel_t
     Ogre::Real  wh_last_retorque;     //!< Last external forces (friction, ...)
     float       wh_net_rp;
     float       wh_width;
-    int         wh_detacher_group;
     bool        wh_is_detached;
 
     // Debug
@@ -394,6 +393,12 @@ struct wheel_t
     Ogre::Vector3 debug_slip;
     Ogre::Vector3 debug_force;
     Ogre::Vector3 debug_scaled_cforce;
+};
+
+struct wheeldetacher_t
+{
+    int wd_wheel_id;
+    int wd_detacher_group;
 };
 
 struct hook_t


### PR DESCRIPTION
This will now work:
```
wheeldetachers
; wheel_ID, detacher_group
0, 1
0, 2
```

Also, beam break logging (`diag_log_beam_break` in RoR.cfg or TopMenubar/Tools) now logs to ingame console (in addition to classic RoR.log).

Suggested by DannyWerewolf on Discord.