### PR TITLE
:boomerang: Actor (BeamClass) functions renamed to original format.

### DIFF
--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -355,7 +355,7 @@ void AppContext::CaptureScreenshot()
             App::GetGameContext()->GetPlayerActor())
         {
             png.addData("Truck_file", App::GetGameContext()->GetPlayerActor()->ar_filename);
-            png.addData("Truck_name", App::GetGameContext()->GetPlayerActor()->GetActorDesignName());
+            png.addData("Truck_name", App::GetGameContext()->GetPlayerActor()->getTruckName());
         }
         if (App::GetSimTerrain())
         {

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1138,7 +1138,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
         if (m_player_actor->ar_driveable == TRUCK)
             m_player_actor->ar_trailer_parking_brake = !m_player_actor->ar_trailer_parking_brake;
         else if (m_player_actor->ar_driveable == NOT_DRIVEABLE)
-            m_player_actor->ToggleParkingBrake();
+            m_player_actor->parkingbrakeToggle();
     }
 
     // videocam
@@ -1259,7 +1259,7 @@ void GameContext::UpdateAirplaneInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_AIRPLANE_PARKING_BRAKE))
     {
-        m_player_actor->ToggleParkingBrake();
+        m_player_actor->parkingbrakeToggle();
     }
 
     // reverse
@@ -1560,22 +1560,22 @@ void GameContext::UpdateTruckInputEvents(float dt)
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_PARKING_BRAKE) &&
             !App::GetInputEngine()->getEventBoolValue(EV_TRUCK_TRAILER_PARKING_BRAKE))
     {
-        m_player_actor->ToggleParkingBrake();
+        m_player_actor->parkingbrakeToggle();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_ANTILOCK_BRAKE))
     {
-        m_player_actor->ToggleAntiLockBrake();
+        m_player_actor->antilockbrakeToggle();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TRACTION_CONTROL))
     {
-        m_player_actor->ToggleTractionControl();
+        m_player_actor->tractioncontrolToggle();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_CRUISE_CONTROL))
     {
-        m_player_actor->ToggleCruiseControl();
+        m_player_actor->cruisecontrolToggle();
     }
 
     if (m_player_actor->GetTyrePressure().IsEnabled())

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -153,7 +153,7 @@ Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
             {
                 float h = m_player_actor->GetMaxHeight(true);
                 rq.asr_rotation = Ogre::Quaternion(Ogre::Degree(270) - Ogre::Radian(m_player_actor->getRotation()), Ogre::Vector3::UNIT_Y);
-                rq.asr_position = m_player_actor->GetRotationCenter();
+                rq.asr_position = m_player_actor->getRotationCenter();
                 rq.asr_position.y = App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(rq.asr_position.x, rq.asr_position.z, h);
                 rq.asr_position.y += m_player_actor->GetHeightAboveGroundBelow(h, true); // retain height above ground
             }
@@ -322,7 +322,7 @@ void GameContext::DeleteActor(Actor* actor)
 {
     if (actor == m_player_actor)
     {
-        Ogre::Vector3 center = m_player_actor->GetRotationCenter();
+        Ogre::Vector3 center = m_player_actor->getRotationCenter();
         this->ChangePlayerActor(nullptr); // Get out of the vehicle
         this->GetPlayerCharacter()->setPosition(center);
     }

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -305,7 +305,7 @@ void GameContext::ModifyActor(ActorModifyRequest& rq)
         srq->asr_position   = Ogre::Vector3(rq.amr_actor->getPosition().x, rq.amr_actor->getMinHeight(), rq.amr_actor->getPosition().z);
         srq->asr_rotation   = Ogre::Quaternion(Ogre::Degree(270) - Ogre::Radian(rq.amr_actor->getRotation()), Ogre::Vector3::UNIT_Y);
         srq->asr_config     = rq.amr_actor->getSectionConfig();
-        srq->asr_skin_entry = rq.amr_actor->GetUsedSkin();
+        srq->asr_skin_entry = rq.amr_actor->getUsedSkin();
         srq->asr_cache_entry= entry;
         srq->asr_debugview  = (int)rq.amr_actor->GetGfxActor()->GetDebugView();
         srq->asr_origin     = ActorSpawnRequest::Origin::USER;

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -338,7 +338,7 @@ void GameContext::DeleteActor(Actor* actor)
     }
 
     // Find linked actors and un-tie if tied
-    auto linked_actors = actor->GetAllLinkedActors();
+    auto linked_actors = actor->getAllLinkedActors();
     for (auto actorx : m_actor_manager.GetLocalActors())
     {
         if (actorx->isTied() && std::find(linked_actors.begin(), linked_actors.end(), actorx) != linked_actors.end())
@@ -702,7 +702,7 @@ void GameContext::TeleportPlayer(float x, float z)
 
     Ogre::Vector3 translation = Ogre::Vector3(x, y, z) - this->GetPlayerActor()->ar_nodes[0].AbsPosition;
 
-    auto actors = this->GetPlayerActor()->GetAllLinkedActors();
+    auto actors = this->GetPlayerActor()->getAllLinkedActors();
     actors.push_back(this->GetPlayerActor());
 
     float src_agl = std::numeric_limits<float>::max(); 
@@ -1085,7 +1085,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_DEBUG_VIEW))
     {
         m_player_actor->GetGfxActor()->ToggleDebugView();
-        for (auto actor : m_player_actor->GetAllLinkedActors())
+        for (auto actor : m_player_actor->getAllLinkedActors())
         {
             actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());
         }
@@ -1094,7 +1094,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_CYCLE_DEBUG_VIEWS))
     {
         m_player_actor->GetGfxActor()->CycleDebugViews();
-        for (auto actor : m_player_actor->GetAllLinkedActors())
+        for (auto actor : m_player_actor->getAllLinkedActors())
         {
             actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());
         }
@@ -1163,7 +1163,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
     // toggle physics
     if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_PHYSICS))
     {
-        for (auto actor : App::GetGameContext()->GetPlayerActor()->GetAllLinkedActors())
+        for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
         {
             actor->ar_physics_paused = !App::GetGameContext()->GetPlayerActor()->ar_physics_paused;
         }

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1107,7 +1107,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TRUCK_BEACONS))
     {
-        m_player_actor->ToggleBeacons();
+        m_player_actor->beaconsToggle();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESCUE_TRUCK, 0.5f) &&

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1522,8 +1522,8 @@ void GameContext::UpdateTruckInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_INTER_WHEEL_DIFF))
     {
-        m_player_actor->ToggleWheelDiffMode();
-        m_player_actor->DisplayWheelDiffMode();
+        m_player_actor->toggleWheelDiffMode();
+        m_player_actor->displayWheelDiffMode();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_TCASE_4WD_MODE))

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1578,9 +1578,9 @@ void GameContext::UpdateTruckInputEvents(float dt)
         m_player_actor->cruisecontrolToggle();
     }
 
-    if (m_player_actor->GetTyrePressure().IsEnabled())
+    if (m_player_actor->getTyrePressure().IsEnabled())
     {
-        m_player_actor->GetTyrePressure().UpdateInputEvents(dt);
+        m_player_actor->getTyrePressure().UpdateInputEvents(dt);
     }
 }
 

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1102,7 +1102,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TRUCK_LIGHTS))
     {
-        m_player_actor->ToggleLights();
+        m_player_actor->lightsToggle();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_TRUCK_BEACONS))

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -343,7 +343,7 @@ void GameContext::DeleteActor(Actor* actor)
     {
         if (actorx->isTied() && std::find(linked_actors.begin(), linked_actors.end(), actorx) != linked_actors.end())
         {
-            actorx->ToggleTies();
+            actorx->tieToggle();
         }
 
         if (actorx->isLocked() && std::find(linked_actors.begin(), linked_actors.end(), actorx) != linked_actors.end())

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -304,7 +304,7 @@ void GameContext::ModifyActor(ActorModifyRequest& rq)
         ActorSpawnRequest* srq = new ActorSpawnRequest;
         srq->asr_position   = Ogre::Vector3(rq.amr_actor->getPosition().x, rq.amr_actor->getMinHeight(), rq.amr_actor->getPosition().z);
         srq->asr_rotation   = Ogre::Quaternion(Ogre::Degree(270) - Ogre::Radian(rq.amr_actor->getRotation()), Ogre::Vector3::UNIT_Y);
-        srq->asr_config     = rq.amr_actor->GetSectionConfig();
+        srq->asr_config     = rq.amr_actor->getSectionConfig();
         srq->asr_skin_entry = rq.amr_actor->GetUsedSkin();
         srq->asr_cache_entry= entry;
         srq->asr_debugview  = (int)rq.amr_actor->GetGfxActor()->GetDebugView();

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -722,7 +722,7 @@ void GameContext::TeleportPlayer(float x, float z)
 
     for (auto actor : actors)
     {
-        actor->ResetPosition(actor->ar_nodes[0].AbsPosition + translation, false);
+        actor->resetPosition(actor->ar_nodes[0].AbsPosition + translation, false);
     }
 }
 

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1516,8 +1516,8 @@ void GameContext::UpdateTruckInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_INTER_AXLE_DIFF))
     {
-        m_player_actor->ToggleAxleDiffMode();
-        m_player_actor->DisplayAxleDiffMode();
+        m_player_actor->toggleAxleDiffMode();
+        m_player_actor->displayAxleDiffMode();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_INTER_WHEEL_DIFF))

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1528,14 +1528,14 @@ void GameContext::UpdateTruckInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_TCASE_4WD_MODE))
     {
-        m_player_actor->ToggleTransferCaseMode();
-        m_player_actor->DisplayTransferCaseMode();
+        m_player_actor->toggleTransferCaseMode();
+        m_player_actor->displayTransferCaseMode();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_TCASE_GEAR_RATIO))
     {
-        m_player_actor->ToggleTransferCaseGearRatio();
-        m_player_actor->DisplayTransferCaseMode();
+        m_player_actor->toggleTransferCaseGearRatio();
+        m_player_actor->displayTransferCaseMode();
     }
 
     if (m_player_actor->ar_is_police)

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1213,9 +1213,9 @@ void GameContext::UpdateCommonInputEvents(float dt)
         }
     }
 
-    if (m_player_actor->GetReplay())
+    if (m_player_actor->getReplay())
     {
-        m_player_actor->GetReplay()->UpdateInputEvents();
+        m_player_actor->getReplay()->UpdateInputEvents();
     }
 }
 

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -206,7 +206,7 @@ Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
     // lock slide nodes after spawning the actor?
     if (def->slide_nodes_connect_instantly)
     {
-        fresh_actor->ToggleSlideNodeLock();
+        fresh_actor->toggleSlideNodeLock();
     }
 
     if (rq.asr_origin == ActorSpawnRequest::Origin::USER)
@@ -1063,7 +1063,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_LOCK))
     {
         m_player_actor->hookToggle(-1, HOOK_TOGGLE, -1);
-        m_player_actor->ToggleSlideNodeLock();
+        m_player_actor->toggleSlideNodeLock();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_AUTOLOCK))

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -151,11 +151,11 @@ Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
         {
             if (m_player_actor != nullptr)
             {
-                float h = m_player_actor->GetMaxHeight(true);
+                float h = m_player_actor->getMaxHeight(true);
                 rq.asr_rotation = Ogre::Quaternion(Ogre::Degree(270) - Ogre::Radian(m_player_actor->getRotation()), Ogre::Vector3::UNIT_Y);
                 rq.asr_position = m_player_actor->getRotationCenter();
                 rq.asr_position.y = App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(rq.asr_position.x, rq.asr_position.z, h);
-                rq.asr_position.y += m_player_actor->GetHeightAboveGroundBelow(h, true); // retain height above ground
+                rq.asr_position.y += m_player_actor->getHeightAboveGroundBelow(h, true); // retain height above ground
             }
             else
             {
@@ -302,7 +302,7 @@ void GameContext::ModifyActor(ActorModifyRequest& rq)
 
         // Create spawn request while actor still exists
         ActorSpawnRequest* srq = new ActorSpawnRequest;
-        srq->asr_position   = Ogre::Vector3(rq.amr_actor->getPosition().x, rq.amr_actor->GetMinHeight(), rq.amr_actor->getPosition().z);
+        srq->asr_position   = Ogre::Vector3(rq.amr_actor->getPosition().x, rq.amr_actor->getMinHeight(), rq.amr_actor->getPosition().z);
         srq->asr_rotation   = Ogre::Quaternion(Ogre::Degree(270) - Ogre::Radian(rq.amr_actor->getRotation()), Ogre::Vector3::UNIT_Y);
         srq->asr_config     = rq.amr_actor->GetSectionConfig();
         srq->asr_skin_entry = rq.amr_actor->GetUsedSkin();

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1079,7 +1079,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_CUSTOM_PARTICLES))
     {
-        m_player_actor->ToggleCustomParticles();
+        m_player_actor->toggleCustomParticles();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_DEBUG_VIEW))

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -348,7 +348,7 @@ void GameContext::DeleteActor(Actor* actor)
 
         if (actorx->isLocked() && std::find(linked_actors.begin(), linked_actors.end(), actorx) != linked_actors.end())
         {
-            actorx->ToggleHooks();
+            actorx->hookToggle();
         }
     }
 
@@ -1062,13 +1062,13 @@ void GameContext::UpdateCommonInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_LOCK))
     {
-        m_player_actor->ToggleHooks(-1, HOOK_TOGGLE, -1);
+        m_player_actor->hookToggle(-1, HOOK_TOGGLE, -1);
         m_player_actor->ToggleSlideNodeLock();
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_AUTOLOCK))
     {
-        m_player_actor->ToggleHooks(-2, HOOK_UNLOCK, -1); //unlock all autolocks
+        m_player_actor->hookToggle(-2, HOOK_UNLOCK, -1); //unlock all autolocks
     }
 
     //strap

--- a/source/main/gameplay/CruiseControl.cpp
+++ b/source/main/gameplay/CruiseControl.cpp
@@ -28,7 +28,7 @@
 
 using namespace RoR;
 
-void Actor::ToggleCruiseControl()
+void Actor::cruisecontrolToggle()
 {
     cc_mode = !cc_mode;
 
@@ -54,7 +54,7 @@ void Actor::UpdateCruiseControl(float dt)
         !ar_engine->IsRunning() ||
         !ar_engine->HasStarterContact())
     {
-        this->ToggleCruiseControl();
+        this->cruisecontrolToggle();
         return;
     }
 

--- a/source/main/gameplay/EngineSim.cpp
+++ b/source/main/gameplay/EngineSim.cpp
@@ -750,7 +750,7 @@ void EngineSim::UpdateEngineSim(float dt, int doUpdate)
             if (newGear < m_cur_gear && std::abs(m_cur_wheel_revolutions * (m_gear_ratios[newGear + 1] - m_gear_ratios[m_cur_gear + 1])) > m_one_third_rpm_range / 6.0f ||
                 newGear > m_cur_gear && std::abs(m_cur_wheel_revolutions * (m_gear_ratios[newGear + 1] - m_gear_ratios[m_cur_gear + 1])) > m_one_third_rpm_range / 3.0f)
             {
-                if (std::abs(m_actor->GetGForcesCur().y) < 0.25f)
+                if (std::abs(m_actor->getGForces().y) < 0.25f)
                     shiftTo(newGear);
             }
 

--- a/source/main/gameplay/RecoveryMode.cpp
+++ b/source/main/gameplay/RecoveryMode.cpp
@@ -105,7 +105,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
             scale *= App::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) ? 3.0f : 1.0f;
             scale *= App::GetInputEngine()->isKeyDown(OIS::KC_LCONTROL) ? 10.0f : 1.0f;
 
-            Ogre::Vector3 rotation_center = App::GetGameContext()->GetPlayerActor()->GetRotationCenter();
+            Ogre::Vector3 rotation_center = App::GetGameContext()->GetPlayerActor()->getRotationCenter();
 
             rotation *= Ogre::Math::Clamp(scale, 0.1f, 10.0f);
             translation *= scale;

--- a/source/main/gameplay/RecoveryMode.cpp
+++ b/source/main/gameplay/RecoveryMode.cpp
@@ -110,15 +110,15 @@ void RecoveryMode::UpdateInputEvents(float dt)
             rotation *= Ogre::Math::Clamp(scale, 0.1f, 10.0f);
             translation *= scale;
 
-            App::GetGameContext()->GetPlayerActor()->RequestRotation(rotation, rotation_center);
-            App::GetGameContext()->GetPlayerActor()->RequestTranslation(translation);
+            App::GetGameContext()->GetPlayerActor()->requestRotation(rotation, rotation_center);
+            App::GetGameContext()->GetPlayerActor()->requestTranslation(translation);
 
             if (App::sim_soft_reset_mode->GetBool())
             {
                 for (auto actor : App::GetGameContext()->GetPlayerActor()->GetAllLinkedActors())
                 {
-                    actor->RequestRotation(rotation, rotation_center);
-                    actor->RequestTranslation(translation);
+                    actor->requestRotation(rotation, rotation_center);
+                    actor->requestTranslation(translation);
                 }
             }
 
@@ -126,12 +126,12 @@ void RecoveryMode::UpdateInputEvents(float dt)
         }
         else if (App::GetInputEngine()->isKeyDownValueBounce(OIS::KC_SPACE))
         {
-            App::GetGameContext()->GetPlayerActor()->RequestAngleSnap(45);
+            App::GetGameContext()->GetPlayerActor()->requestAngleSnap(45);
             if (App::sim_soft_reset_mode->GetBool())
             {
                 for (auto actor : App::GetGameContext()->GetPlayerActor()->GetAllLinkedActors())
                 {
-                    actor->RequestAngleSnap(45);
+                    actor->requestAngleSnap(45);
                 }
             }
         }

--- a/source/main/gameplay/RecoveryMode.cpp
+++ b/source/main/gameplay/RecoveryMode.cpp
@@ -115,7 +115,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
 
             if (App::sim_soft_reset_mode->GetBool())
             {
-                for (auto actor : App::GetGameContext()->GetPlayerActor()->GetAllLinkedActors())
+                for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
                 {
                     actor->requestRotation(rotation, rotation_center);
                     actor->requestTranslation(translation);
@@ -129,7 +129,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
             App::GetGameContext()->GetPlayerActor()->requestAngleSnap(45);
             if (App::sim_soft_reset_mode->GetBool())
             {
-                for (auto actor : App::GetGameContext()->GetPlayerActor()->GetAllLinkedActors())
+                for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
                 {
                     actor->requestAngleSnap(45);
                 }
@@ -144,7 +144,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
         if (App::sim_soft_reset_mode->GetBool())
         {
             reset_type = ActorModifyRequest::Type::SOFT_RESET;
-            for (auto actor : App::GetGameContext()->GetPlayerActor()->GetAllLinkedActors())
+            for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
             {
                 ActorModifyRequest* rq = new ActorModifyRequest;
                 rq->amr_actor = actor;

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -92,7 +92,7 @@ void SceneMouse::releaseMousePick()
 
     // remove forces
     if (grab_truck)
-        grab_truck->HandleMouseMove(minnode, Vector3::ZERO, 0);
+        grab_truck->mouseMove(minnode, Vector3::ZERO, 0);
 
     this->reset();
 }
@@ -196,7 +196,7 @@ void SceneMouse::UpdateSimulation()
         lastgrabpos = mouseRay.getPoint(mindist);
 
         // add forces
-        grab_truck->HandleMouseMove(minnode, lastgrabpos, MOUSE_GRAB_FORCE);
+        grab_truck->mouseMove(minnode, lastgrabpos, MOUSE_GRAB_FORCE);
     }
 }
 

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -164,7 +164,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
             {
                 if (it->hk_hook_node->pos == minnode)
                 {
-                    grab_truck->ToggleHooks(it->hk_group, MOUSE_HOOK_TOGGLE, minnode);
+                    grab_truck->hookToggle(it->hk_group, MOUSE_HOOK_TOGGLE, minnode);
                 }
             }
         }

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -115,7 +115,7 @@ void VehicleAI::updateWaypoint()
             beam->ToggleLights();
             break;
         case AI_BEACONSTOGGLE:
-            beam->ToggleBeacons();
+            beam->beaconsToggle();
             break;
         default:
             break;

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -112,7 +112,7 @@ void VehicleAI::updateWaypoint()
         switch (event)
         {
         case AI_LIGHTSTOGGLE:
-            beam->ToggleLights();
+            beam->lightsToggle();
             break;
         case AI_BEACONSTOGGLE:
             beam->beaconsToggle();

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -135,7 +135,7 @@ void VehicleAI::updateWaypoint()
     {
         current_waypoint_id = 0;
         is_enabled = false;
-        beam->ToggleParkingBrake();
+        beam->parkingbrakeToggle();
     }
     current_waypoint = waypoints[current_waypoint_id];
 }

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1728,7 +1728,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
 {
     m_simbuf.simbuf_live_local = (m_actor->ar_sim_state == Actor::SimState::LOCAL_SIMULATED);
     m_simbuf.simbuf_physics_paused = m_actor->ar_physics_paused;
-    m_simbuf.simbuf_pos = m_actor->GetRotationCenter();
+    m_simbuf.simbuf_pos = m_actor->getRotationCenter();
     m_simbuf.simbuf_rotation = m_actor->getRotation();
     m_simbuf.simbuf_tyre_pressure = m_actor->GetTyrePressure().GetCurPressure();
     m_simbuf.simbuf_tyre_pressurizing = m_actor->GetTyrePressure().IsPressurizing();

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1730,8 +1730,8 @@ void RoR::GfxActor::UpdateSimDataBuffer()
     m_simbuf.simbuf_physics_paused = m_actor->ar_physics_paused;
     m_simbuf.simbuf_pos = m_actor->getRotationCenter();
     m_simbuf.simbuf_rotation = m_actor->getRotation();
-    m_simbuf.simbuf_tyre_pressure = m_actor->GetTyrePressure().GetCurPressure();
-    m_simbuf.simbuf_tyre_pressurizing = m_actor->GetTyrePressure().IsPressurizing();
+    m_simbuf.simbuf_tyre_pressure = m_actor->getTyrePressure().GetCurPressure();
+    m_simbuf.simbuf_tyre_pressurizing = m_actor->getTyrePressure().IsPressurizing();
     m_simbuf.simbuf_aabb = m_actor->ar_bounding_box;
     m_simbuf.simbuf_wheel_speed = m_actor->ar_wheel_speed;
     m_simbuf.simbuf_beaconlight_active = m_actor->m_beacon_light_on;

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -3318,7 +3318,6 @@ void RoR::GfxActor::UpdateWingMeshes()
     }
 }
 
-std::string   RoR::GfxActor::FetchActorDesignName() const                { return m_actor->GetActorDesignName(); }
 int           RoR::GfxActor::FetchNumBeams      () const                 { return m_actor->ar_num_beams; }
 int           RoR::GfxActor::FetchNumNodes      () const                 { return m_actor->ar_num_nodes; }
 int           RoR::GfxActor::FetchNumWheelNodes () const                 { return m_actor->getWheelNodeCount(); }

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1867,7 +1867,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
 
     // Linked Actors
     m_linked_gfx_actors.clear();
-    for (auto actor : m_actor->GetAllLinkedActors())
+    for (auto actor : m_actor->getAllLinkedActors())
     {
         m_linked_gfx_actors.insert(actor->GetGfxActor());
     }

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -240,7 +240,7 @@ public:
     SimBuffer::NodeSB*        GetSimNodeBuffer   ()                       { return m_simbuf.simbuf_nodes.get(); }
     std::set<GfxActor*>       GetLinkedGfxActors ()                       { return m_linked_gfx_actors; }
     Ogre::String              GetResourceGroup   ()                       { return m_custom_resource_group; }
-    std::string               FetchActorDesignName() const;
+    Actor*                    GetActor           ()                       { return m_actor; } // Watch out for multithreading with this!
     int                       FetchNumBeams      () const ;
     int                       FetchNumNodes      () const ;
     int                       FetchNumWheelNodes () const ;

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -720,7 +720,7 @@ void CameraManager::UpdateCameraBehaviorStatic()
 
         if (m_cct_player_actor->ar_sim_state == Actor::SimState::LOCAL_REPLAY)
         {
-            speed *= m_cct_player_actor->GetReplay()->getPrecision();
+            speed *= m_cct_player_actor->getReplay()->getPrecision();
         }
     }
     else

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -1125,7 +1125,7 @@ void CameraManager::CameraBehaviorVehicleSplineUpdate()
         m_cam_target_pitch = -asin(dir.dotProduct(Vector3::UNIT_Y));
     }
 
-    if (m_cct_player_actor->GetAllLinkedActors().size() != m_splinecam_num_linked_beams)
+    if (m_cct_player_actor->getAllLinkedActors().size() != m_splinecam_num_linked_beams)
     {
         this->CameraBehaviorVehicleSplineCreateSpline();
     }
@@ -1243,7 +1243,7 @@ void CameraManager::CameraBehaviorVehicleSplineCreateSpline()
         m_splinecam_spline_nodes.push_back(&m_cct_player_actor->ar_nodes[m_cct_player_actor->ar_camera_rail[i]]);
     }
 
-    auto linkedBeams = m_cct_player_actor->GetAllLinkedActors();
+    auto linkedBeams = m_cct_player_actor->getAllLinkedActors();
 
     m_splinecam_num_linked_beams = static_cast<int>(linkedBeams.size());
 

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -584,7 +584,7 @@ bool OverlayWrapper::mouseMoved(const OIS::MouseEvent& _arg)
                 if (element == m_aerial_dashboard.brks.element)
                 {
                     mTimeUntilNextToggle = 0.2;
-                    player_actor->ToggleParkingBrake();
+                    player_actor->parkingbrakeToggle();
                 }
                 //trims
                 if (element == m_aerial_dashboard.hdg_trim.up_button)

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -929,7 +929,7 @@ void OverlayWrapper::UpdateMarineHUD(Actor* vehicle)
 
     // depth
     char tmp[50] = "";
-    float height = vehicle->GetHeightAboveGround();
+    float height = vehicle->getHeightAboveGround();
     if (height > 0.1 && height < 99.9)
     {
         sprintf(tmp, "%2.1f", height);

--- a/source/main/gui/panels/GUI_NodeBeamUtils.cpp
+++ b/source/main/gui/panels/GUI_NodeBeamUtils.cpp
@@ -50,37 +50,37 @@ void NodeBeamUtils::Draw()
     {
         actor->ar_nb_mass_scale = cur_mass / ref_mass;
         actor->ar_nb_initialized = false;
-        actor->ApplyNodeBeamScales();
+        actor->applyNodeBeamScales();
     }
     ImGui::Separator();
     ImGui::TextColored(GRAY_HINT_TEXT, _LC("NodeBeamUtils", "Beams:"));
     if (ImGui::SliderFloat("Spring##Beams", &actor->ar_nb_beams_scale.first, 0.1f, 10.0f, "%.5f"))
     {
-        actor->ApplyNodeBeamScales();
+        actor->applyNodeBeamScales();
     }
     if (ImGui::SliderFloat("Damping##Beams", &actor->ar_nb_beams_scale.second, 0.1f, 10.0f, "%.5f"))
     {
-        actor->ApplyNodeBeamScales();
+        actor->applyNodeBeamScales();
     }
     ImGui::Separator();
     ImGui::TextColored(GRAY_HINT_TEXT, _LC("NodeBeamUtils", "Shocks:"));
     if (ImGui::SliderFloat("Spring##Shocks", &actor->ar_nb_shocks_scale.first, 0.1f, 10.0f, "%.5f"))
     {
-        actor->ApplyNodeBeamScales();
+        actor->applyNodeBeamScales();
     }
     if (ImGui::SliderFloat("Damping##Shocks", &actor->ar_nb_shocks_scale.second, 0.1f, 10.0f, "%.5f"))
     {
-        actor->ApplyNodeBeamScales();
+        actor->applyNodeBeamScales();
     }
     ImGui::Separator();
     ImGui::TextColored(GRAY_HINT_TEXT, _LC("NodeBeamUtils", "Wheels:"));
     if (ImGui::SliderFloat("Spring##Wheels", &actor->ar_nb_wheels_scale.first, 0.1f, 10.0f, "%.5f"))
     {
-        actor->ApplyNodeBeamScales();
+        actor->applyNodeBeamScales();
     }
     if (ImGui::SliderFloat("Damping##Wheels", &actor->ar_nb_wheels_scale.second, 0.1f, 10.0f, "%.5f"))
     {
-        actor->ApplyNodeBeamScales();
+        actor->applyNodeBeamScales();
     }
     ImGui::Separator();
     ImGui::Spacing();
@@ -95,7 +95,7 @@ void NodeBeamUtils::Draw()
     ImGui::SameLine();
     if (ImGui::Button(_LC("NodeBeamUtils", "Update initial node positions"), ImVec2(280.f, 25.f)))
     {
-        actor->UpdateInitPosition();
+        actor->updateInitPosition();
     }
     ImGui::PopItemWidth();
 
@@ -172,7 +172,7 @@ void NodeBeamUtils::Draw()
 
     if (m_is_searching)
     {
-        actor->SearchBeamDefaults();
+        actor->searchBeamDefaults();
     }
 
     App::GetGuiManager()->RequestGuiCaptureKeyboard(ImGui::IsWindowHovered());

--- a/source/main/gui/panels/GUI_SimActorStats.cpp
+++ b/source/main/gui/panels/GUI_SimActorStats.cpp
@@ -42,7 +42,7 @@ void SimActorStats::Draw(RoR::GfxActor* actorx)
     ImGui::SetNextWindowPos(ImVec2(theme.screen_edge_padding.x, (theme.screen_edge_padding.y + 150)));
     ImGui::Begin("SimActorStats", nullptr, flags);
 
-    RoR::ImTextWrappedColorMarked(actorx->FetchActorDesignName());
+    RoR::ImTextWrappedColorMarked(actorx->GetActor()->getTruckName());
     ImGui::Dummy(ImGui::GetStyle().FramePadding);
 
     ImGui::Separator();

--- a/source/main/gui/panels/GUI_SimActorStats.cpp
+++ b/source/main/gui/panels/GUI_SimActorStats.cpp
@@ -232,8 +232,8 @@ void SimActorStats::UpdateStats(float dt, Actor* actor)
     float mass = actor->getTotalMass();
     int beambroken = 0;
     int beamdeformed = 0;
-    Ogre::Vector3 gcur = actor->GetGForcesCur();
-    Ogre::Vector3 gmax = actor->GetGForcesMax();
+    Ogre::Vector3 gcur = actor->getGForces();
+    Ogre::Vector3 gmax = actor->getMaxGForces();
 
     for (int i = 0; i < actor->ar_num_beams; i++ , beam++)
     {

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -859,7 +859,7 @@ void TopMenubar::DrawSpecialStateBox(float top_offset)
                 ImGui::SameLine();
                 
                 // Progress bar with frame index/count
-                Replay* replay = App::GetGameContext()->GetPlayerActor()->GetReplay();
+                Replay* replay = App::GetGameContext()->GetPlayerActor()->getReplay();
                 float fraction = (float)std::abs(replay->getCurrentFrame())/(float)replay->getNumFrames();
                 Str<100> pbar_text; pbar_text << replay->getCurrentFrame() << "/" << replay->getNumFrames();
                 float pbar_width = content_width - (ImGui::GetStyle().ItemSpacing.x + ImGui::CalcTextSize(special_text.c_str()).x);

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -783,7 +783,7 @@ void TopMenubar::DrawActorListSinglePlayer()
             ImGui::SameLine();
 
             std::string text_buf = fmt::format( "[{}] {}", i++, actor->ar_design_name.c_str());
-            auto linked_actors = actor->GetAllLinkedActors();
+            auto linked_actors = actor->getAllLinkedActors();
             if (actor == player_actor)
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, GREEN_TEXT);

--- a/source/main/gui/panels/GUI_VehicleDescription.cpp
+++ b/source/main/gui/panels/GUI_VehicleDescription.cpp
@@ -50,7 +50,7 @@ void VehicleDescription::Draw()
     ImGui::SetNextWindowPosCenter(ImGuiCond_Appearing);
     ImVec2 size(HELP_TEXTURE_WIDTH + 2*ImGui::GetStyle().WindowPadding.x, 0.f);
     ImGui::SetNextWindowSize(size, ImGuiCond_Appearing);
-    if (!ImGui::Begin(actor->GetActorDesignName().c_str(), &m_is_visible))
+    if (!ImGui::Begin(actor->getTruckName().c_str(), &m_is_visible))
     {
         ImGui::End(); // The window is collapsed
         return;

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -458,7 +458,7 @@ int main(int argc, char *argv[])
                 case MSG_SIM_PAUSE_REQUESTED:
                     for (Actor* actor: App::GetGameContext()->GetActorManager()->GetActors())
                     {
-                        actor->StopAllSounds();
+                        actor->muteAllSounds();
                     }
                     App::sim_state->SetVal((int)SimState::PAUSED);
                     break;
@@ -466,7 +466,7 @@ int main(int argc, char *argv[])
                 case MSG_SIM_UNPAUSE_REQUESTED:
                     for (Actor* actor: App::GetGameContext()->GetActorManager()->GetActors())
                     {
-                        actor->UnmuteAllSounds();
+                        actor->unmuteAllSounds();
                     }
                     App::sim_state->SetVal((int)SimState::RUNNING);
                     break;

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1160,7 +1160,7 @@ void Actor::ResetAngle(float rot)
     calculateAveragePosition();
 }
 
-void Actor::UpdateInitPosition()
+void Actor::updateInitPosition()
 {
     for (int i = 0; i < ar_num_nodes; i++)
     {
@@ -1553,7 +1553,7 @@ void Actor::SyncReset(bool reset_position)
         ar_beams[i].bm_disabled     = false;
     }
 
-    this->ApplyNodeBeamScales();
+    this->applyNodeBeamScales();
 
     this->DisjoinInterActorBeams();
 
@@ -1679,7 +1679,7 @@ void Actor::SyncReset(bool reset_position)
     m_ongoing_reset = true;
 }
 
-void Actor::ApplyNodeBeamScales()
+void Actor::applyNodeBeamScales()
 {
     for (int i = 0; i < ar_num_nodes; i++)
     {
@@ -1731,7 +1731,7 @@ void Actor::HandleAngelScriptEvents(float dt)
 #endif // USE_ANGELSCRIPT
 }
 
-void Actor::SearchBeamDefaults()
+void Actor::searchBeamDefaults()
 {
     SyncReset(true);
 
@@ -1760,7 +1760,7 @@ void Actor::SearchBeamDefaults()
         ar_nb_optimum   = std::vector<float>(ar_nb_reference.size(), std::numeric_limits<float>::max());
     }
 
-    this->ApplyNodeBeamScales();
+    this->applyNodeBeamScales();
 
     m_ongoing_reset = false;
     this->CalcForcesEulerPrepare(true);

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -342,7 +342,7 @@ Vector3 Actor::getPosition()
     return m_avg_node_position; //the position is already in absolute position
 }
 
-void Actor::PushNetwork(char* data, int size)
+void Actor::pushNetwork(char* data, int size)
 {
     NetUpdate update;
 
@@ -418,7 +418,7 @@ void Actor::PushNetwork(char* data, int size)
     m_net_updates.push_back(update);
 }
 
-void Actor::CalcNetwork()
+void Actor::calcNetwork()
 {
     using namespace RoRnet;
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -592,7 +592,7 @@ void Actor::CalcNetwork()
     if (((flagmask & NETMASK_LIGHTS) != 0) != m_headlight_on)
         ToggleLights();
     if (((flagmask & NETMASK_BEACONS) != 0) != m_beacon_light_on)
-        ToggleBeacons();
+        beaconsToggle();
 
     m_antilockbrake = flagmask & NETMASK_ALB_ACTIVE;
     m_tractioncontrol = flagmask & NETMASK_TC_ACTIVE;
@@ -3765,7 +3765,7 @@ void Actor::tractioncontrolToggle()
         tc_mode = !tc_mode;
 }
 
-void Actor::ToggleBeacons()
+void Actor::beaconsToggle()
 {
     if (m_flares_mode == GfxFlaresMode::NONE)
     {

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1258,7 +1258,7 @@ void Actor::mouseMove(int node, Vector3 pos, float force)
     m_mouse_grab_pos = pos;
 }
 
-void Actor::ToggleWheelDiffMode()
+void Actor::toggleWheelDiffMode()
 {
     for (int i = 0; i < m_num_wheel_diffs; ++i)
     {
@@ -1302,7 +1302,7 @@ void Actor::displayAxleDiffMode()
     }
 }
 
-void Actor::DisplayWheelDiffMode()
+void Actor::displayWheelDiffMode()
 {
     if (m_num_wheel_diffs == 0)
     {

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -590,7 +590,7 @@ void Actor::calcNetwork()
 
     // set lights
     if (((flagmask & NETMASK_LIGHTS) != 0) != m_headlight_on)
-        ToggleLights();
+        lightsToggle();
     if (((flagmask & NETMASK_BEACONS) != 0) != m_beacon_light_on)
         beaconsToggle();
 
@@ -2944,7 +2944,7 @@ void Actor::prepareInside(bool inside)
     }
 }
 
-void Actor::ToggleLights()
+void Actor::lightsToggle()
 {
     // export light command
     Actor* player_actor = App::GetGameContext()->GetPlayerActor();
@@ -2953,7 +2953,7 @@ void Actor::ToggleLights()
         for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             if (actor->ar_sim_state == Actor::SimState::LOCAL_SIMULATED && this != actor && actor->ar_import_commands)
-                actor->ToggleLights();
+                actor->lightsToggle();
         }
     }
     m_headlight_on = !m_headlight_on;

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4544,7 +4544,7 @@ Ogre::Real Actor::getMinimalCameraRadius()
     return m_min_camera_radius;
 }
 
-Replay* Actor::GetReplay()
+Replay* Actor::getReplay()
 {
     if (m_replay_handler && m_replay_handler->isValid())
         return m_replay_handler;

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3493,7 +3493,7 @@ void Actor::tieToggle(int group)
     TRIGGER_EVENT(SE_TRUCK_TIE_TOGGLE, ar_instance_id);
 }
 
-void Actor::ToggleRopes(int group)
+void Actor::ropeToggle(int group)
 {
     Actor* player_actor = App::GetGameContext()->GetPlayerActor();
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -586,7 +586,7 @@ void Actor::CalcNetwork()
 
     // set particle cannon
     if (((flagmask & NETMASK_PARTICLE) != 0) != m_custom_particles_enabled)
-        ToggleCustomParticles();
+        toggleCustomParticles();
 
     // set lights
     if (((flagmask & NETMASK_LIGHTS) != 0) != m_headlight_on)
@@ -3131,7 +3131,7 @@ void Actor::autoBlinkReset()
     }
 }
 
-void Actor::ToggleCustomParticles()
+void Actor::toggleCustomParticles()
 {
     m_custom_particles_enabled = !m_custom_particles_enabled;
     for (int i = 0; i < ar_num_custom_particles; i++)

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2719,7 +2719,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                         if (trigger_hooks)
                         {
                             //autolock hooktoggle unlock
-                            ToggleHooks(ar_beams[i].shock->trigger_cmdlong, HOOK_UNLOCK, -1);
+                            hookToggle(ar_beams[i].shock->trigger_cmdlong, HOOK_UNLOCK, -1);
                         }
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_HOOK_LOCK)
@@ -2727,7 +2727,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                         if (trigger_hooks)
                         {
                             //autolock hooktoggle lock
-                            ToggleHooks(ar_beams[i].shock->trigger_cmdlong, HOOK_LOCK, -1);
+                            hookToggle(ar_beams[i].shock->trigger_cmdlong, HOOK_LOCK, -1);
                         }
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_ENGINE)
@@ -2758,7 +2758,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                         if (trigger_hooks)
                         {
                             //autolock hooktoggle unlock
-                            ToggleHooks(ar_beams[i].shock->trigger_cmdshort, HOOK_UNLOCK, -1);
+                            hookToggle(ar_beams[i].shock->trigger_cmdshort, HOOK_UNLOCK, -1);
                         }
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_HOOK_LOCK)
@@ -2766,7 +2766,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                         if (trigger_hooks)
                         {
                             //autolock hooktoggle lock
-                            ToggleHooks(ar_beams[i].shock->trigger_cmdshort, HOOK_LOCK, -1);
+                            hookToggle(ar_beams[i].shock->trigger_cmdshort, HOOK_LOCK, -1);
                         }
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_ENGINE)
@@ -3602,7 +3602,7 @@ void Actor::ToggleRopes(int group)
     }
 }
 
-void Actor::ToggleHooks(int group, HookAction mode, int node_number)
+void Actor::hookToggle(int group, HookAction mode, int node_number)
 {
     // iterate over all hooks
     for (std::vector<hook_t>::iterator it = ar_hooks.begin(); it != ar_hooks.end(); it++)

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1473,6 +1473,14 @@ float Actor::GetHeightAboveGroundBelow(float height, bool skip_virtual_nodes)
     return (!skip_virtual_nodes || agl < std::numeric_limits<float>::max()) ? agl : GetHeightAboveGroundBelow(height, false);
 }
 
+void Actor::reset(bool keep_position)
+{
+    ActorModifyRequest* rq = new ActorModifyRequest;
+    rq->amr_actor = this;
+    rq->amr_type  = (keep_position) ? ActorModifyRequest::Type::RESET_ON_SPOT : ActorModifyRequest::Type::RESET_ON_INIT_POS;
+    App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
+}
+
 void Actor::SoftReset()
 {
     TRIGGER_EVENT(SE_TRUCK_RESET, ar_instance_id);

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -288,7 +288,7 @@ Actor::~Actor()
 
 // This method scales actors. Stresses should *NOT* be scaled, they describe
 // the material type and they do not depend on length or scale.
-void Actor::ScaleActor(float value)
+void Actor::scaleTruck(float value)
 {
     if (value < 0)
         return;

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1401,7 +1401,7 @@ String Actor::GetTransferCaseName()
     return name;
 }
 
-Ogre::Vector3 Actor::GetRotationCenter()
+Ogre::Vector3 Actor::getRotationCenter()
 {
     Vector3 sum = Vector3::ZERO;
     std::vector<Vector3> positions;
@@ -1832,7 +1832,7 @@ void Actor::HandleInputEvents(float dt)
         float rotation = Radian(getRotation()).valueDegrees();
         float target_rotation = std::round(rotation / m_anglesnap_request) * m_anglesnap_request;
         m_rotation_request = -Degree(target_rotation - rotation).valueRadians();
-	m_rotation_request_center = GetRotationCenter();
+	m_rotation_request_center = getRotationCenter();
         m_anglesnap_request = 0;
     }
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3345,7 +3345,7 @@ void Actor::DisjoinInterActorBeams()
     }
 }
 
-void Actor::ToggleTies(int group)
+void Actor::tieToggle(int group)
 {
     Actor* player_actor = App::GetGameContext()->GetPlayerActor();
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1328,12 +1328,12 @@ void Actor::displayWheelDiffMode()
     }
 }
 
-void Actor::DisplayTransferCaseMode()
+void Actor::displayTransferCaseMode()
 {
     if (m_transfer_case)
     {
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                _L("Transfercase switched to: ") + this->GetTransferCaseName(), "cog.png", 3000);
+                _L("Transfercase switched to: ") + this->getTransferCaseName(), "cog.png", 3000);
     }
     else
     {
@@ -1342,7 +1342,7 @@ void Actor::DisplayTransferCaseMode()
     }
 }
 
-void Actor::ToggleTransferCaseMode()
+void Actor::toggleTransferCaseMode()
 {
     if (!ar_engine || !m_transfer_case || m_transfer_case->tr_ax_2 < 0 || !m_transfer_case->tr_2wd)
         return;
@@ -1351,7 +1351,7 @@ void Actor::ToggleTransferCaseMode()
     {
         for (int i = 0; i < m_transfer_case->tr_gear_ratios.size(); i++)
         {
-            this->ToggleTransferCaseGearRatio();
+            this->toggleTransferCaseGearRatio();
             if (m_transfer_case->tr_gear_ratios[0] == 1.0f)
                 break;
         }
@@ -1373,7 +1373,7 @@ void Actor::ToggleTransferCaseMode()
     }
 }
 
-void Actor::ToggleTransferCaseGearRatio()
+void Actor::toggleTransferCaseGearRatio()
 {
     if (!ar_engine || !m_transfer_case || m_transfer_case->tr_gear_ratios.size() < 2)
         return;
@@ -1387,7 +1387,7 @@ void Actor::ToggleTransferCaseGearRatio()
     }
 }
 
-String Actor::GetTransferCaseName()
+String Actor::getTransferCaseName()
 {
     String name = "";
     if (m_transfer_case)

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1009,7 +1009,7 @@ void Actor::resolveCollisions(Vector3 direction)
     // Additional 20 cm safe-guard (horizontally)
     offset += 0.2f * Vector3(offset.x, 0.0f, offset.z).normalisedCopy();
 
-    resetPosition(ar_nodes[0].AbsPosition.x + offset.x, ar_nodes[0].AbsPosition.z + offset.z, false, this->GetMinHeight() + offset.y);
+    resetPosition(ar_nodes[0].AbsPosition.x + offset.x, ar_nodes[0].AbsPosition.z + offset.z, false, this->getMinHeight() + offset.y);
 }
 
 void Actor::resolveCollisions(float max_distance, bool consider_up)
@@ -1048,7 +1048,7 @@ void Actor::resolveCollisions(float max_distance, bool consider_up)
     // Additional 20 cm safe-guard (horizontally)
     offset += 0.2f * Vector3(offset.x, 0.0f, offset.z).normalisedCopy();
 
-    resetPosition(ar_nodes[0].AbsPosition.x + offset.x, ar_nodes[0].AbsPosition.z + offset.z, true, this->GetMinHeight() + offset.y);
+    resetPosition(ar_nodes[0].AbsPosition.x + offset.x, ar_nodes[0].AbsPosition.z + offset.z, true, this->getMinHeight() + offset.y);
 }
 
 void Actor::calculateAveragePosition()
@@ -1179,7 +1179,7 @@ void Actor::resetPosition(float px, float pz, bool setInitPosition, float miny)
     }
 
     // vertical displacement
-    float vertical_offset = miny - this->GetMinHeight();
+    float vertical_offset = miny - this->getMinHeight();
     if (App::GetSimTerrain()->getWater())
     {
         vertical_offset += std::max(0.0f, App::GetSimTerrain()->getWater()->GetStaticWaterHeight() - miny);
@@ -1419,7 +1419,7 @@ Ogre::Vector3 Actor::getRotationCenter()
     return sum / positions.size();
 }
 
-float Actor::GetMinHeight(bool skip_virtual_nodes)
+float Actor::getMinHeight(bool skip_virtual_nodes)
 {
     float height = std::numeric_limits<float>::max(); 
     for (int i = 0; i < ar_num_nodes; i++)
@@ -1429,10 +1429,10 @@ float Actor::GetMinHeight(bool skip_virtual_nodes)
             height = std::min(ar_nodes[i].AbsPosition.y, height);
         }
     }
-    return (!skip_virtual_nodes || height < std::numeric_limits<float>::max()) ? height : GetMinHeight(false);
+    return (!skip_virtual_nodes || height < std::numeric_limits<float>::max()) ? height : getMinHeight(false);
 }
 
-float Actor::GetMaxHeight(bool skip_virtual_nodes)
+float Actor::getMaxHeight(bool skip_virtual_nodes)
 {
     float height = std::numeric_limits<float>::min(); 
     for (int i = 0; i < ar_num_nodes; i++)
@@ -1442,10 +1442,10 @@ float Actor::GetMaxHeight(bool skip_virtual_nodes)
             height = std::max(height, ar_nodes[i].AbsPosition.y);
         }
     }
-    return (!skip_virtual_nodes || height > std::numeric_limits<float>::min()) ? height : GetMaxHeight(false);
+    return (!skip_virtual_nodes || height > std::numeric_limits<float>::min()) ? height : getMaxHeight(false);
 }
 
-float Actor::GetHeightAboveGround(bool skip_virtual_nodes)
+float Actor::getHeightAboveGround(bool skip_virtual_nodes)
 {
     float agl = std::numeric_limits<float>::max(); 
     for (int i = 0; i < ar_num_nodes; i++)
@@ -1456,10 +1456,10 @@ float Actor::GetHeightAboveGround(bool skip_virtual_nodes)
             agl = std::min(pos.y - App::GetSimTerrain()->GetCollisions()->getSurfaceHeight(pos.x, pos.z), agl);
         }
     }
-    return (!skip_virtual_nodes || agl < std::numeric_limits<float>::max()) ? agl : GetHeightAboveGround(false);
+    return (!skip_virtual_nodes || agl < std::numeric_limits<float>::max()) ? agl : getHeightAboveGround(false);
 }
 
-float Actor::GetHeightAboveGroundBelow(float height, bool skip_virtual_nodes)
+float Actor::getHeightAboveGroundBelow(float height, bool skip_virtual_nodes)
 {
     float agl = std::numeric_limits<float>::max(); 
     for (int i = 0; i < ar_num_nodes; i++)
@@ -1470,7 +1470,7 @@ float Actor::GetHeightAboveGroundBelow(float height, bool skip_virtual_nodes)
             agl = std::min(pos.y - App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(pos.x, pos.z, height), agl);
         }
     }
-    return (!skip_virtual_nodes || agl < std::numeric_limits<float>::max()) ? agl : GetHeightAboveGroundBelow(height, false);
+    return (!skip_virtual_nodes || agl < std::numeric_limits<float>::max()) ? agl : getHeightAboveGroundBelow(height, false);
 }
 
 void Actor::reset(bool keep_position)
@@ -1485,11 +1485,11 @@ void Actor::SoftReset()
 {
     TRIGGER_EVENT(SE_TRUCK_RESET, ar_instance_id);
 
-    float agl = this->GetHeightAboveGroundBelow(this->GetMaxHeight(true), true);
+    float agl = this->getHeightAboveGroundBelow(this->getMaxHeight(true), true);
 
     if (App::GetSimTerrain()->getWater())
     {
-        agl = std::min(this->GetMinHeight(true) - App::GetSimTerrain()->getWater()->GetStaticWaterHeight(), agl);
+        agl = std::min(this->getMinHeight(true) - App::GetSimTerrain()->getWater()->GetStaticWaterHeight(), agl);
     }
 
     if (agl < 0.0f)
@@ -1642,10 +1642,10 @@ void Actor::SyncReset(bool reset_position)
     {
         this->ResetAngle(cur_rot);
         this->resetPosition(cur_position, false);
-        float agl = this->GetHeightAboveGroundBelow(this->GetMaxHeight(true), true);
+        float agl = this->getHeightAboveGroundBelow(this->getMaxHeight(true), true);
         if (App::GetSimTerrain()->getWater())
         {
-            agl = std::min(this->GetMinHeight(true) - App::GetSimTerrain()->getWater()->GetStaticWaterHeight(), agl);
+            agl = std::min(this->getMinHeight(true) - App::GetSimTerrain()->getWater()->GetStaticWaterHeight(), agl);
         }
         if (agl < 0.0f)
         {
@@ -4064,7 +4064,7 @@ void Actor::updateDashBoards(float dt)
         }
 
         // water depth display, only if we have a screw prop at least
-        float depth = this->GetHeightAboveGround();
+        float depth = this->getHeightAboveGround();
         ar_dashboard->setFloat(DD_WATER_DEPTH, depth);
 
         // water speed

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3740,7 +3740,7 @@ void Actor::ToggleHooks(int group, HookAction mode, int node_number)
     }
 }
 
-void Actor::ToggleParkingBrake()
+void Actor::parkingbrakeToggle()
 {
     ar_parking_brake = !ar_parking_brake;
 
@@ -3753,13 +3753,13 @@ void Actor::ToggleParkingBrake()
     TRIGGER_EVENT(SE_TRUCK_PARKINGBREAK_TOGGLE, ar_instance_id);
 }
 
-void Actor::ToggleAntiLockBrake()
+void Actor::antilockbrakeToggle()
 {
     if (!alb_notoggle)
         alb_mode = !alb_mode;
 }
 
-void Actor::ToggleTractionControl()
+void Actor::tractioncontrolToggle()
 {
     if (!tc_notoggle)
         tc_mode = !tc_mode;

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -96,7 +96,7 @@ Actor::~Actor()
         SOUND_STOP(this, i);
     }
 #endif // USE_OPENAL
-    StopAllSounds();
+    muteAllSounds();
 
     if (ar_engine != nullptr)
     {
@@ -3147,7 +3147,7 @@ void Actor::toggleCustomParticles()
     TRIGGER_EVENT(SE_TRUCK_CPARTICLES_TOGGLE, ar_instance_id);
 }
 
-void Actor::UpdateSoundSources()
+void Actor::updateSoundSources()
 {
 #ifdef USE_OPENAL
     if (App::GetSoundScriptManager()->isDisabled())
@@ -3167,7 +3167,7 @@ void Actor::updateVisual(float dt)
 {
     Vector3 ref(Vector3::UNIT_Y);
     autoBlinkReset();
-    UpdateSoundSources();
+    updateSoundSources();
 
 #ifdef USE_OPENAL
     //airplane radio chatter
@@ -3789,7 +3789,7 @@ bool Actor::getReverseLightVisible()
     return m_extern_reverse_light_on;
 }
 
-void Actor::StopAllSounds()
+void Actor::muteAllSounds()
 {
 #ifdef USE_OPENAL
     for (int i = 0; i < ar_num_soundsources; i++)
@@ -3800,7 +3800,7 @@ void Actor::StopAllSounds()
 #endif // USE_OPENAL
 }
 
-void Actor::UnmuteAllSounds()
+void Actor::unmuteAllSounds()
 {
 #ifdef USE_OPENAL
     for (int i = 0; i < ar_num_soundsources; i++)

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2732,7 +2732,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_ENGINE)
                     {
-                        EngineTriggerHelper(ar_beams[i].shock->trigger_cmdshort, EngineTriggerType(ar_beams[i].shock->trigger_cmdlong), 1.0f);
+                        engineTriggerHelper(ar_beams[i].shock->trigger_cmdshort, EngineTriggerType(ar_beams[i].shock->trigger_cmdlong), 1.0f);
                     }
                     else
                     {
@@ -2773,7 +2773,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                     {
                         bool triggerValue = !(ar_beams[i].shock->flags & SHOCK_FLAG_TRG_CONTINUOUS); // 0 if trigger is continuous, 1 otherwise
 
-                        EngineTriggerHelper(ar_beams[i].shock->trigger_cmdshort, EngineTriggerType(ar_beams[i].shock->trigger_cmdlong), triggerValue);
+                        engineTriggerHelper(ar_beams[i].shock->trigger_cmdshort, EngineTriggerType(ar_beams[i].shock->trigger_cmdlong), triggerValue);
                     }
                     else
                     {
@@ -2809,7 +2809,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
 
                     if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_ENGINE) // this trigger controls an engine
                     {
-                        EngineTriggerHelper(ar_beams[i].shock->trigger_cmdshort, EngineTriggerType(ar_beams[i].shock->trigger_cmdlong), triggerValue);
+                        engineTriggerHelper(ar_beams[i].shock->trigger_cmdshort, EngineTriggerType(ar_beams[i].shock->trigger_cmdlong), triggerValue);
                     }
                     else
                     {
@@ -4301,7 +4301,7 @@ void Actor::calculateLocalGForces()
     }
 }
 
-void Actor::EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue)
+void Actor::engineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue)
 {
     // engineNumber tells us which engine
     EngineSim* e = ar_engine; // placeholder: actors do not have multiple engines yet

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1251,7 +1251,7 @@ void Actor::resetPosition(Vector3 translation, bool setInitPosition)
     calculateAveragePosition();
 }
 
-void Actor::HandleMouseMove(int node, Vector3 pos, float force)
+void Actor::mouseMove(int node, Vector3 pos, float force)
 {
     m_mouse_grab_node = node;
     m_mouse_grab_move_force = force * std::pow(m_total_mass / 3000.0f, 0.75f);

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1266,7 +1266,7 @@ void Actor::ToggleWheelDiffMode()
     }
 }
 
-void Actor::ToggleAxleDiffMode()
+void Actor::toggleAxleDiffMode()
 {
     for (int i = 0; i < m_num_axle_diffs; ++i)
     {
@@ -1274,7 +1274,7 @@ void Actor::ToggleAxleDiffMode()
     }
 }
 
-void Actor::DisplayAxleDiffMode()
+void Actor::displayAxleDiffMode()
 {
     if (m_num_axle_diffs == 0)
     {

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1009,7 +1009,7 @@ void Actor::resolveCollisions(Vector3 direction)
     // Additional 20 cm safe-guard (horizontally)
     offset += 0.2f * Vector3(offset.x, 0.0f, offset.z).normalisedCopy();
 
-    ResetPosition(ar_nodes[0].AbsPosition.x + offset.x, ar_nodes[0].AbsPosition.z + offset.z, false, this->GetMinHeight() + offset.y);
+    resetPosition(ar_nodes[0].AbsPosition.x + offset.x, ar_nodes[0].AbsPosition.z + offset.z, false, this->GetMinHeight() + offset.y);
 }
 
 void Actor::resolveCollisions(float max_distance, bool consider_up)
@@ -1048,7 +1048,7 @@ void Actor::resolveCollisions(float max_distance, bool consider_up)
     // Additional 20 cm safe-guard (horizontally)
     offset += 0.2f * Vector3(offset.x, 0.0f, offset.z).normalisedCopy();
 
-    ResetPosition(ar_nodes[0].AbsPosition.x + offset.x, ar_nodes[0].AbsPosition.z + offset.z, true, this->GetMinHeight() + offset.y);
+    resetPosition(ar_nodes[0].AbsPosition.x + offset.x, ar_nodes[0].AbsPosition.z + offset.z, true, this->GetMinHeight() + offset.y);
 }
 
 void Actor::calculateAveragePosition()
@@ -1168,7 +1168,7 @@ void Actor::UpdateInitPosition()
     }
 }
 
-void Actor::ResetPosition(float px, float pz, bool setInitPosition, float miny)
+void Actor::resetPosition(float px, float pz, bool setInitPosition, float miny)
 {
     // horizontal displacement
     Vector3 offset = Vector3(px, ar_nodes[0].AbsPosition.y, pz) - ar_nodes[0].AbsPosition;
@@ -1223,10 +1223,10 @@ void Actor::ResetPosition(float px, float pz, bool setInitPosition, float miny)
         ar_nodes[i].RelPosition = ar_nodes[i].AbsPosition - ar_origin;
     }
 
-    ResetPosition(Vector3::ZERO, setInitPosition);
+    resetPosition(Vector3::ZERO, setInitPosition);
 }
 
-void Actor::ResetPosition(Vector3 translation, bool setInitPosition)
+void Actor::resetPosition(Vector3 translation, bool setInitPosition)
 {
     // total displacement
     if (translation != Vector3::ZERO)
@@ -1495,10 +1495,10 @@ void Actor::SoftReset()
     if (agl < 0.0f)
     {
         Vector3 translation = -agl * Vector3::UNIT_Y;
-        this->ResetPosition(ar_nodes[0].AbsPosition + translation, false);
+        this->resetPosition(ar_nodes[0].AbsPosition + translation, false);
         for (auto actor : m_linked_actors)
         {
-            actor->ResetPosition(actor->ar_nodes[0].AbsPosition + translation, false);
+            actor->resetPosition(actor->ar_nodes[0].AbsPosition + translation, false);
         }
     }
 
@@ -1641,7 +1641,7 @@ void Actor::SyncReset(bool reset_position)
     if (!reset_position)
     {
         this->ResetAngle(cur_rot);
-        this->ResetPosition(cur_position, false);
+        this->resetPosition(cur_position, false);
         float agl = this->GetHeightAboveGroundBelow(this->GetMaxHeight(true), true);
         if (App::GetSimTerrain()->getWater())
         {
@@ -1649,7 +1649,7 @@ void Actor::SyncReset(bool reset_position)
         }
         if (agl < 0.0f)
         {
-            this->ResetPosition(ar_nodes[0].AbsPosition - agl * Vector3::UNIT_Y, false);
+            this->resetPosition(ar_nodes[0].AbsPosition - agl * Vector3::UNIT_Y, false);
         }
     }
     else

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3376,13 +3376,13 @@ void Actor::tieToggle(int group)
             {
                 this->RemoveInterActorBeam(it->ti_beam);
                 // update skeletonview on the untied actors
-                auto linked_actors = it->ti_locked_actor->GetAllLinkedActors();
+                auto linked_actors = it->ti_locked_actor->getAllLinkedActors();
                 if (!(std::find(linked_actors.begin(), linked_actors.end(), this) != linked_actors.end()))
                 {
                     if (this == player_actor)
                     {
                         it->ti_locked_actor->GetGfxActor()->SetDebugView(GfxActor::DebugViewType::DEBUGVIEW_NONE);
-                        for (auto actor : it->ti_locked_actor->GetAllLinkedActors())
+                        for (auto actor : it->ti_locked_actor->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(GfxActor::DebugViewType::DEBUGVIEW_NONE);
                         }
@@ -3390,7 +3390,7 @@ void Actor::tieToggle(int group)
                     else if (it->ti_locked_actor == player_actor)
                     {
                         m_gfx_actor->SetDebugView(GfxActor::DebugViewType::DEBUGVIEW_NONE);
-                        for (auto actor : this->GetAllLinkedActors())
+                        for (auto actor : this->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(GfxActor::DebugViewType::DEBUGVIEW_NONE);
                         }
@@ -3470,7 +3470,7 @@ void Actor::tieToggle(int group)
                         if (this == player_actor)
                         {
                             nearest_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
-                            for (auto actor : nearest_actor->GetAllLinkedActors())
+                            for (auto actor : nearest_actor->getAllLinkedActors())
                             {
                                 actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
                             }
@@ -3478,7 +3478,7 @@ void Actor::tieToggle(int group)
                         else if (nearest_actor == player_actor)
                         {
                             m_gfx_actor->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
-                            for (auto actor : this->GetAllLinkedActors())
+                            for (auto actor : this->getAllLinkedActors())
                             {
                                 actor->GetGfxActor()->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
                             }
@@ -3515,13 +3515,13 @@ void Actor::ropeToggle(int group)
             {
                 this->RemoveInterActorBeam(it->rp_beam);
                 // update skeletonview on the unroped actors
-                auto linked_actors = it->rp_locked_actor->GetAllLinkedActors();
+                auto linked_actors = it->rp_locked_actor->getAllLinkedActors();
                 if (!(std::find(linked_actors.begin(), linked_actors.end(), this) != linked_actors.end()))
                 {
                     if (this == player_actor)
                     {
                         it->rp_locked_actor->GetGfxActor()->SetDebugView(GfxActor::DebugViewType::DEBUGVIEW_NONE);
-                        for (auto actor : it->rp_locked_actor->GetAllLinkedActors())
+                        for (auto actor : it->rp_locked_actor->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(GfxActor::DebugViewType::DEBUGVIEW_NONE);
                         }
@@ -3529,7 +3529,7 @@ void Actor::ropeToggle(int group)
                     else if (it->rp_locked_actor == player_actor)
                     {
                         m_gfx_actor->SetDebugView(GfxActor::DebugViewType::DEBUGVIEW_NONE);
-                        for (auto actor : this->GetAllLinkedActors())
+                        for (auto actor : this->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(GfxActor::DebugViewType::DEBUGVIEW_NONE);
                         }
@@ -3583,7 +3583,7 @@ void Actor::ropeToggle(int group)
                     if (this == player_actor)
                     {
                         nearest_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
-                        for (auto actor : nearest_actor->GetAllLinkedActors())
+                        for (auto actor : nearest_actor->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
                         }
@@ -3591,7 +3591,7 @@ void Actor::ropeToggle(int group)
                     else if (nearest_actor == player_actor)
                     {
                         m_gfx_actor->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
-                        for (auto actor : this->GetAllLinkedActors())
+                        for (auto actor : this->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
                         }
@@ -3723,7 +3723,7 @@ void Actor::hookToggle(int group, HookAction mode, int node_number)
             if (it->hk_locked_actor)
             {
                 it->hk_locked_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
-                for (auto actor : it->hk_locked_actor->GetAllLinkedActors())
+                for (auto actor : it->hk_locked_actor->getAllLinkedActors())
                 {
                     actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
                 }
@@ -3731,7 +3731,7 @@ void Actor::hookToggle(int group, HookAction mode, int node_number)
             else if (prev_locked_actor != this)
             {
                 prev_locked_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
-                for (auto actor : prev_locked_actor->GetAllLinkedActors())
+                for (auto actor : prev_locked_actor->getAllLinkedActors())
                 {
                     actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
                 }

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1673,7 +1673,7 @@ void Actor::SyncReset(bool reset_position)
     this->resetSlideNodes();
     if (m_slidenodes_locked)
     {
-        this->ToggleSlideNodeLock();
+        this->toggleSlideNodeLock();
     }
 
     m_ongoing_reset = true;

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -116,6 +116,10 @@ public:
     void              displayAxleDiffMode();               //! Writes info to console/notify box
     void              toggleWheelDiffMode();               //! Cycles through the available inter wheel diff modes
     void              displayWheelDiffMode();              //! Writes info to console/notify box
+    void              toggleTransferCaseMode();            //! Toggles between 2WD and 4WD mode
+    void              toggleTransferCaseGearRatio();       //! Toggles between Hi and Lo mode
+    Ogre::String      getTransferCaseName();               //! Gets the current transfer case mode name (4WD Hi, ...)
+    void              displayTransferCaseMode();           //! Writes info to console/notify area
     void              toggleCustomParticles();
     bool              getCustomParticleMode();
     void              beaconsToggle();
@@ -161,10 +165,6 @@ public:
     void              UpdateSoundSources();
     void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              ToggleSlideNodeLock();
-    void              ToggleTransferCaseMode();            //! Toggles between 2WD and 4WD mode
-    void              ToggleTransferCaseGearRatio();       //! Toggles between Hi and Lo mode
-    Ogre::String      GetTransferCaseName();               //! Gets the current transfer case mode name (4WD Hi, ...)
-    void              DisplayTransferCaseMode();           //! Displays the current transfer case mode
     void              UpdateCruiseControl(float dt);       //!< Defined in 'gameplay/CruiseControl.cpp'
     bool              Intersects(Actor* actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test
     /// Moves the actor at most 'direction.length()' meters towards 'direction' to resolve any collisions

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -66,6 +66,16 @@ public:
     void              scaleTruck(float value);
     void              reset(bool keep_position = false); //!< call this one to reset a truck from any context
     int               getNodeCount() { return ar_num_nodes; }
+    float             getTotalMass(bool withLocked=true);
+    int               getWheelNodeCount() const;
+    void              setMass(float m);
+    float             getWheelSpeed() const { return ar_wheel_speed; }
+    float             getSpeed() { return m_avg_node_velocity.length(); };
+    Ogre::Vector3     getVelocity() const { return m_avg_node_velocity; }; //!< average actor velocity, calculated using the actor positions of the last two frames
+    float             getRotation();
+    Ogre::Vector3     getDirection();
+    Ogre::Vector3     getPosition();
+    Ogre::Vector3     getNodePosition(int nodeNumber);     //!< Returns world position of node
     //! @}
 
     //! @{ User interaction functions
@@ -74,7 +84,16 @@ public:
     void              tractioncontrolToggle();
     void              cruisecontrolToggle();               //!< Defined in 'gameplay/CruiseControl.cpp'
     void              toggleCustomParticles();
+    bool              getCustomParticleMode();
     void              beaconsToggle();
+    bool              getBrakeLightVisible();
+    bool              getCustomLightVisible(int number);
+    void              setCustomLightVisible(int number, bool visible);
+    bool              getReverseLightVisible();            //!< Tells if the reverse-light is currently lit.
+    bool              getBeaconMode();
+    void              toggleBlinkType(BlinkType blink);
+    BlinkType         getBlinkType();
+    void              setBlinkType(BlinkType blink);
     //! @}
 
     //! @{ Organizational things
@@ -86,9 +105,6 @@ public:
     void              ApplyNodeBeamScales();
     void              PushNetwork(char* data, int size);   //!< Parses network data; fills actor's data buffers and flips them. Called by the network thread.
     void              CalcNetwork();
-    float             getRotation();
-    Ogre::Vector3     getDirection();
-    Ogre::Vector3     getPosition();
     void              UpdateInitPosition();
     /// Moves the actor.
     /// @param translation Offset to move in world coordinates
@@ -144,19 +160,8 @@ public:
     void              NotifyActorCameraChanged();                 //!< Logic: sound, display; Notify this vehicle that camera changed;
     void              StopAllSounds();
     void              UnmuteAllSounds();
-    float             getTotalMass(bool withLocked=true);
     float             getAvgPropedWheelRadius() { return m_avg_proped_wheel_radius; };
-    int               getWheelNodeCount() const;
-    void              setMass(float m);
-    bool              getBrakeLightVisible();
-    bool              getReverseLightVisible();            //!< Tells if the reverse-light is currently lit.
-    bool              getCustomLightVisible(int number);
-    void              setCustomLightVisible(int number, bool visible);
-    bool              getBeaconMode();
-    void              toggleBlinkType(BlinkType blink);
-    void              setBlinkType(BlinkType blink);
     void              setAirbrakeIntensity(float intensity);
-    bool              getCustomParticleMode();
     void              sendStreamData();
     bool              isTied();
     bool              isLocked(); 
@@ -168,7 +173,6 @@ public:
     void              updateSlideNodePositions();          //!< incrementally update the position of all SlideNodes
     void              SoftReset();
     void              SyncReset(bool reset_position);      //!< this one should be called only synchronously (without physics running in background)
-    BlinkType         getBlinkType();
     std::vector<authorinfo_t>     getAuthors();
     std::vector<std::string>      getDescription();
     Ogre::String     GetSectionConfig()                 { return m_section_config; }
@@ -179,18 +183,14 @@ public:
     Ogre::Vector3     GetFFbBodyForces() const          { return m_force_sensors.out_body_forces; }
     GfxActor*         GetGfxActor()                     { return m_gfx_actor.get(); }
     void              RequestUpdateHudFeatures()        { m_hud_features_ok = false; }
-    Ogre::Vector3     getNodePosition(int nodeNumber);     //!< Returns world position of node
     Ogre::Real        getMinimalCameraRadius();
     Replay*           GetReplay();
     float             GetFFbHydroForces() const         { return m_force_sensors.out_hydros_forces; }
     bool              isPreloadedWithTerrain() const    { return m_preloaded_with_terrain; };
     bool              isBeingReset() const              { return m_ongoing_reset; };
     VehicleAI*        getVehicleAI()                    { return ar_vehicle_ai; }
-    float             getWheelSpeed() const             { return ar_wheel_speed; }
     CacheEntry*       GetUsedSkin() const               { return m_used_skin_entry; }
     void              SetUsedSkin(CacheEntry* skin)     { m_used_skin_entry = skin; }
-    float             getSpeed()                        { return m_avg_node_velocity.length(); };
-    Ogre::Vector3     getVelocity() const               { return m_avg_node_velocity; }; //!< average actor velocity, calculated using the actor positions of the last two frames
     TyrePressure&     GetTyrePressure()                 { return m_tyre_pressure; }
 #ifdef USE_ANGELSCRIPT
     // we have to add this to be able to use the class as reference inside scripts

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -65,6 +65,7 @@ public:
     //! @{ Physic related functions
 
     void              scaleTruck(float value);
+    void              reset(bool keep_position = false); //!< call this one to reset a truck from any context
 
     //! @}
 

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -70,7 +70,9 @@ public:
 
     //! @{ Physic related functions
     void              scaleTruck(float value);
-    void              reset(bool keep_position = false); //!< call this one to reset a truck from any context
+    void              reset(bool keep_position = false);   //!< call this one to reset a truck from any context
+    void              resetPosition(Ogre::Vector3 translation, bool setInitPosition); //!< Moves the actor to given world coords.
+    void              resetPosition(float px, float pz, bool setInitPosition, float miny); //!< Moves the actor to given world coords.
     int               getNodeCount() { return ar_num_nodes; }
     float             getTotalMass(bool withLocked=true);
     int               getWheelNodeCount() const;
@@ -110,11 +112,6 @@ public:
 
     void              ApplyNodeBeamScales();
     void              UpdateInitPosition();
-    /// Moves the actor.
-    /// @param translation Offset to move in world coordinates
-    /// @param setInitPosition Set initial positions of nodes to current position?
-    void              ResetPosition(Ogre::Vector3 translation, bool setInitPosition);
-    void              ResetPosition(float px, float pz, bool setInitPosition, float miny);
     void              RequestRotation(float rotation, Ogre::Vector3 center) { m_rotation_request += rotation; m_rotation_request_center = center; };
     void              RequestAngleSnap(int division) { m_anglesnap_request = division; };
     void              RequestTranslation(Ogre::Vector3 translation) { m_translation_request += translation; };

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -135,7 +135,8 @@ public:
 
     //! @{ Subsystems
     Replay*           getReplay();
-    TyrePressure&     getTyrePressure()                 { return m_tyre_pressure; }
+    TyrePressure&     getTyrePressure() { return m_tyre_pressure; }
+    VehicleAI*        getVehicleAI() { return ar_vehicle_ai; }
     //! @}
 
     //! @{ Organizational things
@@ -164,7 +165,6 @@ public:
     void              ToggleTransferCaseGearRatio();       //! Toggles between Hi and Lo mode
     Ogre::String      GetTransferCaseName();               //! Gets the current transfer case mode name (4WD Hi, ...)
     void              DisplayTransferCaseMode();           //! Displays the current transfer case mode
-
     void              UpdateCruiseControl(float dt);       //!< Defined in 'gameplay/CruiseControl.cpp'
     bool              Intersects(Actor* actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test
     /// Moves the actor at most 'direction.length()' meters towards 'direction' to resolve any collisions
@@ -200,7 +200,6 @@ public:
     Ogre::Real        getMinimalCameraRadius();
     float             GetFFbHydroForces() const         { return m_force_sensors.out_hydros_forces; }
     bool              isBeingReset() const              { return m_ongoing_reset; };
-    VehicleAI*        getVehicleAI()                    { return ar_vehicle_ai; }
 #ifdef USE_ANGELSCRIPT
     // we have to add this to be able to use the class as reference inside scripts
     void              addRef()                          {};

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -90,6 +90,8 @@ public:
     float             getMaxHeight(bool skip_virtual_nodes=true);
     float             getHeightAboveGround(bool skip_virtual_nodes=true);
     float             getHeightAboveGroundBelow(float height, bool skip_virtual_nodes=true);
+    Ogre::Vector3     getGForces() { return m_camera_local_gforces_cur; };
+    Ogre::Vector3     getMaxGForces() { return m_camera_local_gforces_max; };
     bool              hasSlidenodes() { return !m_slidenodes.empty(); };
     void              updateSlideNodePositions();          //!< incrementally update the position of all SlideNodes
     void              updateSlideNodeForces(const Ogre::Real delta_time_sec); //!< calculate and apply Corrective forces
@@ -183,8 +185,6 @@ public:
     /// Auto detects an ideal collision avoidance direction (front, back, left, right, up)
     /// Then moves the actor at most 'max_distance' meters towards that direction to resolve any collisions
     void              resolveCollisions(float max_distance, bool consider_up);    
-    Ogre::Vector3     GetGForcesCur() { return m_camera_local_gforces_cur; };
-    Ogre::Vector3     GetGForcesMax() { return m_camera_local_gforces_max; };
     float             getSteeringAngle();
     float             getMinCameraRadius() { return m_min_camera_radius; };
     int               GetNumActiveConnectedBeams(int nodeid);     //!< Returns the number of active (non bounded) beams connected to a node

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -148,6 +148,12 @@ public:
     void              updateDashBoards(float dt);
     //! @}
 
+    //! @{ Audio related functions
+    void              updateSoundSources();
+    void              muteAllSounds();
+    void              unmuteAllSounds();
+    //! @}
+
     //! @{ Subsystems
     Replay*           getReplay();
     TyrePressure&     getTyrePressure() { return m_tyre_pressure; }
@@ -169,7 +175,6 @@ public:
     void              ForceFeedbackStep(int steps);
     void              HandleInputEvents(float dt);
     void              HandleAngelScriptEvents(float dt);
-    void              UpdateSoundSources();
     void              UpdateCruiseControl(float dt);       //!< Defined in 'gameplay/CruiseControl.cpp'
     bool              Intersects(Actor* actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test
     /// Moves the actor at most 'direction.length()' meters towards 'direction' to resolve any collisions
@@ -183,8 +188,6 @@ public:
     float             getMinCameraRadius() { return m_min_camera_radius; };
     int               GetNumActiveConnectedBeams(int nodeid);     //!< Returns the number of active (non bounded) beams connected to a node
     void              NotifyActorCameraChanged();                 //!< Logic: sound, display; Notify this vehicle that camera changed;
-    void              StopAllSounds();
-    void              UnmuteAllSounds();
     float             getAvgPropedWheelRadius() { return m_avg_proped_wheel_radius; };
     void              setAirbrakeIntensity(float intensity);
     void              UpdateBoundingBoxes();

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -114,6 +114,8 @@ public:
     void              cruisecontrolToggle();               //!< Defined in 'gameplay/CruiseControl.cpp'
     void              toggleAxleDiffMode();                //! Cycles through the available inter axle diff modes
     void              displayAxleDiffMode();               //! Writes info to console/notify box
+    void              toggleWheelDiffMode();               //! Cycles through the available inter wheel diff modes
+    void              displayWheelDiffMode();              //! Writes info to console/notify box
     void              toggleCustomParticles();
     bool              getCustomParticleMode();
     void              beaconsToggle();
@@ -159,8 +161,6 @@ public:
     void              UpdateSoundSources();
     void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              ToggleSlideNodeLock();
-    void              ToggleWheelDiffMode();               //! Cycles through the available inter wheel diff modes
-    void              DisplayWheelDiffMode();              //! Displays the current inter wheel diff mode
     void              ToggleTransferCaseMode();            //! Toggles between 2WD and 4WD mode
     void              ToggleTransferCaseGearRatio();       //! Toggles between Hi and Lo mode
     Ogre::String      GetTransferCaseName();               //! Gets the current transfer case mode name (4WD Hi, ...)

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -98,13 +98,15 @@ public:
     void              applyNodeBeamScales();               //!< For GUI::NodeBeamUtils
     void              searchBeamDefaults();                //!< Searches for more stable beam defaults
     void              updateInitPosition();
-    //! @}//! 
+    //! @}
 
     //! @{ User interaction functions
     void              mouseMove(int node, Ogre::Vector3 pos, float force);
     void              lightsToggle();
     void              tieToggle(int group=-1);
     bool              isTied();
+    void              hookToggle(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1);
+    bool              isLocked();                          //!< Are hooks locked?
     void              parkingbrakeToggle();
     void              antilockbrakeToggle();
     void              tractioncontrolToggle();
@@ -136,7 +138,6 @@ public:
     void              HandleAngelScriptEvents(float dt);
     void              UpdateSoundSources();
     void              ToggleRopes(int group=-1);            //!< Event handler
-    void              ToggleHooks(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1); //!< Event handler
     void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              ToggleSlideNodeLock();
     void              ToggleAxleDiffMode();                //! Cycles through the available inter axle diff modes
@@ -171,7 +172,6 @@ public:
     float             getAvgPropedWheelRadius() { return m_avg_proped_wheel_radius; };
     void              setAirbrakeIntensity(float intensity);
     void              sendStreamData();
-    bool              isLocked(); 
     bool              hasSlidenodes() { return !m_slidenodes.empty(); };
     void              updateDashBoards(float dt);
     void              UpdateBoundingBoxes();

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -68,11 +68,12 @@ public:
     //! @}
 
     //! @{ User interaction functions
-    void              parkingbrakeToggle();                //!< Event handler
-    void              antilockbrakeToggle();               //!< Event handler
-    void              tractioncontrolToggle();             //!< Event handler
+    void              parkingbrakeToggle();
+    void              antilockbrakeToggle();
+    void              tractioncontrolToggle();
     void              cruisecontrolToggle();               //!< Defined in 'gameplay/CruiseControl.cpp'
     void              toggleCustomParticles();
+    void              beaconsToggle();
     //! @}
 
     //! @{ Organizational things
@@ -123,7 +124,6 @@ public:
     void              DisplayTransferCaseMode();           //! Displays the current transfer case mode
 
     void              UpdateCruiseControl(float dt);       //!< Defined in 'gameplay/CruiseControl.cpp'
-    void              ToggleBeacons();                     //!< Event handler
     bool              Intersects(Actor* actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test
     /// Moves the actor at most 'direction.length()' meters towards 'direction' to resolve any collisions
     void              resolveCollisions(Ogre::Vector3 direction);

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -135,6 +135,9 @@ public:
     std::string       getTruckFileName() { return ar_filename; }
     int               getTruckType() { return ar_driveable; }
     Ogre::String      getSectionConfig() { return m_section_config; }
+    CacheEntry*       getUsedSkin() { return m_used_skin_entry; }
+    void              setUsedSkin(CacheEntry* skin) { m_used_skin_entry = skin; }
+    bool              isPreloadedWithTerrain() const { return m_preloaded_with_terrain; };
     std::vector<authorinfo_t> getAuthors();
     std::vector<std::string>  getDescription();
     //! @}
@@ -194,12 +197,8 @@ public:
     void              RequestUpdateHudFeatures()        { m_hud_features_ok = false; }
     Ogre::Real        getMinimalCameraRadius();
     float             GetFFbHydroForces() const         { return m_force_sensors.out_hydros_forces; }
-    bool              isPreloadedWithTerrain() const    { return m_preloaded_with_terrain; };
     bool              isBeingReset() const              { return m_ongoing_reset; };
     VehicleAI*        getVehicleAI()                    { return ar_vehicle_ai; }
-    CacheEntry*       GetUsedSkin() const               { return m_used_skin_entry; }
-    void              SetUsedSkin(CacheEntry* skin)     { m_used_skin_entry = skin; }
-    
 #ifdef USE_ANGELSCRIPT
     // we have to add this to be able to use the class as reference inside scripts
     void              addRef()                          {};

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -72,6 +72,7 @@ public:
     void              antilockbrakeToggle();               //!< Event handler
     void              tractioncontrolToggle();             //!< Event handler
     void              cruisecontrolToggle();               //!< Defined in 'gameplay/CruiseControl.cpp'
+    void              toggleCustomParticles();
     //! @}
 
     //! @{ Organizational things
@@ -111,7 +112,7 @@ public:
     void              ToggleHooks(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1); //!< Event handler
     void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              ToggleSlideNodeLock();
-    void              ToggleCustomParticles();
+    
     void              ToggleAxleDiffMode();                //! Cycles through the available inter axle diff modes
     void              DisplayAxleDiffMode();               //! Displays the current inter axle diff mode
     void              ToggleWheelDiffMode();               //! Cycles through the available inter wheel diff modes

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -108,6 +108,7 @@ public:
     void              hookToggle(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1);
     bool              isLocked();                          //!< Are hooks locked?
     void              ropeToggle(int group=-1);
+    void              engineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              parkingbrakeToggle();
     void              antilockbrakeToggle();
     void              tractioncontrolToggle();
@@ -163,7 +164,6 @@ public:
     void              HandleInputEvents(float dt);
     void              HandleAngelScriptEvents(float dt);
     void              UpdateSoundSources();
-    void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              ToggleSlideNodeLock();
     void              UpdateCruiseControl(float dt);       //!< Defined in 'gameplay/CruiseControl.cpp'
     bool              Intersects(Actor* actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -112,6 +112,8 @@ public:
     void              antilockbrakeToggle();
     void              tractioncontrolToggle();
     void              cruisecontrolToggle();               //!< Defined in 'gameplay/CruiseControl.cpp'
+    void              toggleAxleDiffMode();                //! Cycles through the available inter axle diff modes
+    void              displayAxleDiffMode();               //! Writes info to console/notify box
     void              toggleCustomParticles();
     bool              getCustomParticleMode();
     void              beaconsToggle();
@@ -125,7 +127,7 @@ public:
     void              setBlinkType(BlinkType blink);
     //! @}
 
-    //! @{ Visuals state
+    //! @{ Visual state updates
     void              updateSkidmarks();                   //!< Creates or updates skidmarks.
     void              prepareInside(bool inside);          //!< Prepares vehicle for in-cabin camera use.
     void              updateFlareStates(float dt);
@@ -157,8 +159,6 @@ public:
     void              UpdateSoundSources();
     void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              ToggleSlideNodeLock();
-    void              ToggleAxleDiffMode();                //! Cycles through the available inter axle diff modes
-    void              DisplayAxleDiffMode();               //! Displays the current inter axle diff mode
     void              ToggleWheelDiffMode();               //! Cycles through the available inter wheel diff modes
     void              DisplayWheelDiffMode();              //! Displays the current inter wheel diff mode
     void              ToggleTransferCaseMode();            //! Toggles between 2WD and 4WD mode

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -138,6 +138,7 @@ public:
     void              toggleBlinkType(BlinkType blink);
     BlinkType         getBlinkType();
     void              setBlinkType(BlinkType blink);
+    std::vector<Actor*> getAllLinkedActors() { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
     //! @}
 
     //! @{ Visual state updates
@@ -196,7 +197,6 @@ public:
     void              SoftReset();
     void              SyncReset(bool reset_position);      //!< this one should be called only synchronously (without physics running in background)
     PerVehicleCameraContext* GetCameraContext()    { return &m_camera_context; }
-    std::vector<Actor*> GetAllLinkedActors()            { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
     Ogre::Vector3     GetCameraDir()                    { return (ar_nodes[ar_main_camera_node_pos].RelPosition - ar_nodes[ar_main_camera_node_dir].RelPosition).normalisedCopy(); }
     Ogre::Vector3     GetCameraRoll()                   { return (ar_nodes[ar_main_camera_node_pos].RelPosition - ar_nodes[ar_main_camera_node_roll].RelPosition).normalisedCopy(); }
     Ogre::Vector3     GetFFbBodyForces() const          { return m_force_sensors.out_body_forces; }

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -65,6 +65,7 @@ public:
     //! @{ Physic related functions
     void              scaleTruck(float value);
     void              reset(bool keep_position = false); //!< call this one to reset a truck from any context
+    int               getNodeCount() { return ar_num_nodes; }
     //! @}
 
     //! @{ User interaction functions
@@ -77,9 +78,9 @@ public:
     //! @}
 
     //! @{ Organizational things
-    std::string       getTruckName() { return ar_design_name; };
-    std::string       getTruckFileName() { return ar_filename; };
-    int               getTruckType() { return ar_driveable; };
+    std::string       getTruckName() { return ar_design_name; }
+    std::string       getTruckFileName() { return ar_filename; }
+    int               getTruckType() { return ar_driveable; }
     //! @}
 
     void              ApplyNodeBeamScales();
@@ -186,7 +187,6 @@ public:
     bool              isBeingReset() const              { return m_ongoing_reset; };
     VehicleAI*        getVehicleAI()                    { return ar_vehicle_ai; }
     float             getWheelSpeed() const             { return ar_wheel_speed; }
-    int               GetNumNodes() const               { return ar_num_nodes; }
     CacheEntry*       GetUsedSkin() const               { return m_used_skin_entry; }
     void              SetUsedSkin(CacheEntry* skin)     { m_used_skin_entry = skin; }
     float             getSpeed()                        { return m_avg_node_velocity.length(); };

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -35,8 +35,7 @@
 namespace RoR {
 
 /// Softbody object; can be anything from soda can to a space shuttle
-/// Monsterclass; contains logic related to physics, network, sound, threading, rendering.
-/// NOTE: Until 01/2018, this class was named `Beam` (and was derived from `rig_t`), you may find references to this.
+/// Former name: `Beam` (that's why scripting uses `BeamClass`)
 class Actor : public ZeroedMemoryAllocator
 {
     friend class ActorSpawner;
@@ -64,7 +63,8 @@ public:
 
     //! @{ Network related functions
     void              sendStreamSetup();
-    void              pushNetwork(char* data, int size);   //!< Parses network data; fills actor's data buffers and flips them. Called by the network thread.//! 
+    void              sendStreamData();                    //!< Send outgoing data
+    void              pushNetwork(char* data, int size);   //!< Process incoming data; fills actor's data buffers and flips them. Called by the network thread.//! 
     void              calcNetwork();
     //!
 
@@ -183,7 +183,6 @@ public:
     void              UnmuteAllSounds();
     float             getAvgPropedWheelRadius() { return m_avg_proped_wheel_radius; };
     void              setAirbrakeIntensity(float intensity);
-    void              sendStreamData();
     bool              hasSlidenodes() { return !m_slidenodes.empty(); };
     void              UpdateBoundingBoxes();
     void              calculateAveragePosition();

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -62,11 +62,17 @@ public:
 
     ~Actor();
 
-        //! @{ Physic related functions
+    //! @{ Physic related functions
 
     void              scaleTruck(float value);
 
-        //! @}
+    //! @}
+
+    //! @{ Organizational things
+
+    std::string       getTruckName() { return ar_design_name; };
+
+    //! @}
 
     void              ApplyNodeBeamScales();
     void              PushNetwork(char* data, int size);   //!< Parses network data; fills actor's data buffers and flips them. Called by the network thread.
@@ -129,7 +135,6 @@ public:
     Ogre::Vector3     GetGForcesMax() { return m_camera_local_gforces_max; };
     float             getSteeringAngle();
     float             getMinCameraRadius() { return m_min_camera_radius; };
-    std::string       GetActorDesignName() { return ar_design_name; };
     std::string       GetActorFileName() { return ar_filename; };
     std::string       GetActorFileHash() { return ar_filehash; };
     int               GetActorType() { return ar_driveable; };

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -73,6 +73,9 @@ public:
     void              reset(bool keep_position = false);   //!< call this one to reset a truck from any context
     void              resetPosition(Ogre::Vector3 translation, bool setInitPosition); //!< Moves the actor to given world coords.
     void              resetPosition(float px, float pz, bool setInitPosition, float miny); //!< Moves the actor to given world coords.
+    void              requestRotation(float rotation, Ogre::Vector3 center) { m_rotation_request += rotation; m_rotation_request_center = center; };
+    void              requestAngleSnap(int division) { m_anglesnap_request = division; };
+    void              requestTranslation(Ogre::Vector3 translation) { m_translation_request += translation; };
     int               getNodeCount() { return ar_num_nodes; }
     float             getTotalMass(bool withLocked=true);
     int               getWheelNodeCount() const;
@@ -112,9 +115,6 @@ public:
 
     void              ApplyNodeBeamScales();
     void              UpdateInitPosition();
-    void              RequestRotation(float rotation, Ogre::Vector3 center) { m_rotation_request += rotation; m_rotation_request_center = center; };
-    void              RequestAngleSnap(int division) { m_anglesnap_request = division; };
-    void              RequestTranslation(Ogre::Vector3 translation) { m_translation_request += translation; };
     Ogre::Vector3     GetRotationCenter();
     float             GetMinHeight(bool skip_virtual_nodes=true);
     float             GetMaxHeight(bool skip_virtual_nodes=true);

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -101,6 +101,7 @@ public:
     //! @}//! 
 
     //! @{ User interaction functions
+    void              mouseMove(int node, Ogre::Vector3 pos, float force);
     void              lightsToggle();
     void              parkingbrakeToggle();
     void              antilockbrakeToggle();
@@ -132,7 +133,6 @@ public:
     void              HandleInputEvents(float dt);
     void              HandleAngelScriptEvents(float dt);
     void              UpdateSoundSources();
-    void              HandleMouseMove(int node, Ogre::Vector3 pos, float force); //!< Event handler
     void              ToggleTies(int group=-1);
     void              ToggleRopes(int group=-1);            //!< Event handler
     void              ToggleHooks(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1); //!< Event handler

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -68,8 +68,7 @@ public:
     void              calcNetwork();
     //!
 
-    //! @{ Physic related functions
-    void              scaleTruck(float value);
+    //! @{ Physic state functions
     void              reset(bool keep_position = false);   //!< call this one to reset a truck from any context
     void              resetPosition(Ogre::Vector3 translation, bool setInitPosition); //!< Moves the actor to given world coords.
     void              resetPosition(float px, float pz, bool setInitPosition, float miny); //!< Moves the actor to given world coords.
@@ -79,7 +78,6 @@ public:
     int               getNodeCount() { return ar_num_nodes; }
     float             getTotalMass(bool withLocked=true);
     int               getWheelNodeCount() const;
-    void              setMass(float m);
     float             getWheelSpeed() const { return ar_wheel_speed; }
     float             getSpeed() { return m_avg_node_velocity.length(); };
     Ogre::Vector3     getVelocity() const { return m_avg_node_velocity; }; //!< average actor velocity, calculated using the actor positions of the last two frames
@@ -88,6 +86,14 @@ public:
     Ogre::Vector3     getPosition();
     Ogre::Vector3     getNodePosition(int nodeNumber);     //!< Returns world position of node
     //! @}
+
+    //! @{ Physics editing functions
+    void              scaleTruck(float value);
+    void              setMass(float m);
+    void              applyNodeBeamScales();               //!< For GUI::NodeBeamUtils
+    void              searchBeamDefaults();                //!< Searches for more stable beam defaults
+    void              updateInitPosition();
+    //! @}//! 
 
     //! @{ User interaction functions
     void              parkingbrakeToggle();
@@ -113,8 +119,6 @@ public:
     int               getTruckType() { return ar_driveable; }
     //! @}
 
-    void              ApplyNodeBeamScales();
-    void              UpdateInitPosition();
     Ogre::Vector3     GetRotationCenter();
     float             GetMinHeight(bool skip_virtual_nodes=true);
     float             GetMaxHeight(bool skip_virtual_nodes=true);
@@ -352,7 +356,6 @@ public:
     ground_model_t*   ar_last_fuzzy_ground_model;     //!< GUI state
 
     // Realtime node/beam structure editing helpers
-    void                    SearchBeamDefaults();     //!< Searches for more stable beam defaults
     bool                    ar_nb_initialized;
     std::vector<float>      ar_nb_optimum;            //!< Temporary storage of the optimum search result
     std::vector<float>      ar_nb_reference;          //!< Temporary storage of the reference search result

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -101,6 +101,7 @@ public:
     //! @}//! 
 
     //! @{ User interaction functions
+    void              lightsToggle();
     void              parkingbrakeToggle();
     void              antilockbrakeToggle();
     void              tractioncontrolToggle();
@@ -132,7 +133,6 @@ public:
     void              HandleAngelScriptEvents(float dt);
     void              UpdateSoundSources();
     void              HandleMouseMove(int node, Ogre::Vector3 pos, float force); //!< Event handler
-    void              ToggleLights();                      //!< Event handler
     void              ToggleTies(int group=-1);
     void              ToggleRopes(int group=-1);            //!< Event handler
     void              ToggleHooks(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1); //!< Event handler

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -62,6 +62,12 @@ public:
 
     ~Actor();
 
+    //! @{ Network related functions
+    void              sendStreamSetup();
+    void              pushNetwork(char* data, int size);   //!< Parses network data; fills actor's data buffers and flips them. Called by the network thread.//! 
+    void              calcNetwork();
+    //!
+
     //! @{ Physic related functions
     void              scaleTruck(float value);
     void              reset(bool keep_position = false); //!< call this one to reset a truck from any context
@@ -103,8 +109,6 @@ public:
     //! @}
 
     void              ApplyNodeBeamScales();
-    void              PushNetwork(char* data, int size);   //!< Parses network data; fills actor's data buffers and flips them. Called by the network thread.
-    void              CalcNetwork();
     void              UpdateInitPosition();
     /// Moves the actor.
     /// @param translation Offset to move in world coordinates
@@ -130,7 +134,6 @@ public:
     void              ToggleHooks(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1); //!< Event handler
     void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              ToggleSlideNodeLock();
-    
     void              ToggleAxleDiffMode();                //! Cycles through the available inter axle diff modes
     void              DisplayAxleDiffMode();               //! Displays the current inter axle diff mode
     void              ToggleWheelDiffMode();               //! Cycles through the available inter wheel diff modes
@@ -419,7 +422,6 @@ private:
     void              RemoveInterActorBeam(beam_t* beam);
     void              DisjoinInterActorBeams();            //!< Destroys all inter-actor beams which are connected with this actor
     void              autoBlinkReset();                    //!< Resets the turn signal when the steering wheel is turned back.
-    void              sendStreamSetup();
     void              UpdateSlideNodeForces(const Ogre::Real delta_time_sec); //!< calculate and apply Corrective forces
     void              resetSlideNodePositions();           //!< Recalculate SlideNode positions
     void              resetSlideNodes();                   //!< Reset all the SlideNodes

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -90,6 +90,11 @@ public:
     float             getMaxHeight(bool skip_virtual_nodes=true);
     float             getHeightAboveGround(bool skip_virtual_nodes=true);
     float             getHeightAboveGroundBelow(float height, bool skip_virtual_nodes=true);
+    bool              hasSlidenodes() { return !m_slidenodes.empty(); };
+    void              updateSlideNodePositions();          //!< incrementally update the position of all SlideNodes
+    void              updateSlideNodeForces(const Ogre::Real delta_time_sec); //!< calculate and apply Corrective forces
+    void              resetSlideNodePositions();           //!< Recalculate SlideNode positions
+    void              resetSlideNodes();                   //!< Reset all the SlideNodes
     //! @}
 
     //! @{ Physics editing functions
@@ -109,6 +114,7 @@ public:
     bool              isLocked();                          //!< Are hooks locked?
     void              ropeToggle(int group=-1);
     void              engineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
+    void              toggleSlideNodeLock();
     void              parkingbrakeToggle();
     void              antilockbrakeToggle();
     void              tractioncontrolToggle();
@@ -164,15 +170,13 @@ public:
     void              HandleInputEvents(float dt);
     void              HandleAngelScriptEvents(float dt);
     void              UpdateSoundSources();
-    void              ToggleSlideNodeLock();
     void              UpdateCruiseControl(float dt);       //!< Defined in 'gameplay/CruiseControl.cpp'
     bool              Intersects(Actor* actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test
     /// Moves the actor at most 'direction.length()' meters towards 'direction' to resolve any collisions
     void              resolveCollisions(Ogre::Vector3 direction);
     /// Auto detects an ideal collision avoidance direction (front, back, left, right, up)
     /// Then moves the actor at most 'max_distance' meters towards that direction to resolve any collisions
-    void              resolveCollisions(float max_distance, bool consider_up);
-    
+    void              resolveCollisions(float max_distance, bool consider_up);    
     Ogre::Vector3     GetGForcesCur() { return m_camera_local_gforces_cur; };
     Ogre::Vector3     GetGForcesMax() { return m_camera_local_gforces_max; };
     float             getSteeringAngle();
@@ -183,11 +187,9 @@ public:
     void              UnmuteAllSounds();
     float             getAvgPropedWheelRadius() { return m_avg_proped_wheel_radius; };
     void              setAirbrakeIntensity(float intensity);
-    bool              hasSlidenodes() { return !m_slidenodes.empty(); };
     void              UpdateBoundingBoxes();
     void              calculateAveragePosition();
     void              UpdatePhysicsOrigin();
-    void              updateSlideNodePositions();          //!< incrementally update the position of all SlideNodes
     void              SoftReset();
     void              SyncReset(bool reset_position);      //!< this one should be called only synchronously (without physics running in background)
     PerVehicleCameraContext* GetCameraContext()    { return &m_camera_context; }
@@ -426,9 +428,6 @@ private:
     void              RemoveInterActorBeam(beam_t* beam);
     void              DisjoinInterActorBeams();            //!< Destroys all inter-actor beams which are connected with this actor
     void              autoBlinkReset();                    //!< Resets the turn signal when the steering wheel is turned back.
-    void              UpdateSlideNodeForces(const Ogre::Real delta_time_sec); //!< calculate and apply Corrective forces
-    void              resetSlideNodePositions();           //!< Recalculate SlideNode positions
-    void              resetSlideNodes();                   //!< Reset all the SlideNodes
     void              ResetAngle(float rot);
     void              calculateLocalGForces();             //!< Derive the truck local g-forces from the global ones
     /// Virtually moves the actor at most 'direction.length()' meters towards 'direction' trying to resolve any collisions

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -125,6 +125,10 @@ public:
     void              setBlinkType(BlinkType blink);
     //! @}
 
+    //! @{ Subsystems
+    Replay*           getReplay();
+    //! @}
+
     //! @{ Organizational things
     std::string       getTruckName() { return ar_design_name; }
     std::string       getTruckFileName() { return ar_filename; }
@@ -188,7 +192,6 @@ public:
     GfxActor*         GetGfxActor()                     { return m_gfx_actor.get(); }
     void              RequestUpdateHudFeatures()        { m_hud_features_ok = false; }
     Ogre::Real        getMinimalCameraRadius();
-    Replay*           GetReplay();
     float             GetFFbHydroForces() const         { return m_force_sensors.out_hydros_forces; }
     bool              isPreloadedWithTerrain() const    { return m_preloaded_with_terrain; };
     bool              isBeingReset() const              { return m_ongoing_reset; };

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -103,6 +103,8 @@ public:
     //! @{ User interaction functions
     void              mouseMove(int node, Ogre::Vector3 pos, float force);
     void              lightsToggle();
+    void              tieToggle(int group=-1);
+    bool              isTied();
     void              parkingbrakeToggle();
     void              antilockbrakeToggle();
     void              tractioncontrolToggle();
@@ -133,7 +135,6 @@ public:
     void              HandleInputEvents(float dt);
     void              HandleAngelScriptEvents(float dt);
     void              UpdateSoundSources();
-    void              ToggleTies(int group=-1);
     void              ToggleRopes(int group=-1);            //!< Event handler
     void              ToggleHooks(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1); //!< Event handler
     void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
@@ -170,7 +171,6 @@ public:
     float             getAvgPropedWheelRadius() { return m_avg_proped_wheel_radius; };
     void              setAirbrakeIntensity(float intensity);
     void              sendStreamData();
-    bool              isTied();
     bool              isLocked(); 
     bool              hasSlidenodes() { return !m_slidenodes.empty(); };
     void              updateDashBoards(float dt);

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -85,6 +85,7 @@ public:
     Ogre::Vector3     getDirection();
     Ogre::Vector3     getPosition();
     Ogre::Vector3     getNodePosition(int nodeNumber);     //!< Returns world position of node
+    Ogre::Vector3     getRotationCenter();
     //! @}
 
     //! @{ Physics editing functions
@@ -119,7 +120,6 @@ public:
     int               getTruckType() { return ar_driveable; }
     //! @}
 
-    Ogre::Vector3     GetRotationCenter();
     float             GetMinHeight(bool skip_virtual_nodes=true);
     float             GetMaxHeight(bool skip_virtual_nodes=true);
     float             GetHeightAboveGround(bool skip_virtual_nodes=true);

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -127,6 +127,7 @@ public:
 
     //! @{ Subsystems
     Replay*           getReplay();
+    TyrePressure&     getTyrePressure()                 { return m_tyre_pressure; }
     //! @}
 
     //! @{ Organizational things
@@ -198,7 +199,7 @@ public:
     VehicleAI*        getVehicleAI()                    { return ar_vehicle_ai; }
     CacheEntry*       GetUsedSkin() const               { return m_used_skin_entry; }
     void              SetUsedSkin(CacheEntry* skin)     { m_used_skin_entry = skin; }
-    TyrePressure&     GetTyrePressure()                 { return m_tyre_pressure; }
+    
 #ifdef USE_ANGELSCRIPT
     // we have to add this to be able to use the class as reference inside scripts
     void              addRef()                          {};

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -122,6 +122,9 @@ public:
     std::string       getTruckName() { return ar_design_name; }
     std::string       getTruckFileName() { return ar_filename; }
     int               getTruckType() { return ar_driveable; }
+    Ogre::String      getSectionConfig() { return m_section_config; }
+    std::vector<authorinfo_t> getAuthors();
+    std::vector<std::string>  getDescription();
     //! @}
 
     void              ForceFeedbackStep(int steps);
@@ -177,9 +180,6 @@ public:
     void              updateSlideNodePositions();          //!< incrementally update the position of all SlideNodes
     void              SoftReset();
     void              SyncReset(bool reset_position);      //!< this one should be called only synchronously (without physics running in background)
-    std::vector<authorinfo_t>     getAuthors();
-    std::vector<std::string>      getDescription();
-    Ogre::String     GetSectionConfig()                 { return m_section_config; }
     PerVehicleCameraContext* GetCameraContext()    { return &m_camera_context; }
     std::vector<Actor*> GetAllLinkedActors()            { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
     Ogre::Vector3     GetCameraDir()                    { return (ar_nodes[ar_main_camera_node_pos].RelPosition - ar_nodes[ar_main_camera_node_dir].RelPosition).normalisedCopy(); }

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -107,6 +107,7 @@ public:
     bool              isTied();
     void              hookToggle(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1);
     bool              isLocked();                          //!< Are hooks locked?
+    void              ropeToggle(int group=-1);
     void              parkingbrakeToggle();
     void              antilockbrakeToggle();
     void              tractioncontrolToggle();
@@ -137,7 +138,6 @@ public:
     void              HandleInputEvents(float dt);
     void              HandleAngelScriptEvents(float dt);
     void              UpdateSoundSources();
-    void              ToggleRopes(int group=-1);            //!< Event handler
     void              EngineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              ToggleSlideNodeLock();
     void              ToggleAxleDiffMode();                //! Cycles through the available inter axle diff modes

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -86,6 +86,10 @@ public:
     Ogre::Vector3     getPosition();
     Ogre::Vector3     getNodePosition(int nodeNumber);     //!< Returns world position of node
     Ogre::Vector3     getRotationCenter();
+    float             getMinHeight(bool skip_virtual_nodes=true);
+    float             getMaxHeight(bool skip_virtual_nodes=true);
+    float             getHeightAboveGround(bool skip_virtual_nodes=true);
+    float             getHeightAboveGroundBelow(float height, bool skip_virtual_nodes=true);
     //! @}
 
     //! @{ Physics editing functions
@@ -120,10 +124,6 @@ public:
     int               getTruckType() { return ar_driveable; }
     //! @}
 
-    float             GetMinHeight(bool skip_virtual_nodes=true);
-    float             GetMaxHeight(bool skip_virtual_nodes=true);
-    float             GetHeightAboveGround(bool skip_virtual_nodes=true);
-    float             GetHeightAboveGroundBelow(float height, bool skip_virtual_nodes=true);
     void              ForceFeedbackStep(int steps);
     void              HandleInputEvents(float dt);
     void              HandleAngelScriptEvents(float dt);

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -62,6 +62,12 @@ public:
 
     ~Actor();
 
+        //! @{ Physic related functions
+
+    void              scaleTruck(float value);
+
+        //! @}
+
     void              ApplyNodeBeamScales();
     void              PushNetwork(char* data, int size);   //!< Parses network data; fills actor's data buffers and flips them. Called by the network thread.
     void              CalcNetwork();
@@ -118,7 +124,7 @@ public:
     void              prepareInside(bool inside);          //!< Prepares vehicle for in-cabin camera use.
     void              updateFlareStates(float dt);
     void              updateVisual(float dt=0);
-    void              ScaleActor(float value);
+    
     Ogre::Vector3     GetGForcesCur() { return m_camera_local_gforces_cur; };
     Ogre::Vector3     GetGForcesMax() { return m_camera_local_gforces_max; };
     float             getSteeringAngle();

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -63,18 +63,21 @@ public:
     ~Actor();
 
     //! @{ Physic related functions
-
     void              scaleTruck(float value);
     void              reset(bool keep_position = false); //!< call this one to reset a truck from any context
+    //! @}
 
+    //! @{ User interaction functions
+    void              parkingbrakeToggle();                //!< Event handler
+    void              antilockbrakeToggle();               //!< Event handler
+    void              tractioncontrolToggle();             //!< Event handler
+    void              cruisecontrolToggle();               //!< Defined in 'gameplay/CruiseControl.cpp'
     //! @}
 
     //! @{ Organizational things
-
     std::string       getTruckName() { return ar_design_name; };
     std::string       getTruckFileName() { return ar_filename; };
     int               getTruckType() { return ar_driveable; };
-
     //! @}
 
     void              ApplyNodeBeamScales();
@@ -117,10 +120,7 @@ public:
     void              ToggleTransferCaseGearRatio();       //! Toggles between Hi and Lo mode
     Ogre::String      GetTransferCaseName();               //! Gets the current transfer case mode name (4WD Hi, ...)
     void              DisplayTransferCaseMode();           //! Displays the current transfer case mode
-    void              ToggleParkingBrake();                //!< Event handler
-    void              ToggleAntiLockBrake();               //!< Event handler
-    void              ToggleTractionControl();             //!< Event handler
-    void              ToggleCruiseControl();               //!< Defined in 'gameplay/CruiseControl.cpp'
+
     void              UpdateCruiseControl(float dt);       //!< Defined in 'gameplay/CruiseControl.cpp'
     void              ToggleBeacons();                     //!< Event handler
     bool              Intersects(Actor* actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -125,6 +125,14 @@ public:
     void              setBlinkType(BlinkType blink);
     //! @}
 
+    //! @{ Visuals state
+    void              updateSkidmarks();                   //!< Creates or updates skidmarks.
+    void              prepareInside(bool inside);          //!< Prepares vehicle for in-cabin camera use.
+    void              updateFlareStates(float dt);
+    void              updateVisual(float dt=0);
+    void              updateDashBoards(float dt);
+    //! @}
+
     //! @{ Subsystems
     Replay*           getReplay();
     TyrePressure&     getTyrePressure()                 { return m_tyre_pressure; }
@@ -164,10 +172,6 @@ public:
     /// Auto detects an ideal collision avoidance direction (front, back, left, right, up)
     /// Then moves the actor at most 'max_distance' meters towards that direction to resolve any collisions
     void              resolveCollisions(float max_distance, bool consider_up);
-    void              updateSkidmarks();                   //!< Creates or updates skidmarks. No side effects.
-    void              prepareInside(bool inside);          //!< Prepares vehicle for in-cabin camera use.
-    void              updateFlareStates(float dt);
-    void              updateVisual(float dt=0);
     
     Ogre::Vector3     GetGForcesCur() { return m_camera_local_gforces_cur; };
     Ogre::Vector3     GetGForcesMax() { return m_camera_local_gforces_max; };
@@ -181,7 +185,6 @@ public:
     void              setAirbrakeIntensity(float intensity);
     void              sendStreamData();
     bool              hasSlidenodes() { return !m_slidenodes.empty(); };
-    void              updateDashBoards(float dt);
     void              UpdateBoundingBoxes();
     void              calculateAveragePosition();
     void              UpdatePhysicsOrigin();

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -72,6 +72,7 @@ public:
 
     std::string       getTruckName() { return ar_design_name; };
     std::string       getTruckFileName() { return ar_filename; };
+    int               getTruckType() { return ar_driveable; };
 
     //! @}
 
@@ -136,7 +137,6 @@ public:
     Ogre::Vector3     GetGForcesMax() { return m_camera_local_gforces_max; };
     float             getSteeringAngle();
     float             getMinCameraRadius() { return m_min_camera_radius; };
-    int               GetActorType() { return ar_driveable; };
     int               GetNumActiveConnectedBeams(int nodeid);     //!< Returns the number of active (non bounded) beams connected to a node
     void              NotifyActorCameraChanged();                 //!< Logic: sound, display; Notify this vehicle that camera changed;
     void              StopAllSounds();

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -71,6 +71,7 @@ public:
     //! @{ Organizational things
 
     std::string       getTruckName() { return ar_design_name; };
+    std::string       getTruckFileName() { return ar_filename; };
 
     //! @}
 
@@ -135,8 +136,6 @@ public:
     Ogre::Vector3     GetGForcesMax() { return m_camera_local_gforces_max; };
     float             getSteeringAngle();
     float             getMinCameraRadius() { return m_min_camera_radius; };
-    std::string       GetActorFileName() { return ar_filename; };
-    std::string       GetActorFileHash() { return ar_filehash; };
     int               GetActorType() { return ar_driveable; };
     int               GetNumActiveConnectedBeams(int nodeid);     //!< Returns the number of active (non bounded) beams connected to a node
     void              NotifyActorCameraChanged();                 //!< Logic: sound, display; Notify this vehicle that camera changed;

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -1102,7 +1102,7 @@ bool Actor::CalcForcesEulerPrepare(bool doUpdate)
         return false;
 
     if (doUpdate)
-        this->ToggleHooks(-2, HOOK_LOCK, -1);
+        this->hookToggle(-2, HOOK_LOCK, -1);
 
     this->CalcHooks();
     this->CalcRopes();

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -59,7 +59,7 @@ void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
     this->CalcMouse();
     this->CalcBeams(doUpdate);
     this->CalcCabCollisions();
-    this->UpdateSlideNodeForces(PHYSICS_DT); // must be done after the contacters are updated
+    this->updateSlideNodeForces(PHYSICS_DT); // must be done after the contacters are updated
     this->CalcForceFeedback(doUpdate);
 }
 

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -286,9 +286,9 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
             actor->ar_engine->OffStart();
     }
     // pressurize tires
-    if (actor->GetTyrePressure().IsEnabled())
+    if (actor->getTyrePressure().IsEnabled())
     {
-        actor->GetTyrePressure().ModifyTyrePressure(0.f); // Initialize springiness of pressure-beams.
+        actor->getTyrePressure().ModifyTyrePressure(0.f); // Initialize springiness of pressure-beams.
     }
 
     actor->ar_sim_state = Actor::SimState::LOCAL_SLEEPING;

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -666,7 +666,7 @@ void ActorManager::ForwardCommands(Actor* source_actor)
 {
     if (source_actor->ar_forward_commands)
     {
-        auto linked_actors = source_actor->GetAllLinkedActors();
+        auto linked_actors = source_actor->getAllLinkedActors();
 
         for (auto actor : this->GetActors())
         {

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -695,7 +695,7 @@ void ActorManager::ForwardCommands(Actor* source_actor)
                 }
                 if (source_actor->ar_toggle_ties)
                 {
-                    actor->ToggleTies();
+                    actor->tieToggle();
                 }
                 if (source_actor->ar_toggle_ropes)
                 {
@@ -1052,7 +1052,7 @@ void ActorManager::UpdateActors(Actor* player_actor)
         this->ForwardCommands(player_actor);
         if (player_actor->ar_toggle_ties)
         {
-            player_actor->ToggleTies();
+            player_actor->tieToggle();
             player_actor->ar_toggle_ties = false;
         }
         if (player_actor->ar_toggle_ropes)

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -699,7 +699,7 @@ void ActorManager::ForwardCommands(Actor* source_actor)
                 }
                 if (source_actor->ar_toggle_ropes)
                 {
-                    actor->ToggleRopes(-1);
+                    actor->ropeToggle(-1);
                 }
             }
         }
@@ -1057,7 +1057,7 @@ void ActorManager::UpdateActors(Actor* player_actor)
         }
         if (player_actor->ar_toggle_ropes)
         {
-            player_actor->ToggleRopes(-1);
+            player_actor->ropeToggle(-1);
             player_actor->ar_toggle_ropes = false;
         }
 

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -713,7 +713,7 @@ void ActorManager::ForwardCommands(Actor* source_actor)
             hook.hk_locked_actor->ar_brake = source_actor->ar_brake;
             if (hook.hk_locked_actor->ar_parking_brake != source_actor->ar_trailer_parking_brake)
             {
-                hook.hk_locked_actor->ToggleParkingBrake();
+                hook.hk_locked_actor->parkingbrakeToggle();
             }
 
             // forward lights

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -1065,7 +1065,7 @@ void ActorManager::UpdateActors(Actor* player_actor)
 
         if (player_actor->ar_sim_state == Actor::SimState::LOCAL_REPLAY)
         {
-            player_actor->GetReplay()->replayStepActor();
+            player_actor->getReplay()->replayStepActor();
         }
     }
 

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -340,7 +340,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
 Actor* ActorManager::CreateActorInstance(ActorSpawnRequest rq, std::shared_ptr<RigDef::File> def)
 {
     Actor* actor = new Actor(m_actor_counter++, static_cast<int>(m_actors.size()), def, rq);
-    actor->SetUsedSkin(rq.asr_skin_entry);
+    actor->setUsedSkin(rq.asr_skin_entry);
 
     if (App::mp_state->GetEnum<MpState>() == MpState::CONNECTED && rq.asr_origin != ActorSpawnRequest::Origin::NETWORK)
     {

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -828,7 +828,7 @@ void ActorManager::MuteAllActors()
 {
     for (auto actor : m_actors)
     {
-        actor->StopAllSounds();
+        actor->muteAllSounds();
     }
 }
 
@@ -836,7 +836,7 @@ void ActorManager::UnmuteAllActors()
 {
     for (auto actor : m_actors)
     {
-        actor->UnmuteAllSounds();
+        actor->unmuteAllSounds();
     }
 }
 

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -501,7 +501,7 @@ void ActorManager::HandleActorStreamData(std::vector<RoR::NetRecvPacket> packet_
                     continue;
                 if (packet.header.source == actor->ar_net_source_id && packet.header.streamid == actor->ar_net_stream_id)
                 {
-                    actor->PushNetwork(packet.buffer, packet.header.size);
+                    actor->pushNetwork(packet.buffer, packet.header.size);
                     break;
                 }
             }
@@ -1041,7 +1041,7 @@ void ActorManager::UpdateActors(Actor* player_actor)
         if (App::mp_state->GetEnum<MpState>() == RoR::MpState::CONNECTED)
         {
             if (actor->ar_sim_state == Actor::SimState::NETWORKED_OK)
-                actor->CalcNetwork();
+                actor->calcNetwork();
             else
                 actor->sendStreamData();
         }

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -149,9 +149,9 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
         }
 
         if (rq.asr_free_position)
-            actor->ResetPosition(vehicle_position, true);
+            actor->resetPosition(vehicle_position, true);
         else
-            actor->ResetPosition(vehicle_position.x, vehicle_position.z, true, miny);
+            actor->resetPosition(vehicle_position.x, vehicle_position.z, true, miny);
 
         if (rq.asr_spawnbox != nullptr)
         {
@@ -166,13 +166,13 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
 
                 gpos -= rq.asr_rotation * Vector3((rq.asr_spawnbox->hi.x - rq.asr_spawnbox->lo.x + actor->ar_bounding_box.getMaximum().x - actor->ar_bounding_box.getMinimum().x) * 0.6f, 0.0f, 0.0f);
 
-                actor->ResetPosition(gpos.x, gpos.z, true, miny);
+                actor->resetPosition(gpos.x, gpos.z, true, miny);
             }
         }
     }
     else
     {
-        actor->ResetPosition(rq.asr_position, true);
+        actor->resetPosition(rq.asr_position, true);
     }
     actor->UpdateBoundingBoxes();
 

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -256,7 +256,7 @@ void ActorManager::SetupActor(Actor* actor, ActorSpawnRequest rq, std::shared_pt
 
     // Initialize visuals
     actor->updateVisual();
-    actor->ToggleLights();
+    actor->lightsToggle();
     actor->GetGfxActor()->SetDebugView((GfxActor::DebugViewType)rq.asr_debugview);
 
     // perform full visual update only if the vehicle won't be immediately driven by player.

--- a/source/main/physics/ActorSlideNode.cpp
+++ b/source/main/physics/ActorSlideNode.cpp
@@ -31,7 +31,7 @@
 using namespace RoR;
 
 // ug... BAD PERFORMNCE, BAD!!
-void Actor::ToggleSlideNodeLock()
+void Actor::toggleSlideNodeLock()
 {
     // for every slide node on this truck
     for (std::vector<SlideNode>::iterator itNode = m_slidenodes.begin(); itNode != m_slidenodes.end(); itNode++)
@@ -100,7 +100,7 @@ std::pair<RailGroup*, Ogre::Real> Actor::GetClosestRailOnActor(Actor* actor, con
 
 // SlideNode Utility functions /////////////////////////////////////////////////
 
-void Actor::UpdateSlideNodeForces(const Ogre::Real dt)
+void Actor::updateSlideNodeForces(const Ogre::Real dt)
 {
     for (std::vector<SlideNode>::iterator it = m_slidenodes.begin(); it != m_slidenodes.end(); ++it)
     {

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -4947,7 +4947,7 @@ unsigned int ActorSpawner::AddTyreBeam(RigDef::Wheel2 & wheel_2_def, node_t *nod
     beam.k = wheel_2_def.tyre_springiness;
     beam.d = wheel_2_def.tyre_damping;
 
-    m_actor->GetTyrePressure().AddBeam((int)beam_index);
+    m_actor->getTyrePressure().AddBeam((int)beam_index);
 
     return beam_index;
 }

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -875,7 +875,7 @@ void ActorManager::RestoreSavedState(Actor* actor, rapidjson::Value const& j_ent
         for (int k = 0; k < actor->m_transfer_case->tr_gear_ratios.size(); k++)
         {
             if (actor->m_transfer_case->tr_gear_ratios[0] != j_entry["transfercase"]["GearRatio"].GetFloat())
-                actor->ToggleTransferCaseGearRatio();
+                actor->toggleTransferCaseGearRatio();
         }
     }
 

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -993,7 +993,7 @@ void ActorManager::RestoreSavedState(Actor* actor, rapidjson::Value const& j_ent
     actor->resetSlideNodes();
     if (actor->m_slidenodes_locked != j_entry["slidenodes_locked"].GetBool())
     {
-        actor->ToggleSlideNodeLock();
+        actor->toggleSlideNodeLock();
     }
 
     actor->UpdateBoundingBoxes();

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -799,7 +799,7 @@ void ActorManager::RestoreSavedState(Actor* actor, rapidjson::Value const& j_ent
 
     if (actor->m_headlight_on != (bool)j_entry["lights"].GetInt())
     {
-        actor->ToggleLights();
+        actor->lightsToggle();
     }
     actor->m_beacon_light_on = j_entry["pp_beacon_light"].GetBool();
     if (actor->m_custom_particles_enabled != j_entry["custom_particles"].GetBool())

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -804,7 +804,7 @@ void ActorManager::RestoreSavedState(Actor* actor, rapidjson::Value const& j_ent
     actor->m_beacon_light_on = j_entry["pp_beacon_light"].GetBool();
     if (actor->m_custom_particles_enabled != j_entry["custom_particles"].GetBool())
     {
-        actor->ToggleCustomParticles();
+        actor->toggleCustomParticles();
     }
 
     if (j_entry.HasMember("custom_lights"))

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -325,7 +325,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
         {
             if (j_entry["filename"].GetString() != x_actors[index]->ar_filename ||
                     (skin != nullptr && skin->dname != x_actors[index]->m_used_skin_entry->dname) ||
-                    section_config != x_actors[index]->GetSectionConfig())
+                    section_config != x_actors[index]->getSectionConfig())
             {
                 if (x_actors[index] == player_actor)
                 {

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -477,7 +477,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
         j_actor_position.PushBack(actor->ar_nodes[0].AbsPosition.z, j_doc.GetAllocator());
         j_entry.AddMember("position", j_actor_position, j_doc.GetAllocator());
         j_entry.AddMember("rotation", actor->getRotation(), j_doc.GetAllocator());
-        j_entry.AddMember("min_height", actor->GetMinHeight(), j_doc.GetAllocator());
+        j_entry.AddMember("min_height", actor->getMinHeight(), j_doc.GetAllocator());
         j_entry.AddMember("spawn_rotation", actor->m_spawn_rotation, j_doc.GetAllocator());
         j_entry.AddMember("preloaded_with_terrain", actor->isPreloadedWithTerrain(), j_doc.GetAllocator());
         j_entry.AddMember("sim_state", static_cast<int>(actor->ar_sim_state), j_doc.GetAllocator());

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -45,7 +45,7 @@ void PointColDetector::UpdateIntraPoint(bool contactables)
 
 void PointColDetector::UpdateInterPoint(bool ignorestate)
 {
-    m_linked_actors = m_actor->GetAllLinkedActors();
+    m_linked_actors = m_actor->getAllLinkedActors();
 
     int contacters_size = 0;
     std::vector<Actor*> collision_partners;

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -735,7 +735,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     j_doc.AddMember("actor-hash", rapidjson::StringRef(player_actor->ar_filehash.c_str()), j_doc.GetAllocator());
 
     rapidjson::Value j_linked_actors(rapidjson::kArrayType);
-    for (auto actor : player_actor->GetAllLinkedActors())
+    for (auto actor : player_actor->getAllLinkedActors())
     {
         rapidjson::Value j_actor(rapidjson::kObjectType);
         j_actor.AddMember("actor-name", rapidjson::StringRef(actor->ar_design_name.c_str()), j_doc.GetAllocator());

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -185,9 +185,9 @@ void ScriptEngine::init()
 
 
     // Register everything
-    // class Beam
+    // class Actor (historically Beam)
     result = engine->RegisterObjectType("BeamClass", sizeof(Actor), AngelScript::asOBJ_REF); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", AngelScript::asMETHOD(Actor,ScaleActor), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", AngelScript::asMETHOD(Actor,scaleTruck), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", AngelScript::asMETHOD(Actor,GetActorDesignName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,GetActorFileName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,GetActorType), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -189,7 +189,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectType("BeamClass", sizeof(Actor), AngelScript::asOBJ_REF); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", AngelScript::asMETHOD(Actor,scaleTruck), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", AngelScript::asMETHOD(Actor,getTruckName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,GetActorFileName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,getTruckFileName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,GetActorType), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asFUNCTION(AS_RequestActorReset), AngelScript::asCALL_CDECL_OBJFIRST); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", AngelScript::asMETHOD(Actor,ToggleParkingBrake), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -186,7 +186,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "void tractioncontrolToggle()", AngelScript::asMETHOD(Actor,tractioncontrolToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void antilockbrakeToggle()", AngelScript::asMETHOD(Actor,antilockbrakeToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void beaconsToggle()", AngelScript::asMETHOD(Actor,ToggleBeacons), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "void ToggleCustomParticles()", AngelScript::asMETHOD(Actor,ToggleCustomParticles), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void toggleCustomParticles()", AngelScript::asMETHOD(Actor,toggleCustomParticles), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int getNodeCount()", AngelScript::asMETHOD(Actor,GetNumNodes), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "float getTotalMass(bool)", AngelScript::asMETHOD(Actor,getTotalMass), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int getWheelNodeCount()", AngelScript::asMETHOD(Actor,getWheelNodeCount), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -190,7 +190,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", AngelScript::asMETHOD(Actor,scaleTruck), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", AngelScript::asMETHOD(Actor,getTruckName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,getTruckFileName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,GetActorType), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,getTruckType), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asFUNCTION(AS_RequestActorReset), AngelScript::asCALL_CDECL_OBJFIRST); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", AngelScript::asMETHOD(Actor,ToggleParkingBrake), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void tractioncontrolToggle()", AngelScript::asMETHOD(Actor,ToggleTractionControl), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -182,9 +182,9 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,getTruckFileName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,getTruckType), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asMETHOD(Actor,reset), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", AngelScript::asMETHOD(Actor,ToggleParkingBrake), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "void tractioncontrolToggle()", AngelScript::asMETHOD(Actor,ToggleTractionControl), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "void antilockbrakeToggle()", AngelScript::asMETHOD(Actor,ToggleAntiLockBrake), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", AngelScript::asMETHOD(Actor,parkingbrakeToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void tractioncontrolToggle()", AngelScript::asMETHOD(Actor,tractioncontrolToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void antilockbrakeToggle()", AngelScript::asMETHOD(Actor,antilockbrakeToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void beaconsToggle()", AngelScript::asMETHOD(Actor,ToggleBeacons), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void ToggleCustomParticles()", AngelScript::asMETHOD(Actor,ToggleCustomParticles), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int getNodeCount()", AngelScript::asMETHOD(Actor,GetNumNodes), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -203,7 +203,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "bool isLocked()", AngelScript::asMETHOD(Actor,isLocked), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "float getWheelSpeed()", AngelScript::asMETHOD(Actor,getWheelSpeed), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "float getSpeed()", AngelScript::asMETHOD(Actor,getSpeed), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "vector3 getGForces()", AngelScript::asMETHOD(Actor,GetGForcesCur), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "vector3 getGForces()", AngelScript::asMETHOD(Actor,getGForces), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
 
     result = engine->RegisterObjectMethod("BeamClass", "float getRotation()", AngelScript::asMETHOD(Actor,getRotation), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "vector3 getVehiclePosition()", AngelScript::asMETHOD(Actor,getPosition), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -187,7 +187,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "void antilockbrakeToggle()", AngelScript::asMETHOD(Actor,antilockbrakeToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void beaconsToggle()", AngelScript::asMETHOD(Actor,beaconsToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void toggleCustomParticles()", AngelScript::asMETHOD(Actor,toggleCustomParticles), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "int getNodeCount()", AngelScript::asMETHOD(Actor,GetNumNodes), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "int getNodeCount()", AngelScript::asMETHOD(Actor,getNodeCount), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "float getTotalMass(bool)", AngelScript::asMETHOD(Actor,getTotalMass), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int getWheelNodeCount()", AngelScript::asMETHOD(Actor,getWheelNodeCount), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void setMass(float)", AngelScript::asMETHOD(Actor,setMass), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -188,7 +188,7 @@ void ScriptEngine::init()
     // class Actor (historically Beam)
     result = engine->RegisterObjectType("BeamClass", sizeof(Actor), AngelScript::asOBJ_REF); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", AngelScript::asMETHOD(Actor,scaleTruck), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", AngelScript::asMETHOD(Actor,GetActorDesignName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", AngelScript::asMETHOD(Actor,getTruckName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,GetActorFileName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,GetActorType), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asFUNCTION(AS_RequestActorReset), AngelScript::asCALL_CDECL_OBJFIRST); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -185,7 +185,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", AngelScript::asMETHOD(Actor,parkingbrakeToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void tractioncontrolToggle()", AngelScript::asMETHOD(Actor,tractioncontrolToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void antilockbrakeToggle()", AngelScript::asMETHOD(Actor,antilockbrakeToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "void beaconsToggle()", AngelScript::asMETHOD(Actor,ToggleBeacons), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void beaconsToggle()", AngelScript::asMETHOD(Actor,beaconsToggle), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void toggleCustomParticles()", AngelScript::asMETHOD(Actor,toggleCustomParticles), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int getNodeCount()", AngelScript::asMETHOD(Actor,GetNumNodes), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "float getTotalMass(bool)", AngelScript::asMETHOD(Actor,getTotalMass), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -90,19 +90,9 @@ ScriptEngine::~ScriptEngine()
     if (context) context->Release();
 }
 
-
-
 void ScriptEngine::messageLogged( const String& message, LogMessageLevel lml, bool maskDebug, const String &logName, bool& skipThisMessage)
 {
     RoR::App::GetConsole()->ForwardLogMessage(Console::CONSOLE_MSGTYPE_SCRIPT, message, lml);
-}
-
-void AS_RequestActorReset(Actor* a, bool keep_position) // Substitute for removed `Actor` function
-{
-    ActorModifyRequest* rq = new ActorModifyRequest;
-    rq->amr_actor = a;
-    rq->amr_type  = (keep_position) ? ActorModifyRequest::Type::RESET_ON_SPOT : ActorModifyRequest::Type::RESET_ON_INIT_POS;
-    App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
 }
 
 // continue with initializing everything
@@ -191,7 +181,7 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", AngelScript::asMETHOD(Actor,getTruckName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", AngelScript::asMETHOD(Actor,getTruckFileName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", AngelScript::asMETHOD(Actor,getTruckType), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asFUNCTION(AS_RequestActorReset), AngelScript::asCALL_CDECL_OBJFIRST); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", AngelScript::asMETHOD(Actor,reset), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", AngelScript::asMETHOD(Actor,ToggleParkingBrake), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void tractioncontrolToggle()", AngelScript::asMETHOD(Actor,ToggleTractionControl), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void antilockbrakeToggle()", AngelScript::asMETHOD(Actor,ToggleAntiLockBrake), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -291,7 +291,7 @@ public:
             }
             else if (b)
             {
-                b->ResetPosition(pos, false);
+                b->resetPosition(pos, false);
                 TRIGGER_EVENT(SE_TRUCK_TELEPORT, b->ar_instance_id);
                 reply << _L("Vehicle position set to: ") << "x: " << pos.x << " y: " << pos.y << " z: " << pos.z;
             }


### PR DESCRIPTION
This is a code cleanup only. No features should change.

Functions in `class Actor` (aka `BeamClass` in script) restored to original format in v0.4.0.8 (year 2013 and prior). Reference: https://github.com/only-a-ptr/rigs-of-rods/blob/retro-0407/source/main/physics/Beam.h

Motivations:
* To have same function names in script and codebase. In recent years it diverged a lot, for no good reason.
* To be able to consistently extend the scripting interface.
* To restore the useful grouping of functions in Actor.h (formerly Beam.h)