### PR TITLE
Hotfix: game hangs when spawning any truck with hooks.

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -3233,5 +3233,6 @@ void RoR::GfxActor::RemoveBeam(int beam_index)
             m_gfx_beams.erase(itor);
             return;
         }
+        itor++;
     }
 }


### PR DESCRIPTION
For example Liebherr13HM.
Introduced by 5095ec9263138fd5fb55abb63bf55554d508cdba