### PR TITLE
Paged: check if farther details level is greater than closer

### DIFF
--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -310,7 +310,13 @@ void TerrainObjectManager::ProcessTree(
     float max = maxDist * terrainManager->getPagedDetailFactor();
     if (max < 10)
         max = 10;
-    geom->addDetailLevel<ImpostorPage>(max, max / 10);
+
+    // Check if farther details level is greater than closer
+    if (max / 10 > min / 2)
+    {
+        geom->addDetailLevel<ImpostorPage>(max, max / 10);
+    }
+
     TreeLoader2D *treeLoader = new TreeLoader2D(geom, TBounds(0, 0, mapsizex, mapsizez));
     geom->setPageLoader(treeLoader);
     treeLoader->setHeightFunction(&getTerrainHeight);


### PR DESCRIPTION
Lately i'm getting

```
FATAL ERROR: An internal error occured in Rigs of Rods.

Technical details below: 

RenderingAPIException: Closer detail levels must be added before farther ones in PagedGeometry::addDetailLevel() at /home/babis/Downloads/ror-dependencies/Source/paged-geometry/source/PagedGeometry.cpp (line 365)
```

when loading brutal valley. This fixes it

min is 40 and max 41 which makes the error valid

vegetation density must be set to 20% to reproduce.