### PR TITLE
Fixed incorrect command key in vehicle description UI

### DIFF
--- a/source/main/gui/panels/GUI_VehicleDescription.cpp
+++ b/source/main/gui/panels/GUI_VehicleDescription.cpp
@@ -83,8 +83,16 @@ void VehicleDescription::Draw()
 
             int eventID = RoR::InputEngine::resolveEventName(fmt::format("COMMANDS_{:02d}", i));
             Ogre::String keya = RoR::App::GetInputEngine()->getEventCommand(eventID);
-            eventID = RoR::InputEngine::resolveEventName(fmt::format("COMMANDS_{:02d}", i + 1));
-            Ogre::String keyb = RoR::App::GetInputEngine()->getEventCommand(eventID);
+            Ogre::String keyb;
+
+            for (int x = i+1; x < MAX_COMMANDS; x++)
+            {
+                if (actor->ar_command_key[x].description == actor->ar_command_key[i].description)
+                {
+                    eventID = RoR::InputEngine::resolveEventName(fmt::format("COMMANDS_{:02d}", x));
+                    keyb = RoR::App::GetInputEngine()->getEventCommand(eventID);
+                }
+            }
 
             // cut off expl
             if (keya.size() > 6 && keya.substr(0, 5) == "EXPL+")
@@ -92,18 +100,13 @@ void VehicleDescription::Draw()
             if (keyb.size() > 6 && keyb.substr(0, 5) == "EXPL+")
                 keyb = keyb.substr(5);
 
-            ImGui::Text("%s/%s", keya.c_str(), keyb.c_str());
-            ImGui::NextColumn();
-
-            if (!actor->ar_command_key[i].description.empty())
+            if (!keya.empty() && !keyb.empty())
             {
+                ImGui::Text("%s/%s", keya.c_str(), keyb.c_str());
+                ImGui::NextColumn();
                 ImGui::Text("%s", actor->ar_command_key[i].description.c_str());
+                ImGui::NextColumn();
             }
-            else
-            {
-                ImGui::TextDisabled("%s", _LC("VehicleDescription", "unknown function"));
-            }
-            ImGui::NextColumn();
         }
         ImGui::Columns(1);
     }

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -3416,9 +3416,13 @@ void ActorSpawner::ProcessCommand(RigDef::Command2 & def)
     cmd_beam.cmb_center_length = center_length;
     cmd_beam.cmb_state = std::shared_ptr<commandbeam_state_t>(new commandbeam_state_t);
     contract_command->beams.push_back(cmd_beam);
-    if (contract_command->description.empty())
+    if (!def.description.empty())
     {
         contract_command->description = def.description;
+    }
+    else
+    {
+        contract_command->description = fmt::format(_L("Unnamed command {}"), commandCounter);
     }
 
     command_t* extend_command = &m_actor->ar_command_key[def.extend_key];
@@ -3426,9 +3430,13 @@ void ActorSpawner::ProcessCommand(RigDef::Command2 & def)
     cmd_beam.cmb_speed = def.lengthen_rate;
     cmd_beam.cmb_boundary_length = def.max_extension;
     extend_command->beams.push_back(cmd_beam);
-    if (extend_command->description.empty())
+    if (!def.description.empty())
     {
         extend_command->description = def.description;
+    }
+    else
+    {
+        extend_command->description = fmt::format(_L("Unnamed command {}"), commandCounter);
     }
 
     this->_ProcessKeyInertia(def.inertia, *def.inertia_defaults,
@@ -3442,6 +3450,7 @@ void ActorSpawner::ProcessCommand(RigDef::Command2 & def)
 
     m_actor->m_num_command_beams++;
     m_actor->m_has_command_beams = true;
+    commandCounter += 1;
 }
 
 void ActorSpawner::ProcessAnimator(RigDef::Animator & def)

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -1082,7 +1082,7 @@ private:
     std::vector<WheelVisualsTicket>        m_wheel_visuals_queue; //!< We want to spawn visuals asynchronously in the future
     std::map<std::string, Ogre::MaterialPtr>  m_managed_materials;
     std::list<std::shared_ptr<RigDef::File::Module>>  m_selected_modules;
-
+    int commandCounter = 0;
 };
 
 } // namespace RoR


### PR DESCRIPTION
Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/193

Second command key always assumed as the first + 1 https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/gui/panels/GUI_VehicleDescription.cpp#L86, but actually we can have commands in other keys like F5/F12 for example.

This properly (i think :laughing:) fills empty command descriptions and pairs keys by description in vehicle description panel.

Example:
```
61, 113, 0.3, 0.5, 1.0, 4, 1, 2, f
62, 112, 0.3, 0.5, 1.0, 4, 1, 2, f Boom

136,116, 0.4,0.4,1.0, 10, 5,12, n
136,117, 0.4,0.4,1.0, 10, 5,12, n
136,118, 0.4,0.4,1.0, 10, 5,12, n
136,119, 0.4,0.4,1.0, 10, 5,12, n 

116,124,0.1,0.1,1.0, 2.6,   3, 11, n
117,125,0.1,0.1,1.0, 2.6,   3, 11, n Underlift

137, 64, 0.2,0.2,1.0, 3, 7,8, p
138, 70, 0.2,0.2,1.0, 3, 7,8, p Rear_Feet

140, 96, 0.2,0.2,1.0, 3, 9,10, p Left_Feet
```
![kk](https://user-images.githubusercontent.com/2660424/135786599-d6b8d270-d57a-4663-b071-7391a43cced3.png)


