### PR TITLE
Fixed races not loading when event type is not defined

### DIFF
--- a/source/main/resources/odef_fileformat/ODefFileFormat.cpp
+++ b/source/main/resources/odef_fileformat/ODefFileFormat.cpp
@@ -272,7 +272,7 @@ bool ODefParser::ProcessCurrentLine()
         else if (!strncmp(ev_type, "airplane",  8)) { m_ctx.cbox_event_filter = EVENT_AIRPLANE; }
         else if (!strncmp(ev_type, "boat",      4)) { m_ctx.cbox_event_filter = EVENT_BOAT;     }
         else if (!strncmp(ev_type, "delete",    6)) { m_ctx.cbox_event_filter = EVENT_DELETE;   }
-        else                                        { m_ctx.cbox_event_filter = EVENT_NONE;     }
+        else                                        { m_ctx.cbox_event_filter = EVENT_ALL;      }
 
         // hack to avoid fps drops near spawnzones
         if (!strncmp(ev_name, "spawnzone", 9)) { m_ctx.cbox_event_filter = EVENT_AVATAR; }


### PR DESCRIPTION
Old code was:
![kk](https://user-images.githubusercontent.com/2660424/133563270-664d4ea6-df13-44f6-8e27-e65091bee408.png)
https://github.com/RigsOfRods/rigs-of-rods/commit/2046c336068ffd0e024c6b5710fe2113c14cf559


Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/2745

@only-a-ptr Is this correct or we need to be specific? Like
```
if strncmp(ev_type, "",  0)
```