### PR TITLE
Network quality indicator fixes

### DIFF
--- a/source/main/gui/panels/GUI_MultiplayerClientList.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerClientList.cpp
@@ -65,6 +65,11 @@ void MpClientList::Draw()
 
     int y = 20 + (ImGui::GetTextLineHeightWithSpacing() * m_users.size());
 
+    if (App::GetNetwork()->GetNetQuality() != 0)
+    {
+        y += 20;
+    }
+
     ImGui::SetNextWindowSize(ImVec2((content_width + (2*ImGui::GetStyle().WindowPadding.x)), y));
     ImGui::PushStyleColor(ImGuiCol_WindowBg, theme.semitransparent_window_bg);
     ImGui::Begin("Peers", nullptr, flags);

--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -590,6 +590,7 @@ void Network::Disconnect()
         m_socket.close_fd();
     }
 
+    SetNetQuality(0);
     m_users.clear();
     m_disconnected_users.clear();
     m_recv_packet_buffer.clear();


### PR DESCRIPTION
- Fixes visibility
Before:
![kk](https://user-images.githubusercontent.com/2660424/162049254-f8475263-4846-419b-832a-7d64d991dad4.png)
After:
![kkk](https://user-images.githubusercontent.com/2660424/162049272-a438693b-0208-432c-93bd-1996057e7e22.png)

- Fixes not resetting on disconnect, which made it appear always when connecting to another server
