### PR TITLE
Clean last spawned actor on terrain load

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -95,6 +95,8 @@ Message GameContext::PopMessage()
 
 bool GameContext::LoadTerrain(std::string const& filename_part)
 {
+    m_last_spawned_actor = nullptr;
+
     // Find terrain in modcache
     CacheEntry* terrn_entry = App::GetCacheSystem()->FindEntryByFilename(LT_Terrain, /*partial=*/true, filename_part);
     if (!terrn_entry)


### PR DESCRIPTION
Problem: Load terrain, spawn vehicle, go back to menu, load terrain->last spawned actor section was still active in top menu, selecting those options resulted in segfault.