### PR TITLE
Don't popup menubar/buttons if cursor is in another window

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -124,7 +124,7 @@ bool GameContext::LoadTerrain(std::string const& filename_part)
     App::GetGfxScene()->GetEnvMap().UpdateEnvMap(center, /*gfx_actor:*/nullptr, /*full:*/true);
 
     // Scan groundmodels
-    App::GetGuiManager()->GetFrictionSettings()->AnalyzeTerrain();
+    App::GetGuiManager()->FrictionSettings.AnalyzeTerrain();
 
     return true;
 }
@@ -608,7 +608,7 @@ void GameContext::OnLoaderGuiApply(LoaderType type, CacheEntry* entry, std::stri
             skin_query.cqy_filter_type = LT_Skin;
             if (App::GetCacheSystem()->Query(skin_query) > 0)
             {
-                App::GetGuiManager()->GetMainSelector()->Show(LT_Skin, entry->guid); // Intentionally not using MSG_
+                App::GetGuiManager()->MainSelector.Show(LT_Skin, entry->guid); // Intentionally not using MSG_
             }
             else
             {
@@ -741,29 +741,29 @@ void GameContext::UpdateGlobalInputEvents()
     {
         if (App::app_state->getEnum<AppState>() == AppState::MAIN_MENU)
         {
-            if (App::GetGuiManager()->IsVisible_GameAbout())
+            if (App::GetGuiManager()->GameAbout.IsVisible())
             {
-                App::GetGuiManager()->SetVisible_GameAbout(false);
+                App::GetGuiManager()->GameAbout.SetVisible(false);
             }
-            else if (App::GetGuiManager()->IsVisible_MainSelector())
+            else if (App::GetGuiManager()->MainSelector.IsVisible())
             {
-                App::GetGuiManager()->GetMainSelector()->Close();
+                App::GetGuiManager()->MainSelector.Close();
             }
-            else if (App::GetGuiManager()->IsVisible_GameSettings())
+            else if (App::GetGuiManager()->GameSettings.IsVisible())
             {
-                App::GetGuiManager()->SetVisible_GameSettings(false);
+                App::GetGuiManager()->GameSettings.SetVisible(false);
             }
-            else if (App::GetGuiManager()->IsVisible_GameControls())
+            else if (App::GetGuiManager()->GameControls.IsVisible())
             {
-                App::GetGuiManager()->SetVisible_GameControls(false);
+                App::GetGuiManager()->GameControls.SetVisible(false);
             }
-            else if (App::GetGuiManager()->IsVisible_MultiplayerSelector())
+            else if (App::GetGuiManager()->MultiplayerSelector.IsVisible())
             {
-                App::GetGuiManager()->SetVisible_MultiplayerSelector(false);
+                App::GetGuiManager()->MultiplayerSelector.SetVisible(false);
             }
-            else if (App::GetGuiManager()->IsVisible_RepositorySelector())
+            else if (App::GetGuiManager()->RepositorySelector.IsVisible())
             {
-                App::GetGuiManager()->SetVisible_RepositorySelector(false);
+                App::GetGuiManager()->RepositorySelector.SetVisible(false);
             }
             else
             {
@@ -772,13 +772,13 @@ void GameContext::UpdateGlobalInputEvents()
         }
         else if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
         {
-            if (App::GetGuiManager()->IsVisible_MainSelector())
+            if (App::GetGuiManager()->MainSelector.IsVisible())
             {
-                App::GetGuiManager()->GetMainSelector()->Close();
+                App::GetGuiManager()->MainSelector.Close();
             }
-            else if (App::GetGuiManager()->IsVisible_GameControls())
+            else if (App::GetGuiManager()->GameControls.IsVisible())
             {
-                App::GetGuiManager()->SetVisible_GameControls(false);
+                App::GetGuiManager()->GameControls.SetVisible(false);
             }
             else if (App::sim_state->getEnum<SimState>() == SimState::RUNNING)
             {
@@ -1211,7 +1211,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
 
         m_player_actor->ar_command_key[i].playerInputValue = RoR::App::GetInputEngine()->getEventValue(eventID);
 
-        for (auto id: App::GetGuiManager()->GetVehicleButtons()->GetCommandEventID())
+        for (auto id: App::GetGuiManager()->VehicleButtons.GetCommandEventID())
         {
             if (id == eventID)
             {
@@ -1598,7 +1598,7 @@ void GameContext::UpdateTruckInputEvents(float dt)
     }
     else
     {
-        if (App::GetInputEngine()->getEventBoolValue(EV_TRUCK_HORN) || App::GetGuiManager()->GetVehicleButtons()->GetHornButtonState())
+        if (App::GetInputEngine()->getEventBoolValue(EV_TRUCK_HORN) || App::GetGuiManager()->VehicleButtons.GetHornButtonState())
         {
             SOUND_START(m_player_actor, SS_TRIG_HORN);
         }

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -76,7 +76,7 @@ void GfxScene::ClearScene()
 
     // Recover from the wipe
     App::GetCameraManager()->ReCreateCameraNode();
-    App::GetGuiManager()->GetDirectionArrow()->CreateArrow();
+    App::GetGuiManager()->DirectionArrow.CreateArrow();
 }
 
 void GfxScene::Init()

--- a/source/main/gfx/Renderdash.cpp
+++ b/source/main/gfx/Renderdash.cpp
@@ -94,7 +94,7 @@ void RoR::Renderdash::preRenderTargetUpdate(const Ogre::RenderTargetEvent& evt)
 
     // Disable other overlays
     App::GetOverlayWrapper()->HideRacingOverlay();
-    App::GetGuiManager()->GetDirectionArrow()->SetVisible(false);
+    App::GetGuiManager()->DirectionArrow.SetVisible(false);
 
     //show overlay
     m_dash_overlay->show();

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -39,33 +39,6 @@
 #include "RTTLayer.h"
 #include "TerrainManager.h"
 
-//Managed GUI panels
-#include "GUI_ConsoleWindow.h"
-#include "GUI_FrictionSettings.h"
-#include "GUI_RepositorySelector.h"
-#include "GUI_GameMainMenu.h"
-#include "GUI_GameAbout.h"
-#include "GUI_GameChatBox.h"
-#include "GUI_GameSettings.h"
-#include "GUI_LoadingWindow.h"
-#include "GUI_MessageBox.h"
-#include "GUI_MultiplayerSelector.h"
-#include "GUI_MultiplayerClientList.h"
-#include "GUI_MainSelector.h"
-#include "GUI_NodeBeamUtils.h"
-#include "GUI_DirectionArrow.h"
-#include "GUI_SimActorStats.h"
-#include "GUI_SimPerfStats.h"
-#include "GUI_SurveyMap.h"
-#include "GUI_TextureToolWindow.h"
-#include "GUI_GameControls.h"
-#include "GUI_TopMenubar.h"
-#include "GUI_VehicleDescription.h"
-#include "GUI_VehicleButtons.h"
-
-#include <MyGUI.h>
-#include <MyGUI_OgrePlatform.h>
-#include <OgreOverlay.h>
 #include <OgreOverlayElement.h>
 #include <OgreOverlayContainer.h>
 #include <OgreOverlayManager.h>
@@ -73,95 +46,6 @@
 #define RESOURCE_FILENAME "MyGUI_Core.xml"
 
 namespace RoR {
-
-struct GuiManagerImpl
-{
-    GUI::GameMainMenu           panel_GameMainMenu;
-    GUI::GameAbout              panel_GameAbout;
-    GUI::GameSettings           panel_GameSettings;
-    GUI::SimActorStats          panel_SimActorStats;
-    GUI::SimPerfStats           panel_SimPerfStats;
-    GUI::MessageBoxDialog       panel_MessageBox;
-    GUI::MultiplayerSelector    panel_MultiplayerSelector;
-    GUI::MainSelector           panel_MainSelector;
-    GUI::GameChatBox            panel_ChatBox;
-    GUI::VehicleDescription     panel_VehicleDescription;
-    GUI::MpClientList           panel_MpClientList;
-    GUI::FrictionSettings       panel_FrictionSettings;
-    GUI::TextureToolWindow      panel_TextureToolWindow;
-    GUI::GameControls           panel_GameControls;
-    GUI::RepositorySelector     panel_RepositorySelector;
-    GUI::NodeBeamUtils          panel_NodeBeamUtils;
-    GUI::LoadingWindow          panel_LoadingWindow;
-    GUI::TopMenubar             panel_TopMenubar;
-    GUI::ConsoleWindow          panel_ConsoleWindow;
-    GUI::SurveyMap              panel_SurveyMap;
-    GUI::DirectionArrow         panel_DirectionArrow;
-    GUI::VehicleButtons         panel_VehicleButtons;
-    Ogre::Overlay*              overlay_Wallpaper = nullptr;
-
-    MyGUI::Gui*                 mygui = nullptr;
-    MyGUI::OgrePlatform*        mygui_platform = nullptr;
-};
-
-void GUIManager::SetVisible_GameMainMenu        (bool v) { m_impl->panel_GameMainMenu       .SetVisible(v); }
-void GUIManager::SetVisible_GameAbout           (bool v) { m_impl->panel_GameAbout          .SetVisible(v); }
-void GUIManager::SetVisible_MultiplayerSelector (bool v) { m_impl->panel_MultiplayerSelector.SetVisible(v); }
-void GUIManager::SetVisible_ChatBox             (bool v) { m_impl->panel_ChatBox            .SetVisible(v); }
-void GUIManager::SetVisible_VehicleDescription  (bool v) { m_impl->panel_VehicleDescription .SetVisible(v); }
-void GUIManager::SetVisible_FrictionSettings    (bool v) { m_impl->panel_FrictionSettings   .SetVisible(v); }
-void GUIManager::SetVisible_TextureToolWindow   (bool v) { m_impl->panel_TextureToolWindow  .SetVisible(v); }
-void GUIManager::SetVisible_GameControls        (bool v) { m_impl->panel_GameControls       .SetVisible(v); }
-void GUIManager::SetVisible_RepositorySelector  (bool v) { m_impl->panel_RepositorySelector .SetVisible(v); }
-void GUIManager::SetVisible_LoadingWindow       (bool v) { m_impl->panel_LoadingWindow      .SetVisible(v); }
-void GUIManager::SetVisible_Console             (bool v) { m_impl->panel_ConsoleWindow      .SetVisible(v); }
-void GUIManager::SetVisible_GameSettings        (bool v) { m_impl->panel_GameSettings       .SetVisible(v); }
-void GUIManager::SetVisible_NodeBeamUtils       (bool v) { m_impl->panel_NodeBeamUtils      .SetVisible(v); }
-void GUIManager::SetVisible_SimActorStats       (bool v) { m_impl->panel_SimActorStats      .SetVisible(v); }
-void GUIManager::SetVisible_SimPerfStats        (bool v) { m_impl->panel_SimPerfStats       .SetVisible(v); }
-
-void GUIManager::SetVisible_MenuWallpaper(bool v)
-{
-    if (v)
-        m_impl->overlay_Wallpaper->show();
-    else
-        m_impl->overlay_Wallpaper->hide();
-}
-
-bool GUIManager::IsVisible_GameMainMenu         () { return m_impl->panel_GameMainMenu       .IsVisible(); }
-bool GUIManager::IsVisible_GameAbout            () { return m_impl->panel_GameAbout          .IsVisible(); }
-bool GUIManager::IsVisible_MultiplayerSelector  () { return m_impl->panel_MultiplayerSelector.IsVisible(); }
-bool GUIManager::IsVisible_MainSelector         () { return m_impl->panel_MainSelector       .IsVisible(); }
-bool GUIManager::IsVisible_ChatBox              () { return m_impl->panel_ChatBox            .IsVisible(); }
-bool GUIManager::IsVisible_VehicleDescription   () { return m_impl->panel_VehicleDescription .IsVisible(); }
-bool GUIManager::IsVisible_FrictionSettings     () { return m_impl->panel_FrictionSettings   .IsVisible(); }
-bool GUIManager::IsVisible_TextureToolWindow    () { return m_impl->panel_TextureToolWindow  .IsVisible(); }
-bool GUIManager::IsVisible_GameControls         () { return m_impl->panel_GameControls       .IsVisible(); }
-bool GUIManager::IsVisible_RepositorySelector   () { return m_impl->panel_RepositorySelector .IsVisible(); }
-bool GUIManager::IsVisible_LoadingWindow        () { return m_impl->panel_LoadingWindow      .IsVisible(); }
-bool GUIManager::IsVisible_Console              () { return m_impl->panel_ConsoleWindow      .IsVisible(); }
-bool GUIManager::IsVisible_GameSettings         () { return m_impl->panel_GameSettings       .IsVisible(); }
-bool GUIManager::IsVisible_TopMenubar           () { return m_impl->panel_TopMenubar         .IsVisible(); }
-bool GUIManager::IsVisible_NodeBeamUtils        () { return m_impl->panel_NodeBeamUtils      .IsVisible(); }
-bool GUIManager::IsVisible_SimActorStats        () { return m_impl->panel_SimActorStats      .IsVisible(); }
-bool GUIManager::IsVisible_SimPerfStats         () { return m_impl->panel_SimPerfStats       .IsVisible(); }
-bool GUIManager::IsVisible_SurveyMap            () { return m_impl->panel_SurveyMap          .IsVisible(); }
-bool GUIManager::IsVisible_DirectionArrow       () { return m_impl->panel_DirectionArrow     .IsVisible(); }
-
-// GUI GetInstance*()
-GUI::MainSelector*          GUIManager::GetMainSelector()      { return &m_impl->panel_MainSelector        ; }
-GUI::GameMainMenu*          GUIManager::GetMainMenu()          { return &m_impl->panel_GameMainMenu        ; }
-GUI::GameControls*          GUIManager::GetControlsWindow()    { return &m_impl->panel_GameControls        ; }
-GUI::LoadingWindow*         GUIManager::GetLoadingWindow()     { return &m_impl->panel_LoadingWindow       ; }
-GUI::MultiplayerSelector*   GUIManager::GetMpSelector()        { return &m_impl->panel_MultiplayerSelector ; }
-GUI::RepositorySelector*    GUIManager::GetRepoSelector()      { return &m_impl->panel_RepositorySelector  ; }
-GUI::FrictionSettings*      GUIManager::GetFrictionSettings()  { return &m_impl->panel_FrictionSettings    ; }
-GUI::TopMenubar*            GUIManager::GetTopMenubar()        { return &m_impl->panel_TopMenubar          ; }
-GUI::SurveyMap*             GUIManager::GetSurveyMap()         { return &m_impl->panel_SurveyMap           ; }
-GUI::SimActorStats*         GUIManager::GetSimActorStats()     { return &m_impl->panel_SimActorStats       ; }
-GUI::DirectionArrow*        GUIManager::GetDirectionArrow()    { return &m_impl->panel_DirectionArrow      ; }
-GUI::MpClientList*          GUIManager::GetMpClientList()      { return &m_impl->panel_MpClientList        ; }
-GUI::VehicleButtons*        GUIManager::GetVehicleButtons()    { return &m_impl->panel_VehicleButtons      ; }
 
 GUIManager::GUIManager()
 {
@@ -185,9 +69,8 @@ GUIManager::GUIManager()
 
     MyGUI::ResourceManager::getInstance().load("MyGUI_FontsEnglish.xml");
 
-    m_impl = new GuiManagerImpl();
-    m_impl->mygui_platform = mygui_platform;
-    m_impl->mygui = mygui;
+    m_mygui_platform = mygui_platform;
+    m_mygui = mygui;
     MyGUI::PointerManager::getInstance().setVisible(false); // RoR is using mouse cursor drawn by DearIMGUI.
 
 #ifdef _WIN32
@@ -197,32 +80,29 @@ GUIManager::GUIManager()
     this->SetupImGui();
 
     // Configure the chatbox console view
-    m_impl->panel_ChatBox.GetConsoleView().cvw_background_color   = m_theme.semitrans_text_bg_color;
-    m_impl->panel_ChatBox.GetConsoleView().cvw_background_padding = m_theme.semitrans_text_bg_padding;
+    this->ChatBox.GetConsoleView().cvw_background_color   = m_theme.semitrans_text_bg_color;
+    this->ChatBox.GetConsoleView().cvw_background_padding = m_theme.semitrans_text_bg_padding;
 }
 
 GUIManager::~GUIManager()
 {
-    delete m_impl;
 }
 
 void GUIManager::ShutdownMyGUI()
 {
-    if (m_impl->mygui)
+    if (m_mygui)
     {
-        m_impl->mygui->shutdown();
-        delete m_impl->mygui;
-        m_impl->mygui = nullptr;
+        m_mygui->shutdown();
+        delete m_mygui;
+        m_mygui = nullptr;
     }
 
-    if (m_impl->mygui_platform)
+    if (m_mygui_platform)
     {
-        m_impl->mygui_platform->shutdown();
-        delete m_impl->mygui_platform;
-        m_impl->mygui_platform = nullptr;
+        m_mygui_platform->shutdown();
+        delete m_mygui_platform;
+        m_mygui_platform = nullptr;
     }
-
-    delete m_impl;
 }
 
 void GUIManager::ApplyGuiCaptureKeyboard()
@@ -234,22 +114,22 @@ void GUIManager::DrawSimulationGui(float dt)
 {
     if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
     {
-        m_impl->panel_TopMenubar.Update();
+        this->TopMenubar.Update();
 
-        if (m_impl->panel_GameMainMenu.IsVisible())
+        if (this->GameMainMenu.IsVisible())
         {
-            m_impl->panel_GameMainMenu.Draw();
+            this->GameMainMenu.Draw();
         }
     }
 
-    if (m_impl->panel_NodeBeamUtils.IsVisible())
+    if (this->NodeBeamUtils.IsVisible())
     {
-        m_impl->panel_NodeBeamUtils.Draw();
+        this->NodeBeamUtils.Draw();
     }
 
-    if (m_impl->panel_MessageBox.IsVisible())
+    if (this->MessageBoxDialog.IsVisible())
     {
-        m_impl->panel_MessageBox.Draw();
+        this->MessageBoxDialog.Draw();
     }
 };
 
@@ -257,56 +137,56 @@ void GUIManager::DrawSimGuiBuffered(GfxActor* player_gfx_actor)
 {
     this->DrawCommonGui();
 
-    if (player_gfx_actor && this->IsVisible_SimActorStats())
+    if (player_gfx_actor && this->SimActorStats.IsVisible())
     {
-        m_impl->panel_SimActorStats.Draw(player_gfx_actor);
+        this->SimActorStats.Draw(player_gfx_actor);
     }
 
     if (player_gfx_actor && player_gfx_actor->GetActor()->ar_state == ActorState::LOCAL_SIMULATED && 
-        !this->IsVisible_SimActorStats() && !this->IsVisible_SimPerfStats() && !this->IsVisible_GameMainMenu())
+        !this->SimActorStats.IsVisible() && !this->SimPerfStats.IsVisible() && !this->GameMainMenu.IsVisible())
     {
-        m_impl->panel_VehicleButtons.Draw(player_gfx_actor);
+        this->VehicleButtons.Draw(player_gfx_actor);
     }
 
-    if (!this->IsVisible_Console())
+    if (!this->ConsoleWindow.IsVisible())
     {
         if (!m_hide_gui)
         {
-            m_impl->panel_ChatBox.Draw(); // Messages must be always visible
+            this->ChatBox.Draw(); // Messages must be always visible
         }
     }
 
-    if (this->IsVisible_LoadingWindow())
+    if (this->LoadingWindow.IsVisible())
     {
-        m_impl->panel_LoadingWindow.Draw();
+        this->LoadingWindow.Draw();
     }
 
-    if (this->IsVisible_FrictionSettings())
+    if (this->FrictionSettings.IsVisible())
     {
-        m_impl->panel_FrictionSettings.Draw();
+        this->FrictionSettings.Draw();
     }
 
-    if (this->IsVisible_VehicleDescription())
+    if (this->VehicleDescription.IsVisible())
     {
-        m_impl->panel_VehicleDescription.Draw();
+        this->VehicleDescription.Draw();
     }
 
-    if (this->IsVisible_SimPerfStats())
+    if (this->SimPerfStats.IsVisible())
     {
-        m_impl->panel_SimPerfStats.Draw();
+        this->SimPerfStats.Draw();
     }
 
-    if (this->IsVisible_TextureToolWindow())
+    if (this->TextureToolWindow.IsVisible())
     {
-        m_impl->panel_TextureToolWindow.Draw();
+        this->TextureToolWindow.Draw();
     }
 
-    if (this->IsVisible_SurveyMap())
+    if (this->SurveyMap.IsVisible())
     {
-        m_impl->panel_SurveyMap.Draw();
+        this->SurveyMap.Draw();
     }
 
-    m_impl->panel_DirectionArrow.Update(player_gfx_actor);
+    this->DirectionArrow.Update(player_gfx_actor);
 }
 
 void GUIManager::eventRequestTag(const MyGUI::UString& _tag, MyGUI::UString& _result)
@@ -345,15 +225,15 @@ void GUIManager::SetUpMenuWallpaper()
     wp_panel->setMaterial(wp_mat);
     wp_panel->setDimensions(1.f, 1.f);
     // ...overlay...
-    m_impl->overlay_Wallpaper = Ogre::OverlayManager::getSingleton().create("rigsofrods/WallpaperOverlay");
-    m_impl->overlay_Wallpaper->add2D(static_cast<Ogre::OverlayContainer*>(wp_panel)); // 'Panel' inherits from 'Container'
-    m_impl->overlay_Wallpaper->setZOrder(0);
-    m_impl->overlay_Wallpaper->show();
+    this->MenuWallpaper = Ogre::OverlayManager::getSingleton().create("rigsofrods/WallpaperOverlay");
+    this->MenuWallpaper->add2D(static_cast<Ogre::OverlayContainer*>(wp_panel)); // 'Panel' inherits from 'Container'
+    this->MenuWallpaper->setZOrder(0);
+    this->MenuWallpaper->show();
 }
 
 void GUIManager::SetSceneManagerForGuiRendering(Ogre::SceneManager* scene_manager)
 {
-    m_impl->mygui_platform->getRenderManagerPtr()->setSceneManager(scene_manager);
+    m_mygui_platform->getRenderManagerPtr()->setSceneManager(scene_manager);
 }
 
 void GUIManager::SetGuiHidden(bool hidden)
@@ -362,8 +242,8 @@ void GUIManager::SetGuiHidden(bool hidden)
     App::GetOverlayWrapper()->showDashboardOverlays(!hidden, App::GetGameContext()->GetPlayerActor());
     if (hidden)
     {
-        m_impl->panel_SimPerfStats.SetVisible(false);
-        m_impl->panel_ChatBox.SetVisible(false);
+        this->SimPerfStats.SetVisible(false);
+        this->ChatBox.SetVisible(false);
     }
 }
 
@@ -391,7 +271,7 @@ void GUIManager::UpdateMouseCursorVisibility()
 {
     if (m_last_mousemove_time.getMilliseconds() > 5000)
     {
-        App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
+        this->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
     }
 }
 
@@ -472,22 +352,22 @@ void GUIManager::DrawCommonGui()
 {
     if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED && !m_hide_gui)
     {
-        m_impl->panel_MpClientList.Draw();
+        this->MpClientList.Draw();
     }
 
-    if (m_impl->panel_MainSelector.IsVisible())
+    if (this->MainSelector.IsVisible())
     {
-        m_impl->panel_MainSelector.Draw();
+        this->MainSelector.Draw();
     }
 
-    if (m_impl->panel_ConsoleWindow.IsVisible())
+    if (this->ConsoleWindow.IsVisible())
     {
-        m_impl->panel_ConsoleWindow.Draw();
+        this->ConsoleWindow.Draw();
     }
 
-    if (this->IsVisible_GameControls())
+    if (this->GameControls.IsVisible())
     {
-        m_impl->panel_GameControls.Draw();
+        this->GameControls.Draw();
     }
 }
 
@@ -495,50 +375,50 @@ void GUIManager::DrawMainMenuGui()
 {
     this->DrawCommonGui();
 
-    if (m_impl->panel_MultiplayerSelector.IsVisible())
+    if (this->MultiplayerSelector.IsVisible())
     {
-        m_impl->panel_MultiplayerSelector.Draw();
+        this->MultiplayerSelector.Draw();
     }
 
-    if (m_impl->panel_GameMainMenu.IsVisible())
+    if (this->GameMainMenu.IsVisible())
     {
-        m_impl->panel_GameMainMenu.Draw();
+        this->GameMainMenu.Draw();
     }
 
-    if (m_impl->panel_GameSettings.IsVisible())
+    if (this->GameSettings.IsVisible())
     {
-        m_impl->panel_GameSettings.Draw();
+        this->GameSettings.Draw();
     }
 
-    if (m_impl->panel_MessageBox.IsVisible())
+    if (this->MessageBoxDialog.IsVisible())
     {
-        m_impl->panel_MessageBox.Draw();
+        this->MessageBoxDialog.Draw();
     }
 
-    if (m_impl->panel_LoadingWindow.IsVisible())
+    if (this->LoadingWindow.IsVisible())
     {
-        m_impl->panel_LoadingWindow.Draw();
+        this->LoadingWindow.Draw();
     }
 
-    if (m_impl->panel_GameAbout.IsVisible())
+    if (this->GameAbout.IsVisible())
     {
-        m_impl->panel_GameAbout.Draw();
+        this->GameAbout.Draw();
     }
 
-    if (m_impl->panel_RepositorySelector.IsVisible())
+    if (this->RepositorySelector.IsVisible())
     {
-        m_impl->panel_RepositorySelector.Draw();
+        this->RepositorySelector.Draw();
     }
 }
 
 void GUIManager::ShowMessageBox(const char* title, const char* text, bool allow_close, const char* btn1_text, const char* btn2_text)
 {
-    m_impl->panel_MessageBox.Show(title, text, allow_close, btn1_text, btn2_text);
+    this->MessageBoxDialog.Show(title, text, allow_close, btn1_text, btn2_text);
 }
 
 void GUIManager::ShowMessageBox(GUI::MessageBoxConfig const& conf)
 {
-    m_impl->panel_MessageBox.Show(conf);
+    this->MessageBoxDialog.Show(conf);
 }
 
 void GUIManager::RequestGuiCaptureKeyboard(bool val) 
@@ -551,7 +431,7 @@ void GUIManager::WakeUpGUI()
     m_last_mousemove_time.reset();
     if (!m_is_cursor_supressed)
     {
-        App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::VISIBLE);
+        this->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::VISIBLE);
     }
 }
 
@@ -565,7 +445,7 @@ void GUIManager::UpdateInputEvents(float dt)
     // EV_COMMON_CONSOLE_TOGGLE - display console GUI (anytime)
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_CONSOLE_TOGGLE))
     {
-        App::GetGuiManager()->SetVisible_Console(! App::GetGuiManager()->IsVisible_Console());
+        this->ConsoleWindow.SetVisible(!this->ConsoleWindow.IsVisible());
     }
 
     if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
@@ -573,26 +453,26 @@ void GUIManager::UpdateInputEvents(float dt)
         // EV_COMMON_HIDE_GUI
         if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_HIDE_GUI))
         {
-            App::GetGuiManager()->SetGuiHidden(!App::GetGuiManager()->IsGuiHidden());
+            this->SetGuiHidden(!this->IsGuiHidden());
         }
 
         // EV_COMMON_ENTER_CHATMODE
         if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_CHATMODE, 0.5f) &&
             App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
         {
-            App::GetGuiManager()->SetVisible_ChatBox(!App::GetGuiManager()->IsVisible_ChatBox());
+            this->ChatBox.SetVisible(!this->ChatBox.IsVisible());
         }
 
         // EV_COMMON_TRUCK_INFO - Vehicle status panel
         if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TRUCK_INFO) && App::GetGameContext()->GetPlayerActor())
         {
-            App::GetGuiManager()->SetVisible_SimActorStats(!App::GetGuiManager()->IsVisible_SimActorStats());
+            this->SimActorStats.SetVisible(!this->SimActorStats.IsVisible());
         }
 
         // EV_COMMON_TRUCK_DESCRIPTION - Vehicle controls and details
         if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TRUCK_DESCRIPTION) && App::GetGameContext()->GetPlayerActor())
         {
-            App::GetGuiManager()->SetVisible_VehicleDescription(!App::GetGuiManager()->IsVisible_VehicleDescription());
+            this->VehicleDescription.SetVisible(!this->VehicleDescription.IsVisible());
         }
 
         // EV_COMMON_TOGGLE_DASHBOARD
@@ -604,7 +484,7 @@ void GUIManager::UpdateInputEvents(float dt)
         // EV_COMMON_TOGGLE_STATS - FPS, draw batch count etc...
         if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_STATS))
         {
-            App::GetGuiManager()->SetVisible_SimPerfStats(!App::GetGuiManager()->IsVisible_SimPerfStats());
+            this->SimPerfStats.SetVisible(!this->SimPerfStats.IsVisible());
         }
 
         if (App::GetCameraManager()->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_FREE)
@@ -612,13 +492,13 @@ void GUIManager::UpdateInputEvents(float dt)
             // EV_SURVEY_MAP_CYCLE
             if (App::GetInputEngine()->getEventBoolValueBounce(EV_SURVEY_MAP_CYCLE))
             {
-                App::GetGuiManager()->GetSurveyMap()->CycleMode();
+                this->SurveyMap.CycleMode();
             }
 
             // EV_SURVEY_MAP_TOGGLE
             if (App::GetInputEngine()->getEventBoolValueBounce(EV_SURVEY_MAP_TOGGLE))
             {
-                App::GetGuiManager()->GetSurveyMap()->ToggleMode();
+                this->SurveyMap.ToggleMode();
             }
         }
     }

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -110,6 +110,18 @@ void GUIManager::ApplyGuiCaptureKeyboard()
     m_gui_kb_capture_requested = m_gui_kb_capture_queued;
 };
 
+bool GUIManager::AreStaticMenusAllowed() //!< i.e. top menubar / vehicle UI buttons
+{
+    return (App::GetCameraManager()->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_FREE &&
+            !App::GetGuiManager()->ConsoleWindow.IsHovered() &&
+            !App::GetGuiManager()->GameControls.IsHovered() &&
+            !App::GetGuiManager()->FrictionSettings.IsHovered() &&
+            !App::GetGuiManager()->TextureToolWindow.IsHovered() &&
+            !App::GetGuiManager()->NodeBeamUtils.IsHovered() &&
+            !App::GetGuiManager()->MainSelector.IsHovered() &&
+            !App::GetGuiManager()->SurveyMap.IsHovered());
+}
+
 void GUIManager::DrawSimulationGui(float dt)
 {
     if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -130,6 +130,7 @@ public:
     void RequestGuiCaptureKeyboard(bool val); //!< Pass true during frame to prevent input passing to application
     bool IsGuiCaptureKeyboardRequested() const { return m_gui_kb_capture_requested; }
     void ApplyGuiCaptureKeyboard(); //!< Call after rendered frame to apply queued value
+    bool AreStaticMenusAllowed(); //!< i.e. top menubar / vehicle UI buttons
 
     void NewImGuiFrame(float dt);
     void DrawMainMenuGui();

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -28,9 +28,36 @@
 #include "Application.h"
 #include "GUI_MessageBox.h"
 
+// GUI panels
+#include "GUI_ConsoleWindow.h"
+#include "GUI_FrictionSettings.h"
+#include "GUI_RepositorySelector.h"
+#include "GUI_GameMainMenu.h"
+#include "GUI_GameAbout.h"
+#include "GUI_GameChatBox.h"
+#include "GUI_GameSettings.h"
+#include "GUI_LoadingWindow.h"
+#include "GUI_MessageBox.h"
+#include "GUI_MultiplayerSelector.h"
+#include "GUI_MultiplayerClientList.h"
+#include "GUI_MainSelector.h"
+#include "GUI_NodeBeamUtils.h"
+#include "GUI_DirectionArrow.h"
+#include "GUI_SimActorStats.h"
+#include "GUI_SimPerfStats.h"
+#include "GUI_SurveyMap.h"
+#include "GUI_TextureToolWindow.h"
+#include "GUI_GameControls.h"
+#include "GUI_TopMenubar.h"
+#include "GUI_VehicleDescription.h"
+#include "GUI_VehicleButtons.h"
+
+// Deps
 #include <Bites/OgreWindowEventUtilities.h>
-#include <OgreFrameListener.h>
+#include <MyGUI.h>
+#include <MyGUI_OgrePlatform.h>
 #include <MyGUI_UString.h>
+#include <OgreOverlay.h>
 
 namespace RoR {
 
@@ -72,59 +99,30 @@ public:
     GUIManager();
     ~GUIManager();
 
-    // GUI SetVisible*()
-    void SetVisible_GameMainMenu        (bool visible);
-    void SetVisible_GameAbout           (bool visible);
-    void SetVisible_GameSettings        (bool visible);
-    void SetVisible_MultiplayerSelector (bool visible);
-    void SetVisible_ChatBox             (bool visible);
-    void SetVisible_VehicleDescription  (bool visible);
-    void SetVisible_FrictionSettings    (bool visible);
-    void SetVisible_TextureToolWindow   (bool visible);
-    void SetVisible_GameControls        (bool visible);
-    void SetVisible_RepositorySelector  (bool visible);
-    void SetVisible_NodeBeamUtils       (bool visible);
-    void SetVisible_LoadingWindow       (bool visible);
-    void SetVisible_Console             (bool visible);
-    void SetVisible_SimActorStats       (bool visible);
-    void SetVisible_SimPerfStats        (bool visible);
-    void SetVisible_MenuWallpaper       (bool visible);
 
-    // GUI IsVisible*()
-    bool IsVisible_GameMainMenu         ();
-    bool IsVisible_GameAbout            ();
-    bool IsVisible_GameSettings         ();
-    bool IsVisible_TopMenubar           ();
-    bool IsVisible_MultiplayerSelector  ();
-    bool IsVisible_MainSelector         ();
-    bool IsVisible_ChatBox              ();
-    bool IsVisible_VehicleDescription   ();
-    bool IsVisible_FrictionSettings     ();
-    bool IsVisible_TextureToolWindow    ();
-    bool IsVisible_GameControls         ();
-    bool IsVisible_RepositorySelector   ();
-    bool IsVisible_NodeBeamUtils        ();
-    bool IsVisible_LoadingWindow        ();
-    bool IsVisible_Console              ();
-    bool IsVisible_SimActorStats        ();
-    bool IsVisible_SimPerfStats         ();
-    bool IsVisible_SurveyMap            ();
-    bool IsVisible_DirectionArrow       ();
-
-    // GUI GetInstance*()
-    GUI::MainSelector* GetMainSelector();
-    GUI::GameMainMenu* GetMainMenu();
-    GUI::GameControls* GetControlsWindow();
-    GUI::LoadingWindow* GetLoadingWindow();
-    GUI::MultiplayerSelector* GetMpSelector();
-    GUI::RepositorySelector* GetRepoSelector();
-    GUI::FrictionSettings* GetFrictionSettings();
-    GUI::TopMenubar* GetTopMenubar();
-    GUI::SurveyMap* GetSurveyMap();
-    GUI::SimActorStats* GetSimActorStats();
-    GUI::DirectionArrow* GetDirectionArrow();
-    GUI::MpClientList* GetMpClientList();
-    GUI::VehicleButtons* GetVehicleButtons();
+    GUI::GameMainMenu           GameMainMenu;
+    GUI::GameAbout              GameAbout;
+    GUI::GameSettings           GameSettings;
+    GUI::SimActorStats          SimActorStats;
+    GUI::SimPerfStats           SimPerfStats;
+    GUI::MessageBoxDialog       MessageBoxDialog;
+    GUI::MultiplayerSelector    MultiplayerSelector;
+    GUI::MainSelector           MainSelector;
+    GUI::GameChatBox            ChatBox;
+    GUI::VehicleDescription     VehicleDescription;
+    GUI::MpClientList           MpClientList;
+    GUI::FrictionSettings       FrictionSettings;
+    GUI::TextureToolWindow      TextureToolWindow;
+    GUI::GameControls           GameControls;
+    GUI::RepositorySelector     RepositorySelector;
+    GUI::NodeBeamUtils          NodeBeamUtils;
+    GUI::LoadingWindow          LoadingWindow;
+    GUI::TopMenubar             TopMenubar;
+    GUI::ConsoleWindow          ConsoleWindow;
+    GUI::SurveyMap              SurveyMap;
+    GUI::DirectionArrow         DirectionArrow;
+    GUI::VehicleButtons         VehicleButtons;
+    Ogre::Overlay*              MenuWallpaper = nullptr;
 
     // GUI manipulation
     void ShowMessageBox(const char* title, const char* text, bool allow_close = true, const char* btn1_text = "OK", const char* btn2_text = nullptr);
@@ -163,14 +161,15 @@ private:
 
     void eventRequestTag(const MyGUI::UString& _tag, MyGUI::UString& _result);
 
-    GuiManagerImpl*    m_impl                     = nullptr;
-    bool               m_hide_gui                 = false;
-    OgreImGui          m_imgui;
-    GuiTheme           m_theme;
-    bool               m_gui_kb_capture_queued    = false; //!< Resets and accumulates every frame
-    bool               m_gui_kb_capture_requested = false; //!< Effective value, persistent
-    Ogre::Timer        m_last_mousemove_time;
-    bool               m_is_cursor_supressed      = false; //!< True if cursor was manually hidden.
+    MyGUI::Gui*          m_mygui                    = nullptr;
+    MyGUI::OgrePlatform* m_mygui_platform           = nullptr;
+    bool                 m_hide_gui                 = false;
+    OgreImGui            m_imgui;
+    GuiTheme             m_theme;
+    bool                 m_gui_kb_capture_queued    = false; //!< Resets and accumulates every frame
+    bool                 m_gui_kb_capture_requested = false; //!< Effective value, persistent
+    Ogre::Timer          m_last_mousemove_time;
+    bool                 m_is_cursor_supressed      = false; //!< True if cursor was manually hidden.
 };
 
 } // namespace RoR

--- a/source/main/gui/panels/GUI_ConsoleWindow.cpp
+++ b/source/main/gui/panels/GUI_ConsoleWindow.cpp
@@ -107,7 +107,9 @@ void ConsoleWindow::Draw()
         m_cmd_buffer.Clear();
     }
 
-    App::GetGuiManager()->RequestGuiCaptureKeyboard(ImGui::IsWindowHovered());
+    m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+    App::GetGuiManager()->RequestGuiCaptureKeyboard(m_is_hovered);
+
     ImGui::End();
 
     if (!keep_open)

--- a/source/main/gui/panels/GUI_ConsoleWindow.h
+++ b/source/main/gui/panels/GUI_ConsoleWindow.h
@@ -42,9 +42,9 @@ public:
     static const size_t HISTORY_CAP = 100u;
 
     ConsoleWindow();
-    void SetVisible(bool visible) { m_is_visible = visible; m_is_hovered = false; }
+    void SetVisible(bool visible) { m_is_visible = visible; }
     bool IsVisible() const { return m_is_visible; }
-    bool IsHovered() const { return m_is_hovered; }
+    bool IsHovered() const { return IsVisible() && m_is_hovered; }
 
     void Draw();
     void doCommand(std::string msg);

--- a/source/main/gui/panels/GUI_ConsoleWindow.h
+++ b/source/main/gui/panels/GUI_ConsoleWindow.h
@@ -42,8 +42,9 @@ public:
     static const size_t HISTORY_CAP = 100u;
 
     ConsoleWindow();
-    void SetVisible(bool visible) { m_is_visible = visible; }
+    void SetVisible(bool visible) { m_is_visible = visible; m_is_hovered = false; }
     bool IsVisible() const { return m_is_visible; }
+    bool IsHovered() const { return m_is_hovered; }
 
     void Draw();
     void doCommand(std::string msg);
@@ -60,6 +61,7 @@ private:
     std::vector<std::string> m_cmd_history;
     int                      m_cmd_history_cursor = -1;
     bool                     m_is_visible = false;
+    bool                     m_is_hovered = false;
 };
 
 } // namespace GUI

--- a/source/main/gui/panels/GUI_FrictionSettings.cpp
+++ b/source/main/gui/panels/GUI_FrictionSettings.cpp
@@ -114,7 +114,10 @@ void FrictionSettings::Draw()
     }
 
     ImGui::PopItemWidth();
-    App::GetGuiManager()->RequestGuiCaptureKeyboard(ImGui::IsWindowHovered());
+
+    m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+    App::GetGuiManager()->RequestGuiCaptureKeyboard(m_is_hovered);
+
     ImGui::End();
 
     if (!keep_open)

--- a/source/main/gui/panels/GUI_FrictionSettings.h
+++ b/source/main/gui/panels/GUI_FrictionSettings.h
@@ -48,9 +48,9 @@ public:
         const ground_model_t* const live_data;
     };
 
-    void SetVisible(bool visible) { m_is_visible = visible; m_is_hovered = false; }
+    void SetVisible(bool visible) { m_is_visible = visible; }
     bool IsVisible() const { return m_is_visible; }
-    bool IsHovered() const { return m_is_hovered; }
+    bool IsHovered() const { return IsVisible() && m_is_hovered; }
 
     void AnalyzeTerrain();
     void setActiveCol(const ground_model_t* gm) { m_nearest_gm = gm; }

--- a/source/main/gui/panels/GUI_FrictionSettings.h
+++ b/source/main/gui/panels/GUI_FrictionSettings.h
@@ -48,8 +48,9 @@ public:
         const ground_model_t* const live_data;
     };
 
+    void SetVisible(bool visible) { m_is_visible = visible; m_is_hovered = false; }
     bool IsVisible() const { return m_is_visible; }
-    void SetVisible(bool value) { m_is_visible = value; }
+    bool IsHovered() const { return m_is_hovered; }
 
     void AnalyzeTerrain();
     void setActiveCol(const ground_model_t* gm) { m_nearest_gm = gm; }
@@ -59,10 +60,11 @@ private:
     static bool GmComboItemGetter(void* data, int idx, const char** out_text);
     void DrawTooltip(const char* title, const char* text);
 
-    bool m_is_visible = false;
     std::vector<Entry> m_gm_entries;
     int m_selected_gm = 0;
     const ground_model_t* m_nearest_gm = nullptr;
+    bool m_is_visible = false;
+    bool m_is_hovered = false;
 };
 
 } // namespace GUI

--- a/source/main/gui/panels/GUI_GameAbout.cpp
+++ b/source/main/gui/panels/GUI_GameAbout.cpp
@@ -157,7 +157,7 @@ void GameAbout::SetVisible(bool v)
     m_is_visible = v;
     if(!v && (App::app_state->getEnum<AppState>() == AppState::MAIN_MENU))
     {
-        App::GetGuiManager()->SetVisible_GameMainMenu(true);
+        App::GetGuiManager()->GameMainMenu.SetVisible(true);
     }
 }
 

--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -397,7 +397,7 @@ void GameControls::SetVisible(bool vis)
     if (!vis)
     {
         this->CancelChanges();
-        App::GetGuiManager()->SetVisible_GameMainMenu(true);
+        App::GetGuiManager()->GameMainMenu.SetVisible(true);
     }
 }
 

--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -141,6 +141,8 @@ void GameControls::Draw()
 
         ImGui::EndTabBar(); // GameSettingsTabs
 
+        m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+
         ImGui::End();
         if (!keep_open)
         {
@@ -394,6 +396,7 @@ void GameControls::ReloadMapFile()
 void GameControls::SetVisible(bool vis)
 {
     m_is_visible = vis;
+    m_is_hovered = false;
     if (!vis)
     {
         this->CancelChanges();

--- a/source/main/gui/panels/GUI_GameControls.h
+++ b/source/main/gui/panels/GUI_GameControls.h
@@ -31,8 +31,10 @@ public:
     const ImVec4      GRAY_HINT_TEXT = ImVec4(0.62f, 0.62f, 0.61f, 1.f);
     const int         MAPFILE_ID_DEFAULT = -1;
 
-    void SetVisible(bool vis);
+    void SetVisible(bool visible);
     bool IsVisible() const { return m_is_visible; }
+    bool IsHovered() const { return m_is_hovered; }
+
     bool IsInteractiveKeyBindingActive() { return m_interactive_keybinding_active; }
     void Draw();
 
@@ -52,6 +54,7 @@ private:
     bool               ShouldDisplay(event_trigger_t& trig);
 
     bool m_is_visible = false;
+    bool m_is_hovered = false;
     float m_colum_widths[3] = {}; //!< body->header width sync
 
     // Mode/config file selection

--- a/source/main/gui/panels/GUI_GameMainMenu.cpp
+++ b/source/main/gui/panels/GUI_GameMainMenu.cpp
@@ -154,31 +154,31 @@ void GameMainMenu::DrawMenuPanel()
         {
             if (HighlightButton(_LC("MainMenu", "Multiplayer"), btn_size, button_index++))
             {
-                App::GetGuiManager()->SetVisible_MultiplayerSelector(true);
+                App::GetGuiManager()->MultiplayerSelector.SetVisible(true);
                 this->SetVisible(false);
             }
 
             if (HighlightButton(_LC("MainMenu", "Repository"), btn_size, button_index++))
             {
-                App::GetGuiManager()->SetVisible_RepositorySelector(true);
+                App::GetGuiManager()->RepositorySelector.SetVisible(true);
                 this->SetVisible(false);
             }
 
             if (HighlightButton(_LC("MainMenu", "Settings"), btn_size, button_index++))
             {
-                App::GetGuiManager()->SetVisible_GameSettings(true);
+                App::GetGuiManager()->GameSettings.SetVisible(true);
                 this->SetVisible(false);
             }
 
             if (HighlightButton(_LC("MainMenu", "Controls"), btn_size, button_index++))
             {
-                App::GetGuiManager()->SetVisible_GameControls(true);
+                App::GetGuiManager()->GameControls.SetVisible(true);
                 this->SetVisible(false);
             }
 
             if (HighlightButton(_LC("MainMenu", "About"), btn_size, button_index++))
             {
-                App::GetGuiManager()->SetVisible_GameAbout(true);
+                App::GetGuiManager()->GameAbout.SetVisible(true);
                 this->SetVisible(false);
             }
         }
@@ -186,7 +186,7 @@ void GameMainMenu::DrawMenuPanel()
         {
             if (HighlightButton(_LC("MainMenu", "Controls"), btn_size, button_index++))
             {
-                App::GetGuiManager()->SetVisible_GameControls(true);
+                App::GetGuiManager()->GameControls.SetVisible(true);
                 this->SetVisible(false);
             }
 

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -227,7 +227,7 @@ void GameSettings::DrawGeneralSettings()
 
     if (ImGui::Button(_LC("GameSettings", "Update cache")))
     {
-        App::GetGuiManager()->SetVisible_GameSettings(false);
+        App::GetGuiManager()->GameSettings.SetVisible(false);
         App::GetGameContext()->PushMessage(Message(MSG_APP_MODCACHE_UPDATE_REQUESTED));
         App::GetGameContext()->PushMessage(Message(MSG_GUI_OPEN_MENU_REQUESTED));
     }
@@ -399,7 +399,7 @@ void GameSettings::DrawDiagSettings()
     DrawGCheckbox(App::diag_log_beam_trigger,    _LC("GameSettings", "Log beam triggers"));
     if (ImGui::Button(_LC("GameSettings", "Rebuild cache")))
     {
-        App::GetGuiManager()->SetVisible_GameSettings(false);
+        App::GetGuiManager()->GameSettings.SetVisible(false);
         App::GetGameContext()->PushMessage(Message(MSG_APP_MODCACHE_PURGE_REQUESTED));
         App::GetGameContext()->PushMessage(Message(MSG_GUI_OPEN_MENU_REQUESTED));
     }
@@ -446,7 +446,7 @@ void GameSettings::SetVisible(bool v)
     m_is_visible = v;
     if (!v && App::app_state->getEnum<AppState>() == RoR::AppState::MAIN_MENU)
     {
-        App::GetGuiManager()->SetVisible_GameMainMenu(true);
+        App::GetGuiManager()->GameMainMenu.SetVisible(true);
     }
 
     // Pre-format combobox strings.

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -385,6 +385,12 @@ void MainSelector::Draw()
 
     ImGui::EndGroup();
 
+    // Don't update hover if Close() was already called.
+    if (m_loader_type != LoaderType::LT_None)
+    {
+        m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+    }
+
     ImGui::End();
     if (!keep_open)
     {
@@ -554,6 +560,7 @@ void MainSelector::Close()
     m_searchbox_was_active = false;
     m_loader_type = LT_None; // Hide window
     m_kb_focused = true;
+    m_is_hovered = false;
 }
 
 void MainSelector::Cancel()

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -566,7 +566,7 @@ void MainSelector::Cancel()
         {
             App::GetGameContext()->PushMessage(Message(MSG_NET_DISCONNECT_REQUESTED));
         }
-        App::GetGuiManager()->SetVisible_GameMainMenu(true);
+        App::GetGuiManager()->GameMainMenu.SetVisible(true);
     }
     else if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
     {

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -385,11 +385,7 @@ void MainSelector::Draw()
 
     ImGui::EndGroup();
 
-    // Don't update hover if Close() was already called.
-    if (m_loader_type != LoaderType::LT_None)
-    {
-        m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
-    }
+    m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
 
     ImGui::End();
     if (!keep_open)

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -43,7 +43,7 @@ public:
 
     void Show(LoaderType type, std::string const& filter_guid = "");
     bool IsVisible() { return m_loader_type != LT_None; };
-    bool IsHovered() { return m_is_hovered; }
+    bool IsHovered() { return IsVisible() && m_is_hovered; }
     bool m_kb_focused = true;
     void Draw();
     void Close();

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -43,6 +43,7 @@ public:
 
     void Show(LoaderType type, std::string const& filter_guid = "");
     bool IsVisible() { return m_loader_type != LT_None; };
+    bool IsHovered() { return m_is_hovered; }
     bool m_kb_focused = true;
     void Draw();
     void Close();
@@ -91,6 +92,7 @@ private:
     bool               m_show_details = false;
     bool               m_searchbox_was_active = false;
     CacheEntry         m_dummy_skin;
+    bool               m_is_hovered = false;
 
     int                m_selected_category = 0;    //!< Combobox position (uses display list)
     int                m_selected_cid = 0;         //!< Category ID

--- a/source/main/gui/panels/GUI_MultiplayerSelector.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerSelector.cpp
@@ -382,7 +382,7 @@ void MultiplayerSelector::SetVisible(bool visible)
     }
     else if (!visible && App::app_state->getEnum<AppState>() == AppState::MAIN_MENU)
     {
-        App::GetGuiManager()->SetVisible_GameMainMenu(true);
+        App::GetGuiManager()->GameMainMenu.SetVisible(true);
     }
 }
 

--- a/source/main/gui/panels/GUI_NodeBeamUtils.cpp
+++ b/source/main/gui/panels/GUI_NodeBeamUtils.cpp
@@ -175,7 +175,9 @@ void NodeBeamUtils::Draw()
         actor->searchBeamDefaults();
     }
 
-    App::GetGuiManager()->RequestGuiCaptureKeyboard(ImGui::IsWindowHovered());
+    m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+    App::GetGuiManager()->RequestGuiCaptureKeyboard(m_is_hovered);
+
     ImGui::End();
     if (!keep_open)
     {
@@ -186,6 +188,7 @@ void NodeBeamUtils::Draw()
 void NodeBeamUtils::SetVisible(bool v)
 {
     m_is_visible = v;
+    m_is_hovered = false;
     if (!v)
     {
         m_is_searching = false;

--- a/source/main/gui/panels/GUI_NodeBeamUtils.h
+++ b/source/main/gui/panels/GUI_NodeBeamUtils.h
@@ -30,11 +30,13 @@ class NodeBeamUtils
 public:
     void Draw();
 
+    void SetVisible(bool visible);
     bool IsVisible() const { return m_is_visible; }
-    void SetVisible(bool v);
+    bool IsHovered() const { return m_is_hovered; }
 
 private:
     bool m_is_visible = false;
+    bool m_is_hovered = false;
     bool m_is_searching = false;
 
     const ImVec4 GRAY_HINT_TEXT = ImVec4(0.62f, 0.62f, 0.61f, 1.f);

--- a/source/main/gui/panels/GUI_NodeBeamUtils.h
+++ b/source/main/gui/panels/GUI_NodeBeamUtils.h
@@ -32,7 +32,7 @@ public:
 
     void SetVisible(bool visible);
     bool IsVisible() const { return m_is_visible; }
-    bool IsHovered() const { return m_is_hovered; }
+    bool IsHovered() const { return IsVisible() && m_is_hovered; }
 
 private:
     bool m_is_visible = false;

--- a/source/main/gui/panels/GUI_RepositorySelector.cpp
+++ b/source/main/gui/panels/GUI_RepositorySelector.cpp
@@ -1182,7 +1182,7 @@ void RepositorySelector::SetVisible(bool visible)
     }
     else if (!visible && (App::app_state->getEnum<AppState>() == AppState::MAIN_MENU))
     {
-        App::GetGuiManager()->SetVisible_GameMainMenu(true);
+        App::GetGuiManager()->GameMainMenu.SetVisible(true);
         if (m_update_cache)
         {
             m_update_cache = false;

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -229,6 +229,8 @@ void SurveyMap::Draw()
         }
     }
 
+    mWindowMouseHovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+
     ImGui::End();
     ImGui::PopStyleVar(2); // WindowPadding, WindowRounding
 }

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -47,7 +47,7 @@ void SurveyMap::Draw()
     // Check special cases
     if ((mMapMode == SurveyMapMode::BIG &&
         App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_FREE) || 
-        App::GetGuiManager()->GetMainSelector()->IsVisible())
+        App::GetGuiManager()->MainSelector.IsVisible())
     {
         mMapMode = SurveyMapMode::NONE;
         return;

--- a/source/main/gui/panels/GUI_SurveyMap.h
+++ b/source/main/gui/panels/GUI_SurveyMap.h
@@ -53,6 +53,7 @@ public:
     void CreateTerrainTextures(); //!< Init
     void Draw();
     bool IsVisible() const { return mMapMode != SurveyMapMode::NONE; }
+    bool IsHovered() const { return IsVisible() && mWindowMouseHovered; }
     void CycleMode();
     void ToggleMode();
 
@@ -75,8 +76,12 @@ protected:
                      std::string const& filename, std::string const& caption, 
                      float pos_x, float pos_y, float angle);
 
+    // Window display
     SurveyMapMode mMapMode = SurveyMapMode::NONE; // Display mode
     SurveyMapMode mMapLastMode = SurveyMapMode::NONE; // Display mode
+    bool          mWindowMouseHovered = false;
+
+    // Map
     Ogre::Vector2 mTerrainSize = Ogre::Vector2::ZERO; // Computed reference map size (in meters)
     Ogre::Vector2 mMapCenterOffset = Ogre::Vector2::ZERO; // Displacement, in meters
     float         mMapZoom = 0.f; // Ratio: 0-1

--- a/source/main/gui/panels/GUI_TextureToolWindow.cpp
+++ b/source/main/gui/panels/GUI_TextureToolWindow.cpp
@@ -145,7 +145,9 @@ void TextureToolWindow::Draw()
 
     ImGui::EndGroup(); // right
 
-    App::GetGuiManager()->RequestGuiCaptureKeyboard(ImGui::IsWindowHovered());
+    m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+    App::GetGuiManager()->RequestGuiCaptureKeyboard(m_is_hovered);
+
     ImGui::End();
 }
 

--- a/source/main/gui/panels/GUI_TextureToolWindow.h
+++ b/source/main/gui/panels/GUI_TextureToolWindow.h
@@ -31,8 +31,9 @@ public:
     const float LEFT_PANE_WIDTH = 200.f;
     const float WINDOW_WIDTH = 600.f;
 
-    void SetVisible(bool vis) { m_is_visible = vis; }
+    void SetVisible(bool visible) { m_is_visible = visible; m_is_hovered = false; }
     bool IsVisible() const { return m_is_visible; }
+    bool IsHovered() const { return m_is_hovered; }
 
     void Draw();
 
@@ -40,6 +41,7 @@ private:
     void SaveTexture(std::string texName, bool usePNG);
 
     bool m_is_visible = false;
+    bool m_is_hovered = false;
     bool m_show_dynamic_only = true;
     Ogre::TexturePtr m_display_tex;
 };

--- a/source/main/gui/panels/GUI_TextureToolWindow.h
+++ b/source/main/gui/panels/GUI_TextureToolWindow.h
@@ -31,9 +31,9 @@ public:
     const float LEFT_PANE_WIDTH = 200.f;
     const float WINDOW_WIDTH = 600.f;
 
-    void SetVisible(bool visible) { m_is_visible = visible; m_is_hovered = false; }
+    void SetVisible(bool visible) { m_is_visible = visible; }
     bool IsVisible() const { return m_is_visible; }
-    bool IsHovered() const { return m_is_hovered; }
+    bool IsHovered() const { return IsVisible() && m_is_hovered; }
 
     void Draw();
 

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -695,13 +695,7 @@ void TopMenubar::Update()
 
 bool TopMenubar::ShouldDisplay(ImVec2 window_pos)
 {
-    if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_FREE ||
-        App::GetGuiManager()->ConsoleWindow.IsHovered() ||
-        App::GetGuiManager()->GameControls.IsHovered() ||
-        App::GetGuiManager()->FrictionSettings.IsHovered() ||
-        App::GetGuiManager()->TextureToolWindow.IsHovered() ||
-        App::GetGuiManager()->NodeBeamUtils.IsHovered() ||
-        App::GetGuiManager()->MainSelector.IsHovered())
+    if (!App::GetGuiManager()->AreStaticMenusAllowed())
     {
         return false;
     }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -695,7 +695,13 @@ void TopMenubar::Update()
 
 bool TopMenubar::ShouldDisplay(ImVec2 window_pos)
 {
-    if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_FREE)
+    if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_FREE ||
+        App::GetGuiManager()->ConsoleWindow.IsHovered() ||
+        App::GetGuiManager()->GameControls.IsHovered() ||
+        App::GetGuiManager()->FrictionSettings.IsHovered() ||
+        App::GetGuiManager()->TextureToolWindow.IsHovered() ||
+        App::GetGuiManager()->NodeBeamUtils.IsHovered() ||
+        App::GetGuiManager()->MainSelector.IsHovered())
     {
         return false;
     }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -186,7 +186,7 @@ void TopMenubar::Update()
             {
                 if (ImGui::Button(_LC("TopMenubar", "Show vehicle description")))
                 {
-                    App::GetGuiManager()->SetVisible_VehicleDescription(true);
+                    App::GetGuiManager()->VehicleDescription.SetVisible(true);
                 }
 
                 if (current_actor->ar_state != ActorState::NETWORKED_OK)
@@ -531,19 +531,19 @@ void TopMenubar::Update()
         {
             if (ImGui::Button(_LC("TopMenubar", "Friction settings")))
             {
-                App::GetGuiManager()->SetVisible_FrictionSettings(true);
+                App::GetGuiManager()->FrictionSettings.SetVisible(true);
                 m_open_menu = TopMenu::TOPMENU_NONE;
             }
 
             if (ImGui::Button(_LC("TopMenubar", "Show console")))
             {
-                App::GetGuiManager()->SetVisible_Console(! App::GetGuiManager()->IsVisible_Console());
+                App::GetGuiManager()->ConsoleWindow.SetVisible(!App::GetGuiManager()->ConsoleWindow.IsVisible());
                 m_open_menu = TopMenu::TOPMENU_NONE;
             }
 
             if (ImGui::Button(_LC("TopMenubar", "Texture tool")))
             {
-                App::GetGuiManager()->SetVisible_TextureToolWindow(true);
+                App::GetGuiManager()->TextureToolWindow.SetVisible(true);
                 m_open_menu = TopMenu::TOPMENU_NONE;
             }
 
@@ -551,7 +551,7 @@ void TopMenubar::Update()
             {
                 if (ImGui::Button(_LC("TopMenubar", "Node / Beam utility")))
                 {
-                    App::GetGuiManager()->SetVisible_NodeBeamUtils(true);
+                    App::GetGuiManager()->NodeBeamUtils.SetVisible(true);
                     m_open_menu = TopMenu::TOPMENU_NONE;
                 }
             }

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -69,14 +69,8 @@ void VehicleButtons::Draw(RoR::GfxActor* actorx)
     }
 
     // Show when mouse is on the left of screen
-    if ((ImGui::GetIO().MousePos.x <= window_pos.x + ImGui::GetStyle().WindowPadding.x) && ImGui::GetIO().MousePos.y <= ImGui::GetIO().DisplaySize.y &&
-         App::GetCameraManager()->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_FREE &&
-         !App::GetGuiManager()->ConsoleWindow.IsHovered() &&
-         !App::GetGuiManager()->GameControls.IsHovered() &&
-         !App::GetGuiManager()->FrictionSettings.IsHovered() &&
-         !App::GetGuiManager()->TextureToolWindow.IsHovered() &&
-         !App::GetGuiManager()->NodeBeamUtils.IsHovered() &&
-         !App::GetGuiManager()->MainSelector.IsHovered())
+    if (App::GetGuiManager()->AreStaticMenusAllowed() &&
+        (ImGui::GetIO().MousePos.x <= window_pos.x + ImGui::GetStyle().WindowPadding.x) && ImGui::GetIO().MousePos.y <= ImGui::GetIO().DisplaySize.y)
     {
         is_visible = true;
     }

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -70,7 +70,13 @@ void VehicleButtons::Draw(RoR::GfxActor* actorx)
 
     // Show when mouse is on the left of screen
     if ((ImGui::GetIO().MousePos.x <= window_pos.x + ImGui::GetStyle().WindowPadding.x) && ImGui::GetIO().MousePos.y <= ImGui::GetIO().DisplaySize.y &&
-         App::GetCameraManager()->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_FREE)
+         App::GetCameraManager()->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_FREE &&
+         !App::GetGuiManager()->ConsoleWindow.IsHovered() &&
+         !App::GetGuiManager()->GameControls.IsHovered() &&
+         !App::GetGuiManager()->FrictionSettings.IsHovered() &&
+         !App::GetGuiManager()->TextureToolWindow.IsHovered() &&
+         !App::GetGuiManager()->NodeBeamUtils.IsHovered() &&
+         !App::GetGuiManager()->MainSelector.IsHovered())
     {
         is_visible = true;
     }

--- a/source/main/gui/panels/GUI_VehicleDescription.h
+++ b/source/main/gui/panels/GUI_VehicleDescription.h
@@ -23,6 +23,8 @@
 /// @author Moncef Ben Slimane
 /// @date   12/2014
 
+#pragma once
+
 #include <imgui.h>
 
 namespace RoR {

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
         }
 
         App::app_state->setVal((int)AppState::MAIN_MENU);
-        App::GetGuiManager()->SetVisible_MenuWallpaper(true);
+        App::GetGuiManager()->MenuWallpaper->show();
 
 #ifdef USE_OPENAL
         if (App::audio_menu_music->getBool())
@@ -298,8 +298,8 @@ int main(int argc, char *argv[])
 
         // Hack to properly init DearIMGUI integration - force rendering image
         //  Will be properly fixed under OGRE 2x
-        App::GetGuiManager()->GetLoadingWindow()->SetProgress(100, "Hack", /*renderFrame=*/true);
-        App::GetGuiManager()->SetVisible_LoadingWindow(false);
+        App::GetGuiManager()->LoadingWindow.SetProgress(100, "Hack", /*renderFrame=*/true);
+        App::GetGuiManager()->LoadingWindow.SetVisible(false);
 
         // --------------------------------------------------------------
         // Main rendering and event handling loop
@@ -399,7 +399,7 @@ int main(int argc, char *argv[])
                         App::GetNetwork()->Disconnect();
                         if (App::app_state->getEnum<AppState>() == AppState::MAIN_MENU)
                         {
-                            App::GetGuiManager()->GetMainSelector()->Close(); // We may get disconnected while still in map selection
+                            App::GetGuiManager()->MainSelector.Close(); // We may get disconnected while still in map selection
                             App::GetGameContext()->PushMessage(Message(MSG_GUI_OPEN_MENU_REQUESTED));
                         }
                     }
@@ -422,17 +422,17 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_NET_CONNECT_STARTED:
-                    App::GetGuiManager()->GetLoadingWindow()->SetProgressNetConnect(m.description);
-                    App::GetGuiManager()->SetVisible_MultiplayerSelector(false);
+                    App::GetGuiManager()->LoadingWindow.SetProgressNetConnect(m.description);
+                    App::GetGuiManager()->MultiplayerSelector.SetVisible(false);
                     App::GetGameContext()->PushMessage(Message(MSG_GUI_CLOSE_MENU_REQUESTED));
                     break;
 
                 case MSG_NET_CONNECT_PROGRESS:
-                    App::GetGuiManager()->GetLoadingWindow()->SetProgressNetConnect(m.description);
+                    App::GetGuiManager()->LoadingWindow.SetProgressNetConnect(m.description);
                     break;
 
                 case MSG_NET_CONNECT_SUCCESS:
-                    App::GetGuiManager()->GetLoadingWindow()->SetVisible(false);
+                    App::GetGuiManager()->LoadingWindow.SetVisible(false);
                     App::GetNetwork()->StopConnecting();
                     App::mp_state->setVal((int)RoR::MpState::CONNECTED);
                     RoR::ChatSystem::SendStreamSetup();
@@ -461,7 +461,7 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_NET_CONNECT_FAILURE:
-                    App::GetGuiManager()->GetLoadingWindow()->SetVisible(false);
+                    App::GetGuiManager()->LoadingWindow.SetVisible(false);
                     App::GetNetwork()->StopConnecting();
                     App::GetGameContext()->PushMessage(Message(MSG_NET_DISCONNECT_REQUESTED));
                     App::GetGameContext()->PushMessage(Message(MSG_GUI_OPEN_MENU_REQUESTED));
@@ -470,26 +470,26 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_NET_REFRESH_SERVERLIST_SUCCESS:
-                    App::GetGuiManager()->GetMpSelector()->UpdateServerlist((GUI::MpServerInfoVec*)m.payload);
+                    App::GetGuiManager()->MultiplayerSelector.UpdateServerlist((GUI::MpServerInfoVec*)m.payload);
                     delete (GUI::MpServerInfoVec*)m.payload;
                     break;
 
                 case MSG_NET_REFRESH_SERVERLIST_FAILURE:
-                    App::GetGuiManager()->GetMpSelector()->DisplayRefreshFailed(m.description);
+                    App::GetGuiManager()->MultiplayerSelector.DisplayRefreshFailed(m.description);
                     break;
 
                 case MSG_NET_REFRESH_REPOLIST_SUCCESS:
-                    App::GetGuiManager()->GetRepoSelector()->UpdateResources((GUI::ResourcesCollection*)m.payload);
+                    App::GetGuiManager()->RepositorySelector.UpdateResources((GUI::ResourcesCollection*)m.payload);
                     delete (GUI::ResourcesCollection*)m.payload;
                     break;
 
                 case MSG_NET_OPEN_RESOURCE_SUCCESS:
-                    App::GetGuiManager()->GetRepoSelector()->UpdateFiles((GUI::ResourcesCollection*)m.payload);
+                    App::GetGuiManager()->RepositorySelector.UpdateFiles((GUI::ResourcesCollection*)m.payload);
                     delete (GUI::ResourcesCollection*)m.payload;
                     break;
 
                 case MSG_NET_REFRESH_REPOLIST_FAILURE:
-                    App::GetGuiManager()->GetRepoSelector()->ShowError(m.description);
+                    App::GetGuiManager()->RepositorySelector.ShowError(m.description);
                     break;
 
                 // -- Gameplay events --
@@ -512,7 +512,7 @@ int main(int argc, char *argv[])
 
                 case MSG_SIM_LOAD_TERRN_REQUESTED:
                     App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
-                    App::GetGuiManager()->GetLoadingWindow()->SetProgress(5, _L("Loading resources"));
+                    App::GetGuiManager()->LoadingWindow.SetProgress(5, _L("Loading resources"));
                     App::GetContentManager()->LoadGameplayResources();
 
                     if (App::GetGameContext()->LoadTerrain(m.description))
@@ -525,7 +525,7 @@ int main(int argc, char *argv[])
                             App::GetGameContext()->SpawnPreselectedActor(App::diag_preset_vehicle->getStr(), App::diag_preset_veh_config->getStr()); // Needs character for position
                         App::GetGameContext()->GetSceneMouse().InitializeVisuals();
                         App::CreateOverlayWrapper();
-                        App::GetGuiManager()->GetDirectionArrow()->LoadOverlay();
+                        App::GetGuiManager()->DirectionArrow.LoadOverlay();
                         if (App::audio_menu_music->getBool())
                         {
                             SOUND_KILL(-1, SS_TRIG_MAIN_MENU);
@@ -534,9 +534,9 @@ int main(int argc, char *argv[])
                         App::GetDiscordRpc()->UpdatePresence();
                         App::sim_state->setVal((int)SimState::RUNNING);
                         App::app_state->setVal((int)AppState::SIMULATION);
-                        App::GetGuiManager()->SetVisible_GameMainMenu(false);
-                        App::GetGuiManager()->SetVisible_MenuWallpaper(false);
-                        App::GetGuiManager()->SetVisible_LoadingWindow(false);
+                        App::GetGuiManager()->GameMainMenu .SetVisible(false);
+                        App::GetGuiManager()->MenuWallpaper->hide();
+                        App::GetGuiManager()->LoadingWindow.SetVisible(false);
                         App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::VISIBLE);
                         App::gfx_fov_external->setVal(App::gfx_fov_external_default->getInt());
                         App::gfx_fov_internal->setVal(App::gfx_fov_internal_default->getInt());
@@ -563,7 +563,7 @@ int main(int argc, char *argv[])
                         {
                             App::GetGameContext()->PushMessage(Message(MSG_GUI_OPEN_MENU_REQUESTED));
                         }
-                        App::GetGuiManager()->SetVisible_LoadingWindow(false);
+                        App::GetGuiManager()->LoadingWindow.SetVisible(false);
                         failed_m = true;
                     }
                     break;
@@ -580,9 +580,9 @@ int main(int argc, char *argv[])
                     App::GetGameContext()->GetSceneMouse().DiscardVisuals();
                     App::DestroyOverlayWrapper();
                     App::GetCameraManager()->ResetAllBehaviors();
-                    App::GetGuiManager()->GetMainSelector()->Close();
-                    App::GetGuiManager()->SetVisible_LoadingWindow(false);
-                    App::GetGuiManager()->SetVisible_MenuWallpaper(true);
+                    App::GetGuiManager()->MainSelector.Close();
+                    App::GetGuiManager()->LoadingWindow.SetVisible(false);
+                    App::GetGuiManager()->MenuWallpaper->show();
                     App::sim_state->setVal((int)SimState::OFF);
                     App::app_state->setVal((int)AppState::MAIN_MENU);
                     delete App::GetSimTerrain();
@@ -703,24 +703,24 @@ int main(int argc, char *argv[])
                 // -- GUI events ---
 
                 case MSG_GUI_OPEN_MENU_REQUESTED:
-                    App::GetGuiManager()->SetVisible_GameMainMenu(true);
+                    App::GetGuiManager()->GameMainMenu.SetVisible(true);
                     break;
 
                 case MSG_GUI_CLOSE_MENU_REQUESTED:
-                    App::GetGuiManager()->SetVisible_GameMainMenu(false);
+                    App::GetGuiManager()->GameMainMenu.SetVisible(false);
                     break;
 
                 case MSG_GUI_OPEN_SELECTOR_REQUESTED:
-                    App::GetGuiManager()->GetMainSelector()->Show(*reinterpret_cast<LoaderType*>(m.payload), m.description);
+                    App::GetGuiManager()->MainSelector.Show(*reinterpret_cast<LoaderType*>(m.payload), m.description);
                     delete reinterpret_cast<LoaderType*>(m.payload);
                     break;
 
                 case MSG_GUI_CLOSE_SELECTOR_REQUESTED:
-                    App::GetGuiManager()->GetMainSelector()->Close();
+                    App::GetGuiManager()->MainSelector.Close();
                     break;
 
                 case MSG_GUI_MP_CLIENTS_REFRESH:
-                    App::GetGuiManager()->GetMpClientList()->UpdateClients();
+                    App::GetGuiManager()->MpClientList.UpdateClients();
                     break;
 
                 case MSG_GUI_SHOW_MESSAGE_BOX_REQUESTED:
@@ -730,14 +730,14 @@ int main(int argc, char *argv[])
 
                 case MSG_GUI_DOWNLOAD_PROGRESS:
                     App::GetGameContext()->PushMessage(Message(MSG_GUI_CLOSE_MENU_REQUESTED));
-                    App::GetGuiManager()->GetLoadingWindow()->SetProgress(*reinterpret_cast<int*>(m.payload), m.description, false);
+                    App::GetGuiManager()->LoadingWindow.SetProgress(*reinterpret_cast<int*>(m.payload), m.description, false);
                     delete reinterpret_cast<int*>(m.payload);
                     break;
 
                 case MSG_GUI_DOWNLOAD_FINISHED:
-                    App::GetGuiManager()->GetLoadingWindow()->SetVisible(false);
-                    App::GetGuiManager()->GetRepoSelector()->SetVisible(true);
-                    App::GetGuiManager()->GetRepoSelector()->DownloadFinished();
+                    App::GetGuiManager()->LoadingWindow.SetVisible(false);
+                    App::GetGuiManager()->RepositorySelector.SetVisible(true);
+                    App::GetGuiManager()->RepositorySelector.DownloadFinished();
                     break;
 
                 // -- Editing events --
@@ -853,11 +853,11 @@ int main(int argc, char *argv[])
                 App::GetInputEngine()->Capture();
                 App::GetInputEngine()->updateKeyBounces(dt);
 
-                if (!App::GetGuiManager()->GetControlsWindow()->IsInteractiveKeyBindingActive())
+                if (!App::GetGuiManager()->GameControls.IsInteractiveKeyBindingActive())
                 {
-                    if (!App::GetGuiManager()->IsVisible_MainSelector() && !App::GetGuiManager()->IsVisible_MultiplayerSelector() &&
-                        !App::GetGuiManager()->IsVisible_GameSettings() && !App::GetGuiManager()->IsVisible_GameControls() &&
-                        !App::GetGuiManager()->IsVisible_GameAbout() && !App::GetGuiManager()->IsVisible_RepositorySelector())
+                    if (!App::GetGuiManager()->MainSelector.IsVisible() && !App::GetGuiManager()->MultiplayerSelector.IsVisible() &&
+                        !App::GetGuiManager()->GameSettings.IsVisible() && !App::GetGuiManager()->GameControls.IsVisible() &&
+                        !App::GetGuiManager()->GameAbout.IsVisible() && !App::GetGuiManager()->RepositorySelector.IsVisible())
                     {
                         App::GetGameContext()->HandleSavegameHotkeys();
                     }
@@ -932,10 +932,10 @@ int main(int argc, char *argv[])
                 }
                 if (App::GetGameContext()->GetPlayerActor())
                 {
-                    App::GetGuiManager()->GetSimActorStats()->UpdateStats(dt, App::GetGameContext()->GetPlayerActor());
-                    if (App::GetGuiManager()->IsVisible_FrictionSettings())
+                    App::GetGuiManager()->SimActorStats.UpdateStats(dt, App::GetGameContext()->GetPlayerActor());
+                    if (App::GetGuiManager()->FrictionSettings.IsVisible())
                     {
-                        App::GetGuiManager()->GetFrictionSettings()->setActiveCol(App::GetGameContext()->GetPlayerActor()->ar_last_fuzzy_ground_model);
+                        App::GetGuiManager()->FrictionSettings.setActiveCol(App::GetGameContext()->GetPlayerActor()->ar_last_fuzzy_ground_model);
                     }
                 }
             }

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -979,14 +979,14 @@ void CacheSystem::ParseZipArchives(String group)
         int progress = ((float)i++ / (float)count) * 100;
         std::string text = fmt::format("{}{}\n{}\n{}/{}",
             _L("Loading zips in group "), group, file.filename, i, count);
-        RoR::App::GetGuiManager()->GetLoadingWindow()->SetProgress(progress, text);
+        RoR::App::GetGuiManager()->LoadingWindow.SetProgress(progress, text);
 
         String path = PathCombine(file.archive->getName(), file.filename);
         this->ParseSingleZip(path);
     }
 
-    RoR::App::GetGuiManager()->SetVisible_LoadingWindow(false);
-    App::GetGuiManager()->GetMainMenu()->CacheUpdatedNotice();
+    RoR::App::GetGuiManager()->LoadingWindow.SetVisible(false);
+    App::GetGuiManager()->GameMainMenu.CacheUpdatedNotice();
 }
 
 void CacheSystem::ParseSingleZip(String path)

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -323,7 +323,7 @@ bool TerrainGeometryManager::InitTerrain(std::string otc_filename)
     }
 
     // sync load since we want everything in place when we start
-    App::GetGuiManager()->GetLoadingWindow()->SetProgress(44, _L("Loading terrain pages ..."));
+    App::GetGuiManager()->LoadingWindow.SetProgress(44, _L("Loading terrain pages ..."));
     m_ogre_terrain_group->loadAllTerrains(true);
 
     Terrain* terrain = m_ogre_terrain_group->getTerrain(0, 0);
@@ -370,7 +370,7 @@ bool TerrainGeometryManager::InitTerrain(std::string otc_filename)
         // always save the results when it was imported
         if (!m_spec->disable_cache)
         {
-            App::GetGuiManager()->GetLoadingWindow()->SetProgress(50, _L("Saving all terrain pages ..."));
+            App::GetGuiManager()->LoadingWindow.SetProgress(50, _L("Saving all terrain pages ..."));
             m_ogre_terrain_group->saveAllTerrains(false);
         }
     }

--- a/source/main/terrain/TerrainManager.cpp
+++ b/source/main/terrain/TerrainManager.cpp
@@ -136,7 +136,7 @@ TerrainManager::~TerrainManager()
 TerrainManager* TerrainManager::LoadAndPrepareTerrain(CacheEntry* entry)
 {
     auto terrn_mgr = std::unique_ptr<TerrainManager>(new TerrainManager(entry));
-    auto loading_window = App::GetGuiManager()->GetLoadingWindow();
+    auto* loading_window = &App::GetGuiManager()->LoadingWindow;
 
     std::string const& filename = entry->fname;
     try
@@ -226,7 +226,7 @@ TerrainManager* TerrainManager::LoadAndPrepareTerrain(CacheEntry* entry)
 
     loading_window->SetProgress(92, _L("Initializing Overview Map Subsystem"));
     App::SetSimTerrain(terrn_mgr.get()); // Hack for the SurveyMapTextureCreator
-    App::GetGuiManager()->GetSurveyMap()->CreateTerrainTextures(); // Should be done before actors are loaded, otherwise they'd show up in the static texture
+    App::GetGuiManager()->SurveyMap.CreateTerrainTextures(); // Should be done before actors are loaded, otherwise they'd show up in the static texture
     App::SetSimTerrain(nullptr); // END Hack for the SurveyMapTextureCreator
 
     LOG(" ===== LOADING TERRAIN ACTORS " + filename);


### PR DESCRIPTION
Quality of life improvement - only pop up the top menubar / buttons UI if the cursor isn't over another window.

![isHovered](https://user-images.githubusercontent.com/491088/180582054-f5987e92-019a-4f22-a0df-6ca6994893e6.gif)

