### PR TITLE
Fixed caelum sky rendered black on mirrors

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -423,6 +423,7 @@ void RoR::GfxActor::UpdateVideoCameras(float dt_sec)
             vidcam.vcam_ogre_camera->setPosition(center);
             vidcam.vcam_ogre_camera->lookAt(App::GetCameraManager()->GetCameraNode()->getPosition() - 2.0f * project);
             vidcam.vcam_ogre_camera->roll(roll);
+            vidcam.vcam_ogre_camera->setNearClipDistance(1); // fixes Caelum sky rendered black on mirrors
 
             continue; // Done processing mirror prop.
         }


### PR DESCRIPTION
Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/330

Tested with agora though, since i can't reproduce the tatra bug