### PR TITLE
Set depth_bias only on character/vehicles

### DIFF
--- a/resources/managed_materials/managed_mats_vehicles.material
+++ b/resources/managed_materials/managed_mats_vehicles.material
@@ -8,6 +8,7 @@ material managed/flexmesh_standard/simple
 	//Texture is rendred here
 		pass BaseRender
 		{
+			depth_bias -20
 			texture_unit Diffuse_Map
 			{
 				texture_alias unknown.dds
@@ -23,6 +24,7 @@ material managed/flexmesh_standard/damageonly
 	//Texture is rendred here
 		pass BaseRender
 		{
+			depth_bias -20
 			diffuse vertexcolour
 			texture_unit Diffuse_Map
 			{
@@ -46,6 +48,7 @@ material managed/flexmesh_standard/specularonly
 	//Texture is rendred here
 		pass BaseRender
 		{
+			depth_bias -20
 			texture_unit Diffuse_Map
 			{
 				texture_alias unknown.dds
@@ -65,6 +68,7 @@ material managed/flexmesh_standard/speculardamage
 	//Texture is rendred here
 		pass BaseRender
 		{
+			depth_bias -20
 			diffuse vertexcolour
 			texture_unit Diffuse_Map
 			{
@@ -91,6 +95,7 @@ material managed/mesh_standard/simple
 	//Texture is rendred here
 		pass BaseRender
 		{
+			depth_bias -20
 			texture_unit Diffuse_Map
 			{
 				texture_alias unknown.dds
@@ -106,6 +111,7 @@ material managed/mesh_standard/specular
 	//Texture is rendred here
 		pass BaseRender
 		{
+			depth_bias -20
 			texture_unit Diffuse_Map
 			{
 				texture_alias unknown.dds

--- a/resources/managed_materials/shadows/pssm/on/shadows.material
+++ b/resources/managed_materials/shadows/pssm/on/shadows.material
@@ -2,7 +2,6 @@ abstract technique Shadows/managed/base_receiver
 {
 	pass BaseRender
 	{
-			depth_bias -20
 			ambient 1 1 1 1
 			diffuse 1 1 1 1
 			

--- a/resources/materials/character.material
+++ b/resources/materials/character.material
@@ -6,6 +6,7 @@ material tracks/character: RoR/Managed_Mats/Base
 	{
 		pass BaseRender
 		{
+			depth_bias -20
 			texture_unit Diffuse_Map 1
 			{
 				texture character.dds


### PR DESCRIPTION
Setting it globally on `shadows.material` kills survey map (with PSSM on):
![kk](https://user-images.githubusercontent.com/2660424/159331042-1a7922cf-772d-4589-8d55-09b4e8e5abd8.png)

