### PR TITLE
👷 Updated windows CI image to windows-2019

### DIFF
--- a/.github/workflows/build-game.yml
+++ b/.github/workflows/build-game.yml
@@ -73,7 +73,7 @@ jobs:
 
   build-msvc:
     name: Windows build
-    runs-on: windows-2016
+    runs-on: windows-2019
     env:
       DXSDK_DIR: C:\apps\Microsoft DirectX SDK\
       BUILD_TOOLS_PATH: C:\apps\build-tools\


### PR DESCRIPTION
Upgraded to windows-2019 since windows-2016 is no longer supported
![image](https://user-images.githubusercontent.com/9480940/158877315-1025d671-7751-4674-bd37-cb79ef79ad6f.png)
