### PR TITLE
Fixed skinned vehicles showing pink after reload

### DIFF
--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1088,13 +1088,7 @@ void CacheSystem::LoadResource(CacheEntry& t)
         return;
     }
 
-    // Check if already loaded for different entry from the same bundle.
     Ogre::String group = "bundle " + t.resource_bundle_path; // Compose group name from full path.
-    if (Ogre::ResourceGroupManager::getSingleton().resourceGroupExists(group))
-    {
-        t.resource_group = group;
-        return;
-    }
 
     // Load now.
     try
@@ -1129,6 +1123,15 @@ void CacheSystem::LoadResource(CacheEntry& t)
         ResourceGroupManager::getSingleton().initialiseResourceGroup(group);
 
         t.resource_group = group;
+
+        // Inform other entries sharing this bundle (i.e. '.skin' entries in vehicle bundles)
+        for (CacheEntry& i_entry: m_entries)
+        {
+            if (i_entry.resource_bundle_path == t.resource_bundle_path)
+            {
+                i_entry.resource_group = group; // Mark as loaded
+            }
+        }
     }
     catch (Ogre::Exception& e)
     {

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1174,7 +1174,6 @@ void CacheSystem::UnLoadResource(CacheEntry& t)
     }
 
     Ogre::ResourceGroupManager::getSingleton().destroyResourceGroup(resource_group);
-    this->LoadResource(t); // Will create the same resource group again
 }
 
 CacheEntry* CacheSystem::FetchSkinByName(std::string const & skin_name)


### PR DESCRIPTION
Resource management is hard.

There's usually more than one .truck and possibly several .skin entries in a ZIP file from the repo. Modcache creates a `CacheEntry` for each of these, and it must keep them in sync - when one is loaded, the others must be notified. This was hapenning correctly on unloading, but not on (re)loading.