### PR TITLE
Fixed visual glitches with PSSM

### DIFF
--- a/resources/managed_materials/shadows/pssm/on/shadows.material
+++ b/resources/managed_materials/shadows/pssm/on/shadows.material
@@ -2,6 +2,7 @@ abstract technique Shadows/managed/base_receiver
 {
 	pass BaseRender
 	{
+			depth_bias -20
 			ambient 1 1 1 1
 			diffuse 1 1 1 1
 			


### PR DESCRIPTION
- Fixes character color glitch with PSSM
Managed to reproduce the issue on my laptop, it also happens with VS 2019
Before:
![bef](https://user-images.githubusercontent.com/2660424/159050369-3af9a59f-dce4-4819-89f6-4518fafc4c5c.png)
After:
![af](https://user-images.githubusercontent.com/2660424/159050397-b6bc4e13-b1c5-461d-83a9-2f801acb40da.png)
- Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/361. It happens with new materials, PSSM and reflections on
Before:
![screenshot_2022-03-19_17-46-05_1](https://user-images.githubusercontent.com/2660424/159128252-26a3b050-fabf-4b57-bda0-72a95cda9ec9.png)
After:
![screenshot_2022-03-19_17-46-33_1](https://user-images.githubusercontent.com/2660424/159128259-45ef3ff4-6005-49a9-9d23-d7755f2d1d00.png)

Reference: https://ogrecave.github.io/ogre/api/13/_material-_scripts.html#autotoc_md131