### PR TITLE
Basic support for plugin scripts.

### DIFF
--- a/doc/angelscript/InputEngineClass.h
+++ b/doc/angelscript/InputEngineClass.h
@@ -1,0 +1,31 @@
+
+
+/**
+ * @brief Manages input devices, their configuration (input.map ...) and state.
+ * @note This object is created automatically as global variable `inputs`.
+ */
+class InputEngineClass
+{
+public:
+    /**
+     * @return full configuration string for given command, including the EXPL modifier.
+     */
+    string getEventCommand(inputEvents ev);
+    
+    /**
+     * @return configuration string for given command, omitting the EXPL modifier.
+     */
+    string getEventCommandTrimmed(inputEvents ev);
+
+    /**
+     * @return true if the event input is active (keyboard key pressed etc.).
+     */
+    bool getEventBoolValue(inputEvents ev);
+
+    /**
+     * @return true if the event input is active (keyboard key pressed etc.)
+     *         and the bouncing on/off cycle is in 'on' state.
+     */
+    bool getEventBoolValueBounce(inputEvents ev, float time=0.2);    
+
+};

--- a/doc/angelscript/global_functions.h
+++ b/doc/angelscript/global_functions.h
@@ -73,6 +73,324 @@ void print(const string message);
 
  };
 
+enum inputEvents
+{
+    EV_AIRPLANE_AIRBRAKES_FULL=0,
+    EV_AIRPLANE_AIRBRAKES_LESS,
+    EV_AIRPLANE_AIRBRAKES_MORE,
+    EV_AIRPLANE_AIRBRAKES_NONE,
+    EV_AIRPLANE_BRAKE,           //!< normal brake for an aircraft.
+    EV_AIRPLANE_ELEVATOR_DOWN,   //!< pull the elevator down in an aircraft.
+    EV_AIRPLANE_ELEVATOR_UP,     //!< pull the elevator up in an aircraft.
+    EV_AIRPLANE_FLAPS_FULL,      //!< full flaps in an aircraft.
+    EV_AIRPLANE_FLAPS_LESS,      //!< one step less flaps.
+    EV_AIRPLANE_FLAPS_MORE,      //!< one step more flaps.
+    EV_AIRPLANE_FLAPS_NONE,      //!< no flaps.
+    EV_AIRPLANE_PARKING_BRAKE,   //!< airplane parking brake.
+    EV_AIRPLANE_REVERSE,         //!< reverse the turboprops
+    EV_AIRPLANE_RUDDER_LEFT,     //!< rudder left
+    EV_AIRPLANE_RUDDER_RIGHT,    //!< rudder right
+    EV_AIRPLANE_STEER_LEFT,      //!< steer left
+    EV_AIRPLANE_STEER_RIGHT,     //!< steer right
+    EV_AIRPLANE_THROTTLE,        
+    EV_AIRPLANE_THROTTLE_AXIS,   //!< throttle axis. Only use this if you have fitting hardware :) (i.e. a Slider)
+    EV_AIRPLANE_THROTTLE_DOWN,   //!< decreases the airplane thrust
+    EV_AIRPLANE_THROTTLE_FULL,   //!< full thrust
+    EV_AIRPLANE_THROTTLE_NO,     //!< no thrust
+    EV_AIRPLANE_THROTTLE_UP,     //!< increase the airplane thrust
+    EV_AIRPLANE_TOGGLE_ENGINES,  //!< switch all engines on / off
+    EV_BOAT_CENTER_RUDDER,       //!< center the rudder
+    EV_BOAT_REVERSE,             //!< no thrust
+    EV_BOAT_STEER_LEFT,          //!< steer left a step
+    EV_BOAT_STEER_LEFT_AXIS,     //!< steer left (analog value!)
+    EV_BOAT_STEER_RIGHT,         //!< steer right a step
+    EV_BOAT_STEER_RIGHT_AXIS,    //!< steer right (analog value!)
+    EV_BOAT_THROTTLE_AXIS,       //!< throttle axis. Only use this if you have fitting hardware :) (i.e. a Slider)
+    EV_BOAT_THROTTLE_DOWN,       //!< decrease throttle
+    EV_BOAT_THROTTLE_UP,         //!< increase throttle
+    EV_SKY_DECREASE_TIME,        //!< decrease day-time
+    EV_SKY_DECREASE_TIME_FAST,   //!< decrease day-time a lot faster
+    EV_SKY_INCREASE_TIME,        //!< increase day-time
+    EV_SKY_INCREASE_TIME_FAST,   //!< increase day-time a lot faster
+    EV_CAMERA_CHANGE,            //!< change camera mode
+    EV_CAMERA_DOWN,
+    EV_CAMERA_FREE_MODE,
+    EV_CAMERA_FREE_MODE_FIX,
+    EV_CAMERA_LOOKBACK,          //!< look back (toggles between normal and lookback)
+    EV_CAMERA_RESET,             //!< reset the camera position
+    EV_CAMERA_ROTATE_DOWN,       //!< rotate camera down
+    EV_CAMERA_ROTATE_LEFT,       //!< rotate camera left
+    EV_CAMERA_ROTATE_RIGHT,      //!< rotate camera right
+    EV_CAMERA_ROTATE_UP,         //!< rotate camera up
+    EV_CAMERA_UP,
+    EV_CAMERA_ZOOM_IN,           //!< zoom camera in
+    EV_CAMERA_ZOOM_IN_FAST,      //!< zoom camera in faster
+    EV_CAMERA_ZOOM_OUT,          //!< zoom camera out
+    EV_CAMERA_ZOOM_OUT_FAST,     //!< zoom camera out faster
+    EV_CHARACTER_BACKWARDS,      //!< step backwards with the character
+    EV_CHARACTER_FORWARD,        //!< step forward with the character
+    EV_CHARACTER_JUMP,           //!< let the character jump
+    EV_CHARACTER_LEFT,           //!< rotate character left
+    EV_CHARACTER_RIGHT,          //!< rotate character right
+    EV_CHARACTER_ROT_DOWN,
+    EV_CHARACTER_ROT_UP,
+    EV_CHARACTER_RUN,            //!< let the character run
+    EV_CHARACTER_SIDESTEP_LEFT,  //!< sidestep to the left
+    EV_CHARACTER_SIDESTEP_RIGHT, //!< sidestep to the right
+    EV_COMMANDS_01,              //!< Command 1
+    EV_COMMANDS_02,              //!< Command 2
+    EV_COMMANDS_03,              //!< Command 3
+    EV_COMMANDS_04,              //!< Command 4
+    EV_COMMANDS_05,              //!< Command 5
+    EV_COMMANDS_06,              //!< Command 6
+    EV_COMMANDS_07,              //!< Command 7
+    EV_COMMANDS_08,              //!< Command 8
+    EV_COMMANDS_09,              //!< Command 9
+    EV_COMMANDS_10,              //!< Command 10
+    EV_COMMANDS_11,              //!< Command 11
+    EV_COMMANDS_12,              //!< Command 12
+    EV_COMMANDS_13,              //!< Command 13
+    EV_COMMANDS_14,              //!< Command 14
+    EV_COMMANDS_15,              //!< Command 15
+    EV_COMMANDS_16,              //!< Command 16
+    EV_COMMANDS_17,              //!< Command 17
+    EV_COMMANDS_18,              //!< Command 18
+    EV_COMMANDS_19,              //!< Command 19
+    EV_COMMANDS_20,              //!< Command 20
+    EV_COMMANDS_21,              //!< Command 21
+    EV_COMMANDS_22,              //!< Command 22
+    EV_COMMANDS_23,              //!< Command 23
+    EV_COMMANDS_24,              //!< Command 24
+    EV_COMMANDS_25,              //!< Command 25
+    EV_COMMANDS_26,              //!< Command 26
+    EV_COMMANDS_27,              //!< Command 27
+    EV_COMMANDS_28,              //!< Command 28
+    EV_COMMANDS_29,              //!< Command 29
+    EV_COMMANDS_30,              //!< Command 30
+    EV_COMMANDS_31,              //!< Command 31
+    EV_COMMANDS_32,              //!< Command 32
+    EV_COMMANDS_33,              //!< Command 33
+    EV_COMMANDS_34,              //!< Command 34
+    EV_COMMANDS_35,              //!< Command 35
+    EV_COMMANDS_36,              //!< Command 36
+    EV_COMMANDS_37,              //!< Command 37
+    EV_COMMANDS_38,              //!< Command 38
+    EV_COMMANDS_39,              //!< Command 39
+    EV_COMMANDS_40,              //!< Command 40
+    EV_COMMANDS_41,              //!< Command 41
+    EV_COMMANDS_42,              //!< Command 42
+    EV_COMMANDS_43,              //!< Command 43
+    EV_COMMANDS_44,              //!< Command 44
+    EV_COMMANDS_45,              //!< Command 45
+    EV_COMMANDS_46,              //!< Command 46
+    EV_COMMANDS_47,              //!< Command 47
+    EV_COMMANDS_48,              //!< Command 48
+    EV_COMMANDS_49,              //!< Command 49
+    EV_COMMANDS_50,              //!< Command 50
+    EV_COMMANDS_51,              //!< Command 51
+    EV_COMMANDS_52,              //!< Command 52
+    EV_COMMANDS_53,              //!< Command 53
+    EV_COMMANDS_54,              //!< Command 54
+    EV_COMMANDS_55,              //!< Command 55
+    EV_COMMANDS_56,              //!< Command 56
+    EV_COMMANDS_57,              //!< Command 57
+    EV_COMMANDS_58,              //!< Command 58
+    EV_COMMANDS_59,              //!< Command 59
+    EV_COMMANDS_60,              //!< Command 50
+    EV_COMMANDS_61,              //!< Command 61
+    EV_COMMANDS_62,              //!< Command 62
+    EV_COMMANDS_63,              //!< Command 63
+    EV_COMMANDS_64,              //!< Command 64
+    EV_COMMANDS_65,              //!< Command 65
+    EV_COMMANDS_66,              //!< Command 66
+    EV_COMMANDS_67,              //!< Command 67
+    EV_COMMANDS_68,              //!< Command 68
+    EV_COMMANDS_69,              //!< Command 69
+    EV_COMMANDS_70,              //!< Command 70
+    EV_COMMANDS_71,              //!< Command 71
+    EV_COMMANDS_72,              //!< Command 72
+    EV_COMMANDS_73,              //!< Command 73
+    EV_COMMANDS_74,              //!< Command 74
+    EV_COMMANDS_75,              //!< Command 75
+    EV_COMMANDS_76,              //!< Command 76
+    EV_COMMANDS_77,              //!< Command 77
+    EV_COMMANDS_78,              //!< Command 78
+    EV_COMMANDS_79,              //!< Command 79
+    EV_COMMANDS_80,              //!< Command 80
+    EV_COMMANDS_81,              //!< Command 81
+    EV_COMMANDS_82,              //!< Command 82
+    EV_COMMANDS_83,              //!< Command 83
+    EV_COMMANDS_84,              //!< Command 84
+    EV_COMMON_ACCELERATE_SIMULATION, //!< accelerate the simulation speed
+    EV_COMMON_DECELERATE_SIMULATION, //!< decelerate the simulation speed
+    EV_COMMON_RESET_SIMULATION_PACE, //!< reset the simulation speed
+    EV_COMMON_AUTOLOCK,              //!< unlock autolock hook node
+    EV_COMMON_CONSOLE_TOGGLE,        //!< show / hide the console
+    EV_COMMON_ENTER_CHATMODE,        //!< enter the chat mode
+    EV_COMMON_ENTER_OR_EXIT_TRUCK,   //!< enter or exit a truck
+    EV_COMMON_ENTER_NEXT_TRUCK,      //!< enter next truck
+    EV_COMMON_ENTER_PREVIOUS_TRUCK,  //!< enter previous truck
+    EV_COMMON_REMOVE_CURRENT_TRUCK,  //!< remove current truck
+    EV_COMMON_RESPAWN_LAST_TRUCK,    //!< respawn last truck
+    EV_COMMON_FOV_LESS,           //!<decreases the current FOV value
+    EV_COMMON_FOV_MORE,           //!<increases the current FOV value
+    EV_COMMON_FOV_RESET,          //!<reset the FOV value
+    EV_COMMON_FULLSCREEN_TOGGLE,
+    EV_COMMON_HIDE_GUI,           //!< hide all GUI elements
+    EV_COMMON_TOGGLE_DASHBOARD,   //!< display or hide the dashboard overlay
+    EV_COMMON_LOCK,               //!< connect hook node to a node in close proximity
+    EV_COMMON_NETCHATDISPLAY,
+    EV_COMMON_NETCHATMODE,
+    EV_COMMON_OUTPUT_POSITION,    //!< write current position to log (you can open the logfile and reuse the position)
+    EV_COMMON_GET_NEW_VEHICLE,    //!< get new vehicle
+    EV_COMMON_PRESSURE_LESS,      //!< decrease tire pressure (note: only very few trucks support this)
+    EV_COMMON_PRESSURE_MORE,      //!< increase tire pressure (note: only very few trucks support this)
+    EV_COMMON_QUICKLOAD,          //!< quickload scene from the disk
+    EV_COMMON_QUICKSAVE,          //!< quicksave scene to the disk
+    EV_COMMON_QUIT_GAME,          //!< exit the game
+    EV_COMMON_REPAIR_TRUCK,       //!< repair truck to original condition
+    EV_COMMON_REPLAY_BACKWARD,
+    EV_COMMON_REPLAY_FAST_BACKWARD,
+    EV_COMMON_REPLAY_FAST_FORWARD,
+    EV_COMMON_REPLAY_FORWARD,
+    EV_COMMON_RESCUE_TRUCK,       //!< teleport to rescue truck
+    EV_COMMON_RESET_TRUCK,        //!< reset truck to original starting position
+    EV_COMMON_TOGGLE_RESET_MODE,  //!< toggle truck reset truck mode (soft vs. hard)
+    EV_COMMON_ROPELOCK,           //!< connect hook node to a node in close proximity
+    EV_COMMON_SAVE_TERRAIN,       //!< save terrain mesh to file
+    EV_COMMON_SCREENSHOT,         //!< take a screenshot
+    EV_COMMON_SCREENSHOT_BIG,     //!< take a BIG screenshot
+    EV_COMMON_SECURE_LOAD,        //!< tie a load to the truck
+    EV_COMMON_SEND_CHAT,          //!< send the chat text
+    EV_COMMON_TOGGLE_DEBUG_VIEW,  //!< toggle debug view mode
+    EV_COMMON_CYCLE_DEBUG_VIEWS,  //!< cycle debug view mode
+    EV_COMMON_TOGGLE_TERRAIN_EDITOR,   //!< toggle terrain editor
+    EV_COMMON_TOGGLE_CUSTOM_PARTICLES, //!< toggle particle cannon
+    EV_COMMON_TOGGLE_MAT_DEBUG,   //!< debug purpose - dont use (currently not used)
+    EV_COMMON_TOGGLE_RENDER_MODE, //!< toggle render mode (solid, wireframe and points)
+    EV_COMMON_TOGGLE_REPLAY_MODE, //!< toggle replay mode
+    EV_COMMON_TOGGLE_PHYSICS,     //!< toggle physics on/off
+    EV_COMMON_TOGGLE_STATS,       //!< toggle Ogre statistics (FPS etc.)
+    EV_COMMON_TOGGLE_TRUCK_BEACONS, //!< toggle truck beacons
+    EV_COMMON_TOGGLE_TRUCK_LIGHTS,//!< toggle truck front lights
+    EV_COMMON_TRUCK_INFO,         //!< toggle truck HUD
+    EV_COMMON_TRUCK_DESCRIPTION,  //!< toggle truck description
+    EV_COMMON_TRUCK_REMOVE,
+    EV_GRASS_LESS,                //!< EXPERIMENTAL: remove some grass
+    EV_GRASS_MORE,                //!< EXPERIMENTAL: add some grass
+    EV_GRASS_MOST,                //!< EXPERIMENTAL: set maximum amount of grass
+    EV_GRASS_NONE,                //!< EXPERIMENTAL: remove grass completely
+    EV_GRASS_SAVE,                //!< EXPERIMENTAL: save changes to the grass density image
+    EV_MENU_DOWN,                 //!< select next element in current category
+    EV_MENU_LEFT,                 //!< select previous category
+    EV_MENU_RIGHT,                //!< select next category
+    EV_MENU_SELECT,               //!< select focussed item and close menu
+    EV_MENU_UP,                   //!< select previous element in current category
+    EV_SURVEY_MAP_TOGGLE_ICONS,   //!< toggle map icons
+    EV_SURVEY_MAP_CYCLE,          //!< cycle overview-map mode
+    EV_SURVEY_MAP_TOGGLE,         //!< toggle overview-map mode
+    EV_SURVEY_MAP_ZOOM_IN,        //!< increase survey map scale
+    EV_SURVEY_MAP_ZOOM_OUT,       //!< decrease survey map scale
+
+    EV_TRUCK_ACCELERATE,             //!< accelerate the truck
+    EV_TRUCK_ACCELERATE_MODIFIER_25, //!< accelerate with 25 percent pedal input
+    EV_TRUCK_ACCELERATE_MODIFIER_50, //!< accelerate with 50 percent pedal input
+    EV_TRUCK_ANTILOCK_BRAKE,      //!< toggle antilockbrake system
+    EV_TRUCK_AUTOSHIFT_DOWN,      //!< shift automatic transmission one gear down
+    EV_TRUCK_AUTOSHIFT_UP,        //!< shift automatic transmission one gear up
+    EV_TRUCK_BLINK_LEFT,          //!< toggle left direction indicator (blinker)
+    EV_TRUCK_BLINK_RIGHT,         //!< toggle right direction indicator (blinker)
+    EV_TRUCK_BLINK_WARN,          //!< toggle all direction indicators
+    EV_TRUCK_BRAKE,               //!< brake
+    EV_TRUCK_BRAKE_MODIFIER_25,   //!< brake with 25 percent pedal input
+    EV_TRUCK_BRAKE_MODIFIER_50,   //!< brake with 50 percent pedal input
+    EV_TRUCK_CRUISE_CONTROL,      //!< toggle cruise control
+    EV_TRUCK_CRUISE_CONTROL_ACCL, //!< increase target speed / rpm
+    EV_TRUCK_CRUISE_CONTROL_DECL, //!< decrease target speed / rpm
+    EV_TRUCK_CRUISE_CONTROL_READJUST, //!< match target speed / rpm with current truck speed / rpm
+    EV_TRUCK_HORN,                //!< truck horn
+    EV_TRUCK_LEFT_MIRROR_LEFT,
+    EV_TRUCK_LEFT_MIRROR_RIGHT,
+    EV_TRUCK_LIGHTTOGGLE01,       //!< toggle custom light 1
+    EV_TRUCK_LIGHTTOGGLE02,       //!< toggle custom light 2
+    EV_TRUCK_LIGHTTOGGLE03,       //!< toggle custom light 3
+    EV_TRUCK_LIGHTTOGGLE04,       //!< toggle custom light 4
+    EV_TRUCK_LIGHTTOGGLE05,       //!< toggle custom light 5
+    EV_TRUCK_LIGHTTOGGLE06,       //!< toggle custom light 6
+    EV_TRUCK_LIGHTTOGGLE07,       //!< toggle custom light 7
+    EV_TRUCK_LIGHTTOGGLE08,       //!< toggle custom light 8
+    EV_TRUCK_LIGHTTOGGLE09,       //!< toggle custom light 9
+    EV_TRUCK_LIGHTTOGGLE10,       //!< toggle custom light 10
+    EV_TRUCK_MANUAL_CLUTCH,       //!< manual clutch (for manual transmission)
+    EV_TRUCK_PARKING_BRAKE,       //!< toggle parking brake
+    EV_TRUCK_TRAILER_PARKING_BRAKE, //!< toggle trailer parking brake
+    EV_TRUCK_RIGHT_MIRROR_LEFT,
+    EV_TRUCK_RIGHT_MIRROR_RIGHT,
+    EV_TRUCK_SHIFT_DOWN,          //!< shift one gear down in manual transmission mode
+    EV_TRUCK_SHIFT_GEAR01,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR02,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR03,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR04,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR05,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR06,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR07,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR08,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR09,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR10,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR11,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR12,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR13,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR14,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR15,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR16,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR17,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR18,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR_REVERSE,  //!< shift directly into this gear
+    EV_TRUCK_SHIFT_HIGHRANGE,     //!< select high range (13-18) for H-shaft
+    EV_TRUCK_SHIFT_LOWRANGE,      //!< select low range (1-6) for H-shaft
+    EV_TRUCK_SHIFT_MIDRANGE,      //!< select middle range (7-12) for H-shaft
+    EV_TRUCK_SHIFT_NEUTRAL,       //!< shift to neutral gear in manual transmission mode
+    EV_TRUCK_SHIFT_UP,            //!< shift one gear up in manual transmission mode
+    EV_TRUCK_STARTER,             //!< hold to start the engine
+    EV_TRUCK_STEER_LEFT,          //!< steer left
+    EV_TRUCK_STEER_RIGHT,         //!< steer right
+    EV_TRUCK_SWITCH_SHIFT_MODES,  //!< toggle between transmission modes
+    EV_TRUCK_TOGGLE_CONTACT,      //!< toggle ignition
+    EV_TRUCK_TOGGLE_FORWARDCOMMANDS,  //!< toggle forwardcommands
+    EV_TRUCK_TOGGLE_IMPORTCOMMANDS,   //!< toggle importcommands
+    EV_TRUCK_TOGGLE_INTER_AXLE_DIFF,  //!< toggle the inter axle differential mode
+    EV_TRUCK_TOGGLE_INTER_WHEEL_DIFF, //!< toggle the inter wheel differential mode
+    EV_TRUCK_TOGGLE_PHYSICS,      //!< toggle physics simulation
+    EV_TRUCK_TOGGLE_TCASE_4WD_MODE,   //!< toggle the transfer case 4wd mode
+    EV_TRUCK_TOGGLE_TCASE_GEAR_RATIO, //!< toggle the transfer case gear ratio
+    EV_TRUCK_TOGGLE_VIDEOCAMERA,  //!< toggle videocamera update
+    EV_TRUCK_TRACTION_CONTROL,    //!< toggle antilockbrake system
+
+    // Savegames
+    EV_COMMON_QUICKSAVE_01,
+    EV_COMMON_QUICKSAVE_02,
+    EV_COMMON_QUICKSAVE_03,
+    EV_COMMON_QUICKSAVE_04,
+    EV_COMMON_QUICKSAVE_05,
+    EV_COMMON_QUICKSAVE_06,
+    EV_COMMON_QUICKSAVE_07,
+    EV_COMMON_QUICKSAVE_08,
+    EV_COMMON_QUICKSAVE_09,
+    EV_COMMON_QUICKSAVE_10,
+
+    EV_COMMON_QUICKLOAD_01,
+    EV_COMMON_QUICKLOAD_02,
+    EV_COMMON_QUICKLOAD_03,
+    EV_COMMON_QUICKLOAD_04,
+    EV_COMMON_QUICKLOAD_05,
+    EV_COMMON_QUICKLOAD_06,
+    EV_COMMON_QUICKLOAD_07,
+    EV_COMMON_QUICKLOAD_08,
+    EV_COMMON_QUICKLOAD_09,
+    EV_COMMON_QUICKLOAD_10,
+
+    EV_TRUCKEDIT_RELOAD,
+}
 
 /**
  * Different truck states registered with the script.

--- a/resources/scripts/demo_script.as
+++ b/resources/scripts/demo_script.as
@@ -1,0 +1,70 @@
+/*
+    ---------------------------------------------------------------------------
+                  Project Rigs of Rods (www.rigsofrods.org)
+                            
+                                DEMO SCRIPT
+                                
+    This program showcases all the various things you can do using scripting:
+     * Use DearIMGUI to draw UI of any kind, including diagnostic views.
+     * Collect and show stats (i.e. frame count, total time)
+     
+    There are 3 ways of invoking a script:
+     1. By defining it with terrain, see terrn2 fileformat, section '[Scripts]':
+        https://docs.rigsofrods.org/terrain-creation/terrn2-subsystem/.
+        This is the classic old method, used for i.e. races.
+     2. By using command line parameter '-runscript <filename>'.
+        You can use this command multiple times at once. Added in 2022.
+     3. By setting 'app_custom_scripts' in RoR.cfg to a comma-separated list
+        of filenames. Spaces in filename are acceptable. Added in 2022.
+    
+    For introduction to game events, read
+    https://docs.rigsofrods.org/terrain-creation/scripting/.
+
+    For reference manual of the interface, see
+    https://github.com/RigsOfRods/rigs-of-rods/tree/master/doc/angelscript.
+    ---------------------------------------------------------------------------
+*/
+
+
+/*
+    ---------------------------------------------------------------------------
+    Global variables
+*/
+int   g_total_frames;
+float g_total_seconds;
+
+/*
+    ---------------------------------------------------------------------------
+    Script setup function - invoked once when script is loaded.
+*/
+void main()
+{
+    log("demo_script: invoked `main()`");
+    g_total_frames = 0;
+    g_total_seconds = 0;
+}
+
+/*
+    ---------------------------------------------------------------------------
+    Script update function - invoked once every rendered frame,
+    with elapsed time (delta time, in seconds) as parameter.
+*/
+void frameStep(float dt)
+{
+    // Open demo window
+    ImGui::Begin("Demo Script", /*open:*/true, /*flags:*/0);
+    
+    // show some stats
+    ImGui::TextDisabled("-- Example stats --");
+    ImGui::Text("Total frames: " + g_total_frames);
+    int minutes = g_total_seconds / 60;
+    int seconds = g_total_seconds % 60;
+    ImGui::Text("Total time: " + minutes + "min, " + seconds + "sec");
+    
+    // End window
+    ImGui::End();
+
+    // Update global counters
+    g_total_frames++;
+    g_total_seconds += dt;
+}

--- a/resources/scripts/demo_script.as
+++ b/resources/scripts/demo_script.as
@@ -37,6 +37,7 @@ float       g_total_seconds = 0;
 CVarClass@  g_app_state = console.cVarFind("app_state"); // 0=bootstrap, 1=main menu, 2=simulation, see AppState in Application.h
 CVarClass@  g_sim_state = console.cVarFind("sim_state"); // 0=off, 1=running, 2=paused, 3=terrain editor, see SimState in Application.h
 CVarClass@  g_mp_state = console.cVarFind("mp_state"); // 0=disabled, 1=connecting, 2=connected, see MpState in Application.h
+CVarClass@  g_io_arcade_controls = console.cVarFind("io_arcade_controls"); // bool
 
 /*
     ---------------------------------------------------------------------------
@@ -55,7 +56,7 @@ void main()
 void frameStep(float dt)
 {
     // Open demo window
-    ImGui::SetNextWindowSize(vector2(300, 150));
+    ImGui::SetNextWindowSize(vector2(400, 320));
     ImGui::Begin("Demo Script", /*open:*/true, /*flags:*/0);
     
     // show some stats
@@ -64,11 +65,14 @@ void frameStep(float dt)
                                + int(g_total_seconds % 60) + "sec");
     
     // Show some game context
-    if (g_app_state.getInt() == 1)
+    if (g_app_state.getInt() == 1) // main menu
     {
         ImGui::Text("Game state: main menu");
+        ImGui::Text("Pro tip: Press '"
+            + inputs.getEventCommandTrimmed(EV_COMMON_CONSOLE_TOGGLE)
+            + "' to open console anytime.");
     }
-    else
+    else if (g_app_state.getInt() == 2) // simulation
     {
         if (g_mp_state.getInt() == 2)
         {
@@ -90,15 +94,61 @@ void frameStep(float dt)
             ImGui::Text("(terrain edit)");
         }
         
+        ImGui::TextDisabled("Camera controls:");
+        ImGui::Text("Change camera: " + inputs.getEventCommandTrimmed(EV_CAMERA_CHANGE));
+        ImGui::Text("Toggle free camera: " + inputs.getEventCommandTrimmed(EV_CAMERA_FREE_MODE));
+        ImGui::Text("Toggle fixed camera: " + inputs.getEventCommandTrimmed(EV_CAMERA_FREE_MODE_FIX));              
+        
         BeamClass@ actor = game.getCurrentTruck();
         if (actor != null)
         {
             ImGui::Text("You are driving " + actor.getTruckName());
+            ImGui::TextDisabled("Vehicle controls:");
+
+            ImGui::Text("Accelerate/Brake: "
+                + inputs.getEventCommandTrimmed(EV_TRUCK_ACCELERATE) + "/"
+                + inputs.getEventCommandTrimmed(EV_TRUCK_BRAKE));
+            if (g_io_arcade_controls.getBool() == true)
+            {
+                ImGui::Text("Arcade controls are enabled (?)");
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::BeginTooltip();
+                    ImGui::Text("'brake' key also accelerates in reverse.");
+                    ImGui::Text("You can change the setting in main menu / settings / gameplay.");
+                    ImGui::EndTooltip();
+                }
+            }
+            else
+            {
+                ImGui::Text("Arcade controls are disabled (?)");
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::BeginTooltip();
+                    ImGui::Text("'brake' key only brakes, to accelerate in reverse use 'accelerate' key.");
+                    ImGui::Text("You can change the setting in main menu / settings / gameplay.");
+                    ImGui::EndTooltip();
+                }
+            }
+            
+            ImGui::Text("Steer left/right: "
+                + inputs.getEventCommandTrimmed(EV_TRUCK_STEER_LEFT) + "/"
+                + inputs.getEventCommandTrimmed(EV_TRUCK_STEER_RIGHT));            
+            
         }
         else
         {
             ImGui::Text("You are on foot");
-        }        
+            ImGui::TextDisabled("Character controls:");
+            ImGui::Text("Forward/Backward: "
+                + inputs.getEventCommandTrimmed(EV_CHARACTER_FORWARD) + "/"
+                + inputs.getEventCommandTrimmed(EV_CHARACTER_BACKWARDS));
+            ImGui::Text("Turn left/right: "
+                + inputs.getEventCommandTrimmed(EV_CHARACTER_LEFT) + "/"
+                + inputs.getEventCommandTrimmed(EV_CHARACTER_RIGHT));
+            ImGui::Text("Run: " + inputs.getEventCommandTrimmed(EV_CHARACTER_RUN));
+        }
+        
     }
     
     // End window

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -86,6 +86,7 @@ CVar* app_force_cache_purge;
 CVar* app_force_cache_update;
 CVar* app_disable_online_api;
 CVar* app_config_long_names;
+CVar* app_custom_scripts;
 
 // Simulation
 CVar* sim_state;
@@ -168,6 +169,7 @@ CVar* cli_preset_spawn_rot;
 CVar* cli_preset_veh_enter;
 CVar* cli_force_cache_update;
 CVar* cli_resume_autosave;
+CVar* cli_custom_scripts;
 
 // Input - Output
 CVar* io_analog_smoothing;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -263,6 +263,7 @@ extern CVar* app_force_cache_purge;
 extern CVar* app_force_cache_update;
 extern CVar* app_disable_online_api;
 extern CVar* app_config_long_names;
+extern CVar* app_custom_scripts;
 
 // Simulation
 extern CVar* sim_state;
@@ -345,6 +346,7 @@ extern CVar* cli_preset_spawn_rot;
 extern CVar* cli_preset_veh_enter;
 extern CVar* cli_force_cache_update;
 extern CVar* cli_resume_autosave;
+extern CVar* cli_custom_scripts;
 
 // Input - Output
 extern CVar* io_analog_smoothing;

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -227,6 +227,7 @@ if (USE_ANGELSCRIPT)
             scripting/LocalStorage.{h,cpp}
             scripting/OgreAngelscript.cpp
             scripting/ImGuiAngelscript.cpp
+            scripting/InputEngineAngelscript.cpp
             scripting/OgreScriptBuilder.{h,cpp}
             scripting/ScriptEngine.{h,cpp}
             )

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -224,7 +224,8 @@ int main(int argc, char *argv[])
             for (Ogre::String const& scriptname: script_names)
             {
                 LOG(fmt::format("Loading startup script '{}' (from command line)", scriptname));
-                App::GetScriptEngine()->loadScript(scriptname); // errors are logged by OGRE + AngelScript
+                App::GetScriptEngine()->loadScript(scriptname, ScriptCategory::CUSTOM);
+                // errors are logged by OGRE & AngelScript
             }
         }
         if (App::app_custom_scripts->getStr() != "")
@@ -233,7 +234,8 @@ int main(int argc, char *argv[])
             for (Ogre::String const& scriptname: script_names)
             {
                 LOG(fmt::format("Loading startup script '{}' (from config file)", scriptname));
-                App::GetScriptEngine()->loadScript(scriptname); // errors are logged by OGRE + AngelScript
+                App::GetScriptEngine()->loadScript(scriptname, ScriptCategory::CUSTOM);
+                // errors are logged by OGRE & AngelScript
             }
         }
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -187,11 +187,11 @@ int main(int argc, char *argv[])
 
         App::GetDiscordRpc()->Init();
 
+        App::GetAppContext()->SetUpInput();
+
 #ifdef USE_ANGELSCRIPT
         App::CreateScriptEngine();
 #endif
-
-        App::GetAppContext()->SetUpInput();
 
         App::GetGuiManager()->SetUpMenuWallpaper();
 

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -385,7 +385,6 @@ void ContentManager::LoadGameplayResources()
         this->AddResourcePack(ContentManager::ResourcePack::MESHES);
         this->AddResourcePack(ContentManager::ResourcePack::OVERLAYS);
         this->AddResourcePack(ContentManager::ResourcePack::PARTICLES);
-        this->AddResourcePack(ContentManager::ResourcePack::SCRIPTS);
 
         m_base_resource_loaded = true;
     }

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -282,7 +282,11 @@ void GameScript::registerForEvent(int eventValue)
 {
     if (App::GetScriptEngine())
     {
-        App::GetScriptEngine()->eventMask |= eventValue;
+        int unit_id = App::GetScriptEngine()->getCurrentlyExecutingScriptUnit();
+        if (unit_id != -1)
+        {
+            App::GetScriptEngine()->getScriptUnits()[unit_id].eventMask |= eventValue;
+        }
     }
 }
 
@@ -290,7 +294,11 @@ void GameScript::unRegisterEvent(int eventValue)
 {
     if (App::GetScriptEngine())
     {
-        App::GetScriptEngine()->eventMask &= ~eventValue;
+        int unit_id = App::GetScriptEngine()->getCurrentlyExecutingScriptUnit();
+        if (unit_id != -1)
+        {
+            App::GetScriptEngine()->getScriptUnits()[unit_id].eventMask &= ~eventValue;
+        }
     }
 }
 
@@ -400,12 +408,18 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
         return;
     }
 
+    if (App::GetScriptEngine()->getTerrainScriptUnit() == -1)
+    {
+        this->logFormat("spawnObject(): Cannot spawn object, no terrain script loaded!");
+        return;
+    }
+
     try
     {
-        AngelScript::asIScriptModule* module = App::GetScriptEngine()->getEngine()->GetModule(App::GetScriptEngine()->getModuleName(), AngelScript::asGM_ONLY_IF_EXISTS);
+        AngelScript::asIScriptModule* module = App::GetScriptEngine()->getScriptUnits()[App::GetScriptEngine()->getTerrainScriptUnit()].scriptModule;
         if (module == nullptr)
         {
-            this->logFormat("spawnObject(): Failed to fetch/create script module '%s'", App::GetScriptEngine()->getModuleName());
+            this->logFormat("spawnObject(): Failed to fetch/create script module '%s'", module->GetName());
             return;
         }
 
@@ -420,7 +434,7 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
             else
             {
                 this->logFormat("spawnObject(): Warning; Failed to find handler function '%s' in script module '%s'",
-                    eventhandler.c_str(), App::GetScriptEngine()->getModuleName());
+                    eventhandler.c_str(), module->GetName());
             }
         }
 
@@ -709,6 +723,10 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     if (App::app_disable_online_api->getBool())
         return 0;
 
+    int unit_id = App::GetScriptEngine()->getCurrentlyExecutingScriptUnit();
+    if (unit_id == -1)
+        return 2;
+
     Actor* player_actor = App::GetGameContext()->GetPlayerActor();
 
     if (player_actor == nullptr)
@@ -721,8 +739,8 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
 
     std::string terrain_name = App::GetSimTerrain()->getTerrainName();
 
-    std::string script_name = App::GetScriptEngine()->getScriptName();
-    std::string script_hash = App::GetScriptEngine()->getScriptHash();
+    std::string script_name = App::GetScriptEngine()->getScriptUnits()[unit_id].scriptName;
+    std::string script_hash = App::GetScriptEngine()->getScriptUnits()[unit_id].scriptHash;
 
     rapidjson::Document j_doc;
     j_doc.SetObject();

--- a/source/main/scripting/InputEngineAngelscript.cpp
+++ b/source/main/scripting/InputEngineAngelscript.cpp
@@ -1,0 +1,376 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2022 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+/// @author Petr Ohlidal
+/// @date   01-2022
+ 
+#include "InputEngine.h"
+#include "ScriptEngine.h"
+
+void registerInputEngineObject(AngelScript::asIScriptEngine* engine)
+{
+    using namespace RoR;
+    int result = 0;
+
+    result = engine->RegisterObjectType("InputEngineClass", sizeof(InputEngine), AngelScript::asOBJ_REF | AngelScript::asOBJ_NOCOUNT); ROR_ASSERT(result>=0);
+    
+    result = engine->RegisterObjectMethod("InputEngineClass", "string getEventCommand(inputEvents ev)", AngelScript::asMETHOD(InputEngine,getEventCommand), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("InputEngineClass", "string getEventCommandTrimmed(inputEvents ev)", AngelScript::asMETHOD(InputEngine,getEventCommandTrimmed), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+
+// TODO: register OIS::KeyCode or port to SDL2 already (for Apple OSX support)
+//    result = engine->RegisterObjectMethod("InputEngineClass", "bool isKeyDown(int keycode)", AngelScript::asMETHOD(InputEngine,isKeyDown), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+//    result = engine->RegisterObjectMethod("InputEngineClass", "bool isKeyDownEffective(int keycode)", AngelScript::asMETHOD(InputEngine,isKeyDownEffective), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+
+    result = engine->RegisterObjectMethod("InputEngineClass", "bool getEventBoolValue(inputEvents ev)", AngelScript::asMETHOD(InputEngine,getEventBoolValue), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("InputEngineClass", "bool getEventBoolValueBounce(inputEvents ev, float time = 0.2f)", AngelScript::asMETHOD(InputEngine,getEventBoolValueBounce), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);    
+}
+
+void registerEventTypeEnum(AngelScript::asIScriptEngine* engine)
+{
+    using namespace RoR;
+    int result = 0;
+
+    result = engine->RegisterEnum("inputEvents"); ROR_ASSERT(result >= 0);
+
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_AIRBRAKES_FULL",        EV_AIRPLANE_AIRBRAKES_FULL      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_AIRBRAKES_LESS",        EV_AIRPLANE_AIRBRAKES_LESS      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_AIRBRAKES_MORE",        EV_AIRPLANE_AIRBRAKES_MORE      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_AIRBRAKES_NONE",        EV_AIRPLANE_AIRBRAKES_NONE      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_BRAKE",                 EV_AIRPLANE_BRAKE               ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_ELEVATOR_DOWN",         EV_AIRPLANE_ELEVATOR_DOWN       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_ELEVATOR_UP",           EV_AIRPLANE_ELEVATOR_UP         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_FLAPS_FULL",            EV_AIRPLANE_FLAPS_FULL          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_FLAPS_LESS",            EV_AIRPLANE_FLAPS_LESS          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_FLAPS_MORE",            EV_AIRPLANE_FLAPS_MORE          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_FLAPS_NONE",            EV_AIRPLANE_FLAPS_NONE          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_PARKING_BRAKE",         EV_AIRPLANE_PARKING_BRAKE       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_REVERSE",               EV_AIRPLANE_REVERSE             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_RUDDER_LEFT",           EV_AIRPLANE_RUDDER_LEFT         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_RUDDER_RIGHT",          EV_AIRPLANE_RUDDER_RIGHT        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_STEER_LEFT",            EV_AIRPLANE_STEER_LEFT          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_STEER_RIGHT",           EV_AIRPLANE_STEER_RIGHT         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_THROTTLE",              EV_AIRPLANE_THROTTLE            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_THROTTLE_AXIS",         EV_AIRPLANE_THROTTLE_AXIS       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_THROTTLE_DOWN",         EV_AIRPLANE_THROTTLE_DOWN       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_THROTTLE_FULL",         EV_AIRPLANE_THROTTLE_FULL       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_THROTTLE_NO",           EV_AIRPLANE_THROTTLE_NO         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_THROTTLE_UP",           EV_AIRPLANE_THROTTLE_UP         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_AIRPLANE_TOGGLE_ENGINES",        EV_AIRPLANE_TOGGLE_ENGINES      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_CENTER_RUDDER",             EV_BOAT_CENTER_RUDDER           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_REVERSE",                   EV_BOAT_REVERSE                 ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_STEER_LEFT",                EV_BOAT_STEER_LEFT              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_STEER_LEFT_AXIS",           EV_BOAT_STEER_LEFT_AXIS         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_STEER_RIGHT",               EV_BOAT_STEER_RIGHT             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_STEER_RIGHT_AXIS",          EV_BOAT_STEER_RIGHT_AXIS        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_THROTTLE_AXIS",             EV_BOAT_THROTTLE_AXIS           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_THROTTLE_DOWN",             EV_BOAT_THROTTLE_DOWN           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_BOAT_THROTTLE_UP",               EV_BOAT_THROTTLE_UP             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SKY_DECREASE_TIME",              EV_SKY_DECREASE_TIME            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SKY_DECREASE_TIME_FAST",         EV_SKY_DECREASE_TIME_FAST       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SKY_INCREASE_TIME",              EV_SKY_INCREASE_TIME            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SKY_INCREASE_TIME_FAST",         EV_SKY_INCREASE_TIME_FAST       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_CHANGE",                  EV_CAMERA_CHANGE                ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_DOWN",                    EV_CAMERA_DOWN                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_FREE_MODE",               EV_CAMERA_FREE_MODE             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_FREE_MODE_FIX",           EV_CAMERA_FREE_MODE_FIX         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_LOOKBACK",                EV_CAMERA_LOOKBACK              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_RESET",                   EV_CAMERA_RESET                 ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_ROTATE_DOWN",             EV_CAMERA_ROTATE_DOWN           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_ROTATE_LEFT",             EV_CAMERA_ROTATE_LEFT           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_ROTATE_RIGHT",            EV_CAMERA_ROTATE_RIGHT          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_ROTATE_UP",               EV_CAMERA_ROTATE_UP             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_UP",                      EV_CAMERA_UP                    ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_ZOOM_IN",                 EV_CAMERA_ZOOM_IN               ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_ZOOM_IN_FAST",            EV_CAMERA_ZOOM_IN_FAST          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_ZOOM_OUT",                EV_CAMERA_ZOOM_OUT              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CAMERA_ZOOM_OUT_FAST",           EV_CAMERA_ZOOM_OUT_FAST         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_BACKWARDS",            EV_CHARACTER_BACKWARDS          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_FORWARD",              EV_CHARACTER_FORWARD            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_JUMP",                 EV_CHARACTER_JUMP               ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_LEFT",                 EV_CHARACTER_LEFT               ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_RIGHT",                EV_CHARACTER_RIGHT              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_ROT_DOWN",             EV_CHARACTER_ROT_DOWN           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_ROT_UP",               EV_CHARACTER_ROT_UP             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_RUN",                  EV_CHARACTER_RUN                ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_SIDESTEP_LEFT",        EV_CHARACTER_SIDESTEP_LEFT      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_CHARACTER_SIDESTEP_RIGHT",       EV_CHARACTER_SIDESTEP_RIGHT     ); ROR_ASSERT(result >= 0);
+
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_01",                    EV_COMMANDS_01                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_02",                    EV_COMMANDS_02                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_03",                    EV_COMMANDS_03                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_04",                    EV_COMMANDS_04                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_05",                    EV_COMMANDS_05                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_06",                    EV_COMMANDS_06                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_07",                    EV_COMMANDS_07                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_08",                    EV_COMMANDS_08                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_09",                    EV_COMMANDS_09                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_10",                    EV_COMMANDS_10                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_11",                    EV_COMMANDS_11                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_12",                    EV_COMMANDS_12                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_13",                    EV_COMMANDS_13                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_14",                    EV_COMMANDS_14                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_15",                    EV_COMMANDS_15                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_16",                    EV_COMMANDS_16                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_17",                    EV_COMMANDS_17                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_18",                    EV_COMMANDS_18                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_19",                    EV_COMMANDS_19                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_20",                    EV_COMMANDS_20                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_21",                    EV_COMMANDS_21                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_22",                    EV_COMMANDS_22                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_23",                    EV_COMMANDS_23                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_24",                    EV_COMMANDS_24                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_25",                    EV_COMMANDS_25                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_26",                    EV_COMMANDS_26                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_27",                    EV_COMMANDS_27                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_28",                    EV_COMMANDS_28                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_29",                    EV_COMMANDS_29                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_30",                    EV_COMMANDS_30                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_31",                    EV_COMMANDS_31                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_32",                    EV_COMMANDS_32                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_33",                    EV_COMMANDS_33                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_34",                    EV_COMMANDS_34                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_35",                    EV_COMMANDS_35                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_36",                    EV_COMMANDS_36                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_37",                    EV_COMMANDS_37                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_38",                    EV_COMMANDS_38                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_39",                    EV_COMMANDS_39                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_40",                    EV_COMMANDS_40                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_41",                    EV_COMMANDS_41                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_42",                    EV_COMMANDS_42                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_43",                    EV_COMMANDS_43                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_44",                    EV_COMMANDS_44                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_45",                    EV_COMMANDS_45                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_46",                    EV_COMMANDS_46                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_47",                    EV_COMMANDS_47                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_48",                    EV_COMMANDS_48                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_49",                    EV_COMMANDS_49                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_50",                    EV_COMMANDS_50                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_51",                    EV_COMMANDS_51                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_52",                    EV_COMMANDS_52                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_53",                    EV_COMMANDS_53                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_54",                    EV_COMMANDS_54                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_55",                    EV_COMMANDS_55                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_56",                    EV_COMMANDS_56                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_57",                    EV_COMMANDS_57                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_58",                    EV_COMMANDS_58                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_59",                    EV_COMMANDS_59                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_60",                    EV_COMMANDS_60                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_61",                    EV_COMMANDS_61                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_62",                    EV_COMMANDS_62                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_63",                    EV_COMMANDS_63                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_64",                    EV_COMMANDS_64                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_65",                    EV_COMMANDS_65                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_66",                    EV_COMMANDS_66                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_67",                    EV_COMMANDS_67                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_68",                    EV_COMMANDS_68                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_69",                    EV_COMMANDS_69                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_70",                    EV_COMMANDS_70                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_71",                    EV_COMMANDS_71                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_72",                    EV_COMMANDS_72                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_73",                    EV_COMMANDS_73                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_74",                    EV_COMMANDS_74                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_75",                    EV_COMMANDS_75                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_76",                    EV_COMMANDS_76                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_77",                    EV_COMMANDS_77                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_78",                    EV_COMMANDS_78                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_79",                    EV_COMMANDS_79                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_80",                    EV_COMMANDS_80                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_81",                    EV_COMMANDS_81                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_82",                    EV_COMMANDS_82                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_83",                    EV_COMMANDS_83                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMANDS_84",                    EV_COMMANDS_84                  ); ROR_ASSERT(result >= 0);
+
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_ACCELERATE_SIMULATION",   EV_COMMON_ACCELERATE_SIMULATION ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_DECELERATE_SIMULATION",   EV_COMMON_DECELERATE_SIMULATION ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_RESET_SIMULATION_PACE",   EV_COMMON_RESET_SIMULATION_PACE ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_AUTOLOCK",                EV_COMMON_AUTOLOCK              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_CONSOLE_TOGGLE",          EV_COMMON_CONSOLE_TOGGLE        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_ENTER_CHATMODE",          EV_COMMON_ENTER_CHATMODE        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_ENTER_OR_EXIT_TRUCK",     EV_COMMON_ENTER_OR_EXIT_TRUCK   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_ENTER_NEXT_TRUCK",        EV_COMMON_ENTER_NEXT_TRUCK      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_ENTER_PREVIOUS_TRUCK",    EV_COMMON_ENTER_PREVIOUS_TRUCK  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_REMOVE_CURRENT_TRUCK",    EV_COMMON_REMOVE_CURRENT_TRUCK  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_RESPAWN_LAST_TRUCK",      EV_COMMON_RESPAWN_LAST_TRUCK    ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_FOV_LESS",                EV_COMMON_FOV_LESS              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_FOV_MORE",                EV_COMMON_FOV_MORE              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_FOV_RESET",               EV_COMMON_FOV_RESET             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_FULLSCREEN_TOGGLE",       EV_COMMON_FULLSCREEN_TOGGLE     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_HIDE_GUI",                EV_COMMON_HIDE_GUI              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_DASHBOARD",        EV_COMMON_TOGGLE_DASHBOARD      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_LOCK",                    EV_COMMON_LOCK                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_NETCHATDISPLAY",          EV_COMMON_NETCHATDISPLAY        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_NETCHATMODE",             EV_COMMON_NETCHATMODE           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_OUTPUT_POSITION",         EV_COMMON_OUTPUT_POSITION       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_GET_NEW_VEHICLE",         EV_COMMON_GET_NEW_VEHICLE       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_PRESSURE_LESS",           EV_COMMON_PRESSURE_LESS         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_PRESSURE_MORE",           EV_COMMON_PRESSURE_MORE         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD",               EV_COMMON_QUICKLOAD             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE",               EV_COMMON_QUICKSAVE             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUIT_GAME",               EV_COMMON_QUIT_GAME             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_REPAIR_TRUCK",            EV_COMMON_REPAIR_TRUCK          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_REPLAY_BACKWARD",         EV_COMMON_REPLAY_BACKWARD       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_REPLAY_FAST_BACKWARD",    EV_COMMON_REPLAY_FAST_BACKWARD  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_REPLAY_FAST_FORWARD",     EV_COMMON_REPLAY_FAST_FORWARD   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_REPLAY_FORWARD",          EV_COMMON_REPLAY_FORWARD        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_RESCUE_TRUCK",            EV_COMMON_RESCUE_TRUCK          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_RESET_TRUCK",             EV_COMMON_RESET_TRUCK           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_RESET_MODE",       EV_COMMON_TOGGLE_RESET_MODE     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_ROPELOCK",                EV_COMMON_ROPELOCK              ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_SAVE_TERRAIN",            EV_COMMON_SAVE_TERRAIN          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_SCREENSHOT",              EV_COMMON_SCREENSHOT            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_SCREENSHOT_BIG",          EV_COMMON_SCREENSHOT_BIG        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_SECURE_LOAD",             EV_COMMON_SECURE_LOAD           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_SEND_CHAT",               EV_COMMON_SEND_CHAT             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_DEBUG_VIEW",       EV_COMMON_TOGGLE_DEBUG_VIEW     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_CYCLE_DEBUG_VIEWS",       EV_COMMON_CYCLE_DEBUG_VIEWS     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_TERRAIN_EDITOR",   EV_COMMON_TOGGLE_TERRAIN_EDITOR ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_CUSTOM_PARTICLES", EV_COMMON_TOGGLE_CUSTOM_PARTICLES); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_MAT_DEBUG",        EV_COMMON_TOGGLE_MAT_DEBUG      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_RENDER_MODE",      EV_COMMON_TOGGLE_RENDER_MODE    ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_REPLAY_MODE",      EV_COMMON_TOGGLE_REPLAY_MODE    ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_PHYSICS",          EV_COMMON_TOGGLE_PHYSICS        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_STATS",            EV_COMMON_TOGGLE_STATS          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_TRUCK_BEACONS",    EV_COMMON_TOGGLE_TRUCK_BEACONS  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_TRUCK_LIGHTS",     EV_COMMON_TOGGLE_TRUCK_LIGHTS   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TRUCK_INFO",              EV_COMMON_TRUCK_INFO            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TRUCK_DESCRIPTION",       EV_COMMON_TRUCK_DESCRIPTION     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TRUCK_REMOVE",            EV_COMMON_TRUCK_REMOVE          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_GRASS_LESS",                     EV_GRASS_LESS                   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_GRASS_MORE",                     EV_GRASS_MORE                   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_GRASS_MOST",                     EV_GRASS_MOST                   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_GRASS_NONE",                     EV_GRASS_NONE                   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_GRASS_SAVE",                     EV_GRASS_SAVE                   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_MENU_DOWN",                      EV_MENU_DOWN                    ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_MENU_LEFT",                      EV_MENU_LEFT                    ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_MENU_RIGHT",                     EV_MENU_RIGHT                   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_MENU_SELECT",                    EV_MENU_SELECT                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_MENU_UP",                        EV_MENU_UP                      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SURVEY_MAP_TOGGLE_ICONS",        EV_SURVEY_MAP_TOGGLE_ICONS      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SURVEY_MAP_CYCLE",               EV_SURVEY_MAP_CYCLE             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SURVEY_MAP_TOGGLE",              EV_SURVEY_MAP_TOGGLE            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SURVEY_MAP_ZOOM_IN",             EV_SURVEY_MAP_ZOOM_IN           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_SURVEY_MAP_ZOOM_OUT",            EV_SURVEY_MAP_ZOOM_OUT          ); ROR_ASSERT(result >= 0);
+                                                                                                                           
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_ACCELERATE",               EV_TRUCK_ACCELERATE             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_ACCELERATE_MODIFIER_25",   EV_TRUCK_ACCELERATE_MODIFIER_25 ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_ACCELERATE_MODIFIER_50",   EV_TRUCK_ACCELERATE_MODIFIER_50 ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_ANTILOCK_BRAKE",           EV_TRUCK_ANTILOCK_BRAKE         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_AUTOSHIFT_DOWN",           EV_TRUCK_AUTOSHIFT_DOWN         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_AUTOSHIFT_UP",             EV_TRUCK_AUTOSHIFT_UP           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_BLINK_LEFT",               EV_TRUCK_BLINK_LEFT             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_BLINK_RIGHT",              EV_TRUCK_BLINK_RIGHT            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_BLINK_WARN",               EV_TRUCK_BLINK_WARN             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_BRAKE",                    EV_TRUCK_BRAKE                  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_BRAKE_MODIFIER_25",        EV_TRUCK_BRAKE_MODIFIER_25      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_BRAKE_MODIFIER_50",        EV_TRUCK_BRAKE_MODIFIER_50      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_CRUISE_CONTROL",           EV_TRUCK_CRUISE_CONTROL         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_CRUISE_CONTROL_ACCL",      EV_TRUCK_CRUISE_CONTROL_ACCL    ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_CRUISE_CONTROL_DECL",      EV_TRUCK_CRUISE_CONTROL_DECL    ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_CRUISE_CONTROL_READJUST",  EV_TRUCK_CRUISE_CONTROL_READJUST); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_HORN",                     EV_TRUCK_HORN                   ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LEFT_MIRROR_LEFT",         EV_TRUCK_LEFT_MIRROR_LEFT       ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LEFT_MIRROR_RIGHT",        EV_TRUCK_LEFT_MIRROR_RIGHT      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE01",            EV_TRUCK_LIGHTTOGGLE01          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE02",            EV_TRUCK_LIGHTTOGGLE02          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE03",            EV_TRUCK_LIGHTTOGGLE03          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE04",            EV_TRUCK_LIGHTTOGGLE04          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE05",            EV_TRUCK_LIGHTTOGGLE05          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE06",            EV_TRUCK_LIGHTTOGGLE06          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE07",            EV_TRUCK_LIGHTTOGGLE07          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE08",            EV_TRUCK_LIGHTTOGGLE08          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE09",            EV_TRUCK_LIGHTTOGGLE09          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_LIGHTTOGGLE10",            EV_TRUCK_LIGHTTOGGLE10          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_MANUAL_CLUTCH",            EV_TRUCK_MANUAL_CLUTCH          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_PARKING_BRAKE",            EV_TRUCK_PARKING_BRAKE          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TRAILER_PARKING_BRAKE",    EV_TRUCK_TRAILER_PARKING_BRAKE  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_RIGHT_MIRROR_LEFT",        EV_TRUCK_RIGHT_MIRROR_LEFT      ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_RIGHT_MIRROR_RIGHT",       EV_TRUCK_RIGHT_MIRROR_RIGHT     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_DOWN",               EV_TRUCK_SHIFT_DOWN             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR01",             EV_TRUCK_SHIFT_GEAR01           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR02",             EV_TRUCK_SHIFT_GEAR02           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR03",             EV_TRUCK_SHIFT_GEAR03           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR04",             EV_TRUCK_SHIFT_GEAR04           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR05",             EV_TRUCK_SHIFT_GEAR05           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR06",             EV_TRUCK_SHIFT_GEAR06           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR07",             EV_TRUCK_SHIFT_GEAR07           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR08",             EV_TRUCK_SHIFT_GEAR08           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR09",             EV_TRUCK_SHIFT_GEAR09           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR10",             EV_TRUCK_SHIFT_GEAR10           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR11",             EV_TRUCK_SHIFT_GEAR11           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR12",             EV_TRUCK_SHIFT_GEAR12           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR13",             EV_TRUCK_SHIFT_GEAR13           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR14",             EV_TRUCK_SHIFT_GEAR14           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR15",             EV_TRUCK_SHIFT_GEAR15           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR16",             EV_TRUCK_SHIFT_GEAR16           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR17",             EV_TRUCK_SHIFT_GEAR17           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR18",             EV_TRUCK_SHIFT_GEAR18           ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_GEAR_REVERSE",       EV_TRUCK_SHIFT_GEAR_REVERSE     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_HIGHRANGE",          EV_TRUCK_SHIFT_HIGHRANGE        ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_LOWRANGE",           EV_TRUCK_SHIFT_LOWRANGE         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_MIDRANGE",           EV_TRUCK_SHIFT_MIDRANGE         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_NEUTRAL",            EV_TRUCK_SHIFT_NEUTRAL          ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SHIFT_UP",                 EV_TRUCK_SHIFT_UP               ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_STARTER",                  EV_TRUCK_STARTER                ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_STEER_LEFT",               EV_TRUCK_STEER_LEFT             ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_STEER_RIGHT",              EV_TRUCK_STEER_RIGHT            ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_SWITCH_SHIFT_MODES",       EV_TRUCK_SWITCH_SHIFT_MODES     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_CONTACT",           EV_TRUCK_TOGGLE_CONTACT         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_FORWARDCOMMANDS",   EV_TRUCK_TOGGLE_FORWARDCOMMANDS ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_IMPORTCOMMANDS",    EV_TRUCK_TOGGLE_IMPORTCOMMANDS  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_INTER_AXLE_DIFF",   EV_TRUCK_TOGGLE_INTER_AXLE_DIFF ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_INTER_WHEEL_DIFF",  EV_TRUCK_TOGGLE_INTER_WHEEL_DIFF); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_PHYSICS",           EV_TRUCK_TOGGLE_PHYSICS         ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_TCASE_4WD_MODE",    EV_TRUCK_TOGGLE_TCASE_4WD_MODE  ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_TCASE_GEAR_RATIO",  EV_TRUCK_TOGGLE_TCASE_GEAR_RATIO); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TOGGLE_VIDEOCAMERA",       EV_TRUCK_TOGGLE_VIDEOCAMERA     ); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCK_TRACTION_CONTROL",         EV_TRUCK_TRACTION_CONTROL       ); ROR_ASSERT(result >= 0);
+
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_01",            EV_COMMON_QUICKSAVE_01          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_02",            EV_COMMON_QUICKSAVE_02          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_03",            EV_COMMON_QUICKSAVE_03          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_04",            EV_COMMON_QUICKSAVE_04          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_05",            EV_COMMON_QUICKSAVE_05          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_06",            EV_COMMON_QUICKSAVE_06          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_07",            EV_COMMON_QUICKSAVE_07          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_08",            EV_COMMON_QUICKSAVE_08          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_09",            EV_COMMON_QUICKSAVE_09          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKSAVE_10",            EV_COMMON_QUICKSAVE_10          ); ROR_ASSERT(result >= 0);
+                                                                                                                           
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_01",            EV_COMMON_QUICKLOAD_01          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_02",            EV_COMMON_QUICKLOAD_02          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_03",            EV_COMMON_QUICKLOAD_03          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_04",            EV_COMMON_QUICKLOAD_04          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_05",            EV_COMMON_QUICKLOAD_05          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_06",            EV_COMMON_QUICKLOAD_06          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_07",            EV_COMMON_QUICKLOAD_07          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_08",            EV_COMMON_QUICKLOAD_08          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_09",            EV_COMMON_QUICKLOAD_09          ); ROR_ASSERT(result >= 0);               
+    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_QUICKLOAD_10",            EV_COMMON_QUICKLOAD_10          ); ROR_ASSERT(result >= 0);               
+
+    result = engine->RegisterEnumValue("inputEvents", "EV_TRUCKEDIT_RELOAD",               EV_TRUCKEDIT_RELOAD             ); ROR_ASSERT(result >= 0);               
+}
+
+void RoR::registerInputEngine(AngelScript::asIScriptEngine* engine)
+{
+    registerEventTypeEnum(engine);
+    registerInputEngineObject(engine);
+}

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -53,6 +53,8 @@
 #include "ScriptEvents.h"
 #include "VehicleAI.h"
 
+#include "InputEngine.h"
+
 using namespace Ogre;
 using namespace RoR;
 
@@ -136,6 +138,8 @@ void ScriptEngine::init()
     // This needs to be done after the registration of the ogre objects!
     registerLocalStorage(engine);
 
+    registerInputEngine(engine);
+
     RegisterImGuiBindings(engine);
 
     // some useful global functions
@@ -167,10 +171,6 @@ void ScriptEngine::init()
     result = engine->RegisterObjectBehaviour("VehicleAIClass", AngelScript::asBEHAVE_ADDREF, "void f()", AngelScript::asMETHOD(VehicleAI, addRef), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectBehaviour("VehicleAIClass", AngelScript::asBEHAVE_RELEASE, "void f()", AngelScript::asMETHOD(VehicleAI, release), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
 
-
-
-    // Register everything
-
     // class CVar
     result = engine->RegisterObjectType("CVarClass", sizeof(Console), AngelScript::asOBJ_REF | AngelScript::asOBJ_NOCOUNT); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("CVarClass", "const string& getName()", AngelScript::asMETHOD(CVar,getName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
@@ -194,7 +194,6 @@ void ScriptEngine::init()
     result = engine->RegisterObjectMethod("ConsoleClass", "CVarClass @cVarGet(const string &in, int)", AngelScript::asMETHOD(Console,cVarGet), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("ConsoleClass", "CVarClass @cVarSet(const string &in, const string &in)", AngelScript::asMETHOD(Console,cVarSet), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("ConsoleClass", "void cVarAssign(CVarClass@, const string &in)", AngelScript::asMETHOD(Console,cVarAssign), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
-
 
     // class Actor (historically Beam)
     result = engine->RegisterObjectType("BeamClass", sizeof(Actor), AngelScript::asOBJ_REF); ROR_ASSERT(result>=0);
@@ -385,7 +384,7 @@ void ScriptEngine::init()
     // now the global instances
     result = engine->RegisterGlobalProperty("GameScriptClass game", &m_game_script); ROR_ASSERT(result>=0);
     result = engine->RegisterGlobalProperty("ConsoleClass console", App::GetConsole()); ROR_ASSERT(result>=0);
-
+    result = engine->RegisterGlobalProperty("InputEngineClass inputs", App::GetInputEngine()); ROR_ASSERT(result>=0);
 
     SLOG("Type registrations done. If you see no error above everything should be working");
 

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -208,6 +208,9 @@ void RegisterOgreObjects(AngelScript::asIScriptEngine* engine);
 
 void RegisterImGuiBindings(AngelScript::asIScriptEngine* engine);
 
+/// Registers RoR::InputEngine, defined in InputEngineAngelscript.cpp
+void registerInputEngine(AngelScript::asIScriptEngine* engine);
+
 } // namespace RoR
 
 #else // USE_ANGELSCRIPT

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -180,6 +180,12 @@ protected:
 
     Ogre::String composeModuleName(Ogre::String const& scriptName, ScriptCategory origin);
 
+    /**
+    * Helper for `loadScript()`, does the actual building without worry about unit management.
+    * @return 0 on success, anything else on error.
+    */
+    int setupScriptUnit(int unit_id);
+
     AngelScript::asIScriptEngine* engine; //!< instance of the scripting engine
     AngelScript::asIScriptContext* context; //!< context in which all scripting happens
     Ogre::Log*      scriptLog;

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -40,6 +40,28 @@
 
 namespace RoR {
 
+enum class ScriptCategory
+{
+    INVALID,
+    TERRAIN,
+    CUSTOM
+};
+
+/// Represents a loaded script and all associated resources/handles.
+struct ScriptUnit
+{
+    ScriptCategory scriptCategory = ScriptCategory::INVALID;
+    unsigned int eventMask = 0; //!< filter mask for script events
+    AngelScript::asIScriptModule* scriptModule = nullptr;
+    AngelScript::asIScriptFunction* frameStepFunctionPtr = nullptr; //!< script function pointer to the frameStep function
+    AngelScript::asIScriptFunction* eventCallbackFunctionPtr = nullptr; //!< script function pointer to the event callback function
+    AngelScript::asIScriptFunction* defaultEventCallbackFunctionPtr = nullptr; //!< script function pointer for spawner events
+    Ogre::String scriptName;
+    Ogre::String scriptHash;
+};
+
+typedef std::vector<ScriptUnit> ScriptUnitVec;
+
 /**
  *  @brief This class represents the angelscript scripting interface. It can load and execute scripts.
  *  @authors Thomas Fischer (thomas{AT}rigsofrods{DOT}com)
@@ -58,7 +80,13 @@ public:
      * @param scriptname filename to load
      * @return 0 on success, everything else on error
      */
-    int loadScript(Ogre::String scriptname);
+    int loadScript(Ogre::String scriptname, ScriptCategory category = ScriptCategory::TERRAIN);
+
+    /**
+     * Unloads a script
+     * @param scriptname filename to unload
+     */
+    void unloadScript(Ogre::String scriptname, ScriptCategory category);
 
     /**
      * Calls the script's framestep function to be able to use timed things inside the script
@@ -68,8 +96,6 @@ public:
     int framestep(Ogre::Real dt);
 
     void activateLogging();
-
-    unsigned int eventMask; //!< filter mask for script events
 
     /**
      * triggers an event. Not to be used by the end-user
@@ -121,17 +147,11 @@ public:
     */
     int deleteVariable(const Ogre::String& arg);
 
-    Ogre::StringVector getAutoComplete(Ogre::String command);
-
     int fireEvent(std::string instanceName, float intensity);
 
     int envokeCallback(int functionId, eventsource_t* source, node_t* node = 0, int type = 0);
 
     AngelScript::asIScriptEngine* getEngine() { return engine; };
-
-    Ogre::String getScriptName() { return scriptName; }
-    Ogre::String getScriptHash() { return scriptHash; }
-    const char*  getModuleName() { return moduleName; }
 
     // method from Ogre::LogListener
     void messageLogged(const Ogre::String& message, Ogre::LogMessageLevel lml, bool maskDebug, const Ogre::String& logName, bool& skipThisMessage);
@@ -139,22 +159,12 @@ public:
     inline void SLOG(const char* msg) { this->scriptLog->logMessage(msg); } //!< Replacement of macro
     inline void SLOG(std::string msg) { this->scriptLog->logMessage(msg); } //!< Replacement of macro
 
+    ScriptUnitVec& getScriptUnits() { return m_script_units; }
+    int getTerrainScriptUnit() const { return m_terrain_script_unit; } //!< @return -1 if none exists.
+    int getCurrentlyExecutingScriptUnit() const { return m_currently_executing_script_unit; } //!< @return -1 if none is executing right now.
+
 
 protected:
-
-    AngelScript::asIScriptEngine* engine; //!< instance of the scripting engine
-    AngelScript::asIScriptContext* context; //!< context in which all scripting happens
-    AngelScript::asIScriptFunction* frameStepFunctionPtr; //!< script function pointer to the frameStep function
-    AngelScript::asIScriptFunction* eventCallbackFunctionPtr; //!< script function pointer to the event callback function
-    AngelScript::asIScriptFunction* defaultEventCallbackFunctionPtr; //!< script function pointer for spawner events
-    Ogre::String scriptName;
-    Ogre::String scriptHash;
-    Ogre::Log* scriptLog;
-    GameScript m_game_script;
-
-    InterThreadStoreVector<Ogre::String> stringExecutionQueue; //!< The string execution queue \see queueStringForExecution
-
-    static const char* moduleName;
 
     /**
      * This function initialzies the engine and registeres all types
@@ -167,6 +177,18 @@ protected:
      * @param msg arguments that contain details about the crash
      */
     void msgCallback(const AngelScript::asSMessageInfo* msg);
+
+    Ogre::String composeModuleName(Ogre::String const& scriptName, ScriptCategory origin);
+
+    AngelScript::asIScriptEngine* engine; //!< instance of the scripting engine
+    AngelScript::asIScriptContext* context; //!< context in which all scripting happens
+    Ogre::Log*      scriptLog;
+    GameScript      m_game_script;
+    ScriptUnitVec   m_script_units;
+    int             m_terrain_script_unit = -1;
+    int             m_currently_executing_script_unit = -1;
+
+    InterThreadStoreVector<Ogre::String> stringExecutionQueue; //!< The string execution queue \see queueStringForExecution
 };
 
 // This function will register the following objects with the scriptengine:

--- a/source/main/system/AppCommandLine.cpp
+++ b/source/main/system/AppCommandLine.cpp
@@ -44,6 +44,7 @@ enum {
     OPT_RESUME,
     OPT_CHECKCACHE,
     OPT_TRUCKCONFIG,
+    OPT_RUNSCRIPT,
     OPT_ENTERTRUCK,
     OPT_JOINMPSERVER
 };
@@ -56,6 +57,7 @@ CSimpleOpt::SOption cmdline_options[] = {
     { OPT_ROT,            ("-rot"),         SO_REQ_SEP },
     { OPT_TRUCK,          ("-truck"),       SO_REQ_SEP },
     { OPT_TRUCKCONFIG,    ("-truckconfig"), SO_REQ_SEP },
+    { OPT_RUNSCRIPT,      ("-runscript"),   SO_REQ_SEP },
     { OPT_ENTERTRUCK,     ("-enter"),       SO_NONE    },
     { OPT_HELP,           ("--help"),       SO_NONE    },
     { OPT_HELP,           ("-help"),        SO_NONE    },
@@ -94,6 +96,19 @@ void Console::processCommandLine(int argc, char *argv[])
         else if (args.OptionId() == OPT_TRUCKCONFIG)
         {
             App::cli_preset_veh_config->setStr(args.OptionArg());
+        }
+        else if (args.OptionId() == OPT_RUNSCRIPT)
+        {
+            // Append to startup script list cvar, separate by ','
+            if (App::cli_custom_scripts->getStr() == "")
+            {
+                App::cli_custom_scripts->setStr(args.OptionArg());
+            }
+            else
+            {
+                App::cli_custom_scripts->setStr(
+                    fmt::format("{},{}", App::cli_custom_scripts->getStr(), args.OptionArg()));
+            }
         }
         else if (args.OptionId() == OPT_MAP)
         {
@@ -159,6 +174,7 @@ void Console::showCommandLineUsage()
             "-checkcache forces cache update"                       "\n"
             "-version shows the version information"                "\n"
             "-joinserver=<server>:<port> (join multiplayer server)" "\n"
+            "-runscript <filename> (load script, can be repeated)"  "\n"
             "For example: RoR.exe -map simple2 -pos '518 0 518' -rot 45 -truck semi.truck -enter"));
 }
 

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -41,6 +41,7 @@ void Console::cVarSetupBuiltins()
     App::app_force_cache_update  = this->cVarCreate("app_force_cache_update",  "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::app_disable_online_api  = this->cVarCreate("app_disable_online_api",  "Disable Online API",         CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::app_config_long_names   = this->cVarCreate("app_config_long_names",   "Config uses long names",     CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
+    App::app_custom_scripts      = this->cVarCreate("app_custom_scripts",      "",                           CVAR_ARCHIVE,                     "");
 
     App::sim_state               = this->cVarCreate("sim_state",               "",                                          CVAR_TYPE_INT,     "0"/*(int)SimState::OFF*/);
     App::sim_terrain_name        = this->cVarCreate("sim_terrain_name",        "",                           0);
@@ -117,6 +118,7 @@ void Console::cVarSetupBuiltins()
     App::cli_preset_veh_enter    = this->cVarCreate("cli_preset_veh_enter",    "",                                          CVAR_TYPE_BOOL,    "false");
     App::cli_force_cache_update  = this->cVarCreate("cli_force_cache_update",  "",                                          CVAR_TYPE_BOOL,    "false");
     App::cli_resume_autosave     = this->cVarCreate("cli_resume_autosave",     "",                                          CVAR_TYPE_BOOL,    "false");
+    App::cli_custom_scripts      = this->cVarCreate("cli_custom_scripts",      "",                           0,                                "");
 
     App::io_analog_smoothing     = this->cVarCreate("io_analog_smoothing",     "Analog Input Smoothing",     CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "1.0");
     App::io_analog_sensitivity   = this->cVarCreate("io_analog_sensitivity",   "Analog Input Sensitivity",   CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "1.0");

--- a/source/main/system/Console.h
+++ b/source/main/system/Console.h
@@ -55,7 +55,7 @@ public:
     {
         CONSOLE_MSGTYPE_INFO,   //!< Generic message
         CONSOLE_MSGTYPE_LOG,    //!< Logfile echo
-        CONSOLE_MSGTYPE_SCRIPT, //!< Any scripting subsystem
+        CONSOLE_MSGTYPE_SCRIPT, //!< Messages sent from scripts
         CONSOLE_MSGTYPE_ACTOR,  //!< Parsing/spawn/simulation messages for actors
         CONSOLE_MSGTYPE_TERRN   //!< Parsing/spawn/simulation messages for terrain
     };

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -119,6 +119,11 @@ TerrainManager::~TerrainManager()
         delete(m_collisions);
         m_collisions = nullptr;
     }
+
+    for (std::string as_filename : m_def.as_files)
+    {
+        App::GetScriptEngine()->unloadScript(as_filename, ScriptCategory::TERRAIN);
+    }
 }
 
 TerrainManager* TerrainManager::LoadAndPrepareTerrain(CacheEntry* entry)

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -75,292 +75,292 @@ enum events
     EV_AIRPLANE_AIRBRAKES_LESS,
     EV_AIRPLANE_AIRBRAKES_MORE,
     EV_AIRPLANE_AIRBRAKES_NONE,
-    EV_AIRPLANE_BRAKE, //!< normal brake for an aircraft.
-    EV_AIRPLANE_ELEVATOR_DOWN, //!< pull the elevator down in an aircraft.
-    EV_AIRPLANE_ELEVATOR_UP, //!< pull the elevator up in an aircraft.
-    EV_AIRPLANE_FLAPS_FULL, //!< full flaps in an aircraft.
-    EV_AIRPLANE_FLAPS_LESS, //!< one step less flaps.
-    EV_AIRPLANE_FLAPS_MORE, //!< one step more flaps.
-    EV_AIRPLANE_FLAPS_NONE, //!< no flaps.
-    EV_AIRPLANE_PARKING_BRAKE, //!< airplane parking brake.
-    EV_AIRPLANE_REVERSE, //!< reverse the turboprops
-    EV_AIRPLANE_RUDDER_LEFT, //!< rudder left
-    EV_AIRPLANE_RUDDER_RIGHT, //!< rudder right
-    EV_AIRPLANE_STEER_LEFT, //!< steer left
-    EV_AIRPLANE_STEER_RIGHT, //!< steer right
-    EV_AIRPLANE_THROTTLE,
-    EV_AIRPLANE_THROTTLE_AXIS, //!< throttle axis. Only use this if you have fitting hardware :) (i.e. a Slider)
-    EV_AIRPLANE_THROTTLE_DOWN, //!< decreases the airplane thrust
-    EV_AIRPLANE_THROTTLE_FULL, //!< full thrust
-    EV_AIRPLANE_THROTTLE_NO, //!< no thrust
-    EV_AIRPLANE_THROTTLE_UP, //!< increase the airplane thrust
-    EV_AIRPLANE_TOGGLE_ENGINES, //!< switch all engines on / off
-    EV_BOAT_CENTER_RUDDER, //!< center the rudder
-    EV_BOAT_REVERSE, //!< no thrust
-    EV_BOAT_STEER_LEFT, //!< steer left a step
-    EV_BOAT_STEER_LEFT_AXIS, //!< steer left (analog value!)
-    EV_BOAT_STEER_RIGHT, //!< steer right a step
-    EV_BOAT_STEER_RIGHT_AXIS, //!< steer right (analog value!)
-    EV_BOAT_THROTTLE_AXIS, //!< throttle axis. Only use this if you have fitting hardware :) (i.e. a Slider)
-    EV_BOAT_THROTTLE_DOWN, //!< decrease throttle
-    EV_BOAT_THROTTLE_UP, //!< increase throttle
-    EV_SKY_DECREASE_TIME, //!< decrease day-time
-    EV_SKY_DECREASE_TIME_FAST, //!< decrease day-time a lot faster
-    EV_SKY_INCREASE_TIME, //!< increase day-time
-    EV_SKY_INCREASE_TIME_FAST, //!< increase day-time a lot faster
-    EV_CAMERA_CHANGE, //!< change camera mode
+    EV_AIRPLANE_BRAKE,           //!< normal brake for an aircraft.
+    EV_AIRPLANE_ELEVATOR_DOWN,   //!< pull the elevator down in an aircraft.
+    EV_AIRPLANE_ELEVATOR_UP,     //!< pull the elevator up in an aircraft.
+    EV_AIRPLANE_FLAPS_FULL,      //!< full flaps in an aircraft.
+    EV_AIRPLANE_FLAPS_LESS,      //!< one step less flaps.
+    EV_AIRPLANE_FLAPS_MORE,      //!< one step more flaps.
+    EV_AIRPLANE_FLAPS_NONE,      //!< no flaps.
+    EV_AIRPLANE_PARKING_BRAKE,   //!< airplane parking brake.
+    EV_AIRPLANE_REVERSE,         //!< reverse the turboprops
+    EV_AIRPLANE_RUDDER_LEFT,     //!< rudder left
+    EV_AIRPLANE_RUDDER_RIGHT,    //!< rudder right
+    EV_AIRPLANE_STEER_LEFT,      //!< steer left
+    EV_AIRPLANE_STEER_RIGHT,     //!< steer right
+    EV_AIRPLANE_THROTTLE,        
+    EV_AIRPLANE_THROTTLE_AXIS,   //!< throttle axis. Only use this if you have fitting hardware :) (i.e. a Slider)
+    EV_AIRPLANE_THROTTLE_DOWN,   //!< decreases the airplane thrust
+    EV_AIRPLANE_THROTTLE_FULL,   //!< full thrust
+    EV_AIRPLANE_THROTTLE_NO,     //!< no thrust
+    EV_AIRPLANE_THROTTLE_UP,     //!< increase the airplane thrust
+    EV_AIRPLANE_TOGGLE_ENGINES,  //!< switch all engines on / off
+    EV_BOAT_CENTER_RUDDER,       //!< center the rudder
+    EV_BOAT_REVERSE,             //!< no thrust
+    EV_BOAT_STEER_LEFT,          //!< steer left a step
+    EV_BOAT_STEER_LEFT_AXIS,     //!< steer left (analog value!)
+    EV_BOAT_STEER_RIGHT,         //!< steer right a step
+    EV_BOAT_STEER_RIGHT_AXIS,    //!< steer right (analog value!)
+    EV_BOAT_THROTTLE_AXIS,       //!< throttle axis. Only use this if you have fitting hardware :) (i.e. a Slider)
+    EV_BOAT_THROTTLE_DOWN,       //!< decrease throttle
+    EV_BOAT_THROTTLE_UP,         //!< increase throttle
+    EV_SKY_DECREASE_TIME,        //!< decrease day-time
+    EV_SKY_DECREASE_TIME_FAST,   //!< decrease day-time a lot faster
+    EV_SKY_INCREASE_TIME,        //!< increase day-time
+    EV_SKY_INCREASE_TIME_FAST,   //!< increase day-time a lot faster
+    EV_CAMERA_CHANGE,            //!< change camera mode
     EV_CAMERA_DOWN,
     EV_CAMERA_FREE_MODE,
     EV_CAMERA_FREE_MODE_FIX,
-    EV_CAMERA_LOOKBACK, //!< look back (toggles between normal and lookback)
-    EV_CAMERA_RESET, //!< reset the camera position
-    EV_CAMERA_ROTATE_DOWN, //!< rotate camera down
-    EV_CAMERA_ROTATE_LEFT, //!< rotate camera left
-    EV_CAMERA_ROTATE_RIGHT, //!< rotate camera right
-    EV_CAMERA_ROTATE_UP, //!< rotate camera up
+    EV_CAMERA_LOOKBACK,          //!< look back (toggles between normal and lookback)
+    EV_CAMERA_RESET,             //!< reset the camera position
+    EV_CAMERA_ROTATE_DOWN,       //!< rotate camera down
+    EV_CAMERA_ROTATE_LEFT,       //!< rotate camera left
+    EV_CAMERA_ROTATE_RIGHT,      //!< rotate camera right
+    EV_CAMERA_ROTATE_UP,         //!< rotate camera up
     EV_CAMERA_UP,
-    EV_CAMERA_ZOOM_IN, //!< zoom camera in
-    EV_CAMERA_ZOOM_IN_FAST, //!< zoom camera in faster
-    EV_CAMERA_ZOOM_OUT, //!< zoom camera out
-    EV_CAMERA_ZOOM_OUT_FAST, //!< zoom camera out faster
-    EV_CHARACTER_BACKWARDS, //!< step backwards with the character
-    EV_CHARACTER_FORWARD, //!< step forward with the character
-    EV_CHARACTER_JUMP, //!< let the character jump
-    EV_CHARACTER_LEFT, //!< rotate character left
-    EV_CHARACTER_RIGHT, //!< rotate character right
+    EV_CAMERA_ZOOM_IN,           //!< zoom camera in
+    EV_CAMERA_ZOOM_IN_FAST,      //!< zoom camera in faster
+    EV_CAMERA_ZOOM_OUT,          //!< zoom camera out
+    EV_CAMERA_ZOOM_OUT_FAST,     //!< zoom camera out faster
+    EV_CHARACTER_BACKWARDS,      //!< step backwards with the character
+    EV_CHARACTER_FORWARD,        //!< step forward with the character
+    EV_CHARACTER_JUMP,           //!< let the character jump
+    EV_CHARACTER_LEFT,           //!< rotate character left
+    EV_CHARACTER_RIGHT,          //!< rotate character right
     EV_CHARACTER_ROT_DOWN,
     EV_CHARACTER_ROT_UP,
-    EV_CHARACTER_RUN, //!< let the character run
-    EV_CHARACTER_SIDESTEP_LEFT, //!< sidestep to the left
+    EV_CHARACTER_RUN,            //!< let the character run
+    EV_CHARACTER_SIDESTEP_LEFT,  //!< sidestep to the left
     EV_CHARACTER_SIDESTEP_RIGHT, //!< sidestep to the right
-    EV_COMMANDS_01, //!< Command 1
-    EV_COMMANDS_02, //!< Command 2
-    EV_COMMANDS_03, //!< Command 3
-    EV_COMMANDS_04, //!< Command 4
-    EV_COMMANDS_05, //!< Command 5
-    EV_COMMANDS_06, //!< Command 6
-    EV_COMMANDS_07, //!< Command 7
-    EV_COMMANDS_08, //!< Command 8
-    EV_COMMANDS_09, //!< Command 9
-    EV_COMMANDS_10, //!< Command 10
-    EV_COMMANDS_11, //!< Command 11
-    EV_COMMANDS_12, //!< Command 12
-    EV_COMMANDS_13, //!< Command 13
-    EV_COMMANDS_14, //!< Command 14
-    EV_COMMANDS_15, //!< Command 15
-    EV_COMMANDS_16, //!< Command 16
-    EV_COMMANDS_17, //!< Command 17
-    EV_COMMANDS_18, //!< Command 18
-    EV_COMMANDS_19, //!< Command 19
-    EV_COMMANDS_20, //!< Command 20
-    EV_COMMANDS_21, //!< Command 21
-    EV_COMMANDS_22, //!< Command 22
-    EV_COMMANDS_23, //!< Command 23
-    EV_COMMANDS_24, //!< Command 24
-    EV_COMMANDS_25, //!< Command 25
-    EV_COMMANDS_26, //!< Command 26
-    EV_COMMANDS_27, //!< Command 27
-    EV_COMMANDS_28, //!< Command 28
-    EV_COMMANDS_29, //!< Command 29
-    EV_COMMANDS_30, //!< Command 30
-    EV_COMMANDS_31, //!< Command 31
-    EV_COMMANDS_32, //!< Command 32
-    EV_COMMANDS_33, //!< Command 33
-    EV_COMMANDS_34, //!< Command 34
-    EV_COMMANDS_35, //!< Command 35
-    EV_COMMANDS_36, //!< Command 36
-    EV_COMMANDS_37, //!< Command 37
-    EV_COMMANDS_38, //!< Command 38
-    EV_COMMANDS_39, //!< Command 39
-    EV_COMMANDS_40, //!< Command 40
-    EV_COMMANDS_41, //!< Command 41
-    EV_COMMANDS_42, //!< Command 42
-    EV_COMMANDS_43, //!< Command 43
-    EV_COMMANDS_44, //!< Command 44
-    EV_COMMANDS_45, //!< Command 45
-    EV_COMMANDS_46, //!< Command 46
-    EV_COMMANDS_47, //!< Command 47
-    EV_COMMANDS_48, //!< Command 48
-    EV_COMMANDS_49, //!< Command 49
-    EV_COMMANDS_50, //!< Command 50
-    EV_COMMANDS_51, //!< Command 51
-    EV_COMMANDS_52, //!< Command 52
-    EV_COMMANDS_53, //!< Command 53
-    EV_COMMANDS_54, //!< Command 54
-    EV_COMMANDS_55, //!< Command 55
-    EV_COMMANDS_56, //!< Command 56
-    EV_COMMANDS_57, //!< Command 57
-    EV_COMMANDS_58, //!< Command 58
-    EV_COMMANDS_59, //!< Command 59
-    EV_COMMANDS_60, //!< Command 50
-    EV_COMMANDS_61, //!< Command 61
-    EV_COMMANDS_62, //!< Command 62
-    EV_COMMANDS_63, //!< Command 63
-    EV_COMMANDS_64, //!< Command 64
-    EV_COMMANDS_65, //!< Command 65
-    EV_COMMANDS_66, //!< Command 66
-    EV_COMMANDS_67, //!< Command 67
-    EV_COMMANDS_68, //!< Command 68
-    EV_COMMANDS_69, //!< Command 69
-    EV_COMMANDS_70, //!< Command 70
-    EV_COMMANDS_71, //!< Command 71
-    EV_COMMANDS_72, //!< Command 72
-    EV_COMMANDS_73, //!< Command 73
-    EV_COMMANDS_74, //!< Command 74
-    EV_COMMANDS_75, //!< Command 75
-    EV_COMMANDS_76, //!< Command 76
-    EV_COMMANDS_77, //!< Command 77
-    EV_COMMANDS_78, //!< Command 78
-    EV_COMMANDS_79, //!< Command 79
-    EV_COMMANDS_80, //!< Command 80
-    EV_COMMANDS_81, //!< Command 81
-    EV_COMMANDS_82, //!< Command 82
-    EV_COMMANDS_83, //!< Command 83
-    EV_COMMANDS_84, //!< Command 84
+    EV_COMMANDS_01,              //!< Command 1
+    EV_COMMANDS_02,              //!< Command 2
+    EV_COMMANDS_03,              //!< Command 3
+    EV_COMMANDS_04,              //!< Command 4
+    EV_COMMANDS_05,              //!< Command 5
+    EV_COMMANDS_06,              //!< Command 6
+    EV_COMMANDS_07,              //!< Command 7
+    EV_COMMANDS_08,              //!< Command 8
+    EV_COMMANDS_09,              //!< Command 9
+    EV_COMMANDS_10,              //!< Command 10
+    EV_COMMANDS_11,              //!< Command 11
+    EV_COMMANDS_12,              //!< Command 12
+    EV_COMMANDS_13,              //!< Command 13
+    EV_COMMANDS_14,              //!< Command 14
+    EV_COMMANDS_15,              //!< Command 15
+    EV_COMMANDS_16,              //!< Command 16
+    EV_COMMANDS_17,              //!< Command 17
+    EV_COMMANDS_18,              //!< Command 18
+    EV_COMMANDS_19,              //!< Command 19
+    EV_COMMANDS_20,              //!< Command 20
+    EV_COMMANDS_21,              //!< Command 21
+    EV_COMMANDS_22,              //!< Command 22
+    EV_COMMANDS_23,              //!< Command 23
+    EV_COMMANDS_24,              //!< Command 24
+    EV_COMMANDS_25,              //!< Command 25
+    EV_COMMANDS_26,              //!< Command 26
+    EV_COMMANDS_27,              //!< Command 27
+    EV_COMMANDS_28,              //!< Command 28
+    EV_COMMANDS_29,              //!< Command 29
+    EV_COMMANDS_30,              //!< Command 30
+    EV_COMMANDS_31,              //!< Command 31
+    EV_COMMANDS_32,              //!< Command 32
+    EV_COMMANDS_33,              //!< Command 33
+    EV_COMMANDS_34,              //!< Command 34
+    EV_COMMANDS_35,              //!< Command 35
+    EV_COMMANDS_36,              //!< Command 36
+    EV_COMMANDS_37,              //!< Command 37
+    EV_COMMANDS_38,              //!< Command 38
+    EV_COMMANDS_39,              //!< Command 39
+    EV_COMMANDS_40,              //!< Command 40
+    EV_COMMANDS_41,              //!< Command 41
+    EV_COMMANDS_42,              //!< Command 42
+    EV_COMMANDS_43,              //!< Command 43
+    EV_COMMANDS_44,              //!< Command 44
+    EV_COMMANDS_45,              //!< Command 45
+    EV_COMMANDS_46,              //!< Command 46
+    EV_COMMANDS_47,              //!< Command 47
+    EV_COMMANDS_48,              //!< Command 48
+    EV_COMMANDS_49,              //!< Command 49
+    EV_COMMANDS_50,              //!< Command 50
+    EV_COMMANDS_51,              //!< Command 51
+    EV_COMMANDS_52,              //!< Command 52
+    EV_COMMANDS_53,              //!< Command 53
+    EV_COMMANDS_54,              //!< Command 54
+    EV_COMMANDS_55,              //!< Command 55
+    EV_COMMANDS_56,              //!< Command 56
+    EV_COMMANDS_57,              //!< Command 57
+    EV_COMMANDS_58,              //!< Command 58
+    EV_COMMANDS_59,              //!< Command 59
+    EV_COMMANDS_60,              //!< Command 50
+    EV_COMMANDS_61,              //!< Command 61
+    EV_COMMANDS_62,              //!< Command 62
+    EV_COMMANDS_63,              //!< Command 63
+    EV_COMMANDS_64,              //!< Command 64
+    EV_COMMANDS_65,              //!< Command 65
+    EV_COMMANDS_66,              //!< Command 66
+    EV_COMMANDS_67,              //!< Command 67
+    EV_COMMANDS_68,              //!< Command 68
+    EV_COMMANDS_69,              //!< Command 69
+    EV_COMMANDS_70,              //!< Command 70
+    EV_COMMANDS_71,              //!< Command 71
+    EV_COMMANDS_72,              //!< Command 72
+    EV_COMMANDS_73,              //!< Command 73
+    EV_COMMANDS_74,              //!< Command 74
+    EV_COMMANDS_75,              //!< Command 75
+    EV_COMMANDS_76,              //!< Command 76
+    EV_COMMANDS_77,              //!< Command 77
+    EV_COMMANDS_78,              //!< Command 78
+    EV_COMMANDS_79,              //!< Command 79
+    EV_COMMANDS_80,              //!< Command 80
+    EV_COMMANDS_81,              //!< Command 81
+    EV_COMMANDS_82,              //!< Command 82
+    EV_COMMANDS_83,              //!< Command 83
+    EV_COMMANDS_84,              //!< Command 84
     EV_COMMON_ACCELERATE_SIMULATION, //!< accelerate the simulation speed
     EV_COMMON_DECELERATE_SIMULATION, //!< decelerate the simulation speed
     EV_COMMON_RESET_SIMULATION_PACE, //!< reset the simulation speed
-    EV_COMMON_AUTOLOCK, //!< unlock autolock hook node
-    EV_COMMON_CONSOLE_TOGGLE, //!< show / hide the console
-    EV_COMMON_ENTER_CHATMODE, //!< enter the chat mode
-    EV_COMMON_ENTER_OR_EXIT_TRUCK, //!< enter or exit a truck
-    EV_COMMON_ENTER_NEXT_TRUCK, //!< enter next truck
-    EV_COMMON_ENTER_PREVIOUS_TRUCK, //!< enter previous truck
-    EV_COMMON_REMOVE_CURRENT_TRUCK, //!< remove current truck
-    EV_COMMON_RESPAWN_LAST_TRUCK, //!< respawn last truck
-    EV_COMMON_FOV_LESS, //!<decreases the current FOV value
-    EV_COMMON_FOV_MORE, //!<increases the current FOV value
-    EV_COMMON_FOV_RESET, //!<reset the FOV value
+    EV_COMMON_AUTOLOCK,              //!< unlock autolock hook node
+    EV_COMMON_CONSOLE_TOGGLE,        //!< show / hide the console
+    EV_COMMON_ENTER_CHATMODE,        //!< enter the chat mode
+    EV_COMMON_ENTER_OR_EXIT_TRUCK,   //!< enter or exit a truck
+    EV_COMMON_ENTER_NEXT_TRUCK,      //!< enter next truck
+    EV_COMMON_ENTER_PREVIOUS_TRUCK,  //!< enter previous truck
+    EV_COMMON_REMOVE_CURRENT_TRUCK,  //!< remove current truck
+    EV_COMMON_RESPAWN_LAST_TRUCK,    //!< respawn last truck
+    EV_COMMON_FOV_LESS,           //!<decreases the current FOV value
+    EV_COMMON_FOV_MORE,           //!<increases the current FOV value
+    EV_COMMON_FOV_RESET,          //!<reset the FOV value
     EV_COMMON_FULLSCREEN_TOGGLE,
-    EV_COMMON_HIDE_GUI, //!< hide all GUI elements
-    EV_COMMON_TOGGLE_DASHBOARD, //!< display or hide the dashboard overlay
-    EV_COMMON_LOCK, //!< connect hook node to a node in close proximity
+    EV_COMMON_HIDE_GUI,           //!< hide all GUI elements
+    EV_COMMON_TOGGLE_DASHBOARD,   //!< display or hide the dashboard overlay
+    EV_COMMON_LOCK,               //!< connect hook node to a node in close proximity
     EV_COMMON_NETCHATDISPLAY,
     EV_COMMON_NETCHATMODE,
-    EV_COMMON_OUTPUT_POSITION, //!< write current position to log (you can open the logfile and reuse the position)
-    EV_COMMON_GET_NEW_VEHICLE, //!< get new vehicle
-    EV_COMMON_PRESSURE_LESS, //!< decrease tire pressure (note: only very few trucks support this)
-    EV_COMMON_PRESSURE_MORE, //!< increase tire pressure (note: only very few trucks support this)
-    EV_COMMON_QUICKLOAD, //!< quickload scene from the disk
-    EV_COMMON_QUICKSAVE, //!< quicksave scene to the disk
-    EV_COMMON_QUIT_GAME, //!< exit the game
-    EV_COMMON_REPAIR_TRUCK, //!< repair truck to original condition
+    EV_COMMON_OUTPUT_POSITION,    //!< write current position to log (you can open the logfile and reuse the position)
+    EV_COMMON_GET_NEW_VEHICLE,    //!< get new vehicle
+    EV_COMMON_PRESSURE_LESS,      //!< decrease tire pressure (note: only very few trucks support this)
+    EV_COMMON_PRESSURE_MORE,      //!< increase tire pressure (note: only very few trucks support this)
+    EV_COMMON_QUICKLOAD,          //!< quickload scene from the disk
+    EV_COMMON_QUICKSAVE,          //!< quicksave scene to the disk
+    EV_COMMON_QUIT_GAME,          //!< exit the game
+    EV_COMMON_REPAIR_TRUCK,       //!< repair truck to original condition
     EV_COMMON_REPLAY_BACKWARD,
     EV_COMMON_REPLAY_FAST_BACKWARD,
     EV_COMMON_REPLAY_FAST_FORWARD,
     EV_COMMON_REPLAY_FORWARD,
-    EV_COMMON_RESCUE_TRUCK, //!< teleport to rescue truck
-    EV_COMMON_RESET_TRUCK, //!< reset truck to original starting position
-    EV_COMMON_TOGGLE_RESET_MODE, //!< toggle truck reset truck mode (soft vs. hard)
-    EV_COMMON_ROPELOCK, //!< connect hook node to a node in close proximity
-    EV_COMMON_SAVE_TERRAIN, //!< save terrain mesh to file
-    EV_COMMON_SCREENSHOT, //!< take a screenshot
-    EV_COMMON_SCREENSHOT_BIG, //!< take a BIG screenshot
-    EV_COMMON_SECURE_LOAD, //!< tie a load to the truck
-    EV_COMMON_SEND_CHAT, //!< send the chat text
-    EV_COMMON_TOGGLE_DEBUG_VIEW, //!< toggle debug view mode
-    EV_COMMON_CYCLE_DEBUG_VIEWS, //!< cycle debug view mode
-    EV_COMMON_TOGGLE_TERRAIN_EDITOR, //!< toggle terrain editor
+    EV_COMMON_RESCUE_TRUCK,       //!< teleport to rescue truck
+    EV_COMMON_RESET_TRUCK,        //!< reset truck to original starting position
+    EV_COMMON_TOGGLE_RESET_MODE,  //!< toggle truck reset truck mode (soft vs. hard)
+    EV_COMMON_ROPELOCK,           //!< connect hook node to a node in close proximity
+    EV_COMMON_SAVE_TERRAIN,       //!< save terrain mesh to file
+    EV_COMMON_SCREENSHOT,         //!< take a screenshot
+    EV_COMMON_SCREENSHOT_BIG,     //!< take a BIG screenshot
+    EV_COMMON_SECURE_LOAD,        //!< tie a load to the truck
+    EV_COMMON_SEND_CHAT,          //!< send the chat text
+    EV_COMMON_TOGGLE_DEBUG_VIEW,  //!< toggle debug view mode
+    EV_COMMON_CYCLE_DEBUG_VIEWS,  //!< cycle debug view mode
+    EV_COMMON_TOGGLE_TERRAIN_EDITOR,   //!< toggle terrain editor
     EV_COMMON_TOGGLE_CUSTOM_PARTICLES, //!< toggle particle cannon
-    EV_COMMON_TOGGLE_MAT_DEBUG, //!< debug purpose - dont use (currently not used)
+    EV_COMMON_TOGGLE_MAT_DEBUG,   //!< debug purpose - dont use (currently not used)
     EV_COMMON_TOGGLE_RENDER_MODE, //!< toggle render mode (solid, wireframe and points)
     EV_COMMON_TOGGLE_REPLAY_MODE, //!< toggle replay mode
-    EV_COMMON_TOGGLE_PHYSICS, //!< toggle physics on/off
-    EV_COMMON_TOGGLE_STATS, //!< toggle Ogre statistics (FPS etc.)
+    EV_COMMON_TOGGLE_PHYSICS,     //!< toggle physics on/off
+    EV_COMMON_TOGGLE_STATS,       //!< toggle Ogre statistics (FPS etc.)
     EV_COMMON_TOGGLE_TRUCK_BEACONS, //!< toggle truck beacons
-    EV_COMMON_TOGGLE_TRUCK_LIGHTS, //!< toggle truck front lights
-    EV_COMMON_TRUCK_INFO, //!< toggle truck HUD
-    EV_COMMON_TRUCK_DESCRIPTION, //!< toggle truck description
+    EV_COMMON_TOGGLE_TRUCK_LIGHTS,//!< toggle truck front lights
+    EV_COMMON_TRUCK_INFO,         //!< toggle truck HUD
+    EV_COMMON_TRUCK_DESCRIPTION,  //!< toggle truck description
     EV_COMMON_TRUCK_REMOVE,
-    EV_GRASS_LESS, //!< EXPERIMENTAL: remove some grass
-    EV_GRASS_MORE, //!< EXPERIMENTAL: add some grass
-    EV_GRASS_MOST, //!< EXPERIMENTAL: set maximum amount of grass
-    EV_GRASS_NONE, //!< EXPERIMENTAL: remove grass completely
-    EV_GRASS_SAVE, //!< EXPERIMENTAL: save changes to the grass density image
-    EV_MENU_DOWN, //!< select next element in current category
-    EV_MENU_LEFT, //!< select previous category
-    EV_MENU_RIGHT, //!< select next category
-    EV_MENU_SELECT, //!< select focussed item and close menu
-    EV_MENU_UP, //!< select previous element in current category
-    EV_SURVEY_MAP_TOGGLE_ICONS, //!< toggle map icons
-    EV_SURVEY_MAP_CYCLE, //!< cycle overview-map mode
-    EV_SURVEY_MAP_TOGGLE, //!< toggle overview-map mode
-    EV_SURVEY_MAP_ZOOM_IN, //!< increase survey map scale
-    EV_SURVEY_MAP_ZOOM_OUT, //!< decrease survey map scale
+    EV_GRASS_LESS,                //!< EXPERIMENTAL: remove some grass
+    EV_GRASS_MORE,                //!< EXPERIMENTAL: add some grass
+    EV_GRASS_MOST,                //!< EXPERIMENTAL: set maximum amount of grass
+    EV_GRASS_NONE,                //!< EXPERIMENTAL: remove grass completely
+    EV_GRASS_SAVE,                //!< EXPERIMENTAL: save changes to the grass density image
+    EV_MENU_DOWN,                 //!< select next element in current category
+    EV_MENU_LEFT,                 //!< select previous category
+    EV_MENU_RIGHT,                //!< select next category
+    EV_MENU_SELECT,               //!< select focussed item and close menu
+    EV_MENU_UP,                   //!< select previous element in current category
+    EV_SURVEY_MAP_TOGGLE_ICONS,   //!< toggle map icons
+    EV_SURVEY_MAP_CYCLE,          //!< cycle overview-map mode
+    EV_SURVEY_MAP_TOGGLE,         //!< toggle overview-map mode
+    EV_SURVEY_MAP_ZOOM_IN,        //!< increase survey map scale
+    EV_SURVEY_MAP_ZOOM_OUT,       //!< decrease survey map scale
 
-    EV_TRUCK_ACCELERATE, //!< accelerate the truck
+    EV_TRUCK_ACCELERATE,             //!< accelerate the truck
     EV_TRUCK_ACCELERATE_MODIFIER_25, //!< accelerate with 25 percent pedal input
     EV_TRUCK_ACCELERATE_MODIFIER_50, //!< accelerate with 50 percent pedal input
-    EV_TRUCK_ANTILOCK_BRAKE, //!< toggle antilockbrake system
-    EV_TRUCK_AUTOSHIFT_DOWN, //!< shift automatic transmission one gear down
-    EV_TRUCK_AUTOSHIFT_UP, //!< shift automatic transmission one gear up
-    EV_TRUCK_BLINK_LEFT, //!< toggle left direction indicator (blinker)
-    EV_TRUCK_BLINK_RIGHT, //!< toggle right direction indicator (blinker)
-    EV_TRUCK_BLINK_WARN, //!< toggle all direction indicators
-    EV_TRUCK_BRAKE, //!< brake
-    EV_TRUCK_BRAKE_MODIFIER_25, //!< brake with 25 percent pedal input
-    EV_TRUCK_BRAKE_MODIFIER_50, //!< brake with 50 percent pedal input
-    EV_TRUCK_CRUISE_CONTROL, //!< toggle cruise control
-    EV_TRUCK_CRUISE_CONTROL_ACCL,//!< increase target speed / rpm
-    EV_TRUCK_CRUISE_CONTROL_DECL,//!< decrease target speed / rpm
+    EV_TRUCK_ANTILOCK_BRAKE,      //!< toggle antilockbrake system
+    EV_TRUCK_AUTOSHIFT_DOWN,      //!< shift automatic transmission one gear down
+    EV_TRUCK_AUTOSHIFT_UP,        //!< shift automatic transmission one gear up
+    EV_TRUCK_BLINK_LEFT,          //!< toggle left direction indicator (blinker)
+    EV_TRUCK_BLINK_RIGHT,         //!< toggle right direction indicator (blinker)
+    EV_TRUCK_BLINK_WARN,          //!< toggle all direction indicators
+    EV_TRUCK_BRAKE,               //!< brake
+    EV_TRUCK_BRAKE_MODIFIER_25,   //!< brake with 25 percent pedal input
+    EV_TRUCK_BRAKE_MODIFIER_50,   //!< brake with 50 percent pedal input
+    EV_TRUCK_CRUISE_CONTROL,      //!< toggle cruise control
+    EV_TRUCK_CRUISE_CONTROL_ACCL, //!< increase target speed / rpm
+    EV_TRUCK_CRUISE_CONTROL_DECL, //!< decrease target speed / rpm
     EV_TRUCK_CRUISE_CONTROL_READJUST, //!< match target speed / rpm with current truck speed / rpm
-    EV_TRUCK_HORN, //!< truck horn
+    EV_TRUCK_HORN,                //!< truck horn
     EV_TRUCK_LEFT_MIRROR_LEFT,
     EV_TRUCK_LEFT_MIRROR_RIGHT,
-    EV_TRUCK_LIGHTTOGGLE01, //!< toggle custom light 1
-    EV_TRUCK_LIGHTTOGGLE02, //!< toggle custom light 2
-    EV_TRUCK_LIGHTTOGGLE03, //!< toggle custom light 3
-    EV_TRUCK_LIGHTTOGGLE04, //!< toggle custom light 4
-    EV_TRUCK_LIGHTTOGGLE05, //!< toggle custom light 5
-    EV_TRUCK_LIGHTTOGGLE06, //!< toggle custom light 6
-    EV_TRUCK_LIGHTTOGGLE07, //!< toggle custom light 7
-    EV_TRUCK_LIGHTTOGGLE08, //!< toggle custom light 8
-    EV_TRUCK_LIGHTTOGGLE09, //!< toggle custom light 9
-    EV_TRUCK_LIGHTTOGGLE10, //!< toggle custom light 10
-    EV_TRUCK_MANUAL_CLUTCH, //!< manual clutch (for manual transmission)
-    EV_TRUCK_PARKING_BRAKE, //!< toggle parking brake
+    EV_TRUCK_LIGHTTOGGLE01,       //!< toggle custom light 1
+    EV_TRUCK_LIGHTTOGGLE02,       //!< toggle custom light 2
+    EV_TRUCK_LIGHTTOGGLE03,       //!< toggle custom light 3
+    EV_TRUCK_LIGHTTOGGLE04,       //!< toggle custom light 4
+    EV_TRUCK_LIGHTTOGGLE05,       //!< toggle custom light 5
+    EV_TRUCK_LIGHTTOGGLE06,       //!< toggle custom light 6
+    EV_TRUCK_LIGHTTOGGLE07,       //!< toggle custom light 7
+    EV_TRUCK_LIGHTTOGGLE08,       //!< toggle custom light 8
+    EV_TRUCK_LIGHTTOGGLE09,       //!< toggle custom light 9
+    EV_TRUCK_LIGHTTOGGLE10,       //!< toggle custom light 10
+    EV_TRUCK_MANUAL_CLUTCH,       //!< manual clutch (for manual transmission)
+    EV_TRUCK_PARKING_BRAKE,       //!< toggle parking brake
     EV_TRUCK_TRAILER_PARKING_BRAKE, //!< toggle trailer parking brake
     EV_TRUCK_RIGHT_MIRROR_LEFT,
     EV_TRUCK_RIGHT_MIRROR_RIGHT,
-    EV_TRUCK_SHIFT_DOWN, //!< shift one gear down in manual transmission mode
-    EV_TRUCK_SHIFT_GEAR01, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR02, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR03, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR04, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR05, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR06, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR07, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR08, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR09, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR10, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR11, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR12, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR13, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR14, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR15, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR16, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR17, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR18, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_GEAR_REVERSE, //!< shift directly into this gear
-    EV_TRUCK_SHIFT_HIGHRANGE, //!< select high range (13-18) for H-shaft
-    EV_TRUCK_SHIFT_LOWRANGE, //!< select low range (1-6) for H-shaft
-    EV_TRUCK_SHIFT_MIDRANGE, //!< select middle range (7-12) for H-shaft
-    EV_TRUCK_SHIFT_NEUTRAL, //!< shift to neutral gear in manual transmission mode
-    EV_TRUCK_SHIFT_UP, //!< shift one gear up in manual transmission mode
-    EV_TRUCK_STARTER, //!< hold to start the engine
-    EV_TRUCK_STEER_LEFT, //!< steer left
-    EV_TRUCK_STEER_RIGHT, //!< steer right
-    EV_TRUCK_SWITCH_SHIFT_MODES, //!< toggle between transmission modes
-    EV_TRUCK_TOGGLE_CONTACT, //!< toggle ignition
-    EV_TRUCK_TOGGLE_FORWARDCOMMANDS, //!< toggle forwardcommands
-    EV_TRUCK_TOGGLE_IMPORTCOMMANDS, //!< toggle importcommands
-    EV_TRUCK_TOGGLE_INTER_AXLE_DIFF, //!< toggle the inter axle differential mode
+    EV_TRUCK_SHIFT_DOWN,          //!< shift one gear down in manual transmission mode
+    EV_TRUCK_SHIFT_GEAR01,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR02,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR03,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR04,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR05,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR06,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR07,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR08,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR09,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR10,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR11,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR12,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR13,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR14,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR15,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR16,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR17,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR18,        //!< shift directly into this gear
+    EV_TRUCK_SHIFT_GEAR_REVERSE,  //!< shift directly into this gear
+    EV_TRUCK_SHIFT_HIGHRANGE,     //!< select high range (13-18) for H-shaft
+    EV_TRUCK_SHIFT_LOWRANGE,      //!< select low range (1-6) for H-shaft
+    EV_TRUCK_SHIFT_MIDRANGE,      //!< select middle range (7-12) for H-shaft
+    EV_TRUCK_SHIFT_NEUTRAL,       //!< shift to neutral gear in manual transmission mode
+    EV_TRUCK_SHIFT_UP,            //!< shift one gear up in manual transmission mode
+    EV_TRUCK_STARTER,             //!< hold to start the engine
+    EV_TRUCK_STEER_LEFT,          //!< steer left
+    EV_TRUCK_STEER_RIGHT,         //!< steer right
+    EV_TRUCK_SWITCH_SHIFT_MODES,  //!< toggle between transmission modes
+    EV_TRUCK_TOGGLE_CONTACT,      //!< toggle ignition
+    EV_TRUCK_TOGGLE_FORWARDCOMMANDS,  //!< toggle forwardcommands
+    EV_TRUCK_TOGGLE_IMPORTCOMMANDS,   //!< toggle importcommands
+    EV_TRUCK_TOGGLE_INTER_AXLE_DIFF,  //!< toggle the inter axle differential mode
     EV_TRUCK_TOGGLE_INTER_WHEEL_DIFF, //!< toggle the inter wheel differential mode
-    EV_TRUCK_TOGGLE_PHYSICS, //!< toggle physics simulation
-    EV_TRUCK_TOGGLE_TCASE_4WD_MODE, //!< toggle the transfer case 4wd mode
+    EV_TRUCK_TOGGLE_PHYSICS,      //!< toggle physics simulation
+    EV_TRUCK_TOGGLE_TCASE_4WD_MODE,   //!< toggle the transfer case 4wd mode
     EV_TRUCK_TOGGLE_TCASE_GEAR_RATIO, //!< toggle the transfer case gear ratio
-    EV_TRUCK_TOGGLE_VIDEOCAMERA, //!< toggle videocamera update
-    EV_TRUCK_TRACTION_CONTROL, //!< toggle antilockbrake system
+    EV_TRUCK_TOGGLE_VIDEOCAMERA,  //!< toggle videocamera update
+    EV_TRUCK_TRACTION_CONTROL,    //!< toggle antilockbrake system
 
     // Savegames
     EV_COMMON_QUICKSAVE_01,
@@ -478,6 +478,7 @@ public:
     Ogre::String        getKeyForCommand(int eventID);
     Ogre::String        getDeviceName(event_trigger_t const& evt);
     Ogre::String        getEventCommand(int eventID);
+    std::string         getEventCommandTrimmed(int eventID);                //!< Omits 'EXPL' modifier
     Ogre::String        getTriggerCommand(event_trigger_t const& evt);
     Ogre::String        getEventConfig(int eventID);
     Ogre::String        getEventDefaultConfig(int eventID);
@@ -539,7 +540,6 @@ public:
 
     void windowResized(Ogre::RenderWindow* rw);
     OIS::ForceFeedback* getForceFeedbackDevice() { return mForceFeedback; };
-    std::string getEventCommandTrimmed(int eventID); // Removes EXPL
 
 protected:
 


### PR DESCRIPTION
This feature branch gives you the ability to run AngelScript scripts on launch and have them running continuously until the game shutdown, in both menu and simulation (both single and multiplayer).
The game interface is the same which terrain scripts use, with new extension: global object `input` which lets you retrieve configured controls and current input states.

There is an example script 'demo_script.as' in the "resources/scripts" directory (or 'resources/scripts.zip' package when installed). You can run it by 2 ways:
 * from command line: `ror -runscript demo_script.as` (you can load multiple scripts by using `-runscript` repeatedly)
 * from RoR.cfg: `app_custom_scripts=demo_script.as` (you can enter multiple filenames delimited by comma).

Showcase of the example script:
![image](https://user-images.githubusercontent.com/491088/148252473-d6e64ff0-5ee3-4832-a999-f963e81b343b.png)
![image](https://user-images.githubusercontent.com/491088/148252680-00a38a53-48c8-40c6-a18e-f4ed3efa7574.png)
![image](https://user-images.githubusercontent.com/491088/148259781-f5dd208d-5341-413f-bbbe-94e3dfa38a94.png)


This is probably the least-nonsense feature I coded so far.