### PR TITLE
:video_game: Multiplayer: optional hash check of remote trucks.

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -118,6 +118,7 @@ CVar* mp_server_password;
 CVar* mp_player_name;
 CVar* mp_player_token;
 CVar* mp_api_url;
+CVar* mp_truck_hash_check;
 
 // Diagnostic
 CVar* diag_auto_spawner_report;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -294,6 +294,7 @@ extern CVar* mp_server_password;
 extern CVar* mp_player_name;
 extern CVar* mp_player_token;
 extern CVar* mp_api_url;
+extern CVar* mp_truck_hash_check;
 
 // Diagnostic
 extern CVar* diag_auto_spawner_report;

--- a/source/main/network/RoRnet.h
+++ b/source/main/network/RoRnet.h
@@ -28,7 +28,7 @@ namespace RoRnet {
 #define RORNET_LAN_BROADCAST_PORT   13000  //!< port used to send the broadcast announcement in LAN mode
 #define RORNET_MAX_USERNAME_LEN     40     //!< port used to send the broadcast announcement in LAN mode
 
-#define RORNET_VERSION              "RoRnet_2.43"
+#define RORNET_VERSION              "RoRnet_2.44"
 
 enum MessageType
 {
@@ -142,6 +142,7 @@ struct ActorStreamRegister
     int32_t origin_sourceid;       //!< origin sourceid
     int32_t origin_streamid;       //!< origin streamid
     char    name[128];             //!< filename
+    char    hash[21];              //!< SHA1 file checksum, for tampering detection
     int32_t bufferSize;            //!< initial stream status
     int32_t time;                  //!< initial time stamp
     char    skin[60];              //!< skin

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1870,6 +1870,7 @@ void Actor::sendStreamSetup()
     reg.type = 0;
     reg.time = App::GetGameContext()->GetActorManager()->GetNetTime();
     strncpy(reg.name, ar_filename.c_str(), 128);
+    strncpy(reg.hash, ar_filehash.c_str(), 20);
     if (m_used_skin_entry != nullptr)
     {
         strncpy(reg.skin, m_used_skin_entry->dname.c_str(), 60);

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -70,6 +70,8 @@ void Console::cVarSetupBuiltins()
     App::mp_player_name          = this->cVarCreate("mp_player_name",          "Nickname",                   CVAR_ARCHIVE,                     "Player");
     App::mp_player_token         = this->cVarCreate("mp_player_token",         "User Token",                 CVAR_ARCHIVE | CVAR_NO_LOG);
     App::mp_api_url              = this->cVarCreate("mp_api_url",              "Online API URL",             CVAR_ARCHIVE,                     "http://api.rigsofrods.org");
+    App::mp_truck_hash_check     = this->cVarCreate("mp_truck_hash_check",     "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
+
 
     App::diag_auto_spawner_report= this->cVarCreate("diag_auto_spawner_report","AutoActorSpawnerReport",     CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::diag_camera             = this->cVarCreate("diag_camera",             "Camera Debug",               CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");


### PR DESCRIPTION
RoRnet version bumped to .44 - a STREAM_REGISTER message for a vehicle now contains SHA1 hash - always sent regardless of user setting.

The local check is controlled by cvar `mp_truck_hash_check` - if `true` and the hashes don't match, RoR behaves similarly as if the mod wasn't installed, reporting "Mod hash mismatch: FILENAME" to console and showing stream as failed in MP client list.

The check is enabled by default because I think that's what casual player would expect.

Note that the hashes aren't checked against the online repo, only against the locally installed mods.
