### PR TITLE
Angelscript: added function 'getSectionConfig()' to 'BeamClass'

### DIFF
--- a/doc/angelscript/BeamClass.h
+++ b/doc/angelscript/BeamClass.h
@@ -10,6 +10,11 @@ public:
 	 * Gets the name of the truck.
 	 */
 	string getTruckName();
+
+	/**
+	 * Gets the name of the loaded section for a truck.
+	 */
+	string getSectionConfig();
 	
 	/**
 	 * Resets the truck.

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -190,6 +190,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", AngelScript::asMETHOD(Actor,ScaleActor), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", AngelScript::asMETHOD(Actor,GetActorDesignName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,GetActorFileName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "string getSectionConfig()", AngelScript::asMETHOD(Actor, GetSectionConfig), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,GetActorType), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asFUNCTION(AS_RequestActorReset), AngelScript::asCALL_CDECL_OBJFIRST); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", AngelScript::asMETHOD(Actor,ToggleParkingBrake), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);


### PR DESCRIPTION
This will allow scripts to determine which section config is loaded on a given truck.

Example usage:
```
BeamClass@ t = game.getCurrentTruck();
game.log("Spawned section config is: " + t.getSectionConfig());
```

![Screenshot 2021-08-20 194039](https://user-images.githubusercontent.com/47985434/130302913-1e3b3533-f735-40e5-ad74-04cb77124354.png)