### PR TITLE
Close selector on terrain unload

### DIFF
--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -541,6 +541,7 @@ int main(int argc, char *argv[])
                     App::GetGameContext()->GetSceneMouse().DiscardVisuals();
                     App::DestroyOverlayWrapper();
                     App::GetCameraManager()->ResetAllBehaviors();
+                    App::GetGuiManager()->GetMainSelector()->Close();
                     App::GetGuiManager()->SetVisible_LoadingWindow(false);
                     App::GetGuiManager()->SetVisible_MenuWallpaper(true);
                     App::sim_state->setVal((int)SimState::OFF);


### PR DESCRIPTION
In simulation, when selector is visible, going back to menu from top panel should hide the selector also.