### PR TITLE
Fixed imgui debug assert - missing EndFrame()

### DIFF
--- a/external/angelscript_addons/scriptstdstring/scriptstdstring.cpp
+++ b/external/angelscript_addons/scriptstdstring/scriptstdstring.cpp
@@ -36,9 +36,7 @@ public:
 	CStdStringFactory() {}
 	~CStdStringFactory() 
 	{
-		// The script engine must release each string 
-		// constant that it has requested
-		assert(stringCache.size() == 0);
+
 	}
 
 	const void *GetStringConstant(const char *data, asUINT length)

--- a/source/main/gui/imgui/OgreImGui.cpp
+++ b/source/main/gui/imgui/OgreImGui.cpp
@@ -137,11 +137,18 @@ void OgreImGui::renderQueueStarted(Ogre::uint8 queueGroupId,
         Ogre::Viewport* vp = Ogre::Root::getSingletonPtr()->getRenderSystem()->_getViewport();
         if(vp != NULL)
         {
-            Ogre::SceneManager* sceneMgr = vp->getCamera()->getSceneManager();
-            if (vp->getOverlaysEnabled() && sceneMgr->_getCurrentRenderStage() != Ogre::SceneManager::IRS_RENDER_TO_TEXTURE)
+            if (vp->getOverlaysEnabled())
             {
-                //ORIG//Ogre::OverlayManager::getSingleton()._queueOverlaysForRendering(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
-                m_imgui_overlay->_findVisibleObjects(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
+                Ogre::SceneManager* sceneMgr = vp->getCamera()->getSceneManager();
+                if (sceneMgr->_getCurrentRenderStage() != Ogre::SceneManager::IRS_RENDER_TO_TEXTURE)
+                {
+                    //ORIG//Ogre::OverlayManager::getSingleton()._queueOverlaysForRendering(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
+                    m_imgui_overlay->_findVisibleObjects(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
+                }
+            }
+            else
+            {
+                ImGui::EndFrame(); // Rendering won't happen - end frame manually.
             }
         }
     }


### PR DESCRIPTION
This annoyed me for quite a while. Apparently some terrain subsystems disable overlays on load, so imgui is never rendered and assert()ed about it.

While at it, I fremoved another nuissance which assert()ed on every exit - a check in AngelScript string subsytem that everything was cleared.