### PR TITLE
Code clarity: Using `NodeNum_t/NODENUM_INVALID` instead of `int/-1`

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -415,7 +415,7 @@ void GameContext::ChangePlayerActor(Actor* actor)
             float h = prev_player_actor->getMinCameraRadius();
             float rotation = prev_player_actor->getRotation() - Ogre::Math::HALF_PI;
             Ogre::Vector3 position = prev_player_actor->getPosition();
-            if (prev_player_actor->ar_cinecam_node[0] != -1)
+            if (prev_player_actor->ar_cinecam_node[0] != NODENUM_INVALID)
             {
                 // actor has a cinecam (find optimal exit position)
                 Ogre::Vector3 l = position - 2.0f * prev_player_actor->GetCameraRoll();
@@ -872,7 +872,7 @@ void GameContext::UpdateSimInputEvents(float dt)
             {
                 if (!actor->ar_driveable)
                     continue;
-                if (actor->ar_cinecam_node[0] == -1)
+                if (actor->ar_cinecam_node[0] == NODENUM_INVALID)
                 {
                     LOG("cinecam missing, cannot enter the actor!");
                     continue;

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -99,7 +99,7 @@ void SceneMouse::releaseMousePick()
 
 void SceneMouse::reset()
 {
-    minnode = -1;
+    minnode = NODENUM_INVALID;
     grab_truck = 0;
     mindist = 99999;
     mouseGrabState = 0;
@@ -123,7 +123,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
         Ray mouseRay = getMouseRay();
 
         // walk all trucks
-        minnode = -1;
+        minnode = NODENUM_INVALID;
         grab_truck = NULL;
         for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
@@ -147,7 +147,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
                         if (pair.second < mindist)
                         {
                             mindist = pair.second;
-                            minnode = j;
+                            minnode = (NodeNum_t)j;
                             grab_truck = actor;
                         }
                     }
@@ -156,7 +156,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
         }
 
         // check if we hit a node
-        if (grab_truck && minnode != -1)
+        if (grab_truck && minnode != NODENUM_INVALID)
         {
             mouseGrabState = 1;
 
@@ -264,7 +264,7 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
         {
             Real nearest_camera_distance = std::numeric_limits<float>::max();
             Real nearest_ray_distance = std::numeric_limits<float>::max();
-            int nearest_node_index = -1;
+            NodeNum_t nearest_node_index = NODENUM_INVALID;
 
             for (int i = 0; i < player_actor->ar_num_nodes; i++)
             {
@@ -277,7 +277,7 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
                     {
                         nearest_camera_distance = pair.second;
                         nearest_ray_distance = ray_distance;
-                        nearest_node_index = i;
+                        nearest_node_index = (NodeNum_t)i;
                     }
                 }
             }

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "Application.h"
+#include "SimData.h"
 #include <OIS.h>
 
 #include <OIS.h>
@@ -55,7 +56,7 @@ protected:
     Ogre::SceneNode* pickLineNode;
     int mouseGrabState;
 
-    int minnode;
+    NodeNum_t minnode = NODENUM_INVALID;
     float mindist;
     Actor* grab_truck;
     Ogre::Vector3 lastgrabpos;

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -175,8 +175,8 @@ public:
         bool             xa_speedo_use_engine_max_rpm;
         int              xa_num_gears; //!< Gearbox
         float            xa_engine_max_rpm;
-        int              xa_camera0_pos_node;
-        int              xa_camera0_roll_node;
+        NodeNum_t        xa_camera0_pos_node;
+        NodeNum_t        xa_camera0_roll_node;
         int              xa_driveable;
         bool             xa_has_autopilot;
         bool             xa_has_engine;

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -107,9 +107,9 @@ struct Prop
         , pp_aero_propeller_spin(false)
     {}
 
-    uint16_t              pp_node_ref             = node_t::INVALID_IDX;
-    uint16_t              pp_node_x               = node_t::INVALID_IDX;
-    uint16_t              pp_node_y               = node_t::INVALID_IDX;
+    NodeNum_t             pp_node_ref             = NODENUM_INVALID;
+    NodeNum_t             pp_node_x               = NODENUM_INVALID;
+    NodeNum_t             pp_node_y               = NODENUM_INVALID;
     Ogre::Vector3         pp_offset               = Ogre::Vector3::ZERO;
     Ogre::Vector3         pp_offset_orig          = Ogre::Vector3::ZERO; //!< Used with ANIM_FLAG_OFFSET*
     Ogre::Vector3         pp_rota                 = Ogre::Vector3::ZERO;
@@ -154,11 +154,11 @@ enum VideoCamType
 struct VideoCamera
 {
     VideoCamType         vcam_type           = VCTYPE_INVALID;
-    uint16_t             vcam_node_center    = node_t::INVALID_IDX;
-    uint16_t             vcam_node_dir_y     = node_t::INVALID_IDX;
-    uint16_t             vcam_node_dir_z     = node_t::INVALID_IDX;
-    uint16_t             vcam_node_alt_pos   = node_t::INVALID_IDX;
-    uint16_t             vcam_node_lookat    = node_t::INVALID_IDX; //!< Only for VCTYPE_TRACK_CAM
+    NodeNum_t            vcam_node_center    = NODENUM_INVALID;
+    NodeNum_t            vcam_node_dir_y     = NODENUM_INVALID;
+    NodeNum_t            vcam_node_dir_z     = NODENUM_INVALID;
+    NodeNum_t            vcam_node_alt_pos   = NODENUM_INVALID;
+    NodeNum_t            vcam_node_lookat    = NODENUM_INVALID; //!< Only for VCTYPE_TRACK_CAM
     Ogre::Quaternion     vcam_rotation;
     Ogre::Vector3        vcam_pos_offset     = Ogre::Vector3::ZERO;
     Ogre::MaterialPtr    vcam_material;
@@ -174,7 +174,7 @@ struct VideoCamera
 /// Gfx attributes/state of a softbody node
 struct NodeGfx
 {
-    NodeGfx(uint16_t node_idx):
+    NodeGfx(NodeNum_t node_idx):
         nx_node_idx(node_idx),
         nx_no_particles(false), // Bitfields can't be initialized in-class :(
         nx_may_get_wet(false),
@@ -184,7 +184,7 @@ struct NodeGfx
     {}
 
     float      nx_wet_time_sec = -1; //!< 'Wet' means "already out of water, producing dripping particles". Set to -1 when not 'wet'.
-    uint16_t   nx_node_idx = node_t::INVALID_IDX;
+    NodeNum_t  nx_node_idx = NODENUM_INVALID;
 
     // Bit flags
     bool       nx_no_particles:1;     //!< User-defined attr; disable all particles
@@ -203,8 +203,8 @@ struct Rod
     uint16_t         rod_beam_index      = 0;
     uint16_t         rod_diameter_mm     = 0;                    //!< Diameter in millimeters
 
-    uint16_t         rod_node1           = node_t::INVALID_IDX;  //!< Node index - may change during simulation!
-    uint16_t         rod_node2           = node_t::INVALID_IDX;  //!< Node index - may change during simulation!
+    NodeNum_t        rod_node1           = NODENUM_INVALID;  //!< Node index - may change during simulation!
+    NodeNum_t        rod_node2           = NODENUM_INVALID;  //!< Node index - may change during simulation!
     Actor*           rod_target_actor    = nullptr;
     bool             rod_is_visible      = false;
 };
@@ -222,9 +222,9 @@ struct AirbrakeGfx
     Ogre::SceneNode* abx_scenenode;
     Ogre::Entity*    abx_entity;
     Ogre::Vector3    abx_offset;
-    uint16_t         abx_ref_node;
-    uint16_t         abx_x_node;
-    uint16_t         abx_y_node;
+    NodeNum_t        abx_ref_node = NODENUM_INVALID;
+    NodeNum_t        abx_x_node   = NODENUM_INVALID;
+    NodeNum_t        abx_y_node   = NODENUM_INVALID;
 };
 
 struct FlareMaterial // materialflares

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -208,9 +208,9 @@ void CameraManager::UpdateCurrentBehavior()
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM: {
         CameraManager::CameraBehaviorOrbitUpdate();
 
-        int pos_node  = m_cct_player_actor->ar_camera_node_pos [m_cct_player_actor->ar_current_cinecam];
-        int dir_node  = m_cct_player_actor->ar_camera_node_dir [m_cct_player_actor->ar_current_cinecam];
-        int roll_node = m_cct_player_actor->ar_camera_node_roll[m_cct_player_actor->ar_current_cinecam];
+        const NodeNum_t pos_node  = m_cct_player_actor->ar_camera_node_pos [m_cct_player_actor->ar_current_cinecam];
+        const NodeNum_t dir_node  = m_cct_player_actor->ar_camera_node_dir [m_cct_player_actor->ar_current_cinecam];
+        const NodeNum_t roll_node = m_cct_player_actor->ar_camera_node_roll[m_cct_player_actor->ar_current_cinecam];
 
         Vector3 dir  = (m_cct_player_actor->ar_nodes[pos_node].AbsPosition
                 - m_cct_player_actor->ar_nodes[dir_node].AbsPosition).normalisedCopy();
@@ -1075,7 +1075,7 @@ bool CameraManager::CameraBehaviorVehicleMousePressed(const OIS::MouseEvent& _ar
 
 	if ( ms.buttonDown(OIS::MB_Middle) && RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) )
 	{
-		if ( m_cct_player_actor && m_cct_player_actor->ar_custom_camera_node >= 0 )
+		if ( m_cct_player_actor && m_cct_player_actor->ar_custom_camera_node != NODENUM_INVALID)
 		{
 			// Calculate new camera distance
 			Vector3 lookAt = m_cct_player_actor->ar_nodes[m_cct_player_actor->ar_custom_camera_node].AbsPosition;

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1047,7 +1047,7 @@ void Actor::resolveCollisions(float max_distance, bool consider_up)
 void Actor::calculateAveragePosition()
 {
     // calculate average position
-    if (ar_custom_camera_node >= 0)
+    if (ar_custom_camera_node != NODENUM_INVALID)
     {
         m_avg_node_position = ar_nodes[ar_custom_camera_node].AbsPosition;
     }
@@ -1056,7 +1056,7 @@ void Actor::calculateAveragePosition()
         // the new (strange) approach: reuse the cinecam node
         m_avg_node_position = ar_nodes[ar_cinecam_node[0]].AbsPosition;
     }
-    else if (ar_extern_camera_mode == 2 && ar_extern_camera_node >= 0)
+    else if (ar_extern_camera_mode == 2 && ar_extern_camera_node != NODENUM_INVALID)
     {
         // the new (strange) approach #2: reuse a specified node
         m_avg_node_position = ar_nodes[ar_extern_camera_node].AbsPosition;
@@ -1244,7 +1244,7 @@ void Actor::resetPosition(Vector3 translation, bool setInitPosition)
     calculateAveragePosition();
 }
 
-void Actor::mouseMove(int node, Vector3 pos, float force)
+void Actor::mouseMove(NodeNum_t node, Vector3 pos, float force)
 {
     m_mouse_grab_node = node;
     m_mouse_grab_move_force = force * std::pow(m_total_mass / 3000.0f, 0.75f);
@@ -2712,7 +2712,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                         if (trigger_hooks)
                         {
                             //autolock hooktoggle unlock
-                            hookToggle(ar_beams[i].shock->trigger_cmdlong, HOOK_UNLOCK, -1);
+                            hookToggle(ar_beams[i].shock->trigger_cmdlong, HOOK_UNLOCK, NODENUM_INVALID);
                         }
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_HOOK_LOCK)
@@ -2720,7 +2720,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                         if (trigger_hooks)
                         {
                             //autolock hooktoggle lock
-                            hookToggle(ar_beams[i].shock->trigger_cmdlong, HOOK_LOCK, -1);
+                            hookToggle(ar_beams[i].shock->trigger_cmdlong, HOOK_LOCK, NODENUM_INVALID);
                         }
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_ENGINE)
@@ -2751,7 +2751,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                         if (trigger_hooks)
                         {
                             //autolock hooktoggle unlock
-                            hookToggle(ar_beams[i].shock->trigger_cmdshort, HOOK_UNLOCK, -1);
+                            hookToggle(ar_beams[i].shock->trigger_cmdshort, HOOK_UNLOCK, NODENUM_INVALID);
                         }
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_HOOK_LOCK)
@@ -2759,7 +2759,7 @@ void Actor::CalcTriggers(int i, Real difftoBeamL, bool trigger_hooks)
                         if (trigger_hooks)
                         {
                             //autolock hooktoggle lock
-                            hookToggle(ar_beams[i].shock->trigger_cmdshort, HOOK_LOCK, -1);
+                            hookToggle(ar_beams[i].shock->trigger_cmdshort, HOOK_LOCK, NODENUM_INVALID);
                         }
                     }
                     else if (ar_beams[i].shock->flags & SHOCK_FLAG_TRG_ENGINE)
@@ -3603,7 +3603,7 @@ void Actor::ropeToggle(int group)
     }
 }
 
-void Actor::hookToggle(int group, HookAction mode, int node_number)
+void Actor::hookToggle(int group, HookAction mode, NodeNum_t node_number /*=NODENUM_INVALID*/)
 {
     // iterate over all hooks
     for (std::vector<hook_t>::iterator it = ar_hooks.begin(); it != ar_hooks.end(); it++)
@@ -4396,18 +4396,13 @@ Actor::Actor(
     , m_avg_node_position_prev(rq.asr_position)
     , ar_left_mirror_angle(0.52)
     , m_avg_node_velocity(Ogre::Vector3::ZERO)
-    , ar_custom_camera_node(-1)
     , ar_main_camera_dir_corr(Ogre::Quaternion::IDENTITY)
-    , ar_main_camera_node_pos(0)
-    , ar_main_camera_node_dir(0)
-    , ar_main_camera_node_roll(0)
     , m_preloaded_with_terrain(rq.asr_origin == RoR::ActorSpawnRequest::Origin::TERRN_DEF)
     , ar_net_source_id(0)
     , m_spawn_rotation(0.0)
     , ar_net_stream_id(0)
     , m_min_camera_radius(0.0f)
     , m_mouse_grab_move_force(0.0f)
-    , m_mouse_grab_node(-1)
     , m_mouse_grab_pos(Ogre::Vector3::ZERO)
     , m_net_initialized(false)
     , ar_initial_total_mass(0)

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -100,12 +100,12 @@ public:
     //! @}
 
     //! @{ User interaction functions
-    void              mouseMove(int node, Ogre::Vector3 pos, float force);
+    void              mouseMove(NodeNum_t node, Ogre::Vector3 pos, float force);
     void              lightsToggle();
     void              setLightsOff();
     void              tieToggle(int group=-1);
     bool              isTied();
-    void              hookToggle(int group=-1, HookAction mode=HOOK_TOGGLE, int node_number=-1);
+    void              hookToggle(int group=-1, HookAction mode=HOOK_TOGGLE, NodeNum_t node_number=NODENUM_INVALID);
     bool              isLocked();                          //!< Are hooks locked?
     void              ropeToggle(int group=-1);
     void              engineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
@@ -264,7 +264,7 @@ public:
     int               ar_buoycabs[MAX_CABS];
     int               ar_buoycab_types[MAX_CABS];
     int               ar_num_buoycabs;
-    int               ar_camera_rail[MAX_CAMERARAIL]; //!< Nodes defining camera-movement spline
+    NodeNum_t         ar_camera_rail[MAX_CAMERARAIL]; //!< Nodes defining camera-movement spline
     int               ar_num_camera_rails;
     bool              ar_hide_in_actor_list;      //!< Hide in list of spawned actors (available in top menubar). Useful for fixed-place machinery, i.e. cranes.
     Ogre::String      ar_design_name;             //!< Name of the vehicle/machine/object this actor represents
@@ -294,28 +294,28 @@ public:
     bool              sl_enabled;         //!< Speed limiter;
     float             sl_speed_limit;     //!< Speed limiter;
     int               ar_extern_camera_mode;
-    int               ar_extern_camera_node;
-    int               ar_exhaust_pos_node; //!< Old-format exhaust (one per vehicle) emitter node
-    int               ar_exhaust_dir_node; //!< Old-format exhaust (one per vehicle) backwards direction node
+    NodeNum_t         ar_extern_camera_node = NODENUM_INVALID;
+    NodeNum_t         ar_exhaust_pos_node   = 0;   //!< Old-format exhaust (one per vehicle) emitter node
+    NodeNum_t         ar_exhaust_dir_node   = 0;   //!< Old-format exhaust (one per vehicle) backwards direction node
     int               ar_instance_id;              //!< Static attr; session-unique ID
     unsigned int      ar_vector_index;             //!< Sim attr; actor element index in std::vector<m_actors>
     ActorType         ar_driveable;                //!< Sim attr; marks vehicle type and features
     EngineSim*        ar_engine;
-    int               ar_cinecam_node[MAX_CAMERAS];//!< Sim attr; Cine-camera node indexes
+    NodeNum_t         ar_cinecam_node[MAX_CAMERAS] = {NODENUM_INVALID}; //!< Sim attr; Cine-camera node indexes
     int               ar_num_cinecams;             //!< Sim attr;
     Autopilot*        ar_autopilot;
     float             ar_brake_force;              //!< Physics attr; filled at spawn
     float             ar_speedo_max_kph;           //!< GUI attr
     Ogre::Vector3     ar_origin;                   //!< Physics state; base position for softbody nodes
     int               ar_num_cameras;
-    Ogre::Quaternion  ar_main_camera_dir_corr;     //!< Sim attr;
-    int               ar_main_camera_node_pos;     //!< Sim attr; ar_camera_node_pos[0]  >= 0 ? ar_camera_node_pos[0]  : 0
-    int               ar_main_camera_node_dir;     //!< Sim attr; ar_camera_node_dir[0]  >= 0 ? ar_camera_node_dir[0]  : 0
-    int               ar_main_camera_node_roll;    //!< Sim attr; ar_camera_node_roll[0] >= 0 ? ar_camera_node_roll[0] : 0
-    int               ar_camera_node_pos[MAX_CAMERAS]; //!< Physics attr; 'camera' = frame of reference; origin node
-    int               ar_camera_node_dir[MAX_CAMERAS]; //!< Physics attr; 'camera' = frame of reference; back node
-    int               ar_camera_node_roll[MAX_CAMERAS]; //!< Physics attr; 'camera' = frame of reference; left node
-    bool              ar_camera_node_roll_inv[MAX_CAMERAS]; //!< Physics attr; 'camera' = frame of reference; indicates roll node is right instead of left
+    Ogre::Quaternion  ar_main_camera_dir_corr;              //!< Sim attr;
+    NodeNum_t         ar_main_camera_node_pos            = 0;    //!< Sim attr; ar_camera_node_pos[0]  >= 0 ? ar_camera_node_pos[0]  : 0
+    NodeNum_t         ar_main_camera_node_dir            = 0;    //!< Sim attr; ar_camera_node_dir[0]  >= 0 ? ar_camera_node_dir[0]  : 0
+    NodeNum_t         ar_main_camera_node_roll           = 0;    //!< Sim attr; ar_camera_node_roll[0] >= 0 ? ar_camera_node_roll[0] : 0
+    NodeNum_t         ar_camera_node_pos[MAX_CAMERAS]    = {NODENUM_INVALID};  //!< Physics attr; 'camera' = frame of reference; origin node
+    NodeNum_t         ar_camera_node_dir[MAX_CAMERAS]    = {NODENUM_INVALID};  //!< Physics attr; 'camera' = frame of reference; back node
+    NodeNum_t         ar_camera_node_roll[MAX_CAMERAS]   = {NODENUM_INVALID};  //!< Physics attr; 'camera' = frame of reference; left node
+    bool              ar_camera_node_roll_inv[MAX_CAMERAS] = {false};              //!< Physics attr; 'camera' = frame of reference; indicates roll node is right instead of left
     float             ar_posnode_spawn_height;
     VehicleAI*        ar_vehicle_ai;
     float             ar_scale;               //!< Physics state; scale of the actor (nominal = 1.0)
@@ -344,7 +344,7 @@ public:
     int               ar_aerial_flap;                 //!< Sim state; state of aircraft flaps (values: 0-5)
     Ogre::Vector3     ar_fusedrag;                    //!< Physics state
     int               ar_current_cinecam;             //!< Sim state; index of current CineCam (-1 if using 3rd-person camera)
-    int               ar_custom_camera_node;          //!< Sim state; custom tracking node for 3rd-person camera
+    NodeNum_t         ar_custom_camera_node = NODENUM_INVALID; //!< Sim state; custom tracking node for 3rd-person camera
     std::string       ar_filename;                    //!< Attribute; filled at spawn
     std::string       ar_filehash;                    //!< Attribute; filled at spawn
     int               ar_airbrake_intensity;          //!< Physics state; values 0-5
@@ -464,7 +464,7 @@ private:
     float             m_stabilizer_shock_sleep;     //!< Sim state
     Replay*           m_replay_handler;
     float             m_total_mass;            //!< Physics state; total mass in Kg
-    int               m_mouse_grab_node;       //!< Sim state; node currently being dragged by user
+    NodeNum_t         m_mouse_grab_node = NODENUM_INVALID;  //!< Sim state; node currently being dragged by user
     Ogre::Vector3     m_mouse_grab_pos;
     float             m_mouse_grab_move_force;
     float             m_spawn_rotation;

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -90,7 +90,7 @@ void Actor::CalcForceFeedback(bool doUpdate)
 
 void Actor::CalcMouse()
 {
-    if (m_mouse_grab_node != -1)
+    if (m_mouse_grab_node != NODENUM_INVALID)
     {
         Vector3 dir = m_mouse_grab_pos - ar_nodes[m_mouse_grab_node].AbsPosition;
         ar_nodes[m_mouse_grab_node].Forces += m_mouse_grab_move_force * dir;
@@ -1524,7 +1524,7 @@ void Actor::CalcNodes()
     const float gravity = App::GetSimTerrain()->getGravity();
     m_water_contact = false;
 
-    for (int i = 0; i < ar_num_nodes; i++)
+    for (NodeNum_t i = 0; i < ar_num_nodes; i++)
     {
         // COLLISION
         if (!ar_nodes[i].nd_no_ground_contact)

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -159,7 +159,7 @@ public:
     * @return Index of existing node
     * @throws Exception If the node isn't found.
     */
-    unsigned int GetNodeIndexOrThrow(RigDef::Node::Ref const & id);
+    NodeNum_t GetNodeIndexOrThrow(RigDef::Node::Ref const & id);
 
     static void SetupDefaultSoundSources(Actor *vehicle);
 
@@ -555,14 +555,14 @@ private:
 /* Partial processing functions.                                              */
 /* -------------------------------------------------------------------------- */
 
-    void BuildAerialEngine(
-        int ref_node_index,
-        int back_node_index,
-        int blade_1_node_index,
-        int blade_2_node_index,
-        int blade_3_node_index,
-        int blade_4_node_index,
-        int couplenode_index,
+    void BuildAeroEngine(
+        NodeNum_t ref_node_index,
+        NodeNum_t back_node_index,
+        NodeNum_t blade_1_node_index,
+        NodeNum_t blade_2_node_index,
+        NodeNum_t blade_3_node_index,
+        NodeNum_t blade_4_node_index,
+        NodeNum_t couplenode_index,
         bool is_turboprops,
         Ogre::String const & airfoil,
         float power,
@@ -595,7 +595,7 @@ private:
 
     RailGroup *CreateRail(std::vector<RigDef::Node::Range> & node_ranges);
 
-    static void AddSoundSource(Actor *vehicle, SoundScriptInstance *sound_script, int node_index, int type = -2);
+    static void AddSoundSource(Actor *vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type = -2);
 
     static void AddSoundSourceInstance(Actor *vehicle, Ogre::String const & sound_script_name, int node_index, int type = -2);
 
@@ -680,7 +680,7 @@ private:
     * Seeks node in both RigDef::File definition and rig_t generated rig.
     * @return Node index or -1 if the node was not found.
     */
-    int FindNodeIndex(RigDef::Node::Ref & node_ref, bool silent = false);
+    NodeNum_t FindNodeIndex(RigDef::Node::Ref & node_ref, bool silent = false);
 
     /**
     * Finds wheel with given axle nodes and returns it's index.
@@ -716,7 +716,7 @@ private:
     * Finds existing node by Node::Ref
     * @return First: Index of existing node; Second: true if node was found.
     */
-    std::pair<unsigned int, bool> GetNodeIndex(RigDef::Node::Ref const & node_ref, bool quiet = false);
+    std::pair<NodeNum_t, bool> GetNodeIndex(RigDef::Node::Ref const & node_ref, bool quiet = false);
 
     /**
     * Finds existing node by Node::Ref
@@ -756,7 +756,7 @@ private:
     * Finds existing node by index.
     * @return Pointer to node or nullptr if not found.
     */
-    node_t & GetNode(unsigned int node_index);
+    node_t & GetNode(NodeNum_t node_index);
 
     /**
     * Sets up defaults & position of a node.
@@ -793,7 +793,7 @@ private:
     */
     bool CollectNodesFromRanges(
         std::vector<RigDef::Node::Range> & node_ranges,
-        std::vector<unsigned int> & out_node_indices
+        std::vector<NodeNum_t> & out_node_indices
     );
 
     /**
@@ -835,7 +835,7 @@ private:
 
     void SetBeamDamping(beam_t & beam, float damping);
 
-    beam_t *FindBeamInRig(unsigned int node_a, unsigned int node_b);
+    beam_t *FindBeamInRig(NodeNum_t node_a, NodeNum_t node_b);
 
     void SetBeamDeformationThreshold(beam_t & beam, std::shared_ptr<RigDef::BeamDefaults> beam_defaults);
 
@@ -912,7 +912,7 @@ private:
     /**
     * Validator for the rotator reference structure
     */
-    void ValidateRotator(int id, int axis1, int axis2, int *nodes1, int *nodes2);
+    void ValidateRotator(int id, int axis1, int axis2, NodeNum_t *nodes1, NodeNum_t *nodes2);
 
     /**
     * Helper for 'SetupNewEntity()' - see it's doc.

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -225,14 +225,13 @@ enum class ActorState
 // --------------------------------
 // Soft body physics
 
+typedef uint16_t NodeNum_t;
+static const NodeNum_t NODENUM_INVALID = std::numeric_limits<NodeNum_t>::max();
+
 /// Physics: A vertex in the softbody structure
 struct node_t
 {
-    // REFACTOR IN PROGRESS: Currently nodes are adressed mostly by pointers or int32_t indices,
-    //     although there was always a hidden soft limit of 2^16 nodes (because of `short node_t::pos`).
-    //     Let's use `uint16_t` indices everywhere to be clear.      ~ only_a_ptr, 04/2018
-    static const uint16_t INVALID_IDX = std::numeric_limits<uint16_t>::max();
-    static const int8_t   INVALID_BBOX = -1;
+    static const int8_t    INVALID_BBOX = -1;
 
     node_t()               { memset(this, 0, sizeof(node_t)); nd_coll_bbox_id = INVALID_BBOX; }
     node_t(size_t _pos)    { memset(this, 0, sizeof(node_t)); nd_coll_bbox_id = INVALID_BBOX; pos = static_cast<short>(_pos); }
@@ -248,7 +247,7 @@ struct node_t
     Ogre::Real      surface_coef;
     Ogre::Real      volume_coef;
 
-    int16_t         pos;                     //!< This node's index in Actor::ar_nodes array.
+    NodeNum_t       pos;                     //!< This node's index in Actor::ar_nodes array.
     int16_t         nd_coll_bbox_id;         //!< Optional attribute (-1 = none) - multiple collision bounding boxes defined in truckfile
     int16_t         nd_lockgroup;            //!< Optional attribute (-1 = default, 9999 = deny lock) - used in the hook lock logic
 
@@ -355,7 +354,7 @@ struct collcab_rate_t
 struct soundsource_t
 {
     SoundScriptInstance* ssi;
-    int nodenum;
+    NodeNum_t nodenum;
     int type;
 };
 
@@ -528,10 +527,10 @@ struct hydrobeam_t
 struct rotator_t
 {
     bool needs_engine;
-    int nodes1[4];
-    int nodes2[4];
-    int axis1; //!< rot axis
-    int axis2;
+    NodeNum_t nodes1[4];
+    NodeNum_t nodes2[4];
+    NodeNum_t axis1; //!< rot axis
+    NodeNum_t axis2;
     float angle;
     float rate;
     float force;
@@ -543,9 +542,9 @@ struct rotator_t
 
 struct flare_t
 {
-    int noderef;
-    int nodex;
-    int nodey;
+    NodeNum_t noderef = NODENUM_INVALID;
+    NodeNum_t nodex   = NODENUM_INVALID;
+    NodeNum_t nodey   = NODENUM_INVALID;
     float offsetx;
     float offsety;
     float offsetz;
@@ -564,8 +563,8 @@ struct flare_t
 
 struct exhaust_t
 {
-    int emitterNode;
-    int directionNode;
+    NodeNum_t emitterNode   = NODENUM_INVALID;
+    NodeNum_t directionNode = NODENUM_INVALID;
     Ogre::SceneNode *smokeNode;
     Ogre::ParticleSystem* smoker;
 };
@@ -573,8 +572,8 @@ struct exhaust_t
 
 struct cparticle_t
 {
-    int emitterNode;
-    int directionNode;
+    NodeNum_t emitterNode   = NODENUM_INVALID;
+    NodeNum_t directionNode = NODENUM_INVALID;
     bool active;
     Ogre::SceneNode *snode;
     Ogre::ParticleSystem* psys;

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -33,7 +33,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Turbojet::Turbojet(Actor* actor, int tnodefront, int tnodeback, int tnoderef, RigDef::Turbojet & def)
+Turbojet::Turbojet(Actor* actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def)
 {
     m_actor = actor;
 #ifdef USE_OPENAL
@@ -101,11 +101,14 @@ void TurbojetVisual::SetupVisuals(RigDef::Turbojet & def, int num, std::string c
     
 }
 
-void TurbojetVisual::SetNodes(int front, int back, int ref)
+void TurbojetVisual::SetNodes(NodeNum_t front, NodeNum_t back, NodeNum_t ref)
 {
-    m_node_front = static_cast<uint16_t>(front);
-    m_node_back  = static_cast<uint16_t>(back);
-    m_node_ref   = static_cast<uint16_t>(ref);
+    ROR_ASSERT(front != NODENUM_INVALID);
+    ROR_ASSERT(back != NODENUM_INVALID);
+
+    m_node_front = front;
+    m_node_back  = back;
+    m_node_ref   = ref;
 }
 
 Turbojet::~Turbojet()

--- a/source/main/physics/air/TurboJet.h
+++ b/source/main/physics/air/TurboJet.h
@@ -23,6 +23,7 @@
 #include "Application.h"
 #include "AeroEngine.h"
 #include "RigDef_File.h"
+#include "SimData.h"
 
 namespace RoR {
 
@@ -31,7 +32,7 @@ class TurbojetVisual
 public:
     ~TurbojetVisual();
     void SetupVisuals(RigDef::Turbojet & def, int num, std::string const& propname, Ogre::Entity* nozzle, Ogre::Entity* afterburner_flame);
-    void SetNodes(int front, int back, int ref);
+    void SetNodes(NodeNum_t front, NodeNum_t back, NodeNum_t ref);
     void UpdateVisuals(RoR::GfxActor* gfx_actor);
     void SetVisible(bool visible);
     bool IsVisible() const { return m_visible; }
@@ -47,9 +48,9 @@ private:
     bool     m_visible = false; // Needed for flames which are hidden by default.
     int      m_number;
     float    m_radius;
-    uint16_t m_node_back;
-    uint16_t m_node_front;
-    uint16_t m_node_ref;
+    NodeNum_t m_node_back                      = NODENUM_INVALID;
+    NodeNum_t m_node_front                     = NODENUM_INVALID;
+    NodeNum_t m_node_ref                       = NODENUM_INVALID;
 };
 
 class Turbojet: public AeroEngine, public ZeroedMemoryAllocator
@@ -57,7 +58,7 @@ class Turbojet: public AeroEngine, public ZeroedMemoryAllocator
 
 public:
 
-    Turbojet(Actor* actor, int tnodefront, int tnodeback, int tnoderef, RigDef::Turbojet & def);
+    Turbojet(Actor* actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def);
     ~Turbojet();
 
     void flipStart();
@@ -95,7 +96,6 @@ public:
     TurbojetVisual tjet_visual;
 
 private:
-    Actor* m_actor;
     Ogre::Vector3 m_axis;
     bool m_afterburner_active;
     bool m_is_failed;
@@ -118,11 +118,14 @@ private:
     float m_warmup_time;
     int m_sound_ab;
     int m_sound_mod;
-    int m_node_back;
-    int m_node_front;
-    int m_node_ref;
     int m_sound_src;
     int m_sound_thr;
+
+    // Attachment
+    Actor* m_actor;
+    NodeNum_t m_node_back;
+    NodeNum_t m_node_front;
+    NodeNum_t m_node_ref;
 };
 
 } // namespace RoR

--- a/source/main/physics/air/TurboProp.h
+++ b/source/main/physics/air/TurboProp.h
@@ -23,6 +23,9 @@
 #include "Application.h"
 
 #include "AeroEngine.h"
+#include "SimData.h"
+
+#include <Ogre.h>
 
 using namespace RoR;
 
@@ -36,19 +39,16 @@ public:
     float max_torque;
 
     Turboprop(
-        const char* propname,
-        node_t* nd,
-        int nr,
-        int nb,
-        int np1,
-        int np2,
-        int np3,
-        int np4,
-        int tqn,
+        Actor* a,
+        NodeNum_t nr,
+        NodeNum_t nb,
+        NodeNum_t np1,
+        NodeNum_t np2,
+        NodeNum_t np3,
+        NodeNum_t np4,
+        NodeNum_t tqn,
         float power,
         Ogre::String const& propfoilname,
-        int mnumber,
-        int trucknum,
         bool disable_smoke,
         bool ispiston,
         float fpitch
@@ -88,10 +88,6 @@ public:
 
 private:
 
-    node_t* nodes;
-    int nodeback;
-    int nodep[4];
-    int torquenode;
     float torquedist;
     Airfoil* airfoil;
     float fullpower; //!< in kW
@@ -101,7 +97,6 @@ private:
     float lastflip;
     float warmupstart;
     float warmuptime;
-    int number;
     int numblades;
     float bladewidth;
     float pitchspeed;
@@ -121,12 +116,17 @@ private:
     bool failedold;
     float rpm;
     float throtle;
-    int noderef;
     char debug[256];
     float propwash;
     Ogre::Vector3 axis;
-    int trucknum;
     int mod_id;
     int src_id;
     int thr_id;
+
+    // Attachment
+    Actor* m_actor;
+    NodeNum_t nodeback;
+    NodeNum_t noderef;
+    NodeNum_t nodep[4];
+    NodeNum_t torquenode;
 };

--- a/source/main/physics/flex/FlexAirfoil.cpp
+++ b/source/main/physics/flex/FlexAirfoil.cpp
@@ -74,8 +74,25 @@ float refairfoilpos[90]={
 
 using namespace Ogre;
 
-FlexAirfoil::FlexAirfoil(Ogre::String const & name, Actor* actor, int pnfld, int pnfrd, int pnflu, int pnfru, int pnbld, int pnbrd, int pnblu, int pnbru, std::string const & texband, Vector2 texlf, Vector2 texrf, Vector2 texlb, Vector2 texrb, char mtype, float controlratio, float mind, float maxd, Ogre::String const & afname, float lift_coef, bool break_able)
+FlexAirfoil::FlexAirfoil(Ogre::String const & name, Actor* actor, NodeNum_t pnfld, NodeNum_t pnfrd, NodeNum_t pnflu, NodeNum_t pnfru, NodeNum_t pnbld, NodeNum_t pnbrd, NodeNum_t pnblu, NodeNum_t pnbru, std::string const & texband, Vector2 texlf, Vector2 texrf, Vector2 texlb, Vector2 texrb, char mtype, float controlratio, float mind, float maxd, Ogre::String const & afname, float lift_coef, bool break_able)
+    :nfld(pnfld)
+    ,nfrd(pnfrd)
+    ,nflu(pnflu)
+    ,nfru(pnfru)
+    ,nbld(pnbld)
+    ,nbrd(pnbrd)
+    ,nblu(pnblu)
+    ,nbru(pnbru)
 {
+    ROR_ASSERT(pnfld != NODENUM_INVALID);
+    ROR_ASSERT(pnfrd != NODENUM_INVALID);
+    ROR_ASSERT(pnflu != NODENUM_INVALID);
+    ROR_ASSERT(pnfru != NODENUM_INVALID);
+    ROR_ASSERT(pnbld != NODENUM_INVALID);
+    ROR_ASSERT(pnbrd != NODENUM_INVALID);
+    ROR_ASSERT(pnblu != NODENUM_INVALID);
+    ROR_ASSERT(pnbru != NODENUM_INVALID);
+
     liftcoef=lift_coef;
     breakable=break_able;
     broken=false;
@@ -83,14 +100,7 @@ FlexAirfoil::FlexAirfoil(Ogre::String const & name, Actor* actor, int pnfld, int
     aeroengines=actor->ar_aeroengines;
     nodes=actor->ar_nodes;
     useInducedDrag=false;
-    nfld=pnfld;
-    nfrd=pnfrd;
-    nflu=pnflu;
-    nfru=pnfru;
-    nbld=pnbld;
-    nbrd=pnbrd;
-    nblu=pnblu;
-    nbru=pnbru;
+
     mindef=mind;
     maxdef=maxd;
     airfoil=new Airfoil(afname);

--- a/source/main/physics/flex/FlexAirfoil.h
+++ b/source/main/physics/flex/FlexAirfoil.h
@@ -31,7 +31,7 @@ class FlexAirfoil : public ZeroedMemoryAllocator
 {
 public:
     FlexAirfoil(Ogre::String const& wname, Actor* actor,
-        int pnfld, int pnfrd, int pnflu, int pnfru, int pnbld, int pnbrd, int pnblu, int pnbru,
+        NodeNum_t pnfld, NodeNum_t pnfrd, NodeNum_t pnflu, NodeNum_t pnfru, NodeNum_t pnbld, NodeNum_t pnbrd, NodeNum_t pnblu, NodeNum_t pnbru,
         std::string const & texname,
         Ogre::Vector2 texlf, Ogre::Vector2 texrf, Ogre::Vector2 texlb, Ogre::Vector2 texrb,
         char mtype, float controlratio, float mind, float maxd, Ogre::String const& afname, float lift_coef, bool break_able);
@@ -53,14 +53,14 @@ public:
 
     float aoa;
     char type;
-    int nfld;
-    int nfrd;
-    int nflu;
-    int nfru;
-    int nbld;
-    int nbrd;
-    int nblu;
-    int nbru;
+    NodeNum_t nfld;
+    NodeNum_t nfrd;
+    NodeNum_t nflu;
+    NodeNum_t nfru;
+    NodeNum_t nbld;
+    NodeNum_t nbrd;
+    NodeNum_t nblu;
+    NodeNum_t nbru;
 
     bool broken;
     bool breakable;

--- a/source/main/physics/flex/FlexBody.cpp
+++ b/source/main/physics/flex/FlexBody.cpp
@@ -39,9 +39,9 @@ FlexBody::FlexBody(
     RoR::FlexBodyCacheData* preloaded_from_cache,
     RoR::GfxActor* gfx_actor,
     Ogre::Entity* ent,
-    int ref,
-    int nx,
-    int ny,
+    NodeNum_t ref,
+    NodeNum_t nx,
+    NodeNum_t ny,
     Ogre::Quaternion const & rot,
     std::vector<unsigned int> & node_indices
 ):
@@ -63,6 +63,8 @@ FlexBody::FlexBody(
     , m_src_colors(nullptr)
     , m_gfx_actor(gfx_actor)
 {
+    ROR_ASSERT(m_node_x != NODENUM_INVALID);
+    ROR_ASSERT(m_node_y != NODENUM_INVALID);
 
     Ogre::Vector3* vertices = nullptr;
 
@@ -72,7 +74,7 @@ FlexBody::FlexBody(
 
     RoR::GfxActor::SimBuffer::NodeSB* nodes = m_gfx_actor->GetSimNodeBuffer();
 
-    if (ref >= 0)
+    if (m_node_center != NODENUM_INVALID)
     {
         Vector3 diffX = nodes[nx].AbsPosition-nodes[ref].AbsPosition;
         Vector3 diffY = nodes[ny].AbsPosition-nodes[ref].AbsPosition;
@@ -395,7 +397,7 @@ FlexBody::FlexBody(
                 LOG("FLEXBODY ERROR on mesh "+def->mesh_name+": REF node not found");
                 closest_node_index = 0;
             }
-            m_locators[i].ref=closest_node_index;            
+            m_locators[i].ref=closest_node_index;
 
             //search the second nearest node as the X vector
             closest_node_distance = std::numeric_limits<float>::max();

--- a/source/main/physics/flex/FlexBody.h
+++ b/source/main/physics/flex/FlexBody.h
@@ -24,11 +24,10 @@
 #include "RigDef_Prerequisites.h"
 #include "Application.h"
 #include "Locator_t.h"
+#include "SimData.h"
+#include "RigDef_File.h"
 
-#include <OgreVector3.h>
-#include <OgreQuaternion.h>
-#include <OgreHardwareVertexBuffer.h>
-#include <OgreMesh.h>
+#include <Ogre.h>
 
 namespace RoR {
 
@@ -43,9 +42,9 @@ class FlexBody
         RoR::FlexBodyCacheData* preloaded_from_cache,
         RoR::GfxActor* gfx_actor,
         Ogre::Entity* entity,
-        int ref, 
-        int nx, 
-        int ny,
+        NodeNum_t ref, 
+        NodeNum_t nx, 
+        NodeNum_t ny,
         Ogre::Quaternion const & rot, 
         std::vector<unsigned int> & node_indices
     );
@@ -85,9 +84,9 @@ private:
     Ogre::ARGB*       m_src_colors;
     Locator_t*        m_locators; //!< 1 loc per vertex
 
-    int               m_node_center;
-    int               m_node_x;
-    int               m_node_y;
+    NodeNum_t         m_node_center;
+    NodeNum_t         m_node_x;
+    NodeNum_t         m_node_y;
     Ogre::Vector3     m_center_offset;
     Ogre::SceneNode*  m_scene_node;
     Ogre::Entity*     m_scene_entity;

--- a/source/main/physics/flex/Locator_t.h
+++ b/source/main/physics/flex/Locator_t.h
@@ -1,12 +1,17 @@
 #pragma once
 
 #include <OgreVector3.h>
+#include <SimData.h>
+
+namespace RoR {
 
 struct Locator_t
 {
-    int ref;
-    int nx;
-    int ny;
-    int nz;
+    NodeNum_t ref;
+    NodeNum_t nx;
+    NodeNum_t ny;
+    NodeNum_t nz;
     Ogre::Vector3 coords;
 };
+
+} // namespace RoR

--- a/source/main/physics/water/ScrewProp.cpp
+++ b/source/main/physics/water/ScrewProp.cpp
@@ -21,6 +21,7 @@
 #include "ScrewProp.h"
 
 #include "Application.h"
+#include "Actor.h"
 #include "SimData.h"
 #include "ActorManager.h"
 #include "DustPool.h"
@@ -32,13 +33,12 @@
 using namespace Ogre;
 using namespace RoR;
 
-Screwprop::Screwprop(node_t* nodes, int noderef, int nodeback, int nodeup, float fullpower, int trucknum) :
-    nodes(nodes)
+Screwprop::Screwprop(Actor* a, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float fullpower) :
+    m_actor(a)
     , noderef(noderef)
     , nodeback(nodeback)
     , nodeup(nodeup)
     , fullpower(fullpower)
-    , trucknum(trucknum)
 {
     splashp = RoR::App::GetGfxScene()->GetDustPool("splash");
     ripplep = RoR::App::GetGfxScene()->GetDustPool("ripple");
@@ -50,25 +50,25 @@ void Screwprop::updateForces(int update)
     if (!App::GetSimTerrain()->getWater())
         return;
 
-    float depth = App::GetSimTerrain()->getWater()->CalcWavesHeight(nodes[noderef].AbsPosition) - nodes[noderef].AbsPosition.y;
+    float depth = App::GetSimTerrain()->getWater()->CalcWavesHeight(m_actor->ar_nodes[noderef].AbsPosition) - m_actor->ar_nodes[noderef].AbsPosition.y;
     if (depth < 0)
         return; //out of water!
-    Vector3 dir = nodes[nodeback].RelPosition - nodes[noderef].RelPosition;
-    Vector3 rudaxis = nodes[noderef].RelPosition - nodes[nodeup].RelPosition;
+    Vector3 dir = m_actor->ar_nodes[nodeback].RelPosition - m_actor->ar_nodes[noderef].RelPosition;
+    Vector3 rudaxis = m_actor->ar_nodes[noderef].RelPosition - m_actor->ar_nodes[nodeup].RelPosition;
     dir.normalise();
     if (reverse)
         dir = -dir;
     rudaxis.normalise();
     dir = (throtle * fullpower) * (Quaternion(Degree(rudder), rudaxis) * dir);
-    nodes[noderef].Forces += dir;
+    m_actor->ar_nodes[noderef].Forces += dir;
 
     if (update && splashp && throtle > 0.1)
     {
         if (depth < 0.2)
-            splashp->allocSplash(nodes[noderef].AbsPosition, 10.0 * dir / fullpower);
+            splashp->allocSplash(m_actor->ar_nodes[noderef].AbsPosition, 10.0 * dir / fullpower);
         else
-            splashp->allocSplash(nodes[noderef].AbsPosition, 5.0 * dir / fullpower);
-        ripplep->allocRipple(nodes[noderef].AbsPosition, 10.0 * dir / fullpower);
+            splashp->allocSplash(m_actor->ar_nodes[noderef].AbsPosition, 5.0 * dir / fullpower);
+        ripplep->allocRipple(m_actor->ar_nodes[noderef].AbsPosition, 10.0 * dir / fullpower);
     }
 }
 
@@ -82,7 +82,7 @@ void Screwprop::setThrottle(float val)
     reverse = (val < 0);
     //pseudo-rpm
     float prpm = (0.5 + fabs(val) / 2.0) * 100.0;
-    SOUND_MODULATE(trucknum, SS_MOD_ENGINE, prpm);
+    SOUND_MODULATE(m_actor, SS_MOD_ENGINE, prpm);
 }
 
 void Screwprop::setRudder(float val)

--- a/source/main/physics/water/ScrewProp.h
+++ b/source/main/physics/water/ScrewProp.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "Application.h"
+#include "SimData.h"
 
 namespace RoR {
 
@@ -28,7 +29,7 @@ class Screwprop : public ZeroedMemoryAllocator
 {
 public:
 
-    Screwprop( node_t *nd, int nr, int nb, int nu, float power, int trucknum);
+    Screwprop( Actor* actor, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float power);
 
     void updateForces(int update);
     void setThrottle(float val);
@@ -45,12 +46,12 @@ private:
     float fullpower; //!< in HP
     float rudder;
     float throtle;
-    int nodeback;
-    int noderef;
-    int nodeup;
-    int trucknum;
-    node_t *nodes;
 
+    // Attachment
+    Actor*    m_actor;
+    NodeNum_t nodeback;
+    NodeNum_t noderef;
+    NodeNum_t nodeup;
 };
 
 } // namespace RoR


### PR DESCRIPTION
This PR officially introduces a node limit of 65535 nodes (2^16 - 1). This limit was always present but rather hidden - all node number values were `int` (4 bytes) except `node_t::pos` which was `unsigned short` (2 bytes).

I introduced data type`NodeNum_t` and constant `NODENUM_INVALID` which should be used to address nodes instead of the classic `int` data type and `-1` value, or the newer but only scarcely used `uint16_t` data type and `node_t::INVALID_IDX` value.

2 exceptions:
* Flexbody generation - to be done (just internal - low importance).
* Savegame - to avoid version bump.