### PR TITLE
Fixing DearIMGUI `NewFrame()/EndFrame()` cycle.

### DIFF
--- a/source/main/gui/imgui/OgreImGui.cpp
+++ b/source/main/gui/imgui/OgreImGui.cpp
@@ -137,18 +137,11 @@ void OgreImGui::renderQueueStarted(Ogre::uint8 queueGroupId,
         Ogre::Viewport* vp = Ogre::Root::getSingletonPtr()->getRenderSystem()->_getViewport();
         if(vp != NULL)
         {
-            if (vp->getOverlaysEnabled())
+            Ogre::SceneManager* sceneMgr = vp->getCamera()->getSceneManager();
+            if (vp->getOverlaysEnabled() && sceneMgr->_getCurrentRenderStage() != Ogre::SceneManager::IRS_RENDER_TO_TEXTURE)
             {
-                Ogre::SceneManager* sceneMgr = vp->getCamera()->getSceneManager();
-                if (sceneMgr->_getCurrentRenderStage() != Ogre::SceneManager::IRS_RENDER_TO_TEXTURE)
-                {
-                    //ORIG//Ogre::OverlayManager::getSingleton()._queueOverlaysForRendering(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
-                    m_imgui_overlay->_findVisibleObjects(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
-                }
-            }
-            else
-            {
-                ImGui::EndFrame(); // Rendering won't happen - end frame manually.
+                //ORIG//Ogre::OverlayManager::getSingleton()._queueOverlaysForRendering(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
+                m_imgui_overlay->_findVisibleObjects(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
             }
         }
     }

--- a/source/main/gui/imgui/OgreImGui.cpp
+++ b/source/main/gui/imgui/OgreImGui.cpp
@@ -25,6 +25,7 @@
 
 #include "OgreImGui.h"
 
+#include "AppContext.h"
 #include "ContentManager.h"
 #include "OgreImGuiOverlay.h"
 
@@ -140,8 +141,15 @@ void OgreImGui::renderQueueStarted(Ogre::uint8 queueGroupId,
             Ogre::SceneManager* sceneMgr = vp->getCamera()->getSceneManager();
             if (vp->getOverlaysEnabled() && sceneMgr->_getCurrentRenderStage() != Ogre::SceneManager::IRS_RENDER_TO_TEXTURE)
             {
-                //ORIG//Ogre::OverlayManager::getSingleton()._queueOverlaysForRendering(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
-                m_imgui_overlay->_findVisibleObjects(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
+                // Checking `sceneMgr->_getCurrentRenderStage() == Ogre::SceneManager::IRS_RENDER_TO_TEXTURE`)
+                // doesn't do the trick if the RTT is updated by calling `Ogre::RenderTarget::update()` by hand,
+                // which we do frequently.
+                // To compensate, we also check if the active viewport matches our screen viewport.
+                Ogre::Viewport* vp_target = App::GetAppContext()->GetViewport();
+                if (vp == vp_target)
+                {
+                    m_imgui_overlay->_findVisibleObjects(vp->getCamera(), sceneMgr->getRenderQueue(), vp);
+                }
             }
         }
     }


### PR DESCRIPTION
I'm getting debug asserts from DearIMGUI that `NewFrame()/EndFrame()` functions are not being called in sync. It only happens at certain stage of loading certain terrains. Things to know before moving further:
* our DearIMGUI integration is a port of OGRE 1.12's OgreImGuiOverlay, since we're still running at 1.11.6 (last time we checked, MyGUI didn't work with latest ogre).
* `NewFrame()` is invoked [from main()](https://github.com/RigsOfRods/rigs-of-rods/blob/4cd184a9606851ba89e13591c768f27239085e4b/source/main/main.cpp#L872)
* `Render()` is called from within [`Ogre::RenderQueueListener::renderQueueStarted()` callback](https://github.com/RigsOfRods/rigs-of-rods/blob/4cd184a9606851ba89e13591c768f27239085e4b/source/main/gui/imgui/OgreImGui.cpp#L131) implemented in [OgreImGui](https://github.com/RigsOfRods/rigs-of-rods/blob/4cd184a9606851ba89e13591c768f27239085e4b/source/main/gui/imgui/OgreImGui.h#L54)
* OGRE's `renderOneFrame()` is invoked from 2 places: [main()](https://github.com/RigsOfRods/rigs-of-rods/blob/4cd184a9606851ba89e13591c768f27239085e4b/source/main/main.cpp#L950) for regular gameplay frames and [progress window](https://github.com/RigsOfRods/rigs-of-rods/blob/4cd184a9606851ba89e13591c768f27239085e4b/source/main/gui/panels/GUI_LoadingWindow.cpp#L32) [[which itself is invoked indirectly from main]](https://github.com/RigsOfRods/rigs-of-rods/blob/4cd184a9606851ba89e13591c768f27239085e4b/source/main/main.cpp#L933-L940) when loading things.

### Original concern 
_Update: [root cause found](https://github.com/RigsOfRods/rigs-of-rods/pull/2834#issuecomment-995713443)_

`IM_ASSERT((g.FrameCount == 0 || g.FrameCountEnded == g.FrameCount)  && "Forgot to call Render() or EndFrame() at the end of the previous frame?");` in `NewFrameSanityChecks()`. This happens during loading [Aspen Grove](https://forum.rigsofrods.org/resources/aspen-grove.43/) terrain. When continued with debugger, the game runs fine. See logs:
[RoR-reverted-debuggerAbort.log](https://github.com/RigsOfRods/rigs-of-rods/files/7723554/RoR-reverted-debuggerAbort.log)
[RoR-reverted-debuggerContinueGameRuns.log](https://github.com/RigsOfRods/rigs-of-rods/files/7723555/RoR-reverted-debuggerContinueGameRuns.log)
Note that Train Valley loads without problem.

### The reverted commit 627d85b90bf833ff24de65f79903637951fc7a16 
it fixed the Aspen Grove case, but introduced another in Train Valley terrain: `IM_ASSERT(g.FrameScopeActive);                  // Forgot to call ImGui::NewFrame()` in `Begin()`. Continuing with debugger triggers the FrameCount assert, then FrameScope again, then FrameCount again and then it hangs in `Collisions::hashfunc()`. See logs.
[RoR-upstream-debugerAbort.log](https://github.com/RigsOfRods/rigs-of-rods/files/7723569/RoR-upstream-debugerAbort.log)
[RoR-upstream-debuggerContinue3x.log](https://github.com/RigsOfRods/rigs-of-rods/files/7723570/RoR-upstream-debuggerContinue3x.log)

### Test PC spec:
* OS Windows 10,  Version 10.0.19042 Build 19042
* Processor	AMD Ryzen 5 5600X 6-Core Processor, 3701 Mhz, 6 Core(s), 12 Logical Processor(s)
* Graphics card nVidia GeForce GTX 660, driver 466.27
* Microsoft Visual Studio Community 2019 Version 16.11.3
* using Debug x64, RenderSystem_GL

Tomorrow I'll add debug checks and re-run it to see when it breaks.