### PR TITLE
Survey map fixes

### DIFF
--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -70,10 +70,11 @@ void SurveyMap::Draw()
     }
 
     // Calculate window position
+    Ogre::RenderWindow* rw = RoR::App::GetAppContext()->GetRenderWindow();
     ImVec2 view_size(0, 0);
     if (mMapMode == SurveyMapMode::BIG)
     {
-        view_size.y = ImGui::GetIO().DisplaySize.y -
+        view_size.y = (rw->getWidth() * 0.55f) -
             ((2 * App::GetGuiManager()->GetTheme().screen_edge_padding.y) + (2 * WINDOW_PADDING));
         Vector3 terrn_size = App::GetSimTerrain()->getMaxTerrainSize(); // Y is 'up'!
         if (!terrn_size.isZeroLength())
@@ -87,7 +88,7 @@ void SurveyMap::Draw()
     }
     else if (mMapMode == SurveyMapMode::SMALL)
     {
-        view_size.y = ImGui::GetIO().DisplaySize.y * 0.30f;
+        view_size.y = rw->getWidth() * 0.2f;
         view_size.x = view_size.y;
     }
 
@@ -256,7 +257,7 @@ void SurveyMap::CreateTerrainTextures()
     int res = std::pow(2, std::floor(std::log2(resolution)));
 
     mMapTextureCreatorStatic = std::unique_ptr<SurveyMapTextureCreator>(new SurveyMapTextureCreator(terrain_size.y));
-    mMapTextureCreatorStatic->init(res, fsaa);
+    mMapTextureCreatorStatic->init(res / 1.5, fsaa);
     mMapTextureCreatorStatic->update(mMapCenter + mMapCenterOffset, mTerrainSize);
 
     // TODO: Find out how to zoom into the static texture instead


### PR DESCRIPTION
Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/2767

For some reason when texture filtering is set to Bilinear, with some gpus, `ImGui::GetIO().DisplaySize.y` returns 0
Old code was: https://github.com/RigsOfRods/rigs-of-rods/blob/2020.01/source/main/terrain/map/SurveyMapManager.cpp#L185

Also fixes darker image in Big map with Anisotropic filtering

Before:
![bef](https://user-images.githubusercontent.com/2660424/134260777-9c7359a5-5c18-43f9-b7bf-0874517d96b1.png)
After:
![after](https://user-images.githubusercontent.com/2660424/134260793-757b3d88-c842-407f-95c5-dc34e94e09e9.png)

@paroj any idea why those nasty things happen? :rofl:
