### PR TITLE
Hotfix: only load prop mesh from own resource group.

### DIFF
--- a/source/main/utils/MeshObject.cpp
+++ b/source/main/utils/MeshObject.cpp
@@ -69,9 +69,7 @@ void MeshObject::createEntity(Ogre::String meshName, Ogre::String entityRG, Ogre
 
     try
     {
-        // Classic behavior: look in all resource groups.
-        //   The mesh may live in terrain's resource bundle (aka ZIP) or ror's bundled resource ZIPs.
-        Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().load(meshName, Ogre::RGN_AUTODETECT);
+        Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().load(meshName, entityRG);
 
         // important: you need to add the LODs before creating the entity
         // now find possible LODs, needs to be done before calling createEntity()
@@ -79,7 +77,7 @@ void MeshObject::createEntity(Ogre::String meshName, Ogre::String entityRG, Ogre
         StringUtil::splitBaseFilename(meshName, basename, ext);
 
         // the classic LODs
-        FileInfoListPtr files = ResourceGroupManager::getSingleton().findResourceFileInfo(Ogre::RGN_AUTODETECT, basename + "_lod*.mesh");
+        FileInfoListPtr files = ResourceGroupManager::getSingleton().findResourceFileInfo(entityRG, basename + "_lod*.mesh");
         for (FileInfoList::iterator iterFiles = files->begin(); iterFiles != files->end(); ++iterFiles)
         {
             String format = basename + "_lod%d.mesh";
@@ -89,11 +87,11 @@ void MeshObject::createEntity(Ogre::String meshName, Ogre::String entityRG, Ogre
             if (r <= 0 || i < 0)
                 continue;
 
-            Ogre::MeshManager::getSingleton().load(iterFiles->filename, mesh->getGroup());
+            Ogre::MeshManager::getSingleton().load(iterFiles->filename, entityRG);
         }
 
         // the custom LODs
-        FileInfoListPtr files2 = ResourceGroupManager::getSingleton().findResourceFileInfo(Ogre::RGN_AUTODETECT, basename + "_clod_*.mesh");
+        FileInfoListPtr files2 = ResourceGroupManager::getSingleton().findResourceFileInfo(entityRG, basename + "_clod_*.mesh");
         for (FileInfoList::iterator iterFiles = files2->begin(); iterFiles != files2->end(); ++iterFiles)
         {
             // and custom LODs
@@ -103,7 +101,7 @@ void MeshObject::createEntity(Ogre::String meshName, Ogre::String entityRG, Ogre
             if (r <= 0 || i < 0)
                 continue;
 
-            Ogre::MeshManager::getSingleton().load(iterFiles->filename, mesh->getGroup());
+            Ogre::MeshManager::getSingleton().load(iterFiles->filename, entityRG);
         }
 
         // now create an entity around the mesh and attach it to the scene graph
@@ -116,7 +114,7 @@ void MeshObject::createEntity(Ogre::String meshName, Ogre::String entityRG, Ogre
     }
     catch (Ogre::Exception& e)
     {
-        RoR::LogFormat("[RoR] Error creating entity of mesh '%s' (target group: '%s'), message: %s",
+        RoR::LogFormat("[RoR] Error creating entity of mesh '%s' (group: '%s'), message: %s",
             meshName.c_str(), entityRG.c_str(), e.getFullDescription().c_str());
         return;
     }


### PR DESCRIPTION
**Problem**: when 2 mods (each with it's own bundle) contain mesh with the same file name, they will clash with each other. The first mod loaded will override the mesh for all others until the game is restarted. This applies to props (vehicle) and odefs (terrain).

**Cause**: class MeshObject was searching for the mesh name globally instead of using the mod's resource group. This is classic behavior, some mods might rely on it.

**Fix**: use the mod's resource group, as already done for most resources.

Mods I used for testing:
[agora-meshmix1.zip](https://github.com/RigsOfRods/rigs-of-rods/files/7069858/agora-meshmix1.zip)
[agora-meshmix2.zip](https://github.com/RigsOfRods/rigs-of-rods/files/7069859/agora-meshmix2.zip)
