### PR TITLE
Don't crash on invalid icon name

### DIFF
--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -174,7 +174,11 @@ ImVec2 ConsoleView::DrawMessage(ImVec2 cursor, Console::Message const& m)
     {
         if (m.cm_icon != "")
         {
-            icon = Ogre::TextureManager::getSingleton().load(m.cm_icon, "IconsRG");
+            try
+            {
+                icon = Ogre::TextureManager::getSingleton().load(m.cm_icon, "IconsRG");
+            }
+            catch (...) {}
         }
         else if (m.cm_area == Console::MessageArea::CONSOLE_MSGTYPE_SCRIPT)
         {


### PR DESCRIPTION
Icon names can be defined from scripts etc.... I corrected some invalid names some time ago, but better be sure.

Also i'm not sure if `Ogre::TextureManager::getSingleton().load` every frame is good practice...