### PR TITLE
Fixed segfault when switching terrain with active race

### DIFF
--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -852,7 +852,7 @@ void TopMenubar::DrawSpecialStateBox(float top_offset)
         replay_box = true;
         special_text = _LC("TopMenubar", "Replay");
     }
-    else if (App::GetGfxScene()->GetSimDataBuffer().simbuf_dir_arrow_visible)
+    else if (App::GetGameContext()->GetPlayerActor() && App::GetGfxScene()->GetSimDataBuffer().simbuf_dir_arrow_visible)
     {
         race_box = true;
 


### PR DESCRIPTION
Problem:

Load nhelens, start race, back to menu, load nhelens modded:
```
Thread 1 "RoR" received signal SIGSEGV, Segmentation fault.
0x00005555557ae73c in RoR::GUI::TopMenubar::DrawSpecialStateBox (this=0x5555571efc88, top_offset=10)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/gui/panels/GUI_TopMenubar.cpp:864
864	        if (player_actor != nullptr &&
```
```
(gdb) bt
#0  0x00005555557ae73c in RoR::GUI::TopMenubar::DrawSpecialStateBox (this=0x5555571efc88, top_offset=10)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/gui/panels/GUI_TopMenubar.cpp:864
#1  0x00005555557b11e4 in RoR::GUI::TopMenubar::Update (this=0x5555571efc88)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/gui/panels/GUI_TopMenubar.cpp:83
#2  0x000055555570aa6c in RoR::GUIManager::DrawSimulationGui (this=0x55555648d7e0, dt=dt@entry=1.7699815)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/gui/GUIManager.cpp:220
#3  0x00005555555eb8ad in main (argc=<optimized out>, argv=<optimized out>)
    at /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/main.cpp:831
```

Introduced with https://github.com/RigsOfRods/rigs-of-rods/pull/2790
