### PR TITLE
:bug: Fixed CMake option for specifying a custom version

### DIFF
--- a/cmake/GenerateVersionInfo.cmake
+++ b/cmake/GenerateVersionInfo.cmake
@@ -39,17 +39,24 @@
 # This implementation was inspired by
 # https://github.com/minetest/minetest/blob/master/cmake/Modules/GenerateVersion.cmake
 
+macro(version_str_to_ints version year month suffix)
+    string(REGEX REPLACE "([0-9]+).[0-9]+[^\n\r]+" "\\1" ${year} ${version})
+    string(REGEX REPLACE "[0-9]+.([0-9]+)[^\n\r]+" "\\1" ${month} ${version})
+    string(REGEX REPLACE "[0-9]+.[0-9]+([^\n\r]+)" "\\1" ${suffix} ${version})
+endmacro(version_str_to_ints)
 
-string(TIMESTAMP VERSION_YEAR "%Y" UTC)
-string(TIMESTAMP VERSION_MONTH "%m" UTC)
-string(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC) # more correct would be "%b %d %Y" but this is only supported from cmake >= 3.7
+# Default variables
+string(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
 string(TIMESTAMP BUILD_TIME "%H:%M" UTC)
 
 # Define a suffix to append to the version string in case of a development build (as opposed to
 # an official release). This suffix contains additional information gathered from the git VCS.
 if (BUILD_CUSTOM_VERSION)
-    set(VERSION_SUFFIX "-${CUSTOM_VERSION}")
+    version_str_to_ints(${CUSTOM_VERSION} VERSION_YEAR VERSION_MONTH VERSION_SUFFIX)
 elseif (BUILD_DEV_VERSION)
+    string(TIMESTAMP VERSION_YEAR "%Y" UTC)
+    string(TIMESTAMP VERSION_MONTH "%m" UTC)
+
     # Check if we are inside an actual git repository
     if (GIT_EXECUTABLE)
         execute_process(

--- a/source/version_info/CMakeLists.txt
+++ b/source/version_info/CMakeLists.txt
@@ -14,7 +14,16 @@ find_package(Git)
 # generates the version_info.cpp and version_def.h files.
 set(VERSION_FLAGS -DBUILD_DEV_VERSION=${BUILD_DEV_VERSION})
 
-add_custom_target(generate_version
+if (DEFINED ${_PREFIX}CUSTOM_VERSION)
+    list(
+            APPEND VERSION_FLAGS
+            -DBUILD_CUSTOM_VERSION=TRUE
+            -DCUSTOM_VERSION=${${_PREFIX}CUSTOM_VERSION}
+    )
+endif ()
+
+add_custom_target(
+        generate_version
         COMMAND ${CMAKE_COMMAND} ${VERSION_FLAGS}
         -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
         -DVERSION_FILE_INPUT=${CMAKE_CURRENT_SOURCE_DIR}/RoRVersion.cpp.in
@@ -28,16 +37,17 @@ add_custom_target(generate_version
         BYPRODUCTS ${VERSION_INFO_CPP} ${VERSION_DEF_H}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Generate files containing version information"
-        )
+)
 
 # The version_info library target
 # Other targets can make use of the version information with `target_link_libraries( <target> version_info )`
 add_library(version_info STATIC ${VERSION_INFO_CPP})
 add_dependencies(version_info generate_version)
-target_include_directories(version_info PUBLIC
+target_include_directories(
+        version_info PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
-        )
+)
 
 set_property(TARGET version_info PROPERTY FOLDER "Version Generation")
 set_property(TARGET generate_version PROPERTY FOLDER "Version Generation")


### PR DESCRIPTION
This feature got added in #1387, but it got broken when we switched from semver to rolling releases

Usage: Set `ROR_CUSTOM_VERSION` to `[year].[month]-[prefix]`