### PR TITLE
Removed hotkey COMMON_TOGGLE_RENDER_MODE (Keyboard E)

### DIFF
--- a/resources/skeleton/config/input.map
+++ b/resources/skeleton/config/input.map
@@ -196,7 +196,7 @@ COMMON_CYCLE_DEBUG_VIEWS       Keyboard             EXPL+CTRL+K
 COMMON_TOGGLE_TERRAIN_EDITOR   Keyboard             EXPL+CTRL+Y 
 COMMON_TOGGLE_CUSTOM_PARTICLES Keyboard             G 
 COMMON_TOGGLE_MAT_DEBUG        Keyboard             EXPL+CTRL+SHIFT+ALT+F 
-COMMON_TOGGLE_RENDER_MODE      Keyboard             E 
+COMMON_TOGGLE_RENDER_MODE      None
 COMMON_TOGGLE_REPLAY_MODE      Keyboard             CTRL+J 
 COMMON_TOGGLE_PHYSICS          Keyboard             EXPL+J 
 COMMON_TOGGLE_STATS            Keyboard             EXPL+F 

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -811,19 +811,6 @@ void GameContext::UpdateGlobalInputEvents()
             this->PushMessage(Message(MSG_APP_DISPLAY_FULLSCREEN_REQUESTED));
     }
 
-    // toggle render mode
-    if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_RENDER_MODE, 0.5f))
-    {
-        static int mSceneDetailIndex;
-        mSceneDetailIndex = (mSceneDetailIndex + 1) % 3;
-        switch (mSceneDetailIndex)
-        {
-        case 0: App::GetCameraManager()->GetCamera()->setPolygonMode(Ogre::PM_SOLID);       break;
-        case 1: App::GetCameraManager()->GetCamera()->setPolygonMode(Ogre::PM_WIREFRAME);   break;
-        case 2: App::GetCameraManager()->GetCamera()->setPolygonMode(Ogre::PM_POINTS);      break;
-        }
-    }
-
     // Write player position to log
     if (App::app_state->getEnum<AppState>() == AppState::SIMULATION &&
         App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_OUTPUT_POSITION))

--- a/source/main/scripting/InputEngineAngelscript.cpp
+++ b/source/main/scripting/InputEngineAngelscript.cpp
@@ -245,7 +245,6 @@ void registerEventTypeEnum(AngelScript::asIScriptEngine* engine)
     result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_TERRAIN_EDITOR",   EV_COMMON_TOGGLE_TERRAIN_EDITOR ); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_CUSTOM_PARTICLES", EV_COMMON_TOGGLE_CUSTOM_PARTICLES); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_MAT_DEBUG",        EV_COMMON_TOGGLE_MAT_DEBUG      ); ROR_ASSERT(result >= 0);
-    result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_RENDER_MODE",      EV_COMMON_TOGGLE_RENDER_MODE    ); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_REPLAY_MODE",      EV_COMMON_TOGGLE_REPLAY_MODE    ); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_PHYSICS",          EV_COMMON_TOGGLE_PHYSICS        ); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("inputEvents", "EV_COMMON_TOGGLE_STATS",            EV_COMMON_TOGGLE_STATS          ); ROR_ASSERT(result >= 0);

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -45,7 +45,6 @@ InputEvent eventInfo[] = {
     {"COMMON_SCREENSHOT",             EV_COMMON_SCREENSHOT,             "Keyboard EXPL+SYSRQ",          _LC("InputEvent", "take a screenshot")},
     {"COMMON_SCREENSHOT_BIG",         EV_COMMON_SCREENSHOT_BIG,         "Keyboard EXPL+CTRL+SYSRQ",     _LC("InputEvent", "take a big screenshot (3 times the screen size)")},
     {"COMMON_TOGGLE_MAT_DEBUG",       EV_COMMON_TOGGLE_MAT_DEBUG,       "",                             _LC("InputEvent", "debug purpose - dont use")},
-    {"COMMON_TOGGLE_RENDER_MODE",     EV_COMMON_TOGGLE_RENDER_MODE,     "Keyboard E",                   _LC("InputEvent", "toggle render mode (solid, wireframe and points)")},
     {"COMMON_TOGGLE_PHYSICS",         EV_COMMON_TOGGLE_PHYSICS,         "Keyboard EXPL+J",              _LC("InputEvent", "enable or disable physics")},
     {"COMMON_FOV_LESS",               EV_COMMON_FOV_LESS,               "Keyboard EXPL+NUMPAD7",        _LC("InputEvent", "decreases the current FOV value")},
     {"COMMON_FOV_MORE",               EV_COMMON_FOV_MORE,               "Keyboard EXPL+CTRL+NUMPAD7",   _LC("InputEvent", "increase the current FOV value")},

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -885,24 +885,6 @@ bool InputEngine::isEventAnalog(int eventID)
         }
     }
     return false;
-#if 0
-    // XXX : TODO fix this problem properly
-    std::vector<event_trigger_t> t_vec = events[eventID];
-    for (std::vector<event_trigger_t>::iterator i = t_vec.begin(); i != t_vec.end(); i++)
-    {
-        event_trigger_t t = *i;
-        if (i->eventtype == ET_MouseAxisX \
-            || i->eventtype == ET_MouseAxisX \
-            || i->eventtype == ET_MouseAxisY \
-            || i->eventtype == ET_MouseAxisZ \
-            || i->eventtype == ET_JoystickAxisAbs \
-            || i->eventtype == ET_JoystickAxisRel \
-            || i->eventtype == ET_JoystickSliderX \
-            || i->eventtype == ET_JoystickSliderY)
-            return true;
-    }
-    return false;
-#endif //0
 }
 
 float InputEngine::getEventValue(int eventID, bool pure, InputSourceType valueSource /*= InputSourceType::IST_ANY*/)

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -266,7 +266,6 @@ enum events
     EV_COMMON_TOGGLE_TERRAIN_EDITOR,   //!< toggle terrain editor
     EV_COMMON_TOGGLE_CUSTOM_PARTICLES, //!< toggle particle cannon
     EV_COMMON_TOGGLE_MAT_DEBUG,   //!< debug purpose - dont use (currently not used)
-    EV_COMMON_TOGGLE_RENDER_MODE, //!< toggle render mode (solid, wireframe and points)
     EV_COMMON_TOGGLE_REPLAY_MODE, //!< toggle replay mode
     EV_COMMON_TOGGLE_PHYSICS,     //!< toggle physics on/off
     EV_COMMON_TOGGLE_STATS,       //!< toggle Ogre statistics (FPS etc.)


### PR DESCRIPTION
 'E' is generally known as 'use' and what it does here is confusing... and people obviously press it by accident

![obrazek](https://user-images.githubusercontent.com/491088/180652078-b9ab9673-60e6-4416-bc36-c2000f2cfe1d.png)
