### PR TITLE
Fixed gcc warning

### DIFF
--- a/source/main/physics/flex/FlexMeshWheel.cpp
+++ b/source/main/physics/flex/FlexMeshWheel.cpp
@@ -66,7 +66,7 @@ FlexMeshWheel::FlexMeshWheel(
 
     // Define the vertices
     m_vertex_count = 6*(nrays+1);
-    m_vertices = new FlexMeshWheelVertex[m_vertex_count];
+    m_vertices.resize(m_vertex_count);
 
     int i;
     //textures coordinates
@@ -83,7 +83,7 @@ FlexMeshWheel::FlexMeshWheel(
     // Define triangles
     // The values in this table refer to vertices in the above table
     m_index_count = 3*10*nrays;
-    m_indices=(unsigned short*)malloc(m_index_count*sizeof(unsigned short));
+    m_indices.resize(m_index_count);
     for (i=0; i<nrays; i++)
     {
         m_indices[3*(i*10  )]=i*6;   m_indices[3*(i*10  )+1]=i*6+1;     m_indices[3*(i*10  )+2]=(i+1)*6;
@@ -131,7 +131,7 @@ FlexMeshWheel::FlexMeshWheel(
           offset, m_mesh->sharedVertexData->vertexCount, HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE);
 
     // Upload the position data to the card
-    m_hw_vbuf->writeData(0, m_hw_vbuf->getSizeInBytes(), m_vertices, true);
+    m_hw_vbuf->writeData(0, m_hw_vbuf->getSizeInBytes(), m_vertices.data(), true);
 
     // Set position buffer binding so buffer 0 is bound to our position buffer
     VertexBufferBinding* bind = m_mesh->sharedVertexData->vertexBufferBinding;
@@ -146,7 +146,8 @@ FlexMeshWheel::FlexMeshWheel(
             HardwareBuffer::HBU_STATIC_WRITE_ONLY);
 
     // Upload the index data to the card
-    ibuf->writeData(0, ibuf->getSizeInBytes(), m_indices, true);
+    ibuf->writeData(0, ibuf->getSizeInBytes(), m_indices.data(), true);
+    m_indices.clear(); // We won't need these anymore.
 
     // Set parameters of the submesh
     m_submesh->useSharedVertices = true;
@@ -163,9 +164,6 @@ FlexMeshWheel::FlexMeshWheel(
 
 FlexMeshWheel::~FlexMeshWheel()
 {
-    if (m_vertices != nullptr) { delete m_vertices; }
-    if (m_indices != nullptr) { free (m_indices); }
-
     // Rim: we own both Entity and SceneNode
     m_rim_scene_node->detachAllObjects();
     App::GetGfxScene()->GetSceneManager()->destroySceneNode(m_rim_scene_node);
@@ -259,6 +257,6 @@ void FlexMeshWheel::flexitCompute()
 
 Vector3 FlexMeshWheel::flexitFinal()
 {
-    m_hw_vbuf->writeData(0, m_hw_vbuf->getSizeInBytes(), m_vertices, true);
+    m_hw_vbuf->writeData(0, m_hw_vbuf->getSizeInBytes(), m_vertices.data(), true);
     return m_flexit_center;
 }

--- a/source/main/physics/flex/FlexMeshWheel.h
+++ b/source/main/physics/flex/FlexMeshWheel.h
@@ -26,6 +26,7 @@
 
 #include <Ogre.h>
 #include <string>
+#include <vector>
 
 namespace RoR {
 
@@ -98,13 +99,13 @@ private:
     // Vertices
     float            m_norm_y;
     size_t           m_vertex_count;
-    FlexMeshWheelVertex* m_vertices;
+    std::vector<FlexMeshWheelVertex> m_vertices;
     Ogre::VertexDeclaration* m_vertex_format;
     Ogre::HardwareVertexBufferSharedPtr m_hw_vbuf;
 
     // Indices
     size_t           m_index_count;
-    unsigned short*  m_indices;
+    std::vector<unsigned short>  m_indices;
 };
 
 /// @} // addtogroup Flex

--- a/source/main/terrain/SurveyMapEntity.h
+++ b/source/main/terrain/SurveyMapEntity.h
@@ -34,13 +34,20 @@ namespace RoR {
 
     struct SurveyMapEntity
     {
+        SurveyMapEntity()
+        {}
+
+        SurveyMapEntity(const std::string& _type, const std::string& _caption, const std::string& _filename, const std::string& _rg, Ogre::Vector3 _pos, Ogre::Radian _rot, int _id)
+            :type(_type), caption(_caption), filename(_filename), resource_group(_rg), pos(_pos), rot_angle(_rot), id(_id)
+        {}
+
         std::string type; //!< informational
         std::string caption; //!< display caption
         std::string filename; //!< Requested icon, cached may be out of date.
         std::string resource_group; //!< if empty, defaults to TexturesRG
         Ogre::Vector3 pos; //!< world pos in meters
         Ogre::Radian rot_angle; //!< world yaw in radians
-        int id; //!< race ID (>=0), or -1 if not a race icon. You can use larger negative numbers for custom IDs.
+        int id = -1; //!< race ID (>=0), or -1 if not a race icon. You can use larger negative numbers for custom IDs.
         Ogre::TexturePtr cached_icon;
         bool draw_caption = false; //!< By default, don't draw caption under icon, use the mouse tooltip.
         Ogre::ColourValue caption_color = Ogre::ColourValue::White;

--- a/source/main/terrain/Terrain.cpp
+++ b/source/main/terrain/Terrain.cpp
@@ -570,7 +570,7 @@ std::string RoR::Terrain::getTerrainFileResourceGroup()
 
 void RoR::Terrain::addSurveyMapEntity(const std::string& type, const std::string& filename, const std::string& resource_group, const std::string& caption, const Ogre::Vector3& pos, float angle, int id)
 {
-    m_object_manager->m_map_entities.push_back({ type, caption, filename, resource_group, pos, Ogre::Radian(angle), id });
+    m_object_manager->m_map_entities.push_back(SurveyMapEntity(type, caption, filename, resource_group, pos, Ogre::Radian(angle), id));
 }
 
 void RoR::Terrain::delSurveyMapEntities(int id)

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -674,7 +674,7 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
             type = "racestart";
         }
         int race_id = res.size() > 1 ? StringConverter::parseInt(res[1], -1) : -1;
-        m_map_entities.push_back({type, /*caption:*/type, fmt::format("icon_{}.dds", type), /*resource_group:*/"", object.position, Ogre::Radian(0), race_id});
+        m_map_entities.push_back(SurveyMapEntity(type, /*caption:*/type, fmt::format("icon_{}.dds", type), /*resource_group:*/"", object.position, Ogre::Radian(0), race_id));
     }
     else if (!object.type.empty())
     {
@@ -684,7 +684,7 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
         {
             caption = object.instance_name + " " + object.type;
         }
-        m_map_entities.push_back({object.type, caption, fmt::format("icon_{}.dds", object.type), /*resource_group:*/"", object.position, Ogre::Radian(0), -1});
+        m_map_entities.push_back(SurveyMapEntity(object.type, caption, fmt::format("icon_{}.dds", object.type), /*resource_group:*/"", object.position, Ogre::Radian(0), -1));
     }
 
     this->ProcessODefCollisionBoxes(obj, odef, object, race_event);
@@ -934,7 +934,7 @@ void TerrainObjectManager::LoadTelepoints()
 {
     for (Terrn2Telepoint& telepoint: terrainManager->GetDef().telepoints)
     {
-        m_map_entities.push_back({"telepoint", telepoint.name, "icon_telepoint.dds", /*resource_group:*/"", telepoint.position, Ogre::Radian(0)});
+        m_map_entities.push_back(SurveyMapEntity("telepoint", telepoint.name, "icon_telepoint.dds", /*resource_group:*/"", telepoint.position, Ogre::Radian(0), -1));
     }
 }
 


### PR DESCRIPTION
Lately gcc complains:

```
[ 41%] Building CXX object source/main/CMakeFiles/RoR.dir/physics/flex/FlexMeshWheel.cpp.o
/home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/physics/flex/FlexMeshWheel.cpp: In constructor ‘RoR::FlexMeshWheel::FlexMeshWheel(Ogre::Entity*, RoR::GfxActor*, int, int, int, int, const std::string&, const std::string&, float, bool)’:
/home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/physics/flex/FlexMeshWheel.cpp:86:38: warning: argument 1 value ‘1844674407370955155 ’ exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   86 |     m_indices=(unsigned short*)malloc(m_index_count*sizeof(unsigned short));
      |                                ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/12.1.0/cstdlib:75,
                 from /usr/include/c++/12.1.0/ext/string_conversions.h:41,
                 from /usr/include/c++/12.1.0/bits/basic_string.h:3960,
                 from /usr/include/c++/12.1.0/string:53,
                 from /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/phc.h:25,
                 from /home/babis/Downloads/ror-dependencies/rigs-of-rods/source/main/CMakeFiles/RoR.dir/cmake_pch.hxx:5,
                 from <command-line>:
/usr/include/stdlib.h:540:14: note: in a call to allocation function ‘void* malloc(size_t)’ declared here
  540 | extern void *malloc (size_t __size) __THROW __attribute_malloc__
      |              ^~~~~~
```

I don't know if this is the correct way to fix it but it suppress the warning.