### PR TITLE
Fixed net labels showing in single player.

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -2051,7 +2051,7 @@ void RoR::GfxActor::UpdateNetLabels(float dt)
             m_simbuf.simbuf_actor_state == ActorState::NETWORKED_OK ||
             m_simbuf.simbuf_actor_state == ActorState::NETWORKED_HIDDEN;
 
-        if (App::mp_hide_net_labels->getBool() || (!is_remote && App::mp_hide_own_net_label->getBool()))
+        if (App::mp_hide_net_labels->getBool() || (!is_remote && App::mp_hide_own_net_label->getBool()) || App::mp_state->getEnum<MpState>() != MpState::CONNECTED)
         {
             return;
         }


### PR DESCRIPTION
- Fixes net labels showing in single player when "hide own net label" is disabled

TODO

Fix main menu showing when preselected terrain is defined or given via argument
Fix main menu showing when "skip main menu" option is enabled

Both issues come from https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/gui/panels/GUI_GameControls.cpp#L399