### PR TITLE
[TurboProp] Brought back propname

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -755,7 +755,8 @@ void ActorSpawner::BuildAeroEngine(
     int aeroengine_index = m_actor->ar_num_aeroengines;
 
     Turboprop *turbo_prop = new Turboprop(
-        m_actor, 
+        m_actor,
+        this->ComposeName("Turboprop", aeroengine_index).c_str(),
         ref_node_index,
         back_node_index,
         blade_1_node_index,

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -36,6 +36,7 @@ using namespace RoR;
 
 Turboprop::Turboprop(
     Actor* a,
+    const char* propname,
     NodeNum_t nr,
     NodeNum_t nb,
     NodeNum_t np1,
@@ -133,9 +134,10 @@ Turboprop::Turboprop(
     }
     else
     {
+        char dename[256];
+        sprintf(dename, "%s-smoke", propname);
         smokeNode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
-        smokePS = App::GetGfxScene()->GetSceneManager()->createParticleSystem(
-            fmt::format("TurboPropSmoke {}", m_actor->ar_num_aeroengines), "tracks/TurbopropSmoke");
+        smokePS = App::GetGfxScene()->GetSceneManager()->createParticleSystem(dename, "tracks/TurbopropSmoke");
         if (smokePS)
         {
             smokePS->setVisibilityFlags(DEPTHMAP_DISABLED); // disable particles in depthmap

--- a/source/main/physics/air/TurboProp.h
+++ b/source/main/physics/air/TurboProp.h
@@ -40,6 +40,7 @@ public:
 
     Turboprop(
         Actor* a,
+        const char* propname,
         NodeNum_t nr,
         NodeNum_t nb,
         NodeNum_t np1,


### PR DESCRIPTION
Fixes crash when spawning two skyvans with particle system enabled:

```
[RoR|Actor|Error] (Keyword: turboprops2) ItemIdentityException: An object of type 'ParticleSystem' with name 'TurboPropSmoke 0' already exists. in SceneManager::createMovableObject at /home/runner/.conan/data/ogre3d/1.11.6.1/anotherfoxguy/stable/build/feae01c5ea595a814bc5825447abdab1e39d6062/OgreMain/src/OgreSceneManager.cpp (line 4117)
```

Introduced with https://github.com/RigsOfRods/rigs-of-rods/commit/a8ad30bdd42f64874549681eebd599307c4a156f