### PR TITLE
Revived legacy icons

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1213,11 +1213,11 @@ void GameContext::UpdateCommonInputEvents(float dt)
         m_player_actor->ar_forward_commands = !m_player_actor->ar_forward_commands;
         if (m_player_actor->ar_forward_commands)
         {
-            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("forwardcommands enabled"), "information.png", 3000);
+            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("forwardcommands enabled"), "information.png");
         }
         else
         {
-            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("forwardcommands disabled"), "information.png", 3000);
+            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("forwardcommands disabled"), "information.png");
         }
     }
 
@@ -1226,11 +1226,11 @@ void GameContext::UpdateCommonInputEvents(float dt)
         m_player_actor->ar_import_commands = !m_player_actor->ar_import_commands;
         if (m_player_actor->ar_import_commands)
         {
-            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("importcommands enabled"), "information.png", 3000);
+            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("importcommands enabled"), "information.png");
         }
         else
         {
-            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("importcommands disabled"), "information.png", 3000);
+            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("importcommands disabled"), "information.png");
         }
     }
 

--- a/source/main/gameplay/EngineSim.cpp
+++ b/source/main/gameplay/EngineSim.cpp
@@ -1400,7 +1400,7 @@ void EngineSim::UpdateInputEvents(float dt)
         case SimGearboxMode::MANUAL_RANGES: msg = "Fully Manual: stick shift with ranges";
             break;
         }
-        App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L(msg), "cog.png", 3000);
+        App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L(msg), "cog.png");
     }
 
     // joy clutch
@@ -1446,19 +1446,19 @@ void EngineSim::UpdateInputEvents(float dt)
             {
                 this->SetGearRange(0);
                 gear_changed = true;
-                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png", 3000);
+                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png");
             }
             else if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_MIDRANGE) && curgearrange != 1 && this->getNumGearsRanges() > 1)
             {
                 this->SetGearRange(1);
                 gear_changed = true;
-                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png", 3000);
+                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png");
             }
             else if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_HIGHRANGE) && curgearrange != 2 && this->getNumGearsRanges() > 2)
             {
                 this->SetGearRange(2);
                 gear_changed = true;
-                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png", 3000);
+                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png");
             }
         }
         //zaxxon

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -381,12 +381,12 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
     switch (new_behavior)
     {
     case CAMERA_BEHAVIOR_FREE:
-        RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Free camera"), "camera_go.png", 3000);
+        RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Free camera"), "camera_go.png");
         break;
 
     case CAMERA_BEHAVIOR_ISOMETRIC:
     case CAMERA_BEHAVIOR_FIXED:
-        RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("Fixed camera"), "camera_link.png", 3000);
+        RoR::App::GetConsole()->putMessage(RoR::Console::CONSOLE_MSGTYPE_INFO, RoR::Console::CONSOLE_SYSTEM_NOTICE, _L("Fixed camera"), "camera_link.png");
         break;
 
     case CAMERA_BEHAVIOR_STATIC:
@@ -860,11 +860,11 @@ void CameraManager::CameraBehaviorOrbitUpdate()
         m_cam_limit_movement = !m_cam_limit_movement;
         if (m_cam_limit_movement)
         {
-            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Limited camera movement enabled"), "camera_go.png", 3000);
+            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Limited camera movement enabled"), "camera_go.png");
         }
         else
         {
-            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Limited camera movement disabled"), "camera_go.png", 3000);
+            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Limited camera movement disabled"), "camera_go.png");
         }
     }
 
@@ -1139,11 +1139,11 @@ void CameraManager::CameraBehaviorVehicleSplineUpdate()
         m_splinecam_auto_tracking = !m_splinecam_auto_tracking;
         if (m_splinecam_auto_tracking)
         {
-            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Auto tracking enabled"), "camera_go.png", 3000);
+            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Auto tracking enabled"), "camera_go.png");
         }
         else
         {
-            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Auto tracking disabled"), "camera_go.png", 3000);
+            RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Auto tracking disabled"), "camera_go.png");
         }
     }
 

--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -165,7 +165,11 @@ ImVec2 ConsoleView::DrawMessage(ImVec2 cursor, Console::Message const& m)
     Ogre::TexturePtr icon;
     if (cvw_enable_icons)
     {
-        if (m.cm_area == Console::MessageArea::CONSOLE_MSGTYPE_SCRIPT)
+        if (m.cm_icon != "")
+        {
+            icon = Ogre::TextureManager::getSingleton().load(m.cm_icon, "IconsRG");
+        }
+        else if (m.cm_area == Console::MessageArea::CONSOLE_MSGTYPE_SCRIPT)
         {
             icon = Ogre::TextureManager::getSingleton().load("script.png", "IconsRG");
         }
@@ -329,7 +333,7 @@ int ConsoleView::UpdateMessages()
                     Ogre::StringUtil::trim(s);
                     if (s != "")
                     {
-                        m_filtered_messages.emplace_back(m.cm_area, m.cm_type, s, m.cm_timestamp, m.cm_net_userid);
+                        m_filtered_messages.emplace_back(m.cm_area, m.cm_type, s, m.cm_timestamp, m.cm_net_userid, m.cm_icon);
                     }
                 }
             }

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -75,7 +75,7 @@ void GameChatBox::Draw()
 
     if (initialized == true)
     {
-        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _LC("ChatBox", "Welcome to Rigs of Rods!"), "", 10000, false);
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _LC("ChatBox", "Welcome to Rigs of Rods!"));
         initialized = false;
     }
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -506,7 +506,7 @@ int main(int argc, char *argv[])
                             std::snprintf(text, 300, _L("Press %s to start chatting"),
                                 RoR::App::GetInputEngine()->getKeyForCommand(EV_COMMON_ENTER_CHATMODE).c_str());
                             App::GetConsole()->putMessage(
-                                Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, text, "", 5000);
+                                Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, text);
                         }
 #endif // USE_SOCKETW
                         if (App::io_outgauge_mode->getInt() > 0)

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1272,7 +1272,7 @@ void Actor::displayAxleDiffMode()
     if (m_num_axle_diffs == 0)
     {
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                _L("No inter-axle differential installed on current vehicle!"), "warning.png", 3000);
+                _L("No inter-axle differential installed on current vehicle!"), "warning.png");
     }
     else
     {
@@ -1291,7 +1291,7 @@ void Actor::displayAxleDiffMode()
             }
         }
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                "Inter-axle differentials:\n" + message, "cog.png", 3000);
+                "Inter-axle differentials:\n" + message, "cog.png");
     }
 }
 
@@ -1300,7 +1300,7 @@ void Actor::displayWheelDiffMode()
     if (m_num_wheel_diffs == 0)
     {
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                _L("No inter-wheel differential installed on current vehicle!"), "warning.png", 3000);
+                _L("No inter-wheel differential installed on current vehicle!"), "warning.png");
     }
     else
     {
@@ -1317,7 +1317,7 @@ void Actor::displayWheelDiffMode()
             }
         }
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                "Inter-wheel differentials:\n" + message, "cog.png", 3000);
+                "Inter-wheel differentials:\n" + message, "cog.png");
     }
 }
 
@@ -1326,12 +1326,12 @@ void Actor::displayTransferCaseMode()
     if (m_transfer_case)
     {
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                _L("Transfercase switched to: ") + this->getTransferCaseName(), "cog.png", 3000);
+                _L("Transfercase switched to: ") + this->getTransferCaseName(), "cog.png");
     }
     else
     {
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                _L("No transfercase installed on current vehicle!"), "warning.png", 3000);
+                _L("No transfercase installed on current vehicle!"), "warning.png");
     }
 }
 

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -1171,7 +1171,7 @@ void HandleErrorLoadingFile(std::string type, std::string filename, std::string 
     RoR::Str<200> msg;
     msg << "Failed to load '" << filename << "' (type: '" << type << "'), message: " << exception_msg;
     App::GetConsole()->putMessage(
-        Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_ERROR, msg.ToCStr(), "error.png", 30000, true);
+        Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_ERROR, msg.ToCStr(), "error.png");
 }
 
 void HandleErrorLoadingTruckfile(std::string filename, std::string exception_msg)

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -299,9 +299,9 @@ void GameScript::flashMessage(String& txt, float time, float charHeight)
     RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_SCRIPT, Console::CONSOLE_SYSTEM_NOTICE, txt, "script_code_red.png");
 }
 
-void GameScript::message(String& txt, String& icon, float timeMilliseconds, bool forceVisible)
+void GameScript::message(String& txt, String& icon)
 {
-    RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_SCRIPT, Console::CONSOLE_SYSTEM_NOTICE, txt, icon, timeMilliseconds, forceVisible);
+    RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_SCRIPT, Console::CONSOLE_SYSTEM_NOTICE, txt, icon);
 }
 
 void GameScript::UpdateDirectionArrow(String& text, Vector3& vec)
@@ -768,7 +768,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     std::string json = buffer.GetString();
 
     RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-            _L("using Online API..."), "information.png", 2000);
+            _L("using Online API..."), "information.png");
 
     LOG("[RoR|GameScript] Submitting race results to '" + url + "'");
 

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -186,7 +186,7 @@ public:
     /**
      * shows a message to the user over the console system
      */
-    void message(Ogre::String& txt, Ogre::String& icon, float timeMilliseconds, bool forceVisible);
+    void message(Ogre::String& txt, Ogre::String& icon);
 
     /**
      * set direction arrow

--- a/source/main/system/Console.cpp
+++ b/source/main/system/Console.cpp
@@ -55,7 +55,7 @@ void Console::forwardLogMessage(MessageArea area, std::string const& message, Og
     }
 }
 
-void Console::handleMessage(MessageArea area, MessageType type, std::string const& msg, int net_userid/* = 0*/)
+void Console::handleMessage(MessageArea area, MessageType type, std::string const& msg, int net_userid/* = 0*/, std::string icon)
 {
     if (net_userid < 0) // 0=server, positive=clients, negative=invalid
     {
@@ -91,13 +91,13 @@ void Console::handleMessage(MessageArea area, MessageType type, std::string cons
 
     // Lock and update message list
     std::lock_guard<std::mutex> lock(m_messages_mutex); // Scoped lock
-    m_messages.emplace_back(area, type, msg, this->queryMessageTimer(), net_userid);
+    m_messages.emplace_back(area, type, msg, this->queryMessageTimer(), net_userid, icon);
 }
 
 void Console::putMessage(MessageArea area, MessageType type, std::string const& msg,
     std::string icon, size_t ttl, bool forcevisible)
 {
-    this->handleMessage(area, type, msg);
+    this->handleMessage(area, type, msg, 0, icon);
 }
 
 void Console::putNetMessage(int user_id, MessageType type, const char* text)

--- a/source/main/system/Console.cpp
+++ b/source/main/system/Console.cpp
@@ -94,8 +94,7 @@ void Console::handleMessage(MessageArea area, MessageType type, std::string cons
     m_messages.emplace_back(area, type, msg, this->queryMessageTimer(), net_userid, icon);
 }
 
-void Console::putMessage(MessageArea area, MessageType type, std::string const& msg,
-    std::string icon, size_t ttl, bool forcevisible)
+void Console::putMessage(MessageArea area, MessageType type, std::string const& msg, std::string icon)
 {
     this->handleMessage(area, type, msg, 0, icon);
 }

--- a/source/main/system/Console.h
+++ b/source/main/system/Console.h
@@ -63,8 +63,8 @@ public:
     struct Message
     {
         Message(MessageArea area, MessageType type, std::string const& text,
-                size_t time, uint32_t net_user = 0):
-            cm_area(area), cm_type(type), cm_text(text), cm_timestamp(time), cm_net_userid(net_user)
+                size_t time, uint32_t net_user = 0, std::string icon = ""):
+            cm_area(area), cm_type(type), cm_text(text), cm_timestamp(time), cm_net_userid(net_user), cm_icon(icon)
         {}
 
         MessageArea cm_area;
@@ -72,6 +72,7 @@ public:
         size_t      cm_timestamp;
         uint32_t    cm_net_userid;
         std::string cm_text;
+        std::string cm_icon;
     };
 
     struct MsgLockGuard
@@ -87,7 +88,7 @@ public:
         std::lock_guard<std::mutex> lock;
     };
 
-    // Legacy function, params `icon, ttl, forcevisible` unused
+    // Legacy function, params `ttl, forcevisible` unused
     void putMessage(MessageArea area, MessageType type, std::string const& msg,
         std::string icon = "", size_t ttl = 0, bool forcevisible = false);
     void putNetMessage(int user_id, MessageType type, const char* text);
@@ -148,7 +149,7 @@ private:
         const Ogre::String& message, Ogre::LogMessageLevel lml,
         bool maskDebug, const Ogre::String& logName, bool& skipThisMessage) override;
 
-    void handleMessage(MessageArea area, MessageType type, std::string const& msg, int net_id = 0);
+    void handleMessage(MessageArea area, MessageType type, std::string const& msg, int net_id = 0, std::string icon = "");
 
     std::vector<Message>     m_messages;
     std::mutex               m_messages_mutex;

--- a/source/main/system/Console.h
+++ b/source/main/system/Console.h
@@ -88,9 +88,7 @@ public:
         std::lock_guard<std::mutex> lock;
     };
 
-    // Legacy function, params `ttl, forcevisible` unused
-    void putMessage(MessageArea area, MessageType type, std::string const& msg,
-        std::string icon = "", size_t ttl = 0, bool forcevisible = false);
+    void putMessage(MessageArea area, MessageType type, std::string const& msg, std::string icon = "");
     void putNetMessage(int user_id, MessageType type, const char* text);
     void forwardLogMessage(MessageArea area, std::string const& msg, Ogre::LogMessageLevel lml);
     unsigned long queryMessageTimer() { return m_msg_timer.getMilliseconds(); }

--- a/source/main/terrain/TerrainEditor.cpp
+++ b/source/main/terrain/TerrainEditor.cpp
@@ -135,18 +135,18 @@ void TerrainEditor::UpdateInputEvents(float dt)
             m_rotation_axis = 0;
         }
         UTFString ssmsg = _L("Rotating: ") + axis;
-        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png");
     }
     if (App::GetInputEngine()->isKeyDownValueBounce(OIS::KC_SPACE))
     {
         m_object_tracking = !m_object_tracking;
         UTFString ssmsg = m_object_tracking ? _L("Enabled object tracking") : _L("Disabled object tracking");
-        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png");
     }
     if (m_object_index != -1 && update)
     {
         String ssmsg = _L("Selected object: [") + TOSTRING(m_object_index) + "/" + TOSTRING(object_list.size()) + "] (" + object_list[m_object_index].name + ")";
-        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png", 2000, false);
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "infromation.png");
         if (m_object_tracking)
         {
             App::GetGameContext()->GetPlayerCharacter()->setPosition(object_list[m_object_index].node->getPosition());


### PR DESCRIPTION
Now if icon is given in `putMessage()` it will show up, if not, per area icons apply as before.

There are a lot, some of them:
![screenshot_2021-10-28_20-46-14_1](https://user-images.githubusercontent.com/2660424/139309094-1b907779-e5e1-4659-97a3-b280487585db.png)
![screenshot_2021-10-28_20-46-29_1](https://user-images.githubusercontent.com/2660424/139309107-4508dd3d-03ae-4722-a04f-3e7a84b184bb.png)
![kk](https://user-images.githubusercontent.com/2660424/139314445-25672cd7-7aa1-4b2a-b797-1396c1029b55.png)
![kk](https://user-images.githubusercontent.com/2660424/139703443-2cef38f4-3a20-40d5-aa96-aa8cf8840984.png)

Also cleaned up `putMessage()`, except https://github.com/RigsOfRods/rigs-of-rods/blob/d4ace1fb9787359c46697fc39980a12b7703b681/source/main/scripting/ScriptEngine.cpp#L269 to prevent breakage of https://github.com/tritonas00/RoRServerScripts