### PR TITLE
Fixed selector switching to "All" category when searching

### DIFF
--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -140,7 +140,6 @@ void MainSelector::Draw()
     }
     if (ImGui::InputText("##SelectorSearch", m_search_input.GetBuffer(), m_search_input.GetCapacity()))
     {
-        m_selected_category = 0; // 'All'
         // `m_last_selected_category` intentionally not updated
         this->UpdateSearchParams();
         this->UpdateDisplayLists();


### PR DESCRIPTION
When a certain category is selected, search box searches on that category, not All.