### PR TITLE
Added close button in key input window

### DIFF
--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -94,7 +94,7 @@ void GameControls::Draw()
             ImGui::End();
             if (!open)
             {
-                m_interactive_keybinding_active = false;
+                this->CancelChanges();
             }
         }
     }


### PR DESCRIPTION
Requested from discord

>Is there a way to avoid accidentally changing controls? If I select to change a control, I can't back out of it in any way.  I can only give it a key and then reset everything after.  I guess every key is a possible bind (ESC?), so maybe add an X to the window or a button to cancel?

![kk](https://user-images.githubusercontent.com/2660424/136697100-9b209606-29fc-4f0d-bec1-0ac59ab8dd9b.png)

