### PR TITLE
AngelScript: fixed ref counting, added ProceduralRoad API

### DIFF
--- a/doc/angelscript/Script2Game/GameScriptClass.h
+++ b/doc/angelscript/Script2Game/GameScriptClass.h
@@ -419,6 +419,11 @@ public:
 	 * This method repairs the vehicle in the box
 	 */
 	void repairVehicle(string instance, string box, bool keepPosition);
+    
+	/**
+	 * Gets the currently loaded terrain instance
+	 */    
+	TerrainClass@ getTerrain();
 
 	/**
 	 * This method removes the vehicle in the box

--- a/doc/angelscript/Script2Game/ProceduralManagerClass.h
+++ b/doc/angelscript/Script2Game/ProceduralManagerClass.h
@@ -1,0 +1,37 @@
+
+namespace Script2Game {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */    
+
+/**
+ * @brief Binding of RoR::ProceduralManager; generates dynamic roads for terrain.
+ * @note Obtain the object using `game.getTerrain().getProceduralManager()`.
+ */
+class ProceduralManagerClass
+{
+public:
+    /**
+    * Generates road mesh and adds to internal list
+    */
+    void addObject(ProceduralObjectClass @po);
+
+    /**
+    * Clears road mesh and removes from internal list
+    */
+    void removeObject(ProceduralObjectClass @po);
+
+    int getNumObjects();
+
+    ProceduralObjectClass@ getObject(int pos);
+};
+
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Game

--- a/doc/angelscript/Script2Game/ProceduralObjectClass.h
+++ b/doc/angelscript/Script2Game/ProceduralObjectClass.h
@@ -1,0 +1,41 @@
+
+namespace Script2Game {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */
+
+/**
+ * @brief Binding of RoR::ProceduralObject; a spline for generating dynamic roads.
+ */
+class ProceduralObjectClass
+{
+public:
+    /**
+    * Name of the road/street this spline represents.
+    */
+    string name;
+    
+    /**
+    * Adds point at the end.
+    */
+    void addPoint(procedural_point);
+    
+    /**
+    * Adds point before the element at the specified position.
+    */
+    void insertPoint(int pos, procedural_point);
+    void deletePoint(int pos);
+    procedural_point getPoint(int pos);
+    int getNumPoints();
+    ProceduralRoadClass @getRoad();
+};
+
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Game

--- a/doc/angelscript/Script2Game/ProceduralPointClass.h
+++ b/doc/angelscript/Script2Game/ProceduralPointClass.h
@@ -1,0 +1,30 @@
+
+namespace Script2Game {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */
+
+/**
+ * @brief Binding of RoR::ProceduralPoint;
+ */
+struct ProceduralPointClass
+{
+public:
+    vector3 position;
+    quaternion rotation;
+    float width;
+    float border_width;
+    float border_height;
+    RoadType type;
+    int pillar_type;
+};
+
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Game

--- a/doc/angelscript/Script2Game/ProceduralRoadClass.h
+++ b/doc/angelscript/Script2Game/ProceduralRoadClass.h
@@ -1,0 +1,75 @@
+
+namespace Script2Game {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */
+ 
+enum RoadType
+{
+    ROAD_AUTOMATIC,
+    ROAD_FLAT,
+    ROAD_LEFT,
+    ROAD_RIGHT,
+    ROAD_BOTH,
+    ROAD_BRIDGE,
+    ROAD_MONORAIL
+};
+
+enum TextureFit
+{
+    TEXFIT_NONE,
+    TEXFIT_BRICKWALL,
+    TEXFIT_ROADS1,
+    TEXFIT_ROADS2,
+    TEXFIT_ROAD,
+    TEXFIT_ROADS3,
+    TEXFIT_ROADS4,
+    TEXFIT_CONCRETEWALL,
+    TEXFIT_CONCRETEWALLI,
+    TEXFIT_CONCRETETOP,
+    TEXFIT_CONCRETEUNDER
+};
+
+/**
+ * @brief Binding of RoR::ProceduralRoad; a dynamically generated road mesh.
+ * @note For internal use by ProceduralManagerClass - do not use unless you know what you're doing!
+ */ 
+ */
+class ProceduralRoadClass
+{
+public:
+    /**
+    * For internal use by ProceduralManagerClass - do not use unless you know what you're doing!
+    */
+    void addBlock(vector3 pos, quaternion rot, RoadType type, float width, float border_width, float border_height, int pillar_type = 1);
+    /**
+    * For internal use by ProceduralManagerClass - do not use unless you know what you're doing!
+    */    
+    void addQuad(vector3 p1, vector3 p2, vector3 p3, vector3 p4, TextureFit texfit, vector3 pos, vector3 lastpos, float width, bool flip = false);
+    /**
+    * For internal use by ProceduralManagerClass - do not use unless you know what you're doing!
+    */    
+    void addCollisionQuad(vector3 p1, vector3 p2, vector3 p3, vector3 p4, string const&in gm_name, bool flip = false);
+    /**
+    * For internal use by ProceduralManagerClass - do not use unless you know what you're doing!
+    */    
+    void createMesh();
+    /**
+    * For internal use by ProceduralManagerClass - do not use unless you know what you're doing!
+    */    
+    void finish();
+    /**
+    * For internal use by ProceduralManagerClass - do not use unless you know what you're doing!
+    */    
+    void setCollisionEnabled(bool v);
+};
+
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Game

--- a/doc/angelscript/Script2Game/TerrainClass.h
+++ b/doc/angelscript/Script2Game/TerrainClass.h
@@ -1,0 +1,48 @@
+
+namespace Script2Game {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */    
+
+/**
+ * @brief Binding of RoR::Terrain; represents a loaded terrain.
+ * @note Obtain the object using `game.getTerrain()`.
+ */
+class TerrainClass
+{
+public:
+    /**
+     * @return Full name of the terrain
+     */
+    string getTerrainName();
+    
+    /**
+     * @return GUID (global unique ID) of the terrain, or empty string if not specified.
+     */
+    string getGUID();
+
+    /**
+     * @return true if specified as flat (no heightmap).
+     */
+    bool isFlat();
+
+    /**
+     * @return version of the terrain, as specified by author.
+     */
+    int getVersion();
+ 
+    /**
+     * @return Player spawn position when entering game.
+     */
+    vector3 getSpawnPos();
+};
+
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Game

--- a/doc/angelscript/Script2Game/TerrainClass.h
+++ b/doc/angelscript/Script2Game/TerrainClass.h
@@ -40,6 +40,8 @@ public:
      * @return Player spawn position when entering game.
      */
     vector3 getSpawnPos();
+    
+    ProceduralManagerClass @getProceduralManager();
 };
 
 /// @}    //addtogroup Script2Game

--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -192,7 +192,7 @@ void AppContext::windowResized(Ogre::RenderWindow* rw)
     App::GetOverlayWrapper()->windowResized();
     if (App::sim_state->getEnum<AppState>() == RoR::AppState::SIMULATION)
     {
-        for (Actor* actor: App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor: App::GetGameContext()->GetActorManager()->GetActors())
         {
             actor->ar_dashboard->windowResized();
         }

--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -357,7 +357,7 @@ void AppContext::CaptureScreenshot()
             png.addData("Truck_file", App::GetGameContext()->GetPlayerActor()->ar_filename);
             png.addData("Truck_name", App::GetGameContext()->GetPlayerActor()->getTruckName());
         }
-        if (App::GetSimTerrain())
+        if (App::GetGameContext()->GetTerrain())
         {
             png.addData("Terrn_file", App::sim_terrain_name->getStr());
             png.addData("Terrn_name", App::sim_terrain_gui_name->getStr());

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -42,6 +42,7 @@
 #include "Network.h"
 #include "ScriptEngine.h"
 #include "SoundScriptManager.h"
+#include "Terrain.h"
 #include "ThreadPool.h"
 
 namespace RoR {
@@ -60,7 +61,6 @@ static GUIManager*      g_gui_manager;
 static InputEngine*     g_input_engine;
 static CacheSystem*     g_cache_system;
 static MumbleIntegration* g_mumble;
-static Terrain*  g_sim_terrain;
 static ThreadPool*      g_thread_pool;
 static CameraManager*   g_camera_manager;
 static GfxScene         g_gfx_scene;
@@ -237,7 +237,6 @@ CVar* gfx_reduce_shadows;
 CVar* gfx_enable_rtshaders;
 
 // Instance management
-void SetSimTerrain     (Terrain* obj)          { g_sim_terrain = obj;}
 void SetCacheSystem    (CacheSystem* obj)             { g_cache_system = obj; }
 
 // Instance access
@@ -249,7 +248,6 @@ Console*               GetConsole            () { return &g_console;}
 InputEngine*           GetInputEngine        () { return g_input_engine;}
 CacheSystem*           GetCacheSystem        () { return g_cache_system;}
 MumbleIntegration*     GetMumble             () { return g_mumble; }
-Terrain*        GetSimTerrain         () { return g_sim_terrain; }
 ThreadPool*            GetThreadPool         () { return g_thread_pool; }
 CameraManager*         GetCameraManager      () { return g_camera_manager; }
 GfxScene*              GetGfxScene           () { return &g_gfx_scene; }

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -96,11 +96,11 @@ enum MsgType
     MSG_SIM_UNLOAD_TERRN_REQUESTED,
     MSG_SIM_SPAWN_ACTOR_REQUESTED,         //!< Payload = RoR::ActorSpawnRequest* (owner)
     MSG_SIM_MODIFY_ACTOR_REQUESTED,        //!< Payload = RoR::ActorModifyRequest* (owner)
-    MSG_SIM_DELETE_ACTOR_REQUESTED,        //!< Payload = RoR::Actor* (weak)
-    MSG_SIM_SEAT_PLAYER_REQUESTED,         //!< Payload = RoR::Actor* (weak) | nullptr
+    MSG_SIM_DELETE_ACTOR_REQUESTED,        //!< Payload = RoR::ActorPtr* (owner)
+    MSG_SIM_SEAT_PLAYER_REQUESTED,         //!< Payload = RoR::ActorPtr (owner) | nullptr
     MSG_SIM_TELEPORT_PLAYER_REQUESTED,     //!< Payload = Ogre::Vector3* (owner)
-    MSG_SIM_HIDE_NET_ACTOR_REQUESTED,      //!< Payload = Actor* (weak)
-    MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED,    //!< Payload = Actor* (weak)
+    MSG_SIM_HIDE_NET_ACTOR_REQUESTED,      //!< Payload = ActorPtr* (owner)
+    MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED,    //!< Payload = ActorPtr* (owner)
     // GUI
     MSG_GUI_OPEN_MENU_REQUESTED,
     MSG_GUI_CLOSE_MENU_REQUESTED,

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -442,7 +442,6 @@ Console*             GetConsole();
 InputEngine*         GetInputEngine();
 CacheSystem*         GetCacheSystem();
 MumbleIntegration*   GetMumble();
-Terrain*      GetSimTerrain();
 ThreadPool*          GetThreadPool();
 CameraManager*       GetCameraManager();
 GfxScene*            GetGfxScene();
@@ -466,7 +465,6 @@ void CreateSoundScriptManager();
 void CreateScriptEngine();
 
 // Setters
-void SetSimTerrain           (Terrain*    obj);
 void SetCacheSystem          (CacheSystem*       obj);
 
 // Cleanups

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -234,6 +234,7 @@ if (USE_ANGELSCRIPT)
             scripting/bindings/InputEngineAngelscript.cpp
             scripting/bindings/LocalStorageAngelscript.cpp
             scripting/bindings/OgreAngelscript.cpp
+            scripting/bindings/ProceduralRoadAngelscript.cpp
             scripting/bindings/ScriptEventsAngelscript.cpp
             scripting/bindings/TerrainAngelscript.cpp
             scripting/bindings/VehicleAiAngelscript.cpp

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -203,6 +203,8 @@ set(SOURCE_FILES
         terrain/Terrain.{h,cpp}
         terrain/TerrainObjectManager.{h,cpp}        
         threadpool/ThreadPool.h
+        utils/memory/RefCountingObject.h
+        utils/memory/RefCountingObjectPtr.h        
         utils/ConfigFile.{h,cpp}
         utils/ErrorUtils.{h,cpp}
         utils/ForceFeedback.{h,cpp}
@@ -344,6 +346,7 @@ target_include_directories(${BINNAME} PRIVATE
         terrain
         terrain/map
         threadpool
+        utils/memory
         utils
         )
 

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -235,6 +235,7 @@ if (USE_ANGELSCRIPT)
             scripting/bindings/LocalStorageAngelscript.cpp
             scripting/bindings/OgreAngelscript.cpp
             scripting/bindings/ScriptEventsAngelscript.cpp
+            scripting/bindings/TerrainAngelscript.cpp
             scripting/bindings/VehicleAiAngelscript.cpp
             )
 endif ()

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -84,6 +84,10 @@ namespace RoR
     class  OgreSubsystem;
     struct PlatformUtils;
     class  PointColDetector;
+    class  ProceduralManager;
+    struct ProceduralObject;
+    struct ProceduralPoint;
+    class  ProceduralRoad;
     struct Prop;
     struct PropAnim;
     class  RailGroup;
@@ -146,6 +150,10 @@ namespace RoR
     typedef RefCountingObjectPtr<Actor> ActorPtr;
     typedef RefCountingObjectPtr<VehicleAI> VehicleAIPtr;
     typedef RefCountingObjectPtr<Terrain> TerrainPtr;
+    typedef RefCountingObjectPtr<ProceduralPoint> ProceduralPointPtr;
+    typedef RefCountingObjectPtr<ProceduralObject> ProceduralObjectPtr;
+    typedef RefCountingObjectPtr<ProceduralRoad> ProceduralRoadPtr;
+    typedef RefCountingObjectPtr<ProceduralManager> ProceduralManagerPtr;
 
     namespace GUI
     {

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -25,6 +25,7 @@
 /// @author Petr Ohlidal
 /// @date   12/2013
 
+#include "RefCountingObjectPtr.h"
 
 #pragma once
 
@@ -140,6 +141,9 @@ namespace RoR
     struct ground_model_t;
     struct client_t;
     struct authorinfo_t;
+
+    /// AngelScript-friendly shared pointers
+    typedef RefCountingObjectPtr<Actor> ActorPtr;
 
     namespace GUI
     {

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -145,6 +145,7 @@ namespace RoR
     // AngelScript-friendly shared pointers
     typedef RefCountingObjectPtr<Actor> ActorPtr;
     typedef RefCountingObjectPtr<VehicleAI> VehicleAIPtr;
+    typedef RefCountingObjectPtr<Terrain> TerrainPtr;
 
     namespace GUI
     {

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -142,8 +142,9 @@ namespace RoR
     struct client_t;
     struct authorinfo_t;
 
-    /// AngelScript-friendly shared pointers
+    // AngelScript-friendly shared pointers
     typedef RefCountingObjectPtr<Actor> ActorPtr;
+    typedef RefCountingObjectPtr<VehicleAI> VehicleAIPtr;
 
     namespace GUI
     {

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -113,16 +113,41 @@ bool GameContext::LoadTerrain(std::string const& filename_part)
     // Init resources
     App::GetCacheSystem()->LoadResource(*terrn_entry);
 
-    // Perform the loading and setup
-    App::SetSimTerrain(RoR::Terrain::LoadAndPrepareTerrain(terrn_entry));
-    if (!App::GetSimTerrain())
+    // Load the terrain
+    Terrn2Def terrn2;
+    std::string const& filename = terrn_entry->fname;
+    try
     {
+        Ogre::DataStreamPtr stream = Ogre::ResourceGroupManager::getSingleton().openResource(filename);
+        LOG(" ===== LOADING TERRAIN " + filename);
+        Terrn2Parser parser;
+        if (! parser.LoadTerrn2(terrn2, stream))
+        {
+            return false; // Errors already logged to console
+        }
+    }
+    catch (Ogre::Exception& e)
+    {
+        App::GetGuiManager()->ShowMessageBox(_L("Terrain loading error"), e.getFullDescription().c_str());
+        return false;
+    }
+
+    // CAUTION - the global instance must be set during init! Needed by:
+    // * GameScript::spawnObject()
+    // * ProceduralManager
+    // * Landusemap
+    // * SurveyMapTextureCreator
+    // * Collisions (debug visualization)
+    m_terrain = new RoR::Terrain(terrn_entry, terrn2);
+    if (!m_terrain->initialize())
+    {
+        m_terrain = nullptr; // TerrainPtr deletes the object
         return false; // Message box already displayed
     }
 
     // Initialize envmap textures by rendering center of map
-    Ogre::Vector3 center = App::GetSimTerrain()->getMaxTerrainSize() / 2;
-    center.y = App::GetSimTerrain()->GetHeightAt(center.x, center.z) + 1.0f;
+    Ogre::Vector3 center = m_terrain->getMaxTerrainSize() / 2;
+    center.y = m_terrain->GetHeightAt(center.x, center.z) + 1.0f;
     App::GetGfxScene()->GetEnvMap().UpdateEnvMap(center, /*gfx_actor:*/nullptr, /*full:*/true);
 
     // Scan groundmodels
@@ -133,11 +158,12 @@ bool GameContext::LoadTerrain(std::string const& filename_part)
 
 void GameContext::UnloadTerrain()
 {
-    if (App::GetSimTerrain() != nullptr)
+    if (m_terrain != nullptr)
     {
-        // remove old terrain
-        delete(App::GetSimTerrain());
-        App::SetSimTerrain(nullptr);
+        // dispose(), do not `delete` - script may still hold reference to the object.
+        m_terrain->dispose();
+        // release local reference - object will be deleted when all references are released.
+        m_terrain = nullptr;
     }
 }
 
@@ -159,7 +185,7 @@ ActorPtr GameContext::SpawnActor(ActorSpawnRequest& rq)
                 float h = m_player_actor->getMaxHeight(true);
                 rq.asr_rotation = Ogre::Quaternion(Ogre::Degree(270) - Ogre::Radian(m_player_actor->getRotation()), Ogre::Vector3::UNIT_Y);
                 rq.asr_position = m_player_actor->getRotationCenter();
-                rq.asr_position.y = App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(rq.asr_position.x, rq.asr_position.z, h);
+                rq.asr_position.y = m_terrain->GetCollisions()->getSurfaceHeightBelow(rq.asr_position.x, rq.asr_position.z, h);
                 rq.asr_position.y += m_player_actor->getHeightAboveGroundBelow(h, true); // retain height above ground
             }
             else
@@ -434,11 +460,11 @@ void GameContext::ChangePlayerActor(ActorPtr actor)
                 // actor has a cinecam (find optimal exit position)
                 Ogre::Vector3 l = position - 2.0f * prev_player_actor->GetCameraRoll();
                 Ogre::Vector3 r = position + 2.0f * prev_player_actor->GetCameraRoll();
-                float l_h = App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(l.x, l.z, l.y + h);
-                float r_h = App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(r.x, r.z, r.y + h);
+                float l_h = m_terrain->GetCollisions()->getSurfaceHeightBelow(l.x, l.z, l.y + h);
+                float r_h = m_terrain->GetCollisions()->getSurfaceHeightBelow(r.x, r.z, r.y + h);
                 position  = std::abs(r.y - r_h) * 1.2f < std::abs(l.y - l_h) ? r : l;
             }
-            position.y = App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(position.x, position.z, position.y + h);
+            position.y = m_terrain->GetCollisions()->getSurfaceHeightBelow(position.x, position.z, position.y + h);
 
             Character* player_character = this->GetPlayerCharacter();
             if (player_character)
@@ -504,7 +530,7 @@ void GameContext::UpdateActors()
 
 ActorPtr GameContext::FindActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name)
 {
-    return m_actor_manager.FindActorInsideBox(App::GetSimTerrain()->GetCollisions(),
+    return m_actor_manager.FindActorInsideBox(m_terrain->GetCollisions(),
                                               ev_src_instance_name, box_name);
 }
 
@@ -562,12 +588,12 @@ void GameContext::ShowLoaderGUI(int type, const Ogre::String& instance, const Og
     // first, test if the place if clear, BUT NOT IN MULTIPLAYER
     if (!(App::mp_state->getEnum<MpState>() == MpState::CONNECTED))
     {
-        collision_box_t* spawnbox = App::GetSimTerrain()->GetCollisions()->getBox(instance, box);
+        collision_box_t* spawnbox = m_terrain->GetCollisions()->getBox(instance, box);
         for (ActorPtr actor : this->GetActorManager()->GetActors())
         {
             for (int i = 0; i < actor->ar_num_nodes; i++)
             {
-                if (App::GetSimTerrain()->GetCollisions()->isInside(actor->ar_nodes[i].AbsPosition, spawnbox))
+                if (m_terrain->GetCollisions()->isInside(actor->ar_nodes[i].AbsPosition, spawnbox))
                 {
                     App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Please clear the place first"), "error.png");
                     return;
@@ -576,9 +602,9 @@ void GameContext::ShowLoaderGUI(int type, const Ogre::String& instance, const Og
         }
     }
 
-    m_current_selection.asr_position = App::GetSimTerrain()->GetCollisions()->getPosition(instance, box);
-    m_current_selection.asr_rotation = App::GetSimTerrain()->GetCollisions()->getDirection(instance, box);
-    m_current_selection.asr_spawnbox = App::GetSimTerrain()->GetCollisions()->getBox(instance, box);
+    m_current_selection.asr_position = m_terrain->GetCollisions()->getPosition(instance, box);
+    m_current_selection.asr_rotation = m_terrain->GetCollisions()->getDirection(instance, box);
+    m_current_selection.asr_spawnbox = m_terrain->GetCollisions()->getBox(instance, box);
 
     RoR::Message m(MSG_GUI_OPEN_SELECTOR_REQUESTED);
     m.payload = reinterpret_cast<void*>(new LoaderType(LoaderType(type)));
@@ -675,12 +701,12 @@ void GameContext::CreatePlayerCharacter()
     m_character_factory.CreateLocalCharacter();
 
     // Adjust character position
-    Ogre::Vector3 spawn_pos = App::GetSimTerrain()->getSpawnPos();
+    Ogre::Vector3 spawn_pos = m_terrain->getSpawnPos();
     float spawn_rot = 0.0f;
 
     // Classic behavior, retained for compatibility.
     // Required for maps like N-Labs or F1 Track.
-    if (!App::GetSimTerrain()->HasPredefinedActors())
+    if (!m_terrain->HasPredefinedActors())
     {
         spawn_rot = 180.0f;
     }
@@ -709,7 +735,7 @@ void GameContext::CreatePlayerCharacter()
         App::diag_preset_spawn_rot->setStr("");
     }
 
-    spawn_pos.y = App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(spawn_pos.x, spawn_pos.z, spawn_pos.y + 1.8f);
+    spawn_pos.y = m_terrain->GetCollisions()->getSurfaceHeightBelow(spawn_pos.x, spawn_pos.z, spawn_pos.y + 1.8f);
 
     this->GetPlayerCharacter()->setPosition(spawn_pos);
     this->GetPlayerCharacter()->setRotation(Ogre::Degree(spawn_rot));
@@ -733,7 +759,7 @@ Character* GameContext::GetPlayerCharacter() // Convenience ~ counterpart of `Ge
 
 void GameContext::TeleportPlayer(float x, float z)
 {
-    float y = App::GetSimTerrain()->GetCollisions()->getSurfaceHeight(x, z);
+    float y = m_terrain->GetCollisions()->getSurfaceHeight(x, z);
     if (!this->GetPlayerActor())
     {
         this->GetPlayerCharacter()->setPosition(Ogre::Vector3(x, y, z));
@@ -754,9 +780,9 @@ void GameContext::TeleportPlayer(float x, float z)
         for (int i = 0; i < actor->ar_num_nodes; i++)
         {
             Ogre::Vector3 pos = actor->ar_nodes[i].AbsPosition;
-            src_agl = std::min(pos.y - App::GetSimTerrain()->GetCollisions()->getSurfaceHeight(pos.x, pos.z), src_agl);
+            src_agl = std::min(pos.y - m_terrain->GetCollisions()->getSurfaceHeight(pos.x, pos.z), src_agl);
             pos += translation;
-            dst_agl = std::min(pos.y - App::GetSimTerrain()->GetCollisions()->getSurfaceHeight(pos.x, pos.z), dst_agl);
+            dst_agl = std::min(pos.y - m_terrain->GetCollisions()->getSurfaceHeight(pos.x, pos.z), dst_agl);
         }
     }
 
@@ -1030,7 +1056,7 @@ void GameContext::UpdateSkyInputEvents(float dt)
 {
 #ifdef USE_CAELUM
     if (App::gfx_sky_mode->getEnum<GfxSkyMode>() == GfxSkyMode::CAELUM &&
-        App::GetSimTerrain()->getSkyManager())
+        m_terrain->getSkyManager())
     {
         float time_factor = 1.0f;
 
@@ -1055,37 +1081,37 @@ void GameContext::UpdateSkyInputEvents(float dt)
             time_factor = App::gfx_sky_time_speed->getInt();
         }
 
-        if (App::GetSimTerrain()->getSkyManager()->GetSkyTimeFactor() != time_factor)
+        if (m_terrain->getSkyManager()->GetSkyTimeFactor() != time_factor)
         {
-            App::GetSimTerrain()->getSkyManager()->SetSkyTimeFactor(time_factor);
-            Str<200> msg; msg << _L("Time set to ") << App::GetSimTerrain()->getSkyManager()->GetPrettyTime();
+            m_terrain->getSkyManager()->SetSkyTimeFactor(time_factor);
+            Str<200> msg; msg << _L("Time set to ") << m_terrain->getSkyManager()->GetPrettyTime();
             RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, msg.ToCStr());
         }
     }
 
 #endif // USE_CAELUM
     if (App::gfx_sky_mode->getEnum<GfxSkyMode>() == GfxSkyMode::SKYX &&
-        App::GetSimTerrain()->getSkyXManager())
+        m_terrain->getSkyXManager())
     {
         if (RoR::App::GetInputEngine()->getEventBoolValue(EV_SKY_INCREASE_TIME))
         {
-            App::GetSimTerrain()->getSkyXManager()->GetSkyX()->setTimeMultiplier(1.0f);
+            m_terrain->getSkyXManager()->GetSkyX()->setTimeMultiplier(1.0f);
         }
         else if (RoR::App::GetInputEngine()->getEventBoolValue(EV_SKY_INCREASE_TIME_FAST))
         {
-            App::GetSimTerrain()->getSkyXManager()->GetSkyX()->setTimeMultiplier(2.0f);
+            m_terrain->getSkyXManager()->GetSkyX()->setTimeMultiplier(2.0f);
         }
         else if (RoR::App::GetInputEngine()->getEventBoolValue(EV_SKY_DECREASE_TIME))
         {
-            App::GetSimTerrain()->getSkyXManager()->GetSkyX()->setTimeMultiplier(-1.0f);
+            m_terrain->getSkyXManager()->GetSkyX()->setTimeMultiplier(-1.0f);
         }
         else if (RoR::App::GetInputEngine()->getEventBoolValue(EV_SKY_DECREASE_TIME_FAST))
         {
-            App::GetSimTerrain()->getSkyXManager()->GetSkyX()->setTimeMultiplier(-2.0f);
+            m_terrain->getSkyXManager()->GetSkyX()->setTimeMultiplier(-2.0f);
         }
         else
         {
-            App::GetSimTerrain()->getSkyXManager()->GetSkyX()->setTimeMultiplier(0.01f);
+            m_terrain->getSkyXManager()->GetSkyX()->setTimeMultiplier(0.01f);
         }
     }
 }

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -32,6 +32,7 @@
 #include "RecoveryMode.h"
 #include "SceneMouse.h"
 #include "SimData.h"
+#include "Terrain.h"
 
 #include <list>
 #include <mutex>
@@ -109,6 +110,7 @@ public:
 
     bool                LoadTerrain(std::string const& filename_part);
     void                UnloadTerrain();
+    TerrainPtr&         GetTerrain() { return m_terrain; }
 
     /// @}
     /// @name Actors
@@ -178,6 +180,9 @@ private:
     GameMsgQueue        m_msg_queue;
     Message*            m_msg_chain_end = nullptr;
     std::mutex          m_msg_mutex;
+
+    // Terrain
+    TerrainPtr          m_terrain;
 
     // Actors (physics and netcode)
     ActorManager        m_actor_manager;

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -114,22 +114,22 @@ public:
     /// @name Actors
     /// @{
 
-    Actor*              SpawnActor(ActorSpawnRequest& rq);
+    ActorPtr              SpawnActor(ActorSpawnRequest& rq);
     void                ModifyActor(ActorModifyRequest& rq);
-    void                DeleteActor(Actor* actor);
+    void                DeleteActor(ActorPtr actor);
     void                UpdateActors();
     ActorManager*       GetActorManager() { return &m_actor_manager; }
-    Actor*              FetchPrevVehicleOnList();
-    Actor*              FetchNextVehicleOnList();
-    Actor*              FindActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name);
+    ActorPtr            FetchPrevVehicleOnList();
+    ActorPtr            FetchNextVehicleOnList();
+    ActorPtr            FindActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name);
     void                RespawnLastActor();
     void                SpawnPreselectedActor(std::string const& preset_vehicle, std::string const& preset_veh_config); //!< needs `Character` to exist
 
-    Actor*              GetPlayerActor() { return m_player_actor; }
-    Actor*              GetPrevPlayerActor() { return m_prev_player_actor; }
-    Actor*              GetLastSpawnedActor() { return m_last_spawned_actor; } //!< Last actor spawned by user and still alive.
-    void                SetPrevPlayerActor(Actor* actor) { m_prev_player_actor = actor; }
-    void                ChangePlayerActor(Actor* actor);
+    ActorPtr            GetPlayerActor() { return m_player_actor; }
+    ActorPtr            GetPrevPlayerActor() { return m_prev_player_actor; }
+    ActorPtr            GetLastSpawnedActor() { return m_last_spawned_actor; } //!< Last actor spawned by user and still alive.
+    void                SetPrevPlayerActor(ActorPtr actor) { m_prev_player_actor = actor; }
+    void                ChangePlayerActor(ActorPtr actor);
 
     void                ShowLoaderGUI(int type, const Ogre::String& instance, const Ogre::String& box);
     void                OnLoaderGuiCancel(); //!< GUI callback
@@ -181,9 +181,9 @@ private:
 
     // Actors (physics and netcode)
     ActorManager        m_actor_manager;
-    Actor*              m_player_actor = nullptr;           //!< Actor (vehicle or machine) mounted and controlled by player
-    Actor*              m_prev_player_actor = nullptr;      //!< Previous actor (vehicle or machine) mounted and controlled by player
-    Actor*              m_last_spawned_actor = nullptr;     //!< Last actor spawned by user and still alive.
+    ActorPtr              m_player_actor = nullptr;           //!< Actor (vehicle or machine) mounted and controlled by player
+    ActorPtr              m_prev_player_actor = nullptr;      //!< Previous actor (vehicle or machine) mounted and controlled by player
+    ActorPtr              m_last_spawned_actor = nullptr;     //!< Last actor spawned by user and still alive.
     
     CacheEntry*         m_last_cache_selection = nullptr;   //!< Vehicle/load
     CacheEntry*         m_last_skin_selection = nullptr;

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -110,7 +110,7 @@ public:
 
     bool                LoadTerrain(std::string const& filename_part);
     void                UnloadTerrain();
-    TerrainPtr&         GetTerrain() { return m_terrain; }
+    TerrainPtr          GetTerrain() { return m_terrain; }
 
     /// @}
     /// @name Actors

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -186,9 +186,9 @@ private:
 
     // Actors (physics and netcode)
     ActorManager        m_actor_manager;
-    ActorPtr              m_player_actor = nullptr;           //!< Actor (vehicle or machine) mounted and controlled by player
-    ActorPtr              m_prev_player_actor = nullptr;      //!< Previous actor (vehicle or machine) mounted and controlled by player
-    ActorPtr              m_last_spawned_actor = nullptr;     //!< Last actor spawned by user and still alive.
+    ActorPtr            m_player_actor;           //!< Actor (vehicle or machine) mounted and controlled by player
+    ActorPtr            m_prev_player_actor;      //!< Previous actor (vehicle or machine) mounted and controlled by player
+    ActorPtr            m_last_spawned_actor;     //!< Last actor spawned by user and still alive.
     
     CacheEntry*         m_last_cache_selection = nullptr;   //!< Vehicle/load
     CacheEntry*         m_last_skin_selection = nullptr;

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -98,7 +98,7 @@ SoundScriptManager::~SoundScriptManager()
         delete sound_manager;
 }
 
-void SoundScriptManager::trigOnce(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigOnce(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -126,7 +126,7 @@ void SoundScriptManager::trigOnce(int actor_id, int trig, int linkType, int link
     }
 }
 
-void SoundScriptManager::trigStart(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigStart(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -157,7 +157,7 @@ void SoundScriptManager::trigStart(int actor_id, int trig, int linkType, int lin
     }
 }
 
-void SoundScriptManager::trigStop(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigStop(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -187,7 +187,7 @@ void SoundScriptManager::trigStop(int actor_id, int trig, int linkType, int link
     }
 }
 
-void SoundScriptManager::trigKill(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigKill(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -217,7 +217,7 @@ void SoundScriptManager::trigKill(int actor_id, int trig, int linkType, int link
     }
 }
 
-void SoundScriptManager::trigToggle(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigToggle(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -239,7 +239,7 @@ void SoundScriptManager::trigToggle(int actor_id, int trig, int linkType, int li
         trigStart(actor_id, trig, linkType, linkItemID);
 }
 
-bool SoundScriptManager::getTrigState(Actor* actor, int trig, int linkType, int linkItemID)
+bool SoundScriptManager::getTrigState(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return false;
@@ -258,7 +258,7 @@ bool SoundScriptManager::getTrigState(int actor_id, int trig, int linkType, int 
     return state_map[linkType][linkItemID][actor_id][trig];
 }
 
-void SoundScriptManager::modulate(Actor* actor, int mod, float value, int linkType, int linkItemID)
+void SoundScriptManager::modulate(ActorPtr actor, int mod, float value, int linkType, int linkItemID)
 {
     if (disabled)
         return;

--- a/source/main/audio/SoundScriptManager.h
+++ b/source/main/audio/SoundScriptManager.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "Application.h"
+#include "Actor.h"
 
 #include <OgreScriptLoader.h>
 
@@ -266,19 +267,19 @@ public:
 
     // functions
     void trigOnce    (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void trigOnce    (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void trigOnce    (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void trigStart   (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void trigStart   (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void trigStart   (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void trigStop    (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void trigStop    (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void trigStop    (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void trigToggle  (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void trigToggle  (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void trigToggle  (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void trigKill	 (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID = -1);
-    void trigKill    (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID = -1);
+    void trigKill    (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID = -1);
     bool getTrigState(int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    bool getTrigState(Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    bool getTrigState(ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void modulate    (int actor_id, int mod, float value, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void modulate    (Actor* actor, int mod, float value, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void modulate    (ActorPtr actor, int mod, float value, int linkType = SL_DEFAULT, int linkItemID=-1);
 
     void setEnabled(bool state);
 

--- a/source/main/gameplay/AutoPilot.cpp
+++ b/source/main/gameplay/AutoPilot.cpp
@@ -21,6 +21,7 @@
 #include "AutoPilot.h"
 
 #include "Application.h"
+#include "GameContext.h"
 #include "SimData.h"
 #include "SoundScriptManager.h"
 #include "Terrain.h"
@@ -325,9 +326,9 @@ void Autopilot::gpws_update(float spawnheight)
         return;
     if (mode_gpws && ref_b)
     {
-        float groundalt = App::GetSimTerrain()->GetHeightAt(ref_c->AbsPosition.x, ref_c->AbsPosition.z);
-        if (App::GetSimTerrain()->getWater() && groundalt < App::GetSimTerrain()->getWater()->GetStaticWaterHeight())
-            groundalt = App::GetSimTerrain()->getWater()->GetStaticWaterHeight();
+        float groundalt = App::GetGameContext()->GetTerrain()->GetHeightAt(ref_c->AbsPosition.x, ref_c->AbsPosition.z);
+        if (App::GetGameContext()->GetTerrain()->getWater() && groundalt < App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight())
+            groundalt = App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight();
         float height = (ref_c->AbsPosition.y - groundalt - spawnheight) * 3.28083f; //in feet!
         //skip height warning sounds when the plane is slower then ~10 knots
         if ((ref_c->Velocity.length() * 1.9685f) > 10.0f)

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -159,7 +159,7 @@ void Character::update(float dt)
         // Submesh "collision"
         {
             float depth = 0.0f;
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor->ar_bounding_box.contains(position))
                 {
@@ -496,7 +496,7 @@ void Character::receiveStreamData(unsigned int& type, int& source, unsigned int&
         else if (msg->command == CHARACTER_CMD_ATTACH)
         {
             auto* attach_msg = reinterpret_cast<NetCharacterMsgAttach*>(buffer);
-            Actor* beam = App::GetGameContext()->GetActorManager()->GetActorByNetworkLinks(attach_msg->source_id, attach_msg->stream_id);
+            ActorPtr beam = App::GetGameContext()->GetActorManager()->GetActorByNetworkLinks(attach_msg->source_id, attach_msg->stream_id);
             if (beam != nullptr)
             {
                 this->SetActorCoupling(true, beam);
@@ -520,7 +520,7 @@ void Character::receiveStreamData(unsigned int& type, int& source, unsigned int&
 #endif
 }
 
-void Character::SetActorCoupling(bool enabled, Actor* actor)
+void Character::SetActorCoupling(bool enabled, ActorPtr actor)
 {
     m_actor_coupling = actor;
 #ifdef USE_SOCKETW

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -41,8 +41,7 @@ using namespace RoR;
 #define LOGSTREAM Ogre::LogManager::getSingleton().stream()
 
 Character::Character(int source, unsigned int streamid, UTFString player_name, int color_number, bool is_remote) :
-      m_actor_coupling(nullptr)
-    , m_can_jump(false)
+     m_can_jump(false)
     , m_character_rotation(0.0f)
     , m_character_h_speed(2.0f)
     , m_character_v_speed(0.0f)
@@ -489,7 +488,7 @@ void Character::receiveStreamData(unsigned int& type, int& source, unsigned int&
         else if (msg->command == CHARACTER_CMD_DETACH)
         {
             if (m_actor_coupling != nullptr)
-                this->SetActorCoupling(false, nullptr);
+                this->SetActorCoupling(false, ActorPtr());
             else
                 this->ReportError("Received command `DETACH`, but not currently attached to a vehicle. Ignoring command.");
         }

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -119,7 +119,7 @@ float calculate_collision_depth(Vector3 pos)
     Vector3 query = pos + 0.3f * Vector3::UNIT_Y;
     while (query.y > pos.y)
     {
-        if (App::GetSimTerrain()->GetCollisions()->collisionCorrect(&query, false))
+        if (App::GetGameContext()->GetTerrain()->GetCollisions()->collisionCorrect(&query, false))
             break;
         query.y -= 0.001f;
     }
@@ -145,7 +145,7 @@ void Character::update(float dt)
 
         // Trigger script events and handle mesh (ground) collision
         Vector3 query = position;
-        App::GetSimTerrain()->GetCollisions()->collisionCorrect(&query);
+        App::GetGameContext()->GetTerrain()->GetCollisions()->collisionCorrect(&query);
 
         // Auto compensate minor height differences
         float depth = calculate_collision_depth(position);
@@ -194,7 +194,7 @@ void Character::update(float dt)
             for (int i = 1; i < numstep; i++)
             {
                 Vector3 query = base + diff * ((float)i / numstep);
-                if (App::GetSimTerrain()->GetCollisions()->collisionCorrect(&query, false))
+                if (App::GetGameContext()->GetTerrain()->GetCollisions()->collisionCorrect(&query, false))
                 {
                     m_character_v_speed = std::max(0.0f, m_character_v_speed);
                     position = m_prev_position + diff * ((float)(i - 1) / numstep);
@@ -207,7 +207,7 @@ void Character::update(float dt)
         m_prev_position = position;
 
         // ground contact
-        float pheight = App::GetSimTerrain()->GetHeightAt(position.x, position.z);
+        float pheight = App::GetGameContext()->GetTerrain()->GetHeightAt(position.x, position.z);
 
         if (position.y < pheight)
         {
@@ -220,9 +220,9 @@ void Character::update(float dt)
         bool isswimming = false;
         float wheight = -99999;
 
-        if (App::GetSimTerrain()->getWater())
+        if (App::GetGameContext()->GetTerrain()->getWater())
         {
-            wheight = App::GetSimTerrain()->getWater()->CalcWavesHeight(position);
+            wheight = App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(position);
             if (position.y < wheight - 1.8f)
             {
                 position.y = wheight - 1.8f;
@@ -231,7 +231,7 @@ void Character::update(float dt)
         }
 
         // 0.1 due to 'jumping' from waves -> not nice looking
-        if (App::GetSimTerrain()->getWater() && (wheight - pheight > 1.8f) && (position.y + 0.1f <= wheight))
+        if (App::GetGameContext()->GetTerrain()->getWater() && (wheight - pheight > 1.8f) && (position.y + 0.1f <= wheight))
         {
             isswimming = true;
         }

--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "Actor.h"
 #include "ForwardDeclarations.h"
 
 #include <OgreUTFString.h>
@@ -51,7 +52,7 @@ public:
     std::string const &    GetAnimName() const          { return m_anim_name; }
     float          GetAnimTime() const                  { return m_anim_time; }
     Ogre::Radian   getRotation() const                  { return m_character_rotation; }
-    Actor*         GetActorCoupling()                   { return m_actor_coupling; }
+    ActorPtr       GetActorCoupling()                   { return m_actor_coupling; }
     void           setColour(int color)                 { this->m_color_number = color; }
     Ogre::Vector3  getPosition();
     void           setPosition(Ogre::Vector3 position);
@@ -60,7 +61,7 @@ public:
     void           update(float dt);
     void           updateCharacterRotation();
     void           receiveStreamData(unsigned int& type, int& source, unsigned int& streamid, char* buffer);
-    void           SetActorCoupling(bool enabled, Actor* actor);
+    void           SetActorCoupling(bool enabled, ActorPtr actor);
     GfxCharacter*  SetupGfx();
 
 private:
@@ -70,7 +71,7 @@ private:
     void           SendStreamSetup();
     void           SetAnimState(std::string mode, float time = 0);
 
-    Actor*           m_actor_coupling; //!< The vehicle or machine which the character occupies
+    ActorPtr         m_actor_coupling; //!< The vehicle or machine which the character occupies
     Ogre::Radian     m_character_rotation;
     float            m_character_h_speed;
     float            m_character_v_speed;
@@ -104,7 +105,7 @@ struct GfxCharacter
         Ogre::UTFString    simbuf_net_username;
         bool               simbuf_is_remote;
         int                simbuf_color_number;
-        Actor*             simbuf_actor_coupling;
+        ActorPtr             simbuf_actor_coupling;
         std::string        simbuf_anim_name;
         float              simbuf_anim_time; // Intentionally left empty = forces initial update.
     };

--- a/source/main/gameplay/CharacterFactory.cpp
+++ b/source/main/gameplay/CharacterFactory.cpp
@@ -86,7 +86,7 @@ void CharacterFactory::Update(float dt)
     }
 }
 
-void CharacterFactory::UndoRemoteActorCoupling(Actor* actor)
+void CharacterFactory::UndoRemoteActorCoupling(ActorPtr actor)
 {
     for (auto& c : m_remote_characters)
     {

--- a/source/main/gameplay/CharacterFactory.cpp
+++ b/source/main/gameplay/CharacterFactory.cpp
@@ -92,7 +92,7 @@ void CharacterFactory::UndoRemoteActorCoupling(ActorPtr actor)
     {
         if (c->GetActorCoupling() == actor)
         {
-            c->SetActorCoupling(false, nullptr);
+            c->SetActorCoupling(false, ActorPtr());
         }
     }
 }

--- a/source/main/gameplay/CharacterFactory.h
+++ b/source/main/gameplay/CharacterFactory.h
@@ -43,7 +43,7 @@ public:
     Character* CreateLocalCharacter();
     Character* GetLocalCharacter() { return m_local_character.get(); }
     void DeleteAllCharacters();
-    void UndoRemoteActorCoupling(Actor* actor);
+    void UndoRemoteActorCoupling(ActorPtr actor);
     void Update(float dt);
 #ifdef USE_SOCKETW
     void handleStreamData(std::vector<RoR::NetRecvPacket> packet);

--- a/source/main/gameplay/ChatSystem.cpp
+++ b/source/main/gameplay/ChatSystem.cpp
@@ -20,6 +20,7 @@
 
 #include "ChatSystem.h"
 
+#include "Actor.h"
 #include "Console.h"
 #include "GUIManager.h"
 #include "Language.h"

--- a/source/main/gameplay/EngineSim.cpp
+++ b/source/main/gameplay/EngineSim.cpp
@@ -34,7 +34,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-EngineSim::EngineSim(float _min_rpm, float _max_rpm, float torque, std::vector<float> gears, float dratio, Actor* actor) :
+EngineSim::EngineSim(float _min_rpm, float _max_rpm, float torque, std::vector<float> gears, float dratio, ActorPtr actor) :
     m_air_pressure(0.0f)
     , m_auto_cur_acc(0.0f)
     , m_auto_mode(AUTOMATIC)

--- a/source/main/gameplay/EngineSim.h
+++ b/source/main/gameplay/EngineSim.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "Application.h"
+#include "Actor.h"
 
 namespace RoR {
 
@@ -38,7 +39,7 @@ class EngineSim : public ZeroedMemoryAllocator
 
 public:
 
-    EngineSim(float min_rpm, float max_rpm, float torque, std::vector<float> gears, float dratio, Actor* actor);
+    EngineSim(float min_rpm, float max_rpm, float torque, std::vector<float> gears, float dratio, ActorPtr actor);
     ~EngineSim();
 
     /// Sets current engine state;
@@ -153,7 +154,7 @@ private:
     };
 
     // Vehicle
-    Actor*         m_actor;
+    ActorPtr         m_actor;
 
     // Gearbox
     float          m_ref_wheel_revolutions; //!< Gears; estimated wheel revolutions based on current vehicle speed along the longi. axis

--- a/source/main/gameplay/Landusemap.cpp
+++ b/source/main/gameplay/Landusemap.cpp
@@ -20,6 +20,7 @@
 
 #include "Landusemap.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Collisions.h"
 #include "Console.h"

--- a/source/main/gameplay/Landusemap.cpp
+++ b/source/main/gameplay/Landusemap.cpp
@@ -25,6 +25,7 @@
 #include "Collisions.h"
 #include "Console.h"
 #include "ErrorUtils.h"
+#include "GameContext.h"
 #include "Language.h"
 #include "Terrain.h"
 #ifdef USE_PAGED
@@ -39,7 +40,7 @@ using namespace RoR;
 Landusemap::Landusemap(String configFilename) :
     data(0)
     , default_ground_model(nullptr)
-    , mapsize(App::GetSimTerrain()->getMaxTerrainSize())
+    , mapsize(App::GetGameContext()->GetTerrain()->getMaxTerrainSize())
 {
     loadConfig(configFilename);
 #ifndef USE_PAGED
@@ -119,9 +120,9 @@ int Landusemap::loadConfig(const Ogre::String& filename)
                 if (kname == "texture")
                     textureFilename = kvalue;
                 else if (kname == "frictionconfig" || kname == "loadGroundModelsConfig")
-                    App::GetSimTerrain()->GetCollisions()->loadGroundModelsConfigFile(kvalue);
+                    App::GetGameContext()->GetTerrain()->GetCollisions()->loadGroundModelsConfigFile(kvalue);
                 else if (kname == "defaultuse")
-                    default_ground_model = App::GetSimTerrain()->GetCollisions()->getGroundModelByString(kvalue);
+                    default_ground_model = App::GetGameContext()->GetTerrain()->GetCollisions()->getGroundModelByString(kvalue);
             }
             else if (secName == "use-map")
             {
@@ -178,7 +179,7 @@ int Landusemap::loadConfig(const Ogre::String& filename)
                 //	counters[use]++;
 
                 // store the pointer to the ground model in the data slot
-                *ptr = App::GetSimTerrain()->GetCollisions()->getGroundModelByString(use);
+                *ptr = App::GetGameContext()->GetTerrain()->GetCollisions()->getGroundModelByString(use);
                 ptr++;
             }
         }

--- a/source/main/gameplay/RecoveryMode.cpp
+++ b/source/main/gameplay/RecoveryMode.cpp
@@ -115,7 +115,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
 
             if (App::sim_soft_reset_mode->getBool())
             {
-                for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
+                for (ActorPtr actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
                 {
                     actor->requestRotation(rotation, rotation_center);
                     actor->requestTranslation(translation);
@@ -129,7 +129,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
             App::GetGameContext()->GetPlayerActor()->requestAngleSnap(45);
             if (App::sim_soft_reset_mode->getBool())
             {
-                for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
+                for (ActorPtr actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
                 {
                     actor->requestAngleSnap(45);
                 }
@@ -144,7 +144,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
         if (App::sim_soft_reset_mode->getBool())
         {
             reset_type = ActorModifyRequest::Type::SOFT_RESET;
-            for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
+            for (ActorPtr actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
             {
                 ActorModifyRequest* rq = new ActorModifyRequest;
                 rq->amr_actor = actor;

--- a/source/main/gameplay/Replay.cpp
+++ b/source/main/gameplay/Replay.cpp
@@ -32,7 +32,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Replay::Replay(Actor* actor, int _numFrames)
+Replay::Replay(ActorPtr actor, int _numFrames)
 {
     m_actor = actor;
     numFrames = _numFrames;
@@ -48,7 +48,9 @@ Replay::Replay(Actor* actor, int _numFrames)
 
     outOfMemory = false;
 
-    unsigned long bsize = (actor->ar_num_nodes * numFrames * sizeof(node_simple_t) + actor->ar_num_beams * numFrames * sizeof(beam_simple_t) + numFrames * sizeof(unsigned long)) / 1024.0f;
+    const int numNodes = actor->ar_num_nodes;
+    const int numBeams = actor->ar_num_beams;
+    unsigned long bsize = (numNodes * numFrames * sizeof(node_simple_t) + numBeams * numFrames * sizeof(beam_simple_t) + numFrames * sizeof(unsigned long)) / 1024.0f;
     LOG("replay buffer size: " + TOSTRING(bsize) + " kB");
 
     writeIndex = 0;

--- a/source/main/gameplay/Replay.h
+++ b/source/main/gameplay/Replay.h
@@ -39,7 +39,7 @@ struct beam_simple_t
 class Replay : public ZeroedMemoryAllocator
 {
 public:
-    Replay(Actor* b, int nframes);
+    Replay(ActorPtr b, int nframes);
     ~Replay();
 
     void*               getWriteBuffer(int type);
@@ -56,7 +56,7 @@ public:
     void                UpdateInputEvents();
 
 protected:
-    Actor*              m_actor = nullptr;
+    ActorPtr              m_actor = nullptr;
     float               m_replay_timer = 0.f;
     float               ar_replay_precision = 1.f;
     int                 ar_replay_pos = 0;

--- a/source/main/gameplay/Replay.h
+++ b/source/main/gameplay/Replay.h
@@ -56,7 +56,7 @@ public:
     void                UpdateInputEvents();
 
 protected:
-    ActorPtr              m_actor = nullptr;
+    ActorPtr            m_actor;
     float               m_replay_timer = 0.f;
     float               ar_replay_precision = 1.f;
     int                 ar_replay_pos = 0;

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -39,7 +39,6 @@ using namespace RoR;
 
 SceneMouse::SceneMouse() :
     mouseGrabState(0),
-    grab_truck(nullptr),
     pickLine(nullptr),
     pickLineNode(nullptr)
 {
@@ -100,7 +99,7 @@ void SceneMouse::releaseMousePick()
 void SceneMouse::reset()
 {
     minnode = NODENUM_INVALID;
-    grab_truck = 0;
+    grab_truck = ActorPtr();
     mindist = 99999;
     mouseGrabState = 0;
     lastgrabpos = Vector3::ZERO;
@@ -124,7 +123,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
 
         // walk all trucks
         minnode = NODENUM_INVALID;
-        grab_truck = NULL;
+        grab_truck = ActorPtr();
         for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             if (actor->ar_state == ActorState::LOCAL_SIMULATED)

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -125,7 +125,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
         // walk all trucks
         minnode = NODENUM_INVALID;
         grab_truck = NULL;
-        for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             if (actor->ar_state == ActorState::LOCAL_SIMULATED)
             {
@@ -234,13 +234,13 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
             return true;
         }
 
-        Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+        ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
         // Reselect the player actor
         {
             Real nearest_ray_distance = std::numeric_limits<float>::max();
 
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor != player_actor)
                 {
@@ -252,7 +252,7 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
                         if (ray_distance < nearest_ray_distance)
                         {
                             nearest_ray_distance = ray_distance;
-                            App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)actor));
+                            App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                         }
                     }
                 }

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -58,7 +58,7 @@ protected:
 
     NodeNum_t minnode = NODENUM_INVALID;
     float mindist;
-    Actor* grab_truck;
+    ActorPtr grab_truck;
     Ogre::Vector3 lastgrabpos;
     int lastMouseX, lastMouseY;
 

--- a/source/main/gameplay/TyrePressure.cpp
+++ b/source/main/gameplay/TyrePressure.cpp
@@ -37,7 +37,7 @@ void TyrePressure::UpdateInputEvents(float dt)
         change = Ogre::Math::Clamp(change, -dt * 10.0f, -dt * 1.0f);
         if (m_pressure_pressed = this->ModifyTyrePressure(change))
         {
-            SOUND_START(m_actor, SS_TRIG_AIR);
+            SOUND_START(m_actor.ar_instance_id, SS_TRIG_AIR);
         }
     }
     else if (App::GetInputEngine()->getEventBoolValue(EV_COMMON_PRESSURE_MORE))
@@ -46,12 +46,12 @@ void TyrePressure::UpdateInputEvents(float dt)
         change = Ogre::Math::Clamp(change, +dt * 1.0f, +dt * 10.0f);
         if (m_pressure_pressed = this->ModifyTyrePressure(change))
         {
-            SOUND_START(m_actor, SS_TRIG_AIR);
+            SOUND_START(m_actor.ar_instance_id, SS_TRIG_AIR);
         }
     }
     else if (m_pressure_pressed)
     {
-        SOUND_STOP(m_actor, SS_TRIG_AIR);
+        SOUND_STOP(m_actor.ar_instance_id, SS_TRIG_AIR);
         m_pressure_pressed = false;
         m_pressure_pressed_timer = 1.5f;
     }
@@ -69,7 +69,7 @@ bool TyrePressure::ModifyTyrePressure(float v)
 
     for (int beam_id: m_pressure_beams)
     {
-        m_actor->ar_beams[beam_id].k = 10000 + newpressure * 10000;
+        m_actor.ar_beams[beam_id].k = 10000 + newpressure * 10000;
     }
     m_ref_tyre_pressure = newpressure;
     return true;

--- a/source/main/gameplay/TyrePressure.h
+++ b/source/main/gameplay/TyrePressure.h
@@ -41,7 +41,7 @@ namespace RoR {
 class TyrePressure
 {
 public:
-    TyrePressure(Actor* a): m_actor(a) {}
+    TyrePressure(ActorPtr a): m_actor(a) {}
 
     void                AddBeam(int beam_id) { m_pressure_beams.push_back(beam_id); }
     bool                IsEnabled() const { return m_pressure_beams.size() != 0; }
@@ -51,7 +51,7 @@ public:
     bool                IsPressurizing() const { return m_pressure_pressed; }
 
 private:
-    Actor*              m_actor;
+    ActorPtr              m_actor;
     std::vector<int>    m_pressure_beams;
     bool                m_pressure_pressed = false;
     float               m_pressure_pressed_timer = 0.f;

--- a/source/main/gameplay/TyrePressure.h
+++ b/source/main/gameplay/TyrePressure.h
@@ -41,7 +41,7 @@ namespace RoR {
 class TyrePressure
 {
 public:
-    TyrePressure(ActorPtr a): m_actor(a) {}
+    TyrePressure(Actor& a): m_actor(a) {}
 
     void                AddBeam(int beam_id) { m_pressure_beams.push_back(beam_id); }
     bool                IsEnabled() const { return m_pressure_beams.size() != 0; }
@@ -51,7 +51,7 @@ public:
     bool                IsPressurizing() const { return m_pressure_pressed; }
 
 private:
-    ActorPtr              m_actor;
+    Actor&              m_actor;
     std::vector<int>    m_pressure_beams;
     bool                m_pressure_pressed = false;
     float               m_pressure_pressed_timer = 0.f;

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -39,7 +39,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-VehicleAI::VehicleAI(Actor* b) :
+VehicleAI::VehicleAI(ActorPtr b) :
     is_waiting(false),
     wait_time(0.0f)
 {
@@ -417,7 +417,7 @@ void VehicleAI::update(float dt, int doUpdate)
             }
 
             // Collision avoidance with other actors
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor->ar_driveable == NOT_DRIVEABLE) // Ignore objects that may be actors
                     continue;
@@ -488,7 +488,7 @@ void VehicleAI::update(float dt, int doUpdate)
             }
 
             // Collision avoidance with other actors
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor->ar_driveable == NOT_DRIVEABLE) // Ignore objects that may be actors
                     continue;

--- a/source/main/gameplay/VehicleAI.h
+++ b/source/main/gameplay/VehicleAI.h
@@ -30,6 +30,7 @@
 #ifdef USE_ANGELSCRIPT
 
 #include "Application.h"
+#include "RefCountingObject.h"
 #include "scriptdictionary/scriptdictionary.h"
 
 namespace RoR {
@@ -54,7 +55,7 @@ enum Ai_values
     AI_POWER
 };
 
-class VehicleAI : public ZeroedMemoryAllocator
+class VehicleAI : public ZeroedMemoryAllocator, public RefCountingObject<VehicleAI>
 {
 public:
     VehicleAI(ActorPtr b);
@@ -69,17 +70,6 @@ public:
      *  @return True if the AI is driving
      */
     bool IsActive();
-
-#ifdef USE_ANGELSCRIPT
-    // we have to add this to be able to use the class as reference inside scripts
-    void addRef()
-    {
-    };
-
-    void release()
-    {
-    };
-#endif
     /**
      *  Updates the AI.
      */

--- a/source/main/gameplay/VehicleAI.h
+++ b/source/main/gameplay/VehicleAI.h
@@ -57,7 +57,7 @@ enum Ai_values
 class VehicleAI : public ZeroedMemoryAllocator
 {
 public:
-    VehicleAI(Actor* b);
+    VehicleAI(ActorPtr b);
     ~VehicleAI();
     /**
      *  Activates/Deactivates the AI.
@@ -133,7 +133,7 @@ private:
     float wait_time;//!<(seconds) The amount of time the AI has to wait on this waypoint.
 
     float maxspeed = 50;//!<(KM/H) The max speed the AI is allowed to drive.
-    Actor* beam;//!< The verhicle the AI is driving.
+    ActorPtr beam;//!< The verhicle the AI is driving.
     bool is_enabled = false;//!< True if the AI is driving.
     Ogre::Vector3 current_waypoint;//!< The coordinates of the waypoint that the AI is driving to.
     Ogre::Vector3 prev_waypoint;//!< The coordinates of the previous waypoint.

--- a/source/main/gfx/DustPool.cpp
+++ b/source/main/gfx/DustPool.cpp
@@ -23,6 +23,7 @@
 #include <Ogre.h>
 
 #include "Application.h"
+#include "GameContext.h"
 #include "Terrain.h"
 #include "Water.h"
 
@@ -272,7 +273,7 @@ void DustPool::update()
         }
         else if (types[i] == DUST_RIPPLE)
         {
-            positions[i].y = RoR::App::GetSimTerrain()->getWater()->GetStaticWaterHeight() - 0.02;
+            positions[i].y = RoR::App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight() - 0.02;
             sns[i]->setPosition(positions[i]);
 
             col.a = vel * 0.04;

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -22,6 +22,7 @@
 
 #include "Application.h"
 #include "CameraManager.h"
+#include "GameContext.h"
 #include "GfxActor.h"
 #include "GfxScene.h"
 #include "SkyManager.h"
@@ -231,18 +232,18 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, boo
     {
 #ifdef USE_CAELUM
         // caelum needs to know that we changed the cameras
-        if (App::GetSimTerrain()->getSkyManager())
+        if (App::GetGameContext()->GetTerrain()->getSkyManager())
         {
-            App::GetSimTerrain()->getSkyManager()->NotifySkyCameraChanged(m_cameras[m_update_round]);
+            App::GetGameContext()->GetTerrain()->getSkyManager()->NotifySkyCameraChanged(m_cameras[m_update_round]);
         }
 #endif // USE_CAELUM
         m_render_targets[m_update_round]->update();
         m_update_round = (m_update_round + 1) % NUM_FACES;
     }
 #ifdef USE_CAELUM
-    if (App::GetSimTerrain()->getSkyManager())
+    if (App::GetGameContext()->GetTerrain()->getSkyManager())
     {
-        App::GetSimTerrain()->getSkyManager()->NotifySkyCameraChanged(App::GetCameraManager()->GetCamera());
+        App::GetGameContext()->GetTerrain()->getSkyManager()->NotifySkyCameraChanged(App::GetCameraManager()->GetCamera());
     }
 #endif // USE_CAELUM
 

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -27,6 +27,7 @@
 #include "Collisions.h"
 #include "DustPool.h" // General particle gfx
 #include "EngineSim.h"
+#include "GameContext.h"
 #include "GfxScene.h"
 #include "GUIManager.h"
 #include "GUIUtils.h"
@@ -331,7 +332,7 @@ void RoR::GfxActor::UpdateVideoCameras(float dt_sec)
     {
 #ifdef USE_CAELUM
         // caelum needs to know that we changed the cameras
-        SkyManager* sky = App::GetSimTerrain()->getSkyManager();
+        SkyManager* sky = App::GetGameContext()->GetTerrain()->getSkyManager();
         if ((sky != nullptr) && (RoR::App::app_state->getEnum<AppState>() == RoR::AppState::SIMULATION))
         {
             sky->NotifySkyCameraChanged(vidcam.vcam_ogre_camera);
@@ -445,9 +446,9 @@ void RoR::GfxActor::UpdateVideoCameras(float dt_sec)
 void RoR::GfxActor::UpdateParticles(float dt_sec)
 {
     float water_height = 0.f; // Unused if terrain has no water
-    if (App::GetSimTerrain()->getWater() != nullptr)
+    if (App::GetGameContext()->GetTerrain()->getWater() != nullptr)
     {
-        water_height = App::GetSimTerrain()->getWater()->GetStaticWaterHeight();
+        water_height = App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight();
     }
 
     for (NodeGfx& nfx: m_gfx_nodes)

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -53,7 +53,7 @@
 
 #include <Ogre.h>
 
-RoR::GfxActor::GfxActor(Actor* actor, ActorSpawner* spawner, std::string ogre_resource_group,
+RoR::GfxActor::GfxActor(ActorPtr actor, ActorSpawner* spawner, std::string ogre_resource_group,
                         RoR::Renderdash* renderdash):
     m_actor(actor),
     m_custom_resource_group(ogre_resource_group),
@@ -1797,7 +1797,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
 
     // Linked Actors
     m_linked_gfx_actors.clear();
-    for (auto actor : m_actor->getAllLinkedActors())
+    for (ActorPtr actor : m_actor->getAllLinkedActors())
     {
         m_linked_gfx_actors.insert(actor->GetGfxActor());
     }

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -55,7 +55,7 @@ class GfxActor
 
 public:
 
-    GfxActor(Actor* actor, ActorSpawner* spawner, std::string ogre_resource_group,
+    GfxActor(ActorPtr actor, ActorSpawner* spawner, std::string ogre_resource_group,
         RoR::Renderdash* renderdash);
 
     ~GfxActor();
@@ -139,7 +139,7 @@ public:
     DebugViewType        GetDebugView() const { return m_debug_view; }
     std::set<GfxActor*>  GetLinkedGfxActors() { return m_linked_gfx_actors; }
     Ogre::String         GetResourceGroup() { return m_custom_resource_group; }
-    Actor*               GetActor() { return m_actor; } // Watch out for multithreading with this!
+    ActorPtr               GetActor() { return m_actor; } // Watch out for multithreading with this!
     Ogre::TexturePtr     GetHelpTex() { return m_help_tex; }
     Ogre::MaterialPtr    GetHelpMat() { return m_help_mat; }
     int                  FetchNumBeams() const ;
@@ -156,7 +156,7 @@ private:
     static Ogre::Quaternion SpecialGetRotationTo(const Ogre::Vector3& src, const Ogre::Vector3& dest);
 
     // Static info
-    Actor*                      m_actor = nullptr;
+    ActorPtr                      m_actor = nullptr;
     std::string                 m_custom_resource_group;
     int                         m_driverseat_prop_index = -1;
     Ogre::SceneNode*            m_gfx_beams_parent_scenenode = nullptr;

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -156,7 +156,7 @@ private:
     static Ogre::Quaternion SpecialGetRotationTo(const Ogre::Vector3& src, const Ogre::Vector3& dest);
 
     // Static info
-    ActorPtr                      m_actor = nullptr;
+    ActorPtr                    m_actor;
     std::string                 m_custom_resource_group;
     int                         m_driverseat_prop_index = -1;
     Ogre::SceneNode*            m_gfx_beams_parent_scenenode = nullptr;

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -228,7 +228,7 @@ struct BeamGfx
 
     NodeNum_t        rod_node1           = NODENUM_INVALID;  //!< Node index - may change during simulation!
     NodeNum_t        rod_node2           = NODENUM_INVALID;  //!< Node index - may change during simulation!
-    Actor*           rod_target_actor    = nullptr;
+    ActorPtr           rod_target_actor    = nullptr;
     bool             rod_is_visible      = false;
 };
 

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -228,7 +228,7 @@ struct BeamGfx
 
     NodeNum_t        rod_node1           = NODENUM_INVALID;  //!< Node index - may change during simulation!
     NodeNum_t        rod_node2           = NODENUM_INVALID;  //!< Node index - may change during simulation!
-    ActorPtr           rod_target_actor    = nullptr;
+    ActorPtr         rod_target_actor;
     bool             rod_is_visible      = false;
 };
 

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -136,13 +136,13 @@ void GfxScene::UpdateScene(float dt_sec)
     }
 
     // Terrain - animated meshes and paged geometry
-    App::GetSimTerrain()->getObjectManager()->UpdateTerrainObjects(dt_sec);
+    App::GetGameContext()->GetTerrain()->getObjectManager()->UpdateTerrainObjects(dt_sec);
 
     // Terrain - lightmap; TODO: ported as-is from Terrain::update(), is it needed? ~ only_a_ptr, 05/2018
-    App::GetSimTerrain()->getGeometryManager()->UpdateMainLightPosition(); // TODO: Is this necessary? I'm leaving it here just in case ~ only_a_ptr, 04/2017
+    App::GetGameContext()->GetTerrain()->getGeometryManager()->UpdateMainLightPosition(); // TODO: Is this necessary? I'm leaving it here just in case ~ only_a_ptr, 04/2017
 
     // Terrain - water
-    IWater* water = App::GetSimTerrain()->getWater();
+    IWater* water = App::GetGameContext()->GetTerrain()->getWater();
     if (water)
     {
         if (player_gfx_actor != nullptr)
@@ -158,14 +158,14 @@ void GfxScene::UpdateScene(float dt_sec)
 
     // Terrain - sky
 #ifdef USE_CAELUM
-    SkyManager* sky = App::GetSimTerrain()->getSkyManager();
+    SkyManager* sky = App::GetGameContext()->GetTerrain()->getSkyManager();
     if (sky != nullptr)
     {
         sky->DetectSkyUpdate();
     }
 #endif
 
-    SkyXManager* skyx_man = App::GetSimTerrain()->getSkyXManager();
+    SkyXManager* skyx_man = App::GetGameContext()->GetTerrain()->getSkyXManager();
     if (skyx_man != nullptr)
     {
        skyx_man->update(dt_sec); // Light update

--- a/source/main/gfx/HydraxWater.cpp
+++ b/source/main/gfx/HydraxWater.cpp
@@ -23,6 +23,7 @@
 #include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
+#include "GameContext.h"
 #include "GfxScene.h"
 #include "SkyManager.h"
 #include "Terrain.h"
@@ -97,9 +98,9 @@ bool HydraxWater::IsUnderWater(Ogre::Vector3 pos)
 void HydraxWater::UpdateWater()
 {
 #ifdef USE_CAELUM
-    if (RoR::App::GetSimTerrain()->getSkyManager() != nullptr)
+    if (RoR::App::GetGameContext()->GetTerrain()->getSkyManager() != nullptr)
     {
-        SkyManager* sky = RoR::App::GetSimTerrain()->getSkyManager();
+        SkyManager* sky = RoR::App::GetGameContext()->GetTerrain()->getSkyManager();
         Ogre::Vector3 sunPosition = App::GetCameraManager()->GetCameraNode()->_getDerivedPosition();
         sunPosition -= sky->GetCaelumSys()->getSun()->getLightDirection() * 80000;
         mHydrax->setSunPosition(sunPosition);

--- a/source/main/gfx/HydraxWater.cpp
+++ b/source/main/gfx/HydraxWater.cpp
@@ -20,6 +20,7 @@
 
 #include "HydraxWater.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
 #include "GfxScene.h"

--- a/source/main/gfx/Renderdash.cpp
+++ b/source/main/gfx/Renderdash.cpp
@@ -20,6 +20,7 @@
 
 #include "Renderdash.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "GfxScene.h"
 #include "GUIManager.h"

--- a/source/main/gfx/ShadowManager.cpp
+++ b/source/main/gfx/ShadowManager.cpp
@@ -20,6 +20,7 @@
 
 #include "ShadowManager.h"
 
+#include "Actor.h"
 #include "CameraManager.h"
 #include "GfxScene.h"
 

--- a/source/main/gfx/SimBuffers.h
+++ b/source/main/gfx/SimBuffers.h
@@ -195,7 +195,7 @@ struct ActorSB
 
 struct GameContextSB
 {
-    Actor*            simbuf_player_actor             = nullptr;
+    ActorPtr          simbuf_player_actor;
     Ogre::Vector3     simbuf_character_pos            = Ogre::Vector3::ZERO;
     bool              simbuf_sim_paused               = false;
     float             simbuf_sim_speed                = 1.f;

--- a/source/main/gfx/Skidmark.cpp
+++ b/source/main/gfx/Skidmark.cpp
@@ -20,6 +20,7 @@
 
 #include "Skidmark.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "SimData.h"
 #include "ContentManager.h" // RGN_CONFIG

--- a/source/main/gfx/SkyManager.cpp
+++ b/source/main/gfx/SkyManager.cpp
@@ -26,6 +26,7 @@
 #include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
+#include "GameContext.h"
 #include "GfxScene.h"
 #include "Terrain.h"
 #include "TerrainGeometryManager.h"
@@ -65,7 +66,7 @@ void SkyManager::NotifySkyCameraChanged(Ogre::Camera* cam)
 
 void SkyManager::DetectSkyUpdate()
 {
-    if (!m_caelum_system || !App::GetSimTerrain())
+    if (!m_caelum_system || !App::GetGameContext()->GetTerrain())
     {
         return;
     }
@@ -74,7 +75,7 @@ void SkyManager::DetectSkyUpdate()
 
     if (c - m_last_clock > 0.001f)
     {
-        TerrainGeometryManager* gm = App::GetSimTerrain()->getGeometryManager();
+        TerrainGeometryManager* gm = App::GetGameContext()->GetTerrain()->getGeometryManager();
         if (gm)
             gm->updateLightMap();
     }

--- a/source/main/gfx/SkyManager.cpp
+++ b/source/main/gfx/SkyManager.cpp
@@ -23,6 +23,7 @@
 
 #include "SkyManager.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
 #include "GfxScene.h"

--- a/source/main/gfx/SkyXManager.cpp
+++ b/source/main/gfx/SkyXManager.cpp
@@ -24,6 +24,7 @@
 #include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
+#include "GameContext.h"
 #include "GfxScene.h"
 #include "HydraxWater.h"
 #include "Terrain.h"
@@ -90,10 +91,10 @@ bool SkyXManager::UpdateSkyLight()
 	// Calculate current color gradients point
 	float point = (-lightDir.y + 1.0f) / 2.0f;
 
-    if (App::GetSimTerrain ()->getHydraxManager ()) 
+    if (App::GetGameContext()->GetTerrain()->getHydraxManager ()) 
     {
-        App::GetSimTerrain ()->getHydraxManager ()->GetHydrax ()->setWaterColor (mWaterGradient.getColor (point));
-        App::GetSimTerrain ()->getHydraxManager ()->GetHydrax ()->setSunPosition (sunPos*0.1);
+        App::GetGameContext()->GetTerrain()->getHydraxManager ()->GetHydrax ()->setWaterColor (mWaterGradient.getColor (point));
+        App::GetGameContext()->GetTerrain()->getHydraxManager ()->GetHydrax ()->setSunPosition (sunPos*0.1);
     }
 		
 
@@ -102,15 +103,15 @@ bool SkyXManager::UpdateSkyLight()
 
 	mLight0->setPosition(sunPos*0.02);
 	mLight1->setDirection(lightDir);
-    if (App::GetSimTerrain()->getWater())
+    if (App::GetGameContext()->GetTerrain()->getWater())
     {
-        App::GetSimTerrain()->getWater()->WaterSetSunPosition(sunPos*0.1);
+        App::GetGameContext()->GetTerrain()->getWater()->WaterSetSunPosition(sunPos*0.1);
     }
 
 	//setFadeColour was removed with https://github.com/RigsOfRods/rigs-of-rods/pull/1459
 /*	Ogre::Vector3 sunCol = mSunGradient.getColor(point);
 	mLight0->setSpecularColour(sunCol.x, sunCol.y, sunCol.z);
-	if (App::GetSimTerrain()->getWater()) App::GetSimTerrain()->getWater()->setFadeColour(Ogre::ColourValue(sunCol.x, sunCol.y, sunCol.z));
+	if (App::GetGameContext()->GetTerrain()->getWater()) App::GetGameContext()->GetTerrain()->getWater()->setFadeColour(Ogre::ColourValue(sunCol.x, sunCol.y, sunCol.z));
 	*/
 	Ogre::Vector3 ambientCol = mAmbientGradient.getColor(point);
 	mLight1->setDiffuseColour(ambientCol.x, ambientCol.y, ambientCol.z);
@@ -133,7 +134,7 @@ bool SkyXManager::UpdateSkyLight()
 	
     if (round (mBasicController->getTime ().x) != mLastHour)
     {
-        TerrainGeometryManager* gm = App::GetSimTerrain ()->getGeometryManager ();
+        TerrainGeometryManager* gm = App::GetGameContext()->GetTerrain()->getGeometryManager ();
         if (gm)
             gm->updateLightMap ();
 

--- a/source/main/gfx/SkyXManager.cpp
+++ b/source/main/gfx/SkyXManager.cpp
@@ -21,6 +21,7 @@
 
 #include "SkyXManager.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
 #include "GfxScene.h"

--- a/source/main/gfx/SurveyMapTextureCreator.cpp
+++ b/source/main/gfx/SurveyMapTextureCreator.cpp
@@ -22,6 +22,7 @@
 
 #include "Actor.h"
 #include "Application.h"
+#include "GameContext.h"
 #include "GfxScene.h"
 #include "IWater.h"
 #include "Terrain.h"
@@ -94,7 +95,7 @@ void SurveyMapTextureCreator::update(Vector2 center, Vector2 size)
 
 void SurveyMapTextureCreator::preRenderTargetUpdate(const RenderTargetEvent &evt)
 {
-    auto water = App::GetSimTerrain()->getWater();
+    auto water = App::GetGameContext()->GetTerrain()->getWater();
     if (water)
     {
         water->SetStaticWaterHeight(water->GetStaticWaterHeight());
@@ -107,7 +108,7 @@ void SurveyMapTextureCreator::preRenderTargetUpdate(const RenderTargetEvent &evt
 
 void SurveyMapTextureCreator::postRenderTargetUpdate(const RenderTargetEvent &evt)
 {
-    auto water = App::GetSimTerrain()->getWater();
+    auto water = App::GetGameContext()->GetTerrain()->getWater();
     if (water)
     {
         water->UpdateWater();

--- a/source/main/gfx/SurveyMapTextureCreator.cpp
+++ b/source/main/gfx/SurveyMapTextureCreator.cpp
@@ -20,6 +20,7 @@
 
 #include "SurveyMapTextureCreator.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "GfxScene.h"
 #include "IWater.h"

--- a/source/main/gfx/Water.cpp
+++ b/source/main/gfx/Water.cpp
@@ -21,6 +21,7 @@
 
 #include "Water.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
 #include "GfxScene.h"

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -507,7 +507,7 @@ void CameraManager::switchBehavior(CameraBehaviors new_behavior)
     this->ActivateNewBehavior(new_behavior, true);
 }
 
-void CameraManager::SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, Actor* new_vehicle)
+void CameraManager::SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, ActorPtr new_vehicle)
 {
     if (new_behavior == m_current_behavior)
     {
@@ -626,7 +626,7 @@ void CameraManager::NotifyContextChange()
     }
 }
 
-void CameraManager::NotifyVehicleChanged(Actor* new_vehicle)
+void CameraManager::NotifyVehicleChanged(ActorPtr new_vehicle)
 {
     // Getting out of vehicle
     if (new_vehicle == nullptr)
@@ -1249,7 +1249,7 @@ void CameraManager::CameraBehaviorVehicleSplineCreateSpline()
 
     if (m_splinecam_num_linked_beams > 0)
     {
-        for (auto actor : linkedBeams)
+        for (ActorPtr actor : linkedBeams)
         {
             if (actor->ar_num_camera_rails <= 0)
                 continue;

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -112,7 +112,6 @@ CameraManager::CameraManager() :
     , m_cam_limit_movement(true)
     , m_camera_node(nullptr)
 {
-    m_cct_player_actor = nullptr;
     m_staticcam_update_timer.reset();
 
     m_camera = App::GetGfxScene()->GetSceneManager()->createCamera("PlayerCam");
@@ -528,7 +527,7 @@ bool CameraManager::hasActiveBehavior()
 
 void CameraManager::ResetAllBehaviors()
 {
-    this->SwitchBehaviorOnVehicleChange(CAMERA_BEHAVIOR_INVALID, nullptr);
+    this->SwitchBehaviorOnVehicleChange(CAMERA_BEHAVIOR_INVALID, ActorPtr());
 }
 
 bool CameraManager::mouseMoved(const OIS::MouseEvent& _arg)
@@ -631,7 +630,7 @@ void CameraManager::NotifyVehicleChanged(ActorPtr new_vehicle)
     // Getting out of vehicle
     if (new_vehicle == nullptr)
     {
-        m_cct_player_actor = nullptr;
+        m_cct_player_actor = ActorPtr();
         if (this->m_current_behavior != CAMERA_BEHAVIOR_FIXED && this->m_current_behavior != CAMERA_BEHAVIOR_STATIC &&
                 this->m_current_behavior != CAMERA_BEHAVIOR_FREE)
         {

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -51,19 +51,19 @@ static const float         ROTATE_SPEED = 100.f;
 
 bool intersectsTerrain(Vector3 a, Vector3 b) // internal helper
 {
-    b.y = std::max(b.y, App::GetSimTerrain()->GetHeightAt(b.x, b.z) + 1.0f);
+    b.y = std::max(b.y, App::GetGameContext()->GetTerrain()->GetHeightAt(b.x, b.z) + 1.0f);
 
     int steps = std::max(3.0f, a.distance(b) * 2.0f);
     for (int i = 1; i < steps; i++)
     {
         Vector3 pos = a + (b - a) * (float)i / steps;
-        float h = App::GetSimTerrain()->GetHeightAt(pos.x, pos.z);
+        float h = App::GetGameContext()->GetTerrain()->GetHeightAt(pos.x, pos.z);
         if (h > pos.y)
         {
             return true;
         }
     }
-    return App::GetSimTerrain()->GetCollisions()->intersectsTris(Ray(a, b - a)).first;
+    return App::GetGameContext()->GetTerrain()->GetCollisions()->intersectsTris(Ray(a, b - a)).first;
 }
 
 bool intersectsTerrain(Vector3 a, Vector3 start, Vector3 end, float interval) // internal helper
@@ -744,7 +744,7 @@ void CameraManager::UpdateCameraBehaviorStatic()
                 distance > cmradius * std::max(25.0f, speed * 1.15f) ||
                 intersectsTerrain(m_staticcam_position, lookAt, lookAtPrediction, interval))
         {
-            const auto water = App::GetSimTerrain()->getWater();
+            const auto water = App::GetGameContext()->GetTerrain()->getWater();
             float water_height = (water && !water->IsUnderWater(lookAt)) ? water->GetStaticWaterHeight() : 0.0f;
             float desired_offset = std::max(std::sqrt(radius) * 2.89f, App::gfx_camera_height->getFloat());
 
@@ -766,7 +766,7 @@ void CameraManager::UpdateCameraBehaviorStatic()
                     pos += (velocity + velocity.crossProduct(Vector3::UNIT_Y) * rnd) * dist;
                 }
                 pos.y = std::max(pos.y, water_height);
-                pos.y = std::max(pos.y, App::GetSimTerrain()->GetHeightAt(pos.x, pos.z));
+                pos.y = std::max(pos.y, App::GetGameContext()->GetTerrain()->GetHeightAt(pos.x, pos.z));
                 pos.y += desired_offset * (i < 7 ? 1.0f : frand());
                 if (!intersectsTerrain(pos, lookAt, lookAtPrediction, interval))
                 {
@@ -887,7 +887,7 @@ void CameraManager::CameraBehaviorOrbitUpdate()
 
     if (m_cam_limit_movement)
     {
-        float h = App::GetSimTerrain()->GetHeightAt(desiredPosition.x, desiredPosition.z) + 1.0f;
+        float h = App::GetGameContext()->GetTerrain()->GetHeightAt(desiredPosition.x, desiredPosition.z) + 1.0f;
 
         desiredPosition.y = std::max(h, desiredPosition.y);
     }
@@ -911,10 +911,10 @@ void CameraManager::CameraBehaviorOrbitUpdate()
 
     Vector3 camPosition = (1.0f / (m_cam_ratio + 1.0f)) * desiredPosition + (m_cam_ratio / (m_cam_ratio + 1.0f)) * precedingPosition;
 
-    if (App::GetSimTerrain()->GetCollisions() && App::GetSimTerrain()->GetCollisions()->forcecam)
+    if (App::GetGameContext()->GetTerrain()->GetCollisions() && App::GetGameContext()->GetTerrain()->GetCollisions()->forcecam)
     {
-        this->GetCameraNode()->setPosition(App::GetSimTerrain()->GetCollisions()->forcecampos);
-        App::GetSimTerrain()->GetCollisions()->forcecam = false;
+        this->GetCameraNode()->setPosition(App::GetGameContext()->GetTerrain()->GetCollisions()->forcecampos);
+        App::GetGameContext()->GetTerrain()->GetCollisions()->forcecam = false;
     }
     else
     {

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -64,7 +64,7 @@ public:
     Ogre::Camera*     GetCamera()                 { return m_camera; }
 
     void NotifyContextChange();
-    void NotifyVehicleChanged(Actor* new_vehicle);
+    void NotifyVehicleChanged(ActorPtr new_vehicle);
 
     void CameraBehaviorOrbitReset();
     bool CameraBehaviorOrbitMouseMoved(const OIS::MouseEvent& _arg);
@@ -82,7 +82,7 @@ public:
 protected:
 
     void switchBehavior(CameraBehaviors new_behavior);
-    void SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, Actor* new_vehicle);
+    void SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, ActorPtr new_vehicle);
     void ToggleCameraBehavior(CameraBehaviors new_behavior); //!< Only accepts FREE and FREEFIX modes
     void ActivateNewBehavior(CameraBehaviors new_behavior, bool reset);
     void UpdateCurrentBehavior();
@@ -110,7 +110,7 @@ protected:
     CameraBehaviors      m_cam_before_toggled;  //!< Toggled modes (FREE, FREEFIX) remember original state.
     CameraBehaviors      m_prev_toggled_cam;    //!< Switching toggled modes (FREE, FREEFIX) keeps 1-slot history.
     // Old `CameraContext`
-    Actor*               m_cct_player_actor; // TODO: duplicates `GameContext::m_player_actor`
+    ActorPtr             m_cct_player_actor; // TODO: duplicates `GameContext::m_player_actor`
     Ogre::Degree         m_cct_rot_scale;
     Ogre::Real           m_cct_dt;
     Ogre::Real           m_cct_trans_scale;

--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -19,6 +19,8 @@
 
 #include "GUIUtils.h"
 
+#include "Actor.h"
+
 #include "imgui_internal.h" // ImTextCharFromUtf8
 #include <regex>
 #include <stdio.h> // sscanf

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -370,12 +370,12 @@ void OverlayWrapper::showPressureOverlay(bool show)
     }
 }
 
-void OverlayWrapper::ToggleDashboardOverlays(Actor* actor)
+void OverlayWrapper::ToggleDashboardOverlays(ActorPtr actor)
 {
     showDashboardOverlays(!m_dashboard_visible, actor);
 }
 
-void OverlayWrapper::showDashboardOverlays(bool show, Actor* actor)
+void OverlayWrapper::showDashboardOverlays(bool show, ActorPtr actor)
 {
     m_dashboard_visible = show;
 
@@ -500,7 +500,7 @@ bool OverlayWrapper::mouseMoved(const OIS::MouseEvent& _arg)
     bool res = false;
     const OIS::MouseState ms = _arg.state;
     
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
     if (!player_actor)
         return res;
@@ -919,7 +919,7 @@ void OverlayWrapper::UpdateAerialHUD(RoR::GfxActor* gfx_actor)
         m_aerial_dashboard.vs_trim.DisplayFormat("+%i00", simbuf.simbuf_ap_vs_value / 100);
 }
 
-void OverlayWrapper::UpdateMarineHUD(Actor* vehicle)
+void OverlayWrapper::UpdateMarineHUD(ActorPtr vehicle)
 {
     // throttles
     bthro1->setTop(thrtop + thrheight * (0.5 - vehicle->ar_screwprops[0]->getThrottle() / 2.0) - 1.0);

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -65,7 +65,7 @@ OverlayWrapper::OverlayWrapper():
 
 OverlayWrapper::~OverlayWrapper()
 {
-    showDashboardOverlays(false, nullptr);
+    showDashboardOverlays(false, ActorPtr());
     HideRacingOverlay();
 }
 

--- a/source/main/gui/OverlayWrapper.h
+++ b/source/main/gui/OverlayWrapper.h
@@ -122,9 +122,9 @@ public:
         Ogre::Overlay *o;
     };
 
-    void ToggleDashboardOverlays(Actor *actor);
+    void ToggleDashboardOverlays(ActorPtr actor);
 
-    void showDashboardOverlays(bool show, Actor *actor);
+    void showDashboardOverlays(bool show, ActorPtr actor);
 
     void windowResized();
     void resizeOverlay(LoadedOverlay & overlay);
@@ -138,7 +138,7 @@ public:
     void update(float dt);
     void UpdateLandVehicleHUD(RoR::GfxActor* ga);
     void UpdateAerialHUD(RoR::GfxActor* ga);
-    void UpdateMarineHUD(Actor * vehicle);
+    void UpdateMarineHUD(ActorPtr vehicle);
 
     void ShowRacingOverlay();
     void HideRacingOverlay();

--- a/source/main/gui/imgui/OgreImGui.cpp
+++ b/source/main/gui/imgui/OgreImGui.cpp
@@ -25,6 +25,7 @@
 
 #include "OgreImGui.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "ContentManager.h"
 #include "OgreImGuiOverlay.h"

--- a/source/main/gui/panels/GUI_CollisionsDebug.cpp
+++ b/source/main/gui/panels/GUI_CollisionsDebug.cpp
@@ -47,8 +47,8 @@ void CollisionsDebug::Draw()
     bool keep_open = true;
     ImGui::Begin(_LC("About", "Static collision debug"), &keep_open, win_flags);
 
-    ImGui::Text("Terrain name: %s", App::GetSimTerrain()->getTerrainName().c_str());
-    ImGui::Text("Terrain size: %.2fx%.2f meters", App::GetSimTerrain()->getMaxTerrainSize().x, App::GetSimTerrain()->getMaxTerrainSize().z);
+    ImGui::Text("Terrain name: %s", App::GetGameContext()->GetTerrain()->getTerrainName().c_str());
+    ImGui::Text("Terrain size: %.2fx%.2f meters", App::GetGameContext()->GetTerrain()->getMaxTerrainSize().x, App::GetGameContext()->GetTerrain()->getMaxTerrainSize().z);
     ImGui::Checkbox("Draw labels", &m_draw_labels);
     ImGui::Checkbox("Draw label types", &m_labels_draw_types);
     ImGui::Checkbox("Sources on labels", &m_labels_draw_sources);
@@ -57,7 +57,7 @@ void CollisionsDebug::Draw()
     // EVENTBOX
     ImGui::PushID("EVENTBOX");
     ImGui::TextColored(COLOR_EVENTBOX, "EVENTBOX");
-    ImGui::Text("Num event boxes: %d", (int)App::GetSimTerrain()->GetCollisions()->getCollisionBoxes().size());
+    ImGui::Text("Num event boxes: %d", (int)App::GetGameContext()->GetTerrain()->GetCollisions()->getCollisionBoxes().size());
     if (ImGui::Checkbox("Show event boxes", &m_draw_collision_boxes))
     {
         this->SetDrawEventBoxes(m_draw_collision_boxes);
@@ -83,7 +83,7 @@ void CollisionsDebug::Draw()
     // COLLMESH
     ImGui::PushID("COLLMESH");
     ImGui::TextColored(COLOR_COLLMESH, "COLLMESH");
-    ImGui::Text("Num collision meshes: %d (%d tris)", (int)App::GetSimTerrain()->GetCollisions()->getCollisionBoxes().size());
+    ImGui::Text("Num collision meshes: %d (%d tris)", (int)App::GetGameContext()->GetTerrain()->GetCollisions()->getCollisionBoxes().size());
     if (ImGui::Checkbox("Show collision meshes", &m_draw_collision_meshes))
     {
         this->SetDrawCollisionMeshes(m_draw_collision_meshes);
@@ -164,7 +164,7 @@ void CollisionsDebug::Draw()
 
     if (m_draw_labels && m_draw_collision_boxes)
     {
-        for (const collision_box_t& cbox : App::GetSimTerrain()->GetCollisions()->getCollisionBoxes())
+        for (const collision_box_t& cbox : App::GetGameContext()->GetTerrain()->GetCollisions()->getCollisionBoxes())
         {
             if (IsDistanceWithin(cam_pos, this->GetCollBoxWorldPos(cbox), m_collision_box_draw_distance))
             {
@@ -175,7 +175,7 @@ void CollisionsDebug::Draw()
 
     if (m_draw_labels && m_draw_collision_meshes)
     {
-        for (const collision_mesh_t& cmesh : App::GetSimTerrain()->GetCollisions()->getCollisionMeshes())
+        for (const collision_mesh_t& cmesh : App::GetGameContext()->GetTerrain()->GetCollisions()->getCollisionMeshes())
         {
             if (IsDistanceWithin(cam_pos, cmesh.position, m_collision_mesh_draw_distance))
             {
@@ -188,7 +188,7 @@ void CollisionsDebug::Draw()
 void CollisionsDebug::AddCollisionMeshDebugMesh(collision_mesh_t const& coll_mesh)
 {
     // Gather data
-    const CollisionTriVec& ctris = App::GetSimTerrain()->GetCollisions()->getCollisionTriangles();
+    const CollisionTriVec& ctris = App::GetGameContext()->GetTerrain()->GetCollisions()->getCollisionTriangles();
 
     // Create mesh
     Ogre::ManualObject* debugmo = App::GetGfxScene()->GetSceneManager()->createManualObject();
@@ -219,7 +219,7 @@ void CollisionsDebug::AddCollisionBoxDebugMesh(collision_box_t const& coll_box)
 {
     int scripthandler = -1;
     if (coll_box.eventsourcenum != -1)
-        scripthandler = App::GetSimTerrain()->GetCollisions()->getEventSource(coll_box.eventsourcenum).scripthandler;
+        scripthandler = App::GetGameContext()->GetTerrain()->GetCollisions()->getEventSource(coll_box.eventsourcenum).scripthandler;
 
     SceneNode* debugsn = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
 
@@ -323,7 +323,7 @@ void CollisionsDebug::DrawCollisionBoxDebugText(collision_box_t const& coll_box)
     if (!coll_box.virt || coll_box.eventsourcenum == -1)
         return;
 
-    eventsource_t const& eventsource = App::GetSimTerrain()->GetCollisions()->getEventSource(coll_box.eventsourcenum);
+    eventsource_t const& eventsource = App::GetGameContext()->GetTerrain()->GetCollisions()->getEventSource(coll_box.eventsourcenum);
     const char* type_str = (m_labels_draw_types) ? "EVENTBOX\n" : "";
 
     this->DrawLabelAtWorldPos(
@@ -429,7 +429,7 @@ void CollisionsDebug::SetDrawEventBoxes(bool val)
     // Initial fill
     if (m_draw_collision_boxes && m_collision_boxes.size() == 0)
     {
-        for (const collision_box_t& cbox : App::GetSimTerrain()->GetCollisions()->getCollisionBoxes())
+        for (const collision_box_t& cbox : App::GetGameContext()->GetTerrain()->GetCollisions()->getCollisionBoxes())
         {
             this->AddCollisionBoxDebugMesh(cbox);
         }
@@ -448,7 +448,7 @@ void CollisionsDebug::SetDrawCollisionMeshes(bool val)
     // Initial setup
     if (m_draw_collision_meshes && m_collision_meshes.size() == 0)
     {
-        for (const collision_mesh_t& cmesh : App::GetSimTerrain()->GetCollisions()->getCollisionMeshes())
+        for (const collision_mesh_t& cmesh : App::GetGameContext()->GetTerrain()->GetCollisions()->getCollisionMeshes())
         {
             this->AddCollisionMeshDebugMesh(cmesh);
         }
@@ -477,7 +477,7 @@ void CollisionsDebug::SetDrawCollisionCells(bool val)
         aabb.getMaximum().y = FLT_MAX; // vertical axis
         try
         {
-            App::GetSimTerrain()->GetCollisions()->createCollisionDebugVisualization(m_collision_grid_root, aabb, m_collision_cells);
+            App::GetGameContext()->GetTerrain()->GetCollisions()->createCollisionDebugVisualization(m_collision_grid_root, aabb, m_collision_cells);
         }
         catch (std::bad_alloc const& allocex)
         {

--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -22,6 +22,7 @@
 
 #include "GUI_ConsoleView.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Console.h"
 #include "GUIManager.h"

--- a/source/main/gui/panels/GUI_ConsoleWindow.cpp
+++ b/source/main/gui/panels/GUI_ConsoleWindow.cpp
@@ -21,6 +21,8 @@
 
 
 #include "GUI_ConsoleWindow.h"
+
+#include "Actor.h"
 #include "GUIManager.h"
 #include "GUI_AngelScriptExamples.h"
 

--- a/source/main/gui/panels/GUI_FrictionSettings.cpp
+++ b/source/main/gui/panels/GUI_FrictionSettings.cpp
@@ -138,8 +138,8 @@ bool FrictionSettings::GmComboItemGetter(void* data, int idx, const char** out_t
 void FrictionSettings::AnalyzeTerrain()
 {
     m_gm_entries.clear();
-    auto itor = App::GetSimTerrain()->GetCollisions()->getGroundModels()->begin();
-    auto endi = App::GetSimTerrain()->GetCollisions()->getGroundModels()->end();
+    auto itor = App::GetGameContext()->GetTerrain()->GetCollisions()->getGroundModels()->begin();
+    auto endi = App::GetGameContext()->GetTerrain()->GetCollisions()->getGroundModels()->end();
     for (; itor != endi; ++itor)
     {
         m_gm_entries.emplace_back(&itor->second);

--- a/source/main/gui/panels/GUI_GameAbout.cpp
+++ b/source/main/gui/panels/GUI_GameAbout.cpp
@@ -25,6 +25,7 @@
 
 #include "GUI_GameAbout.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "GUIManager.h"
 #include "Language.h"

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -21,6 +21,7 @@
 
 #include "GUI_GameChatBox.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "ChatSystem.h"
 #include "Console.h"

--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -21,6 +21,7 @@
 
 #include "GUI_GameControls.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Language.h"
 #include "OgreImGui.h"

--- a/source/main/gui/panels/GUI_LoadingWindow.cpp
+++ b/source/main/gui/panels/GUI_LoadingWindow.cpp
@@ -21,6 +21,7 @@
 #include "GUI_LoadingWindow.h"
 #include <fmt/format.h>
 
+#include "Actor.h"
 #include "GUIManager.h"
 #include "GUIUtils.h"
 #include "OgreImGui.h"

--- a/source/main/gui/panels/GUI_NodeBeamUtils.cpp
+++ b/source/main/gui/panels/GUI_NodeBeamUtils.cpp
@@ -31,7 +31,7 @@ using namespace GUI;
 
 void NodeBeamUtils::Draw()
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (!actor)
     {
         this->SetVisible(false);

--- a/source/main/gui/panels/GUI_ScriptMonitor.cpp
+++ b/source/main/gui/panels/GUI_ScriptMonitor.cpp
@@ -16,6 +16,7 @@
 
 #include "GUI_ScriptMonitor.h"
 
+#include "Actor.h"
 #include "ContentManager.h"
 #include "ScriptEngine.h"
 

--- a/source/main/gui/panels/GUI_SimActorStats.cpp
+++ b/source/main/gui/panels/GUI_SimActorStats.cpp
@@ -225,7 +225,7 @@ void SimActorStats::Draw(RoR::GfxActor* actorx)
     ImGui::PopStyleColor(1); // WindowBg
 }
 
-void SimActorStats::UpdateStats(float dt, Actor* actor)
+void SimActorStats::UpdateStats(float dt, ActorPtr actor)
 {
     //taken from TruckHUD.cpp (now removed)
     beam_t* beam = actor->ar_beams;

--- a/source/main/gui/panels/GUI_SimActorStats.h
+++ b/source/main/gui/panels/GUI_SimActorStats.h
@@ -36,7 +36,7 @@ public:
     void SetVisible(bool vis) { m_is_visible = vis; }
     bool IsVisible() const { return m_is_visible; }
 
-    void UpdateStats(float dt, Actor* actor); //!< Caution: touches live data, must be synced with sim. thread
+    void UpdateStats(float dt, ActorPtr actor); //!< Caution: touches live data, must be synced with sim. thread
     void Draw(RoR::GfxActor* actorx);
 
 private:

--- a/source/main/gui/panels/GUI_SimPerfStats.cpp
+++ b/source/main/gui/panels/GUI_SimPerfStats.cpp
@@ -21,6 +21,7 @@
 
 #include "GUI_SimPerfStats.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "GUIManager.h"
 #include "Language.h"

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -138,7 +138,7 @@ void SurveyMap::Draw()
         // Calc. view center
         smallmap_size = mTerrainSize * (1.0f - mMapZoom);
         Ogre::Vector2 player_map_pos;
-        Actor* actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
+        ActorPtr actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
         if (actor)
         {
             auto& actor_data = actor->GetGfxActor()->GetSimDataBuffer();
@@ -422,7 +422,7 @@ void SurveyMap::setMapZoomRelative(float delta)
 }
 
 
-const char* SurveyMap::getTypeByDriveable(ActorType driveable, Actor* actor)
+const char* SurveyMap::getTypeByDriveable(ActorType driveable, ActorPtr actor)
 {
     switch (driveable)
     {
@@ -443,7 +443,7 @@ const char* SurveyMap::getTypeByDriveable(ActorType driveable, Actor* actor)
     }
 }
 
-const char* SurveyMap::getAIType(Actor* actor)
+const char* SurveyMap::getAIType(ActorPtr actor)
 {
     if (actor->ar_engine)
     {

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -85,7 +85,7 @@ void SurveyMap::Draw()
         view_padding.y = 40; // Extra space for hints
         view_size.y = (rw->getWidth() * 0.55f) -
             ((2 * App::GetGuiManager()->GetTheme().screen_edge_padding.y) + (2 * WINDOW_PADDING));
-        Vector3 terrn_size = App::GetSimTerrain()->getMaxTerrainSize(); // Y is 'up'!
+        Vector3 terrn_size = App::GetGameContext()->GetTerrain()->getMaxTerrainSize(); // Y is 'up'!
         if (!terrn_size.isZeroLength())
         {
             view_size.x = (view_size.y / terrn_size.z) * terrn_size.x;
@@ -194,7 +194,7 @@ void SurveyMap::Draw()
 
         if (ImGui::IsItemClicked(1)) // Set AI waypoint
         {
-            float y = App::GetSimTerrain()->GetCollisions()->getSurfaceHeight(mouse_map_pos.x, mouse_map_pos.y);
+            float y = App::GetGameContext()->GetTerrain()->GetCollisions()->getSurfaceHeight(mouse_map_pos.x, mouse_map_pos.y);
             ai_waypoints.push_back(Ogre::Vector3(mouse_map_pos.x, y, mouse_map_pos.y));
         }
         else if (!w_adj) // Teleport
@@ -254,7 +254,7 @@ void SurveyMap::Draw()
                     mouse_map_pos = view_origin + (Vector2(mouse_view_offset.x, mouse_view_offset.y) * smallmap_size);
                 }
 
-                float y = App::GetSimTerrain()->GetCollisions()->getSurfaceHeight(mouse_map_pos.x, mouse_map_pos.y);
+                float y = App::GetGameContext()->GetTerrain()->GetCollisions()->getSurfaceHeight(mouse_map_pos.x, mouse_map_pos.y);
                 ai_waypoints[mWaypointNum] = Ogre::Vector3(mouse_map_pos.x, y, mouse_map_pos.y);
             }
             else if (abs(cw_dist.x) <= 5 && abs(cw_dist.y) <= 5 && ImGui::IsItemClicked(2))
@@ -267,7 +267,7 @@ void SurveyMap::Draw()
     if (App::gfx_surveymap_icons->getBool())
     {
         // Draw terrain object icons
-        for (TerrainObjectManager::MapEntity& e: App::GetSimTerrain()->getObjectManager()->GetMapEntities())
+        for (TerrainObjectManager::MapEntity& e: App::GetGameContext()->GetTerrain()->getObjectManager()->GetMapEntities())
         {
             int id = App::GetGameContext()->GetRaceSystem().GetRaceId();
             bool visible = !((e.type == "checkpoint" && e.id != id) || (e.type == "racestart" && id != -1 && e.id != id));
@@ -375,9 +375,9 @@ void SurveyMap::Draw()
 void SurveyMap::CreateTerrainTextures()
 {
     mMapCenterOffset     = Ogre::Vector2::ZERO; // Reset, maybe new terrain was loaded
-    AxisAlignedBox aab   = App::GetSimTerrain()->getTerrainCollisionAAB();
-    Vector3 terrain_size = App::GetSimTerrain()->getMaxTerrainSize();
-    bool use_aab         = App::GetSimTerrain()->isFlat() && std::min(aab.getSize().x, aab.getSize().z) > 50.0f;
+    AxisAlignedBox aab   = App::GetGameContext()->GetTerrain()->getTerrainCollisionAAB();
+    Vector3 terrain_size = App::GetGameContext()->GetTerrain()->getMaxTerrainSize();
+    bool use_aab         = App::GetGameContext()->GetTerrain()->isFlat() && std::min(aab.getSize().x, aab.getSize().z) > 50.0f;
 
     if (terrain_size.isZeroLength() || use_aab && (aab.getSize().length() < terrain_size.length()))
     {

--- a/source/main/gui/panels/GUI_SurveyMap.h
+++ b/source/main/gui/panels/GUI_SurveyMap.h
@@ -72,8 +72,8 @@ protected:
 
     void setMapZoom(float zoom);
     void setMapZoomRelative(float dt_sec);
-    const char* getTypeByDriveable(ActorType driveable, Actor* actor);
-    const char* getAIType(Actor* actor);
+    const char* getTypeByDriveable(ActorType driveable, ActorPtr actor);
+    const char* getAIType(ActorPtr actor);
 
     void DrawMapIcon(ImVec2 view_pos, ImVec2 view_size, Ogre::Vector2 view_origin,
                      std::string const& filename, std::string const& caption, 

--- a/source/main/gui/panels/GUI_TextureToolWindow.cpp
+++ b/source/main/gui/panels/GUI_TextureToolWindow.cpp
@@ -23,6 +23,7 @@
 
 #include <Ogre.h>
 
+#include "Actor.h"
 #include "Application.h"
 #include "Console.h"
 #include "GUIManager.h"

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -230,7 +230,7 @@ void TopMenubar::Update()
         m_open_menu = TopMenu::TOPMENU_SETTINGS;
 #ifdef USE_CAELUM
         if (App::gfx_sky_mode->getEnum<GfxSkyMode>() == GfxSkyMode::CAELUM)
-            m_daytime = App::GetSimTerrain()->getSkyManager()->GetTime();
+            m_daytime = App::GetGameContext()->GetTerrain()->getSkyManager()->GetTime();
 #endif // USE_CAELUM
     }
 
@@ -367,9 +367,9 @@ void TopMenubar::Update()
                     App::GetGameContext()->PushMessage(Message(MsgType::MSG_SIM_UNLOAD_TERRN_REQUESTED));
                     // Order is required - create chain.
                     App::GetGameContext()->ChainMessage(Message(MsgType::MSG_EDI_RELOAD_BUNDLE_REQUESTED,
-                        (void*)App::GetSimTerrain()->getCacheEntry()));
+                        (void*)App::GetGameContext()->GetTerrain()->getCacheEntry()));
                     App::GetGameContext()->ChainMessage(Message(MsgType::MSG_SIM_LOAD_TERRN_REQUESTED,
-                        App::GetSimTerrain()->getCacheEntry()->fname));
+                        App::GetGameContext()->GetTerrain()->getCacheEntry()->fname));
                 }
             }
 
@@ -563,10 +563,10 @@ void TopMenubar::Update()
             {
                 ImGui::Separator();
                 ImGui::TextColored(GRAY_HINT_TEXT, _LC("TopMenubar", "Time of day:"));
-                float time = App::GetSimTerrain()->getSkyManager()->GetTime();
+                float time = App::GetGameContext()->GetTerrain()->getSkyManager()->GetTime();
                 if (ImGui::SliderFloat("", &time, m_daytime - 0.5f, m_daytime + 0.5f, ""))
                 {
-                    App::GetSimTerrain()->getSkyManager()->SetTime(time);
+                    App::GetGameContext()->GetTerrain()->getSkyManager()->SetTime(time);
                 }
                 ImGui::SameLine();
                 DrawGCheckbox(App::gfx_sky_time_cycle, _LC("TopMenubar", "Cycle"));
@@ -576,7 +576,7 @@ void TopMenubar::Update()
                 }
             }       
 #endif // USE_CAELUM
-            if (RoR::App::gfx_water_waves->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED && App::GetSimTerrain()->getWater())
+            if (RoR::App::gfx_water_waves->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED && App::GetGameContext()->GetTerrain()->getWater())
             {
                 if (App::gfx_water_mode->getEnum<GfxWaterMode>() != GfxWaterMode::HYDRAX && App::gfx_water_mode->getEnum<GfxWaterMode>() != GfxWaterMode::NONE)
                 {
@@ -584,7 +584,7 @@ void TopMenubar::Update()
                     ImGui::TextColored(GRAY_HINT_TEXT, _LC("TopMenubar", "Waves Height:"));
                     if(ImGui::SliderFloat("", &m_waves_height, 0.f, 4.f, ""))
                     {
-                        App::GetSimTerrain()->getWater()->SetWavesHeight(m_waves_height);
+                        App::GetGameContext()->GetTerrain()->getWater()->SetWavesHeight(m_waves_height);
                     }
                     ImGui::PopID();
                 }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -109,8 +109,14 @@ void TopMenubar::Update()
 
     GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
 
-    auto actors = App::GetGameContext()->GetActorManager()->GetActors();
-    int num_playable_actors = std::count_if(actors.begin(), actors.end(), [](Actor* a) {return !a->ar_hide_in_actor_list;});
+    int num_playable_actors = 0;
+    for (ActorPtr& actor: App::GetGameContext()->GetActorManager()->GetActors())
+    {
+        if (!actor->ar_hide_in_actor_list)
+        {
+            num_playable_actors++;
+        }
+    }
 
     std::string sim_title =         _LC("TopMenubar", "Simulation");
     std::string actors_title = fmt::format("{} ({})", _LC("TopMenubar", "Vehicles"), num_playable_actors);
@@ -245,7 +251,7 @@ void TopMenubar::Update()
     this->DrawSpecialStateBox(window_target_pos.y + topmenu_final_size.y + 10.f);
 
     ImVec2 menu_pos;
-    Actor* current_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr current_actor = App::GetGameContext()->GetPlayerActor();
     switch (m_open_menu)
     {
     case TopMenu::TOPMENU_SIM:
@@ -284,7 +290,7 @@ void TopMenubar::Update()
 
                     if (ImGui::Button(_LC("TopMenubar", "Remove current vehicle")))
                     {
-                        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)current_actor));
+                        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(current_actor))));
                     }
                 }
             }
@@ -308,8 +314,8 @@ void TopMenubar::Update()
 
                 if (ImGui::Button(_LC("TopMenubar", "Remove last spawned vehicle")))
                 {
-                    App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED,
-                        (void*)App::GetGameContext()->GetLastSpawnedActor()));
+                    ActorPtr actor = App::GetGameContext()->GetLastSpawnedActor();
+                    App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                 }
             }
 
@@ -324,12 +330,12 @@ void TopMenubar::Update()
                     ImGui::PushStyleColor(ImGuiCol_Text, ORANGE_TEXT);
                     if (ImGui::Button(_LC("TopMenubar", " [!] Confirm removal")))
                     {
-                        for (auto actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
+                        for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
                         {
                             if (!actor->ar_hide_in_actor_list && !actor->isPreloadedWithTerrain() && 
                                     actor->ar_state != ActorState::NETWORKED_OK)
                             {
-                                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
+                                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                             }
                         }
                         m_confirm_remove_all = false;
@@ -994,11 +1000,11 @@ void TopMenubar::Update()
                     App::GetGuiManager()->SurveyMap.ai_waypoints.clear();
                 }
 
-                for (auto actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
+                for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
                 {
                     if (actor->ar_driveable == AI)
                     {
-                        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
+                        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                     }
                 }
             }
@@ -1171,7 +1177,7 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
 {
     // Count actors owned by the player
     unsigned int num_actors_player = 0;
-    for (Actor* actor : App::GetGameContext()->GetActorManager()->GetActors())
+    for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
         if (actor->ar_net_source_id == user.uniqueid)
         {
@@ -1196,7 +1202,7 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
     Ogre::TexturePtr tex1 = FetchIcon("control_pause.png");
     Ogre::TexturePtr tex2 = FetchIcon("control_play.png");
     int i = 0;
-    for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+    for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
         if ((!actor->ar_hide_in_actor_list) && (actor->ar_net_source_id == user.uniqueid))
         {
@@ -1206,14 +1212,14 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
             {
                 if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(tex1->getHandle()), ImVec2(16, 16)))
                 {
-                   App::GetGameContext()->PushMessage(Message(MSG_SIM_HIDE_NET_ACTOR_REQUESTED, (void*)actor));
+                   App::GetGameContext()->PushMessage(Message(MSG_SIM_HIDE_NET_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                 }
             }
             else if (actor->ar_state == ActorState::NETWORKED_HIDDEN)
             {
                 if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(tex2->getHandle()), ImVec2(16, 16)))
                 {
-                   App::GetGameContext()->PushMessage(Message(MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED, (void*)actor));
+                   App::GetGameContext()->PushMessage(Message(MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                 }
             }
             else // Our actor(s)
@@ -1222,7 +1228,7 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
                 ImGui::PushStyleColor(ImGuiCol_Text, RED_TEXT);
                 if (ImGui::Button(text_buf_rem.c_str()))
                 {
-                   App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
+                   App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                 }
                 ImGui::PopStyleColor();
             }
@@ -1232,7 +1238,7 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
             std::string actortext_buf = fmt::format("{} ({}) ##[{}:{}]", StripColorMarksFromText(actor->ar_design_name).c_str(), actor->ar_filename.c_str(), i++, user.uniqueid);
             if (ImGui::Button(actortext_buf.c_str())) // Button clicked?
             {
-                App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)actor));
+                App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
             }
         }
     }
@@ -1240,8 +1246,8 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
 
 void TopMenubar::DrawActorListSinglePlayer()
 {
-    std::vector<Actor*> actor_list;
-    for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+    std::vector<ActorPtr> actor_list;
+    for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
         if (!actor->ar_hide_in_actor_list)
         {
@@ -1257,15 +1263,15 @@ void TopMenubar::DrawActorListSinglePlayer()
     }
     else
     {
-        Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+        ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
         int i = 0;
-        for (auto actor : actor_list)
+        for (ActorPtr actor : actor_list)
         {
             std::string text_buf_rem = fmt::format("X ##[{}]", i);
             ImGui::PushStyleColor(ImGuiCol_Text, RED_TEXT);
             if (ImGui::Button(text_buf_rem.c_str()))
             {
-                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
+                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
             }
             ImGui::PopStyleColor();
             ImGui::SameLine();
@@ -1290,7 +1296,7 @@ void TopMenubar::DrawActorListSinglePlayer()
             }
             if (ImGui::Button(text_buf.c_str())) // Button clicked?
             {
-                App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)actor));
+                App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
             }
             ImGui::PopStyleColor();
         }
@@ -1341,7 +1347,7 @@ void TopMenubar::DrawSpecialStateBox(float top_offset)
         GameContextSB& data = App::GetGfxScene()->GetSimDataBuffer();
         GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
         float distance = 0.0f;
-        Actor* player_actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
+        ActorPtr player_actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
         if (player_actor != nullptr && App::GetGameContext()->GetPlayerActor() &&
             player_actor->GetGfxActor()->GetSimDataBuffer().simbuf_actor_state == ActorState::LOCAL_SIMULATED)
         {

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -627,7 +627,7 @@ void VehicleButtons::DrawActorPhysicsButton(RoR::GfxActor* actorx)
 
     if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(m_actor_physics_icon->getHandle()), ImVec2(24, 24)))
     {
-        for (auto actor : actorx->GetActor()->getAllLinkedActors())
+        for (ActorPtr actor : actorx->GetActor()->getAllLinkedActors())
         {
             actor->ar_physics_paused = !actorx->GetActor()->ar_physics_paused;
         }

--- a/source/main/gui/panels/GUI_VehicleDescription.cpp
+++ b/source/main/gui/panels/GUI_VehicleDescription.cpp
@@ -40,7 +40,7 @@ using namespace GUI;
 
 void VehicleDescription::Draw()
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (!actor)
     {
         m_is_visible = false;

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -578,7 +578,7 @@ int main(int argc, char *argv[])
                 case MSG_SIM_UNLOAD_TERRN_REQUESTED:
                     if (App::sim_state->getEnum<SimState>() == SimState::EDITOR_MODE)
                     {
-                        App::GetSimTerrain()->GetTerrainEditor()->WriteOutputFile();
+                        App::GetGameContext()->GetTerrain()->GetTerrainEditor()->WriteOutputFile();
                     }
                     App::GetGameContext()->SaveScene("autosave.sav");
                     App::GetGameContext()->ChangePlayerActor(nullptr);
@@ -594,8 +594,7 @@ int main(int argc, char *argv[])
                     App::GetGuiManager()->SurveyMap.ai_waypoints.clear();
                     App::sim_state->setVal((int)SimState::OFF);
                     App::app_state->setVal((int)AppState::MAIN_MENU);
-                    delete App::GetSimTerrain();
-                    App::SetSimTerrain(nullptr);
+                    App::GetGameContext()->UnloadTerrain();
                     App::GetGfxScene()->ClearScene();
                     App::sim_terrain_name->setStr("");
                     App::sim_terrain_gui_name->setStr("");
@@ -770,7 +769,7 @@ int main(int argc, char *argv[])
                 case MSG_EDI_MODIFY_GROUNDMODEL_REQUESTED:
                     {
                         ground_model_t* modified_gm = (ground_model_t*)m.payload;
-                        ground_model_t* live_gm = App::GetSimTerrain()->GetCollisions()->getGroundModelByString(modified_gm->name);
+                        ground_model_t* live_gm = App::GetGameContext()->GetTerrain()->GetCollisions()->getGroundModelByString(modified_gm->name);
                         *live_gm = *modified_gm; // Copy over
                     }
                     break;
@@ -790,8 +789,8 @@ int main(int argc, char *argv[])
                 case MSG_EDI_LEAVE_TERRN_EDITOR_REQUESTED:
                     if (App::sim_state->getEnum<SimState>() == SimState::EDITOR_MODE)
                     {
-                        App::GetSimTerrain()->GetTerrainEditor()->WriteOutputFile();
-                        App::GetSimTerrain()->GetTerrainEditor()->ClearSelection();
+                        App::GetGameContext()->GetTerrain()->GetTerrainEditor()->WriteOutputFile();
+                        App::GetGameContext()->GetTerrain()->GetTerrainEditor()->ClearSelection();
                         App::sim_state->setVal((int)SimState::RUNNING);
                         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
                                                       _L("Left terrain editing mode"));
@@ -894,7 +893,7 @@ int main(int argc, char *argv[])
                         if (App::sim_state->getEnum<SimState>() == SimState::EDITOR_MODE)
                         {
                             App::GetGameContext()->UpdateSkyInputEvents(dt);
-                            App::GetSimTerrain()->GetTerrainEditor()->UpdateInputEvents(dt);
+                            App::GetGameContext()->GetTerrain()->GetTerrainEditor()->UpdateInputEvents(dt);
                         }
                         else
                         {

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -19,6 +19,7 @@
     along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "Actor.h"
 #include "Application.h"
 #include "AppContext.h"
 #include "CacheSystem.h"
@@ -342,6 +343,7 @@ int main(int argc, char *argv[])
                     }
 #endif // USE_SOCKETW
                     App::app_state->setVal((int)AppState::SHUTDOWN);
+                    App::GetScriptEngine()->setEventsEnabled(false); // Hack to enable fast shutdown without cleanup.
                     break;
 
                 case MSG_APP_SCREENSHOT_REQUESTED:
@@ -500,7 +502,7 @@ int main(int argc, char *argv[])
                 // -- Gameplay events --
 
                 case MSG_SIM_PAUSE_REQUESTED:
-                    for (Actor* actor: App::GetGameContext()->GetActorManager()->GetActors())
+                    for (ActorPtr& actor: App::GetGameContext()->GetActorManager()->GetActors())
                     {
                         actor->muteAllSounds();
                     }
@@ -508,7 +510,7 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_SIM_UNPAUSE_REQUESTED:
-                    for (Actor* actor: App::GetGameContext()->GetActorManager()->GetActors())
+                    for (ActorPtr& actor: App::GetGameContext()->GetActorManager()->GetActors())
                     {
                         actor->unmuteAllSounds();
                     }
@@ -655,18 +657,26 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_SIM_DELETE_ACTOR_REQUESTED:
+                {
+                    ActorPtr* actor_ptr = static_cast<ActorPtr*>(m.payload);
                     if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
                     {
-                        App::GetGameContext()->DeleteActor((Actor*)m.payload);
+                        App::GetGameContext()->DeleteActor(*actor_ptr);
                     }
+                    delete actor_ptr;
                     break;
+                }
 
                 case MSG_SIM_SEAT_PLAYER_REQUESTED:
+                {
+                    ActorPtr* actor_ptr = static_cast<ActorPtr*>(m.payload);
                     if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
                     {
-                        App::GetGameContext()->ChangePlayerActor((Actor*)m.payload);
+                        App::GetGameContext()->ChangePlayerActor(*actor_ptr);
                     }
+                    delete actor_ptr;
                     break;
+                }
 
                 case MSG_SIM_TELEPORT_PLAYER_REQUESTED:
                     if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
@@ -678,10 +688,12 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_SIM_HIDE_NET_ACTOR_REQUESTED:
-                    if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED &&
-                        ((Actor*)m.payload)->ar_state == ActorState::NETWORKED_OK)
+                {
+                    ActorPtr* actor_ptr = static_cast<ActorPtr*>(m.payload);
+                    if ((App::mp_state->getEnum<MpState>() == MpState::CONNECTED) &&
+                        ((*actor_ptr)->ar_state == ActorState::NETWORKED_OK))
                     {
-                        Actor* actor = (Actor*)m.payload;
+                        ActorPtr actor = *actor_ptr;
                         actor->ar_state = ActorState::NETWORKED_HIDDEN; // Stop net. updates
                         App::GetGfxScene()->RemoveGfxActor(actor->GetGfxActor()); // Remove visuals (also stops updating SimBuffer)
                         actor->GetGfxActor()->GetSimDataBuffer().simbuf_actor_state = ActorState::NETWORKED_HIDDEN; // Hack - manually propagate the new state to SimBuffer so Character can reflect it.
@@ -691,13 +703,17 @@ int main(int argc, char *argv[])
                         actor->setLightsOff(); // Turn all lights off
                         actor->setSmokeEnabled(false);
                     }
+                    delete actor_ptr;
                     break;
+                }
 
                 case MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED:
+                {
+                    ActorPtr* actor_ptr = static_cast<ActorPtr*>(m.payload);
                     if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED &&
-                        ((Actor*)m.payload)->ar_state == ActorState::NETWORKED_HIDDEN)
+                        ((*actor_ptr)->ar_state == ActorState::NETWORKED_HIDDEN))
                     {
-                        Actor* actor = (Actor*)m.payload;
+                        ActorPtr actor = *actor_ptr;
                         actor->ar_state = ActorState::NETWORKED_OK; // Resume net. updates
                         App::GetGfxScene()->RegisterGfxActor(actor->GetGfxActor()); // Restore visuals (also resumes updating SimBuffer)
                         actor->GetGfxActor()->SetAllMeshesVisible(true);
@@ -705,7 +721,9 @@ int main(int argc, char *argv[])
                         actor->unmuteAllSounds(); // Unmute sounds
                         actor->setSmokeEnabled(true);
                     }
+                    delete actor_ptr;
                     break;
+                }
 
                 // -- GUI events ---
 
@@ -785,11 +803,11 @@ int main(int argc, char *argv[])
                         // To reload the bundle, it's resource group must be destroyed and re-created. All actors using it must be deleted.
                         CacheEntry* entry = reinterpret_cast<CacheEntry*>(m.payload);
                         bool all_clear = true;
-                        for (Actor* actor: App::GetGameContext()->GetActorManager()->GetActors())
+                        for (ActorPtr& actor: App::GetGameContext()->GetActorManager()->GetActors())
                         {
                             if (actor->GetGfxActor()->GetResourceGroup() == entry->resource_group)
                             {
-                                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, actor));
+                                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                                 all_clear = false;
                             }
                         }
@@ -933,7 +951,7 @@ int main(int argc, char *argv[])
             if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
             {
                 App::GetGuiManager()->DrawSimulationGui(dt);
-                for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+                for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
                 {
                     actor->GetGfxActor()->UpdateDebugView();
                 }

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -581,7 +581,7 @@ int main(int argc, char *argv[])
                         App::GetGameContext()->GetTerrain()->GetTerrainEditor()->WriteOutputFile();
                     }
                     App::GetGameContext()->SaveScene("autosave.sav");
-                    App::GetGameContext()->ChangePlayerActor(nullptr);
+                    App::GetGameContext()->ChangePlayerActor(ActorPtr());
                     App::GetGameContext()->GetActorManager()->CleanUpSimulation();
                     App::GetGameContext()->GetCharacterFactory()->DeleteAllCharacters();
                     App::GetGameContext()->GetSceneMouse().DiscardVisuals();

--- a/source/main/network/OutGauge.cpp
+++ b/source/main/network/OutGauge.cpp
@@ -100,7 +100,7 @@ void OutGauge::Connect()
 #endif // _WIN32
 }
 
-bool OutGauge::Update(float dt, Actor* truck)
+bool OutGauge::Update(float dt, ActorPtr truck)
 {
 #if defined(_WIN32) && defined(USE_SOCKETW)
     if (!working)

--- a/source/main/network/OutGauge.h
+++ b/source/main/network/OutGauge.h
@@ -49,7 +49,7 @@ public:
     OutGauge(void);
 
     void Connect();
-    bool Update(float dt, Actor* truck);
+    bool Update(float dt, ActorPtr truck);
     void Close();
 
 private:

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -130,8 +130,7 @@ void Actor::dispose()
         delete m_replay_handler;
     m_replay_handler = nullptr;
 
-    if (ar_vehicle_ai)
-        delete ar_vehicle_ai;
+    // The object will be deleted by RefCountingObjectPtr
     ar_vehicle_ai = nullptr;
 
     // remove all scene nodes

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2,7 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
-    Copyright 2013-2020 Petr Ohlidal
+    Copyright 2013-2022 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -79,11 +79,20 @@ static const Ogre::Vector3 BOUNDING_BOX_PADDING(0.05f, 0.05f, 0.05f);
 
 Actor::~Actor()
 {
-    TRIGGER_EVENT(SE_GENERIC_DELETED_TRUCK, ar_instance_id);
+    if (ar_state != ActorState::DISPOSED)
+    {
+        this->dispose();
+    }
+}
 
-    // TODO: IMPROVE below: delete/destroy prop entities, etc
+void Actor::dispose()
+{
+    TRIGGER_EVENT(SE_GENERIC_DELETED_TRUCK, ar_instance_id);
+    ar_state = ActorState::DISPOSED;
 
     this->DisjoinInterActorBeams();
+    ar_hooks.clear();
+    ar_ties.clear();
 
     // delete all classes we might have constructed
     if (ar_dashboard != nullptr)
@@ -115,7 +124,7 @@ Actor::~Actor()
 
     if (m_fusealge_airfoil)
         delete m_fusealge_airfoil;
-    m_fusealge_airfoil = 0;
+    m_fusealge_airfoil = nullptr;
 
     if (m_replay_handler)
         delete m_replay_handler;
@@ -123,9 +132,8 @@ Actor::~Actor()
 
     if (ar_vehicle_ai)
         delete ar_vehicle_ai;
-    ar_vehicle_ai = 0;
+    ar_vehicle_ai = nullptr;
 
-    // TODO: Make sure we catch everything here
     // remove all scene nodes
     if (m_deletion_scene_nodes.size() > 0)
     {
@@ -247,6 +255,7 @@ Actor::~Actor()
     {
         delete (*it);
     }
+    m_railgroups.clear();
 
     if (m_intra_point_col_detector)
     {
@@ -268,26 +277,37 @@ Actor::~Actor()
         if (m_axle_diffs[i] != nullptr)
             delete m_axle_diffs[i];
     }
+    m_num_axle_diffs = 0;
 
     for (int i = 0; i < m_num_wheel_diffs; ++i)
     {
         if (m_wheel_diffs[i] != nullptr)
             delete m_wheel_diffs[i];
     }
+    m_num_wheel_diffs = 0;
 
-    delete ar_nodes;
-    delete ar_beams;
-    delete ar_shocks;
-    delete ar_rotators;
-    delete ar_wings;
+    delete[] ar_nodes;
+    ar_num_nodes = 0;
+    m_wheel_node_count = 0;
+    delete[] ar_beams;
+    ar_num_beams = 0;
+    delete[] ar_shocks;
+    ar_num_shocks = 0;
+    delete[] ar_rotators;
+    ar_num_rotators = 0;
+    delete[] ar_wings;
+    ar_num_wings = 0;
 }
 
 // This method scales actors. Stresses should *NOT* be scaled, they describe
 // the material type and they do not depend on length or scale.
 void Actor::scaleTruck(float value)
 {
+    if (ar_state == ActorState::DISPOSED)
+        return;
     if (value < 0)
         return;
+
     ar_scale *= value;
     // scale beams
     for (int i = 0; i < ar_num_beams; i++)
@@ -323,6 +343,9 @@ void Actor::scaleTruck(float value)
 
 float Actor::getRotation()
 {
+    if (ar_state == ActorState::DISPOSED)
+        return 0.f;
+
     Vector3 dir = getDirection();
 
     return atan2(dir.dotProduct(Vector3::UNIT_X), dir.dotProduct(-Vector3::UNIT_Z));
@@ -400,7 +423,8 @@ void Actor::pushNetwork(char* data, int size)
             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING, text.ToCStr());
 
             // Remove self
-            App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)this));
+            ActorPtr self = App::GetGameContext()->GetActorManager()->GetActorById(ar_instance_id); // Get shared pointer to ourselves so references are added correctly.
+            App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(self))));
 
             m_net_initialized = true;
         }
@@ -738,12 +762,15 @@ void Actor::RecalculateNodeMasses(Real total)
 
 float Actor::getTotalMass(bool withLocked)
 {
+    if (ar_state == ActorState::DISPOSED)
+        return 0.f;
+
     if (!withLocked)
         return m_total_mass; // already computed in RecalculateNodeMasses
 
     float mass = m_total_mass;
 
-    for (auto actor : m_linked_actors)
+    for (ActorPtr actor : m_linked_actors)
     {
         mass += actor->m_total_mass;
     }
@@ -756,10 +783,10 @@ void Actor::DetermineLinkedActors() //TODO: Refactor this - logic iterating over
     m_linked_actors.clear();
 
     bool found = true;
-    std::map<Actor*, bool> lookup_table;
-    std::pair<std::map<Actor*, bool>::iterator, bool> ret;
+    std::map<ActorPtr, bool> lookup_table;
+    std::pair<std::map<ActorPtr, bool>::iterator, bool> ret;
 
-    lookup_table.insert(std::pair<Actor*, bool>(this, false));
+    lookup_table.insert(std::pair<ActorPtr, bool>(this, false));
     
     auto inter_actor_links = App::GetGameContext()->GetActorManager()->inter_actor_links; // TODO: Shouldn't this have been a reference?? Also, ugly, see the TODO note above ~ only_a_ptr, 01/2018
 
@@ -767,18 +794,18 @@ void Actor::DetermineLinkedActors() //TODO: Refactor this - logic iterating over
     {
         found = false;
 
-        for (std::map<Actor*, bool>::iterator it_beam = lookup_table.begin(); it_beam != lookup_table.end(); ++it_beam)
+        for (std::map<ActorPtr, bool>::iterator it_beam = lookup_table.begin(); it_beam != lookup_table.end(); ++it_beam)
         {
             if (!it_beam->second)
             {
-                auto actor = it_beam->first;
+                ActorPtr actor = it_beam->first;
                 for (auto it = inter_actor_links.begin(); it != inter_actor_links.end(); it++)
                 {
                     auto actor_pair = it->second;
                     if (actor == actor_pair.first || actor == actor_pair.second)
                     {
                         auto other_actor = (actor != actor_pair.first) ? actor_pair.first : actor_pair.second;
-                        ret = lookup_table.insert(std::pair<Actor*, bool>(other_actor, false));
+                        ret = lookup_table.insert(std::pair<ActorPtr, bool>(other_actor, false));
                         if (ret.second)
                         {
                             m_linked_actors.push_back(other_actor);
@@ -816,7 +843,7 @@ void Actor::calcNodeConnectivityGraph()
     }
 }
 
-bool Actor::Intersects(Actor* actor, Vector3 offset)
+bool Actor::Intersects(ActorPtr actor, Vector3 offset)
 {
     Vector3 bb_min = ar_bounding_box.getMinimum() + offset;
     Vector3 bb_max = ar_bounding_box.getMaximum() + offset;
@@ -900,7 +927,7 @@ Vector3 Actor::calculateCollisionOffset(Vector3 direction)
 
         bool collision = false;
 
-        for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             if (actor == this)
                 continue;
@@ -980,7 +1007,7 @@ Vector3 Actor::calculateCollisionOffset(Vector3 direction)
         // Test beams (between contactable nodes) against cabs
         if (!collision)
         {
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor == this)
                     continue;
@@ -1480,6 +1507,9 @@ float Actor::getHeightAboveGroundBelow(float height, bool skip_virtual_nodes)
 
 void Actor::reset(bool keep_position)
 {
+    if (ar_state == ActorState::DISPOSED)
+        return;
+
     ActorModifyRequest* rq = new ActorModifyRequest;
     rq->amr_actor = this;
     rq->amr_type  = (keep_position) ? ActorModifyRequest::Type::RESET_ON_SPOT : ActorModifyRequest::Type::RESET_ON_INIT_POS;
@@ -1501,7 +1531,7 @@ void Actor::SoftReset()
     {
         Vector3 translation = -agl * Vector3::UNIT_Y;
         this->resetPosition(ar_nodes[0].AbsPosition + translation, false);
-        for (auto actor : m_linked_actors)
+        for (ActorPtr actor : m_linked_actors)
         {
             actor->resetPosition(actor->ar_nodes[0].AbsPosition + translation, false);
         }
@@ -2931,12 +2961,12 @@ void Actor::prepareInside(bool inside)
 void Actor::lightsToggle()
 {
     // export light command
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
-    if (ar_state == ActorState::LOCAL_SIMULATED && this == player_actor && ar_forward_commands)
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
+    if (ar_state == ActorState::LOCAL_SIMULATED && this == player_actor.GetRef() && ar_forward_commands)
     {
-        for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
-            if (actor->ar_state == ActorState::LOCAL_SIMULATED && this != actor && actor->ar_import_commands)
+            if (actor->ar_state == ActorState::LOCAL_SIMULATED && this != actor.GetRef() && actor->ar_import_commands)
                 actor->lightsToggle();
         }
     }
@@ -3078,6 +3108,9 @@ void Actor::toggleBlinkType(BlinkType blink)
 
 void Actor::setBlinkType(BlinkType blink)
 {
+    if (ar_state == ActorState::DISPOSED)
+        return;
+
     m_blink_type = blink;
 
     ar_dashboard->setBool(DD_SIGNAL_WARNING, false);
@@ -3125,6 +3158,9 @@ void Actor::autoBlinkReset()
 
 void Actor::toggleCustomParticles()
 {
+    if (ar_state == ActorState::DISPOSED)
+        return;
+
     m_custom_particles_enabled = !m_custom_particles_enabled;
     for (int i = 0; i < ar_num_custom_particles; i++)
     {
@@ -3262,7 +3298,7 @@ void Actor::updateVisual(float dt)
     ar_hydro_elevator_command = autoelevator;
 }
 
-void Actor::AddInterActorBeam(beam_t* beam, Actor* a, Actor* b)
+void Actor::AddInterActorBeam(beam_t* beam, ActorPtr a, ActorPtr b)
 {
     beam->bm_locked_actor = b;
 
@@ -3272,15 +3308,15 @@ void Actor::AddInterActorBeam(beam_t* beam, Actor* a, Actor* b)
         ar_inter_beams.push_back(beam);
     }
 
-    std::pair<Actor*, Actor*> actor_pair(a, b);
+    std::pair<ActorPtr, ActorPtr> actor_pair(a, b);
     App::GetGameContext()->GetActorManager()->inter_actor_links[beam] = actor_pair;
 
     a->DetermineLinkedActors();
-    for (auto actor : a->m_linked_actors)
+    for (ActorPtr actor : a->m_linked_actors)
         actor->DetermineLinkedActors();
 
     b->DetermineLinkedActors();
-    for (auto actor : b->m_linked_actors)
+    for (ActorPtr actor : b->m_linked_actors)
         actor->DetermineLinkedActors();
 }
 
@@ -3299,11 +3335,11 @@ void Actor::RemoveInterActorBeam(beam_t* beam)
         App::GetGameContext()->GetActorManager()->inter_actor_links.erase(it);
 
         actor_pair.first->DetermineLinkedActors();
-        for (auto actor : actor_pair.first->m_linked_actors)
+        for (ActorPtr actor : actor_pair.first->m_linked_actors)
             actor->DetermineLinkedActors();
 
         actor_pair.second->DetermineLinkedActors();
-        for (auto actor : actor_pair.second->m_linked_actors)
+        for (ActorPtr actor : actor_pair.second->m_linked_actors)
             actor->DetermineLinkedActors();
     }
 }
@@ -3315,7 +3351,7 @@ void Actor::DisjoinInterActorBeams()
     for (auto it = inter_actor_links->begin(); it != inter_actor_links->end();)
     {
         auto actor_pair = it->second;
-        if (this == actor_pair.first || this == actor_pair.second)
+        if (this == actor_pair.first.GetRef() || this == actor_pair.second.GetRef())
         {
             it->first->bm_locked_actor = nullptr;
             it->first->bm_inter_actor = false;
@@ -3323,11 +3359,11 @@ void Actor::DisjoinInterActorBeams()
             inter_actor_links->erase(it++);
 
             actor_pair.first->DetermineLinkedActors();
-            for (auto actor : actor_pair.first->m_linked_actors)
+            for (ActorPtr actor : actor_pair.first->m_linked_actors)
                 actor->DetermineLinkedActors();
 
             actor_pair.second->DetermineLinkedActors();
-            for (auto actor : actor_pair.second->m_linked_actors)
+            for (ActorPtr actor : actor_pair.second->m_linked_actors)
                 actor->DetermineLinkedActors();
         }
         else
@@ -3339,7 +3375,7 @@ void Actor::DisjoinInterActorBeams()
 
 void Actor::tieToggle(int group)
 {
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
     // untie all ties if one is tied
     bool istied = false;
@@ -3371,10 +3407,10 @@ void Actor::tieToggle(int group)
                 auto linked_actors = it->ti_locked_actor->getAllLinkedActors();
                 if (!(std::find(linked_actors.begin(), linked_actors.end(), this) != linked_actors.end()))
                 {
-                    if (this == player_actor)
+                    if (this == player_actor.GetRef())
                     {
                         it->ti_locked_actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
-                        for (auto actor : it->ti_locked_actor->getAllLinkedActors())
+                        for (ActorPtr actor : it->ti_locked_actor->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
                         }
@@ -3382,7 +3418,7 @@ void Actor::tieToggle(int group)
                     else if (it->ti_locked_actor == player_actor)
                     {
                         m_gfx_actor->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
-                        for (auto actor : this->getAllLinkedActors())
+                        for (ActorPtr actor : this->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
                         }
@@ -3407,10 +3443,10 @@ void Actor::tieToggle(int group)
                 // tie is unlocked and should get locked, search new remote ropable to lock to
                 float mindist = it->ti_beam->refL;
                 node_t* nearest_node = 0;
-                Actor* nearest_actor = 0;
+                ActorPtr nearest_actor = 0;
                 ropable_t* locktedto = 0;
                 // iterate over all actors
-                for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+                for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
                 {
                     if (actor->ar_state == ActorState::LOCAL_SLEEPING ||
                         (actor == this && it->ti_no_self_lock))
@@ -3426,7 +3462,7 @@ void Actor::tieToggle(int group)
                             continue;
 
                         // skip if tienode is ropable too (no selflock)
-                        if (this == actor && itr->node->pos == it->ti_beam->p1->pos)
+                        if (this == actor.GetRef() && itr->node->pos == it->ti_beam->p1->pos)
                             continue;
 
                         // calculate the distance and record the nearest ropable
@@ -3459,10 +3495,10 @@ void Actor::tieToggle(int group)
                     {
                         AddInterActorBeam(it->ti_beam, this, nearest_actor);
                         // update skeletonview on the tied actors
-                        if (this == player_actor)
+                        if (this == player_actor.GetRef())
                         {
                             nearest_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
-                            for (auto actor : nearest_actor->getAllLinkedActors())
+                            for (ActorPtr actor : nearest_actor->getAllLinkedActors())
                             {
                                 actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
                             }
@@ -3470,7 +3506,7 @@ void Actor::tieToggle(int group)
                         else if (nearest_actor == player_actor)
                         {
                             m_gfx_actor->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
-                            for (auto actor : this->getAllLinkedActors())
+                            for (ActorPtr actor : this->getAllLinkedActors())
                             {
                                 actor->GetGfxActor()->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
                             }
@@ -3487,7 +3523,7 @@ void Actor::tieToggle(int group)
 
 void Actor::ropeToggle(int group)
 {
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
     // iterate over all ropes
     for (std::vector<rope_t>::iterator it = ar_ropes.begin(); it != ar_ropes.end(); it++)
@@ -3510,10 +3546,10 @@ void Actor::ropeToggle(int group)
                 auto linked_actors = it->rp_locked_actor->getAllLinkedActors();
                 if (!(std::find(linked_actors.begin(), linked_actors.end(), this) != linked_actors.end()))
                 {
-                    if (this == player_actor)
+                    if (this == player_actor.GetRef())
                     {
                         it->rp_locked_actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
-                        for (auto actor : it->rp_locked_actor->getAllLinkedActors())
+                        for (ActorPtr actor : it->rp_locked_actor->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
                         }
@@ -3521,7 +3557,7 @@ void Actor::ropeToggle(int group)
                     else if (it->rp_locked_actor == player_actor)
                     {
                         m_gfx_actor->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
-                        for (auto actor : this->getAllLinkedActors())
+                        for (ActorPtr actor : this->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
                         }
@@ -3536,10 +3572,10 @@ void Actor::ropeToggle(int group)
             //we lock ropes
             // search new remote ropable to lock to
             float mindist = it->rp_beam->L;
-            Actor* nearest_actor = nullptr;
+            ActorPtr nearest_actor = nullptr;
             ropable_t* rop = 0;
             // iterate over all actor_slots
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor->ar_state == ActorState::LOCAL_SLEEPING)
                     continue;
@@ -3572,10 +3608,10 @@ void Actor::ropeToggle(int group)
                 {
                     AddInterActorBeam(it->rp_beam, this, nearest_actor);
                     // update skeletonview on the roped up actors
-                    if (this == player_actor)
+                    if (this == player_actor.GetRef())
                     {
                         nearest_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
-                        for (auto actor : nearest_actor->getAllLinkedActors())
+                        for (ActorPtr actor : nearest_actor->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
                         }
@@ -3583,7 +3619,7 @@ void Actor::ropeToggle(int group)
                     else if (nearest_actor == player_actor)
                     {
                         m_gfx_actor->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
-                        for (auto actor : this->getAllLinkedActors())
+                        for (ActorPtr actor : this->getAllLinkedActors())
                         {
                             actor->GetGfxActor()->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
                         }
@@ -3638,7 +3674,7 @@ void Actor::hookToggle(int group, HookAction mode, NodeNum_t node_number /*=NODE
             continue;
         }
 
-        Actor* prev_locked_actor = it->hk_locked_actor; // memorize current value
+        ActorPtr prev_locked_actor = it->hk_locked_actor; // memorize current value
 
         // do this only for toggle or lock attempts, skip prelocked or locked nodes for performance
         if (mode != HOOK_UNLOCK && it->hk_locked == UNLOCKED)
@@ -3648,11 +3684,11 @@ void Actor::hookToggle(int group, HookAction mode, NodeNum_t node_number /*=NODE
             float mindist = it->hk_lockrange;
             float distance = 100000000.0f;
             // iterate over all actor_slots
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor->ar_state == ActorState::LOCAL_SLEEPING)
                     continue;
-                if (this == actor && !it->hk_selflock)
+                if (this == actor.GetRef() && !it->hk_selflock)
                     continue; // don't lock to self
 
                 node_t* nearest_node = nullptr;
@@ -3663,7 +3699,7 @@ void Actor::hookToggle(int group, HookAction mode, NodeNum_t node_number /*=NODE
                         continue;
 
                     // exclude this truck and its current hooknode from the locking search
-                    if (this == actor && i == it->hk_hook_node->pos)
+                    if (this == actor.GetRef() && i == it->hk_hook_node->pos)
                         continue;
 
                     // a lockgroup for this hooknode is set -> skip all nodes that do not have the same lockgroup (-1 = default(all nodes))
@@ -3715,7 +3751,7 @@ void Actor::hookToggle(int group, HookAction mode, NodeNum_t node_number /*=NODE
             if (it->hk_locked_actor)
             {
                 it->hk_locked_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
-                for (auto actor : it->hk_locked_actor->getAllLinkedActors())
+                for (ActorPtr actor : it->hk_locked_actor->getAllLinkedActors())
                 {
                     actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
                 }
@@ -3723,7 +3759,7 @@ void Actor::hookToggle(int group, HookAction mode, NodeNum_t node_number /*=NODE
             else if (prev_locked_actor != this)
             {
                 prev_locked_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
-                for (auto actor : prev_locked_actor->getAllLinkedActors())
+                for (ActorPtr actor : prev_locked_actor->getAllLinkedActors())
                 {
                     actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
                 }
@@ -3734,6 +3770,9 @@ void Actor::hookToggle(int group, HookAction mode, NodeNum_t node_number /*=NODE
 
 void Actor::parkingbrakeToggle()
 {
+    if (ar_state == ActorState::DISPOSED)
+        return;
+
     ar_parking_brake = !ar_parking_brake;
 
     if (ar_parking_brake)
@@ -3747,18 +3786,27 @@ void Actor::parkingbrakeToggle()
 
 void Actor::antilockbrakeToggle()
 {
+    if (ar_state == ActorState::DISPOSED)
+        return;
+
     if (!alb_notoggle)
         alb_mode = !alb_mode;
 }
 
 void Actor::tractioncontrolToggle()
 {
+    if (ar_state == ActorState::DISPOSED)
+        return;
+
     if (!tc_notoggle)
         tc_mode = !tc_mode;
 }
 
 void Actor::beaconsToggle()
 {
+    if (ar_state == ActorState::DISPOSED)
+        return;
+
     if (m_flares_mode == GfxFlaresMode::NONE)
     {
         return;
@@ -3772,6 +3820,9 @@ void Actor::beaconsToggle()
 
 bool Actor::getReverseLightVisible()
 {
+    if (ar_state == ActorState::DISPOSED)
+        return false;
+
     if (ar_state == ActorState::NETWORKED_OK)
         return m_net_reverse_light_on;
 
@@ -4562,7 +4613,7 @@ Vector3 Actor::getNodePosition(int nodeNumber)
     }
     else
     {
-        return Ogre::Vector3();
+        return Ogre::Vector3::ZERO;
     }
 }
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1211,15 +1211,15 @@ void Actor::resetPosition(float px, float pz, bool setInitPosition, float miny)
 
     // vertical displacement
     float vertical_offset = miny - this->getMinHeight();
-    if (App::GetSimTerrain()->getWater())
+    if (App::GetGameContext()->GetTerrain()->getWater())
     {
-        vertical_offset += std::max(0.0f, App::GetSimTerrain()->getWater()->GetStaticWaterHeight() - miny);
+        vertical_offset += std::max(0.0f, App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight() - miny);
     }
     for (int i = 1; i < ar_num_nodes; i++)
     {
         if (ar_nodes[i].nd_no_ground_contact)
             continue;
-        float terrainHeight = App::GetSimTerrain()->GetHeightAt(ar_nodes[i].AbsPosition.x, ar_nodes[i].AbsPosition.z);
+        float terrainHeight = App::GetGameContext()->GetTerrain()->GetHeightAt(ar_nodes[i].AbsPosition.x, ar_nodes[i].AbsPosition.z);
         vertical_offset += std::max(0.0f, terrainHeight - (ar_nodes[i].AbsPosition.y + vertical_offset));
     }
     for (int i = 0; i < ar_num_nodes; i++)
@@ -1240,7 +1240,7 @@ void Actor::resetPosition(float px, float pz, bool setInitPosition, float miny)
         while (offset < 1.0f)
         {
             Vector3 query = ar_nodes[i].AbsPosition + Vector3(0.0f, offset, 0.0f);
-            if (!App::GetSimTerrain()->GetCollisions()->collisionCorrect(&query, false))
+            if (!App::GetGameContext()->GetTerrain()->GetCollisions()->collisionCorrect(&query, false))
             {
                 mesh_offset = offset;
                 break;
@@ -1484,7 +1484,7 @@ float Actor::getHeightAboveGround(bool skip_virtual_nodes)
         if (!skip_virtual_nodes || !ar_nodes[i].nd_no_ground_contact)
         {
             Vector3 pos = ar_nodes[i].AbsPosition;
-            agl = std::min(pos.y - App::GetSimTerrain()->GetCollisions()->getSurfaceHeight(pos.x, pos.z), agl);
+            agl = std::min(pos.y - App::GetGameContext()->GetTerrain()->GetCollisions()->getSurfaceHeight(pos.x, pos.z), agl);
         }
     }
     return (!skip_virtual_nodes || agl < std::numeric_limits<float>::max()) ? agl : getHeightAboveGround(false);
@@ -1498,7 +1498,7 @@ float Actor::getHeightAboveGroundBelow(float height, bool skip_virtual_nodes)
         if (!skip_virtual_nodes || !ar_nodes[i].nd_no_ground_contact)
         {
             Vector3 pos = ar_nodes[i].AbsPosition;
-            agl = std::min(pos.y - App::GetSimTerrain()->GetCollisions()->getSurfaceHeightBelow(pos.x, pos.z, height), agl);
+            agl = std::min(pos.y - App::GetGameContext()->GetTerrain()->GetCollisions()->getSurfaceHeightBelow(pos.x, pos.z, height), agl);
         }
     }
     return (!skip_virtual_nodes || agl < std::numeric_limits<float>::max()) ? agl : getHeightAboveGroundBelow(height, false);
@@ -1521,9 +1521,9 @@ void Actor::SoftReset()
 
     float agl = this->getHeightAboveGroundBelow(this->getMaxHeight(true), true);
 
-    if (App::GetSimTerrain()->getWater())
+    if (App::GetGameContext()->GetTerrain()->getWater())
     {
-        agl = std::min(this->getMinHeight(true) - App::GetSimTerrain()->getWater()->GetStaticWaterHeight(), agl);
+        agl = std::min(this->getMinHeight(true) - App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight(), agl);
     }
 
     if (agl < 0.0f)
@@ -1677,9 +1677,9 @@ void Actor::SyncReset(bool reset_position)
         this->ResetAngle(cur_rot);
         this->resetPosition(cur_position, false);
         float agl = this->getHeightAboveGroundBelow(this->getMaxHeight(true), true);
-        if (App::GetSimTerrain()->getWater())
+        if (App::GetGameContext()->GetTerrain()->getWater())
         {
-            agl = std::min(this->getMinHeight(true) - App::GetSimTerrain()->getWater()->GetStaticWaterHeight(), agl);
+            agl = std::min(this->getMinHeight(true) - App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight(), agl);
         }
         if (agl < 0.0f)
         {
@@ -3244,7 +3244,7 @@ void Actor::updateVisual(float dt)
     float autoelevator = 0;
     if (ar_autopilot)
     {
-        ar_autopilot->UpdateIls(App::GetSimTerrain()->getObjectManager()->GetLocalizers());
+        ar_autopilot->UpdateIls(App::GetGameContext()->GetTerrain()->getObjectManager()->GetLocalizers());
         autoaileron = ar_autopilot->getAilerons();
         autorudder = ar_autopilot->getRudder();
         autoelevator = ar_autopilot->getElevator();
@@ -4327,7 +4327,7 @@ void Actor::calculateLocalGForces()
     Vector3 cam_roll = this->GetCameraRoll();
     Vector3 cam_up   = cam_dir.crossProduct(cam_roll);
 
-    float gravity = App::GetSimTerrain()->getGravity();
+    float gravity = App::GetGameContext()->GetTerrain()->getGravity();
 
     float vertacc = m_camera_gforces.dotProduct(cam_up) + gravity;
     float longacc = m_camera_gforces.dotProduct(cam_dir);

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -31,6 +31,7 @@
 #include "RefCountingObjectPtr.h"
 #include "SimData.h"
 #include "TyrePressure.h"
+#include "VehicleAI.h"
 
 #include <Ogre.h>
 
@@ -177,7 +178,7 @@ public:
     /// @{
     Replay*           getReplay();
     TyrePressure&     getTyrePressure() { return m_tyre_pressure; }
-    VehicleAI*        getVehicleAI() { return ar_vehicle_ai; }
+    VehicleAIPtr&     getVehicleAI() { return ar_vehicle_ai; }
     //! @}
 
     /// @name Organizational things
@@ -343,7 +344,7 @@ public:
     NodeNum_t         ar_camera_node_roll[MAX_CAMERAS]   = {NODENUM_INVALID};  //!< Physics attr; 'camera' = frame of reference; left node
     bool              ar_camera_node_roll_inv[MAX_CAMERAS] = {false};              //!< Physics attr; 'camera' = frame of reference; indicates roll node is right instead of left
     float             ar_posnode_spawn_height;
-    VehicleAI*        ar_vehicle_ai;
+    VehicleAIPtr      ar_vehicle_ai;
     float             ar_scale;               //!< Physics state; scale of the actor (nominal = 1.0)
     Ogre::Real        ar_brake;               //!< Physics state; braking intensity
     float             ar_wheel_speed;         //!< Physics state; wheel speed in m/s

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -2,7 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
-    Copyright 2016-2020 Petr Ohlidal
+    Copyright 2016-2022 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -27,6 +27,8 @@
 #include "GfxActor.h"
 #include "PerVehicleCameraContext.h"
 #include "RigDef_Prerequisites.h"
+#include "RefCountingObject.h"
+#include "RefCountingObjectPtr.h"
 #include "SimData.h"
 #include "TyrePressure.h"
 
@@ -37,9 +39,11 @@ namespace RoR {
 /// @addtogroup Physics
 /// @{
 
+typedef std::vector<ActorPtr> ActorPtrVec;
+
 /// Softbody object; can be anything from soda can to a space shuttle
 /// Former name: `Beam` (that's why scripting uses `BeamClass`)
-class Actor : public ZeroedMemoryAllocator
+class Actor : public ZeroedMemoryAllocator, public RefCountingObject<Actor>
 {
     friend class ActorSpawner;
     friend class ActorManager;
@@ -55,6 +59,8 @@ public:
         );
 
     ~Actor();
+
+    void              dispose(); //!< Effectively destroys the object but keeps it in memory to satisfy shared pointers.
 
     /// @name Networking
     /// @{
@@ -148,7 +154,7 @@ public:
     void              toggleBlinkType(BlinkType blink);
     BlinkType         getBlinkType();
     void              setBlinkType(BlinkType blink);
-    std::vector<Actor*>& getAllLinkedActors() { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
+    std::vector<ActorPtr>& getAllLinkedActors() { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
     //! @}
 
     /// @name Visual state updates
@@ -191,7 +197,7 @@ public:
     void              HandleInputEvents(float dt);
     void              HandleAngelScriptEvents(float dt);
     void              UpdateCruiseControl(float dt);       //!< Defined in 'gameplay/CruiseControl.cpp'
-    bool              Intersects(Actor* actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test
+    bool              Intersects(ActorPtr actor, Ogre::Vector3 offset = Ogre::Vector3::ZERO);  //!< Slow intersection test
     /// Moves the actor at most 'direction.length()' meters towards 'direction' to resolve any collisions
     void              resolveCollisions(Ogre::Vector3 direction);
     /// Auto detects an ideal collision avoidance direction (front, back, left, right, up)
@@ -219,11 +225,6 @@ public:
     float             GetFFbHydroForces() const         { return m_force_sensors.out_hydros_forces; }
     bool              isBeingReset() const              { return m_ongoing_reset; };
     void              UpdatePropAnimInputEvents();
-#ifdef USE_ANGELSCRIPT
-    // we have to add this to be able to use the class as reference inside scripts
-    void              addRef()                          {};
-    void              release()                         {};
-#endif
 
     // -------------------- Public data -------------------- //
 
@@ -449,7 +450,7 @@ private:
     void              DetermineLinkedActors();
     void              RecalculateNodeMasses(Ogre::Real total); //!< Previously 'calc_masses2()'
     void              calcNodeConnectivityGraph();
-    void              AddInterActorBeam(beam_t* beam, Actor* a, Actor* b);
+    void              AddInterActorBeam(beam_t* beam, ActorPtr a, ActorPtr b);
     void              RemoveInterActorBeam(beam_t* beam);
     void              DisjoinInterActorBeams();            //!< Destroys all inter-actor beams which are connected with this actor
     void              autoBlinkReset();                    //!< Resets the turn signal when the steering wheel is turned back.
@@ -462,7 +463,7 @@ private:
     /// @param actor which actor to retrieve the closest Rail from
     /// @param node which SlideNode is being checked against
     /// @return a pair containing the rail, and the distant to the SlideNode
-    std::pair<RailGroup*, Ogre::Real> GetClosestRailOnActor( Actor* actor, const SlideNode& node);
+    std::pair<RailGroup*, Ogre::Real> GetClosestRailOnActor( ActorPtr actor, const SlideNode& node);
 
     // -------------------- data -------------------- //
 
@@ -481,7 +482,7 @@ private:
     float             m_avionic_chatter_timer;      //!< Sound fx state
     PointColDetector* m_inter_point_col_detector;   //!< Physics
     PointColDetector* m_intra_point_col_detector;   //!< Physics
-    std::vector<Actor*>  m_linked_actors;           //!< Sim state; other actors linked using 'hooks'
+    ActorPtrVec       m_linked_actors;              //!< Sim state; other actors linked using 'hooks'
     Ogre::Vector3     m_avg_node_position;          //!< average node position
     Ogre::Real        m_min_camera_radius;
     Ogre::Vector3     m_avg_node_position_prev;

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -65,7 +65,7 @@ void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
 
 void Actor::CalcForceFeedback(bool doUpdate)
 {
-    if (this == App::GetGameContext()->GetPlayerActor())
+    if (this == App::GetGameContext()->GetPlayerActor().GetRef())
     {
         if (doUpdate)
         {
@@ -986,7 +986,7 @@ void Actor::CalcCommands(bool doUpdate)
             ar_engine->SetEnginePriming(requested);
         }
 
-        if (doUpdate && this == App::GetGameContext()->GetPlayerActor())
+        if (doUpdate && this == App::GetGameContext()->GetPlayerActor().GetRef())
         {
 #ifdef USE_OPENAL
             if (active > 0)
@@ -1634,7 +1634,7 @@ void Actor::CalcHooks()
             {
                 //enable beam if not enabled yet between those 2 nodes
                 it->hk_beam->p2 = it->hk_lock_node;
-                it->hk_beam->bm_inter_actor = it->hk_locked_actor != 0;
+                it->hk_beam->bm_inter_actor = (it->hk_locked_actor != nullptr);
                 it->hk_beam->L = (it->hk_hook_node->AbsPosition - it->hk_lock_node->AbsPosition).length();
                 it->hk_beam->bm_disabled = false;
                 AddInterActorBeam(it->hk_beam, this, it->hk_locked_actor);

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -147,7 +147,7 @@ void Actor::CalcFuseDrag()
 
 void Actor::CalcBuoyance(bool doUpdate)
 {
-    if (ar_num_buoycabs && App::GetSimTerrain()->getWater())
+    if (ar_num_buoycabs && App::GetGameContext()->GetTerrain()->getWater())
     {
         for (int i = 0; i < ar_num_buoycabs; i++)
         {
@@ -1521,8 +1521,8 @@ void Actor::CalcBeamsInterActor()
 
 void Actor::CalcNodes()
 {
-    const auto water = App::GetSimTerrain()->getWater();
-    const float gravity = App::GetSimTerrain()->getGravity();
+    const auto water = App::GetGameContext()->GetTerrain()->getWater();
+    const float gravity = App::GetGameContext()->GetTerrain()->getGravity();
     m_water_contact = false;
 
     for (NodeNum_t i = 0; i < ar_num_nodes; i++)
@@ -1531,8 +1531,8 @@ void Actor::CalcNodes()
         if (!ar_nodes[i].nd_no_ground_contact)
         {
             Vector3 oripos = ar_nodes[i].AbsPosition;
-            bool contacted = App::GetSimTerrain()->GetCollisions()->groundCollision(&ar_nodes[i], PHYSICS_DT);
-            contacted = contacted | App::GetSimTerrain()->GetCollisions()->nodeCollision(&ar_nodes[i], PHYSICS_DT, false);
+            bool contacted = App::GetGameContext()->GetTerrain()->GetCollisions()->groundCollision(&ar_nodes[i], PHYSICS_DT);
+            contacted = contacted | App::GetGameContext()->GetTerrain()->GetCollisions()->nodeCollision(&ar_nodes[i], PHYSICS_DT, false);
             ar_nodes[i].nd_has_ground_contact = contacted;
             if (ar_nodes[i].nd_has_ground_contact || ar_nodes[i].nd_has_mesh_contact)
             {
@@ -1549,7 +1549,7 @@ void Actor::CalcNodes()
             // record g forces on cameras
             m_camera_gforces_accu += ar_nodes[i].Forces / ar_nodes[i].mass;
             // trigger script callbacks
-            App::GetSimTerrain()->GetCollisions()->nodeCollision(&ar_nodes[i], PHYSICS_DT, true);
+            App::GetGameContext()->GetTerrain()->GetCollisions()->nodeCollision(&ar_nodes[i], PHYSICS_DT, true);
         }
 
         // integration

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -1572,7 +1572,8 @@ void Actor::CalcNodes()
         if (approx_speed > 6860 && !m_ongoing_reset)
         {
             ActorModifyRequest* rq = new ActorModifyRequest; // actor exploded, schedule reset
-            rq->amr_actor = this;
+            ActorPtr self = App::GetGameContext()->GetActorManager()->GetActorById(ar_instance_id); // Fetch a shared pointer to ourselves, so references are added correctly.
+            rq->amr_actor = self;
             rq->amr_type = ActorModifyRequest::Type::RESET_ON_SPOT;
             App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
             m_ongoing_reset = true;
@@ -1637,7 +1638,9 @@ void Actor::CalcHooks()
                 it->hk_beam->bm_inter_actor = (it->hk_locked_actor != nullptr);
                 it->hk_beam->L = (it->hk_hook_node->AbsPosition - it->hk_lock_node->AbsPosition).length();
                 it->hk_beam->bm_disabled = false;
-                AddInterActorBeam(it->hk_beam, this, it->hk_locked_actor);
+                
+                ActorPtr self = App::GetGameContext()->GetActorManager()->GetActorById(ar_instance_id); // Fetch a shared pointer to ourselves, so references are added correctly.
+                AddInterActorBeam(it->hk_beam, self, it->hk_locked_actor);
             }
             else
             {
@@ -1673,7 +1676,7 @@ void Actor::CalcHooks()
                                 //force exceeded reset the hook node
                                 it->hk_locked = UNLOCKED;
                                 it->hk_lock_node = 0;
-                                it->hk_locked_actor = 0;
+                                it->hk_locked_actor = ActorPtr();
                                 it->hk_beam->p2 = &ar_nodes[0];
                                 it->hk_beam->bm_inter_actor = false;
                                 it->hk_beam->L = (ar_nodes[0].AbsPosition - it->hk_hook_node->AbsPosition).length();

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -150,7 +150,7 @@ ActorPtr ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr 
             bool inside = true;
 
             for (int i = 0; i < actor->ar_num_nodes; i++)
-                inside = (inside && App::GetSimTerrain()->GetCollisions()->isInside(actor->ar_nodes[i].AbsPosition, rq.asr_spawnbox, 0.2f));
+                inside = (inside && App::GetGameContext()->GetTerrain()->GetCollisions()->isInside(actor->ar_nodes[i].AbsPosition, rq.asr_spawnbox, 0.2f));
 
             if (!inside)
             {
@@ -204,10 +204,10 @@ ActorPtr ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr 
     std::string subMeshGroundModelName = spawner.GetSubmeshGroundmodelName();
     if (!subMeshGroundModelName.empty())
     {
-        actor->ar_submesh_ground_model = App::GetSimTerrain()->GetCollisions()->getGroundModelByString(subMeshGroundModelName);
+        actor->ar_submesh_ground_model = App::GetGameContext()->GetTerrain()->GetCollisions()->getGroundModelByString(subMeshGroundModelName);
         if (!actor->ar_submesh_ground_model)
         {
-            actor->ar_submesh_ground_model = App::GetSimTerrain()->GetCollisions()->defaultgm;
+            actor->ar_submesh_ground_model = App::GetGameContext()->GetTerrain()->GetCollisions()->defaultgm;
         }
     }
 
@@ -1399,7 +1399,7 @@ void ActorManager::UpdateTruckFeatures(ActorPtr vehicle, float dt)
             {
                 // anti roll back in SimGearboxMode::AUTO (DRIVE, TWO, ONE) mode
                 // anti roll forth in SimGearboxMode::AUTO (REAR) mode
-                float g = std::abs(App::GetSimTerrain()->getGravity());
+                float g = std::abs(App::GetGameContext()->GetTerrain()->getGravity());
                 float downhill_force = std::abs(sin(pitchAngle.valueRadians()) * vehicle->getTotalMass()) * g;
                 float engine_force = std::abs(engine->GetTorque()) / vehicle->getAvgPropedWheelRadius();
                 float ratio = std::max(0.0f, 1.0f - (engine_force / downhill_force));

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -76,7 +76,7 @@ ActorManager::~ActorManager()
 
 ActorPtr ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr def)
 {
-    ActorPtr actor = new Actor(m_actor_counter++, static_cast<int>(m_actors.size()), def, rq);
+    ActorPtr actor = ActorPtr::Bind(new Actor(m_actor_counter++, static_cast<int>(m_actors.size()), def, rq));
 
     if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED && rq.asr_origin != ActorSpawnRequest::Origin::NETWORK)
     {
@@ -555,7 +555,7 @@ ActorPtr ActorManager::GetActorByNetworkLinks(int source_id, int stream_id)
         }
     }
 
-    return nullptr;
+    return ActorPtr();
 }
 
 bool ActorManager::CheckActorCollAabbIntersect(int a, int b)
@@ -775,7 +775,7 @@ void ActorManager::SendAllActorsSleeping()
 ActorPtr ActorManager::FindActorInsideBox(Collisions* collisions, const Ogre::String& inst, const Ogre::String& box)
 {
     // try to find the desired actor (the one in the box)
-    ActorPtr ret = nullptr;
+    ActorPtr ret;
     for (ActorPtr& actor: m_actors)
     {
         if (collisions->isInside(actor->ar_nodes[0].AbsPosition, inst, box))
@@ -785,7 +785,7 @@ ActorPtr ActorManager::FindActorInsideBox(Collisions* collisions, const Ogre::St
                 ret = actor;
             else
             // second actor found -> unclear which one was meant
-                return nullptr;
+                return ActorPtr();
         }
     }
     return ret;
@@ -823,7 +823,7 @@ void ActorManager::UnmuteAllActors()
 
 std::pair<ActorPtr, float> ActorManager::GetNearestActor(Vector3 position)
 {
-    ActorPtr nearest_actor = nullptr;
+    ActorPtr nearest_actor;
     float min_squared_distance = std::numeric_limits<float>::max();
     for (ActorPtr& actor : m_actors)
     {
@@ -878,7 +878,7 @@ void ActorManager::DeleteActorInternal(ActorPtr actor)
     auto actor_i = m_actors.begin();
     while (actor_i != m_actors.end())
     {
-        if (actor == actor_i->GetRef())
+        if (actor == *actor_i)
         {
             actor_i = m_actors.erase(actor_i);
         }
@@ -913,7 +913,7 @@ ActorPtr ActorManager::FetchNextVehicleOnList(ActorPtr player, ActorPtr prev_pla
     {
         if (m_actors[i]->ar_state != ActorState::NETWORKED_OK && !m_actors[i]->isPreloadedWithTerrain())
         {
-            return m_actors[i].GetRef();
+            return m_actors[i];
         }
     }
 
@@ -921,16 +921,16 @@ ActorPtr ActorManager::FetchNextVehicleOnList(ActorPtr player, ActorPtr prev_pla
     {
         if (m_actors[i]->ar_state != ActorState::NETWORKED_OK && !m_actors[i]->isPreloadedWithTerrain())
         {
-            return m_actors[i].GetRef();
+            return m_actors[i];
         }
     }
 
     if (pivot_index >= 0 && m_actors[pivot_index]->ar_state != ActorState::NETWORKED_OK && !m_actors[pivot_index]->isPreloadedWithTerrain())
     {
-        return m_actors[pivot_index].GetRef();
+        return m_actors[pivot_index];
     }
 
-    return nullptr;
+    return ActorPtr();
 }
 
 ActorPtr ActorManager::FetchPreviousVehicleOnList(ActorPtr player, ActorPtr prev_player)
@@ -941,7 +941,7 @@ ActorPtr ActorManager::FetchPreviousVehicleOnList(ActorPtr player, ActorPtr prev
     {
         if (m_actors[i]->ar_state != ActorState::NETWORKED_OK && !m_actors[i]->isPreloadedWithTerrain())
         {
-            return m_actors[i].GetRef();
+            return m_actors[i];
         }
     }
 
@@ -949,16 +949,16 @@ ActorPtr ActorManager::FetchPreviousVehicleOnList(ActorPtr player, ActorPtr prev
     {
         if (m_actors[i]->ar_state != ActorState::NETWORKED_OK && !m_actors[i]->isPreloadedWithTerrain())
         {
-            return m_actors[i].GetRef();
+            return m_actors[i];
         }
     }
 
     if (pivot_index >= 0 && m_actors[pivot_index]->ar_state != ActorState::NETWORKED_OK && !m_actors[pivot_index]->isPreloadedWithTerrain())
     {
-        return m_actors[pivot_index].GetRef();
+        return m_actors[pivot_index];
     }
 
-    return nullptr;
+    return ActorPtr();
 }
 
 ActorPtr ActorManager::FetchRescueVehicle()
@@ -970,7 +970,7 @@ ActorPtr ActorManager::FetchRescueVehicle()
             return actor;
         }
     }
-    return nullptr;
+    return ActorPtr();
 }
 
 void ActorManager::UpdateActors(ActorPtr player_actor)
@@ -1086,7 +1086,7 @@ ActorPtr ActorManager::GetActorById(int actor_id)
             return actor;
         }
     }
-    return 0;
+    return ActorPtr();
 }
 
 void ActorManager::UpdatePhysicsSimulation()

--- a/source/main/physics/ActorSlideNode.cpp
+++ b/source/main/physics/ActorSlideNode.cpp
@@ -53,10 +53,10 @@ void Actor::toggleSlideNodeLock()
         }
 
         // check all the slide rail on all the other trucks :(
-        for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             // make sure this truck is allowed
-            if ((this != actor && !itNode->sn_attach_foreign) || (this == actor && !itNode->sn_attach_self))
+            if ((this != actor.GetRef() && !itNode->sn_attach_foreign) || (this == actor.GetRef() && !itNode->sn_attach_self))
                 continue;
 
             current = GetClosestRailOnActor(actor, (*itNode));
@@ -70,7 +70,7 @@ void Actor::toggleSlideNodeLock()
     m_slidenodes_locked = !m_slidenodes_locked;
 } // is ugly....
 
-std::pair<RailGroup*, Ogre::Real> Actor::GetClosestRailOnActor(Actor* actor, const SlideNode& node)
+std::pair<RailGroup*, Ogre::Real> Actor::GetClosestRailOnActor(ActorPtr actor, const SlideNode& node)
 {
     std::pair<RailGroup*, Ogre::Real> closest((RailGroup*)NULL, std::numeric_limits<Ogre::Real>::infinity());
 

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -338,7 +338,7 @@ void ActorSpawner::InitializeRig()
         m_actor->m_intra_point_col_detector = new PointColDetector(m_actor);
     }
 
-    m_actor->ar_submesh_ground_model = App::GetSimTerrain()->GetCollisions()->defaultgm;
+    m_actor->ar_submesh_ground_model = App::GetGameContext()->GetTerrain()->GetCollisions()->defaultgm;
 
     // Lights mode
     m_actor->m_flares_mode = App::gfx_flares_mode->getEnum<GfxFlaresMode>();

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -287,7 +287,7 @@ void ActorSpawner::InitializeRig()
     }
 
 #ifdef USE_ANGELSCRIPT
-    m_actor->ar_vehicle_ai = new VehicleAI(m_actor);
+    m_actor->ar_vehicle_ai = VehicleAIPtr::Bind(new VehicleAI(m_actor));
 #endif // USE_ANGELSCRIPT
 
     m_actor->ar_airbrake_intensity = 0;
@@ -2677,7 +2677,6 @@ void ActorSpawner::ProcessTie(RigDef::Tie & def)
     tie.ti_tying = false;
     tie.ti_tied = false;
     tie.ti_beam = & beam;
-    tie.ti_locked_actor   = nullptr;
     tie.ti_locked_ropable = nullptr;
     tie.ti_contract_speed = def.auto_shorten_rate;
     tie.ti_max_stress = def.max_stress;
@@ -5677,7 +5676,6 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
         hook.hk_group             = -1;
         hook.hk_locked            = UNLOCKED;
         hook.hk_lock_node         = nullptr;
-        hook.hk_locked_actor      = nullptr;
         hook.hk_lockgroup         = -1;
         hook.hk_beam              = & beam;
         hook.hk_maxforce          = HOOK_FORCE_DEFAULT;

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -1125,14 +1125,14 @@ void ActorSpawner::ProcessSoundSource2(RigDef::SoundSource2 & def)
 #endif // USE_OPENAL
 }
 
-void ActorSpawner::AddSoundSourceInstance(Actor *vehicle, Ogre::String const & sound_script_name, int node_index, int type)
+void ActorSpawner::AddSoundSourceInstance(ActorPtr const& vehicle, Ogre::String const & sound_script_name, int node_index, int type)
 {
 #ifdef USE_OPENAL
     AddSoundSource(vehicle, App::GetSoundScriptManager()->createInstance(sound_script_name, vehicle->ar_instance_id, nullptr), (NodeNum_t)node_index);
 #endif // USE_OPENAL
 }
 
-void ActorSpawner::AddSoundSource(Actor *vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type)
+void ActorSpawner::AddSoundSource(ActorPtr const& vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type)
 {
     if (! CheckSoundScriptLimit(vehicle, 1))
     {
@@ -5873,7 +5873,7 @@ bool ActorSpawner::CheckTexcoordLimit(unsigned int count)
 }
 
 /* Static version */
-bool ActorSpawner::CheckSoundScriptLimit(Actor *vehicle, unsigned int count)
+bool ActorSpawner::CheckSoundScriptLimit(ActorPtr const& vehicle, unsigned int count)
 {
     if ((vehicle->ar_num_soundsources + count) > MAX_SOUNDSCRIPTS_PER_TRUCK)
     {
@@ -5990,7 +5990,7 @@ void ActorSpawner::SetBeamDamping(beam_t & beam, float damping)
     beam.d = damping;
 }
 
-void ActorSpawner::SetupDefaultSoundSources(Actor *vehicle)
+void ActorSpawner::SetupDefaultSoundSources(ActorPtr const& vehicle)
 {
     int trucknum = vehicle->ar_instance_id;
     int ar_exhaust_pos_node = vehicle->ar_exhaust_pos_node;

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -96,13 +96,13 @@ public:
     /// @name Processing
     /// @{
     void                           ConfigureSections(Ogre::String const & sectionconfig, RigDef::DocumentPtr def);
-    void                           ProcessNewActor(Actor *actor, ActorSpawnRequest rq, RigDef::DocumentPtr def);
-    static void                    SetupDefaultSoundSources(Actor *actor);
+    void                           ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef::DocumentPtr def);
+    static void                    SetupDefaultSoundSources(ActorPtr const& actor);
     /// @}
 
     /// @name Utility
     /// @{
-    Actor*                         GetActor() { return m_actor; }
+    ActorPtr                       GetActor() { return m_actor; }
     ActorMemoryRequirements const& GetMemoryRequirements() { return m_memory_requirements; }
     std::string                    GetSubmeshGroundmodelName();
     /// @}
@@ -361,7 +361,7 @@ private:
     bool                          CheckTexcoordLimit(unsigned int count);
     bool                          CheckCabLimit(unsigned int count);
     bool                          CheckCameraRailLimit(unsigned int count);
-    static bool                   CheckSoundScriptLimit(Actor *vehicle, unsigned int count);
+    static bool                   CheckSoundScriptLimit(ActorPtr const& vehicle, unsigned int count);
     bool                          CheckAeroEngineLimit(unsigned int count);
     bool                          CheckScrewpropLimit(unsigned int count);
     /// @}
@@ -415,8 +415,8 @@ private:
 
     /// @name Audio setup
     /// @{
-    static void                   AddSoundSource(Actor *vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type = -2);
-    static void                   AddSoundSourceInstance(Actor *vehicle, Ogre::String const & sound_script_name, int node_index, int type = -2);
+    static void                   AddSoundSource(ActorPtr const& vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type = -2);
+    static void                   AddSoundSourceInstance(ActorPtr const& vehicle, Ogre::String const & sound_script_name, int node_index, int type = -2);
     /// @}
 
     /// Maintenance
@@ -434,7 +434,7 @@ private:
 
     /// @name Settings
     /// @{
-    Actor*                   m_actor;
+    ActorPtr                 m_actor;
     RigDef::DocumentPtr      m_file;
     std::list<std::shared_ptr<RigDef::Document::Module>>
                              m_selected_modules;

--- a/source/main/physics/ActorSpawnerFlow.cpp
+++ b/source/main/physics/ActorSpawnerFlow.cpp
@@ -54,7 +54,7 @@ using namespace RoR;
     this->SetCurrentKeyword(RigDef::Keyword::INVALID);                  \
 }
 
-void ActorSpawner::ProcessNewActor(Actor* actor, ActorSpawnRequest rq, RigDef::DocumentPtr def)
+void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef::DocumentPtr def)
 {
     m_actor = actor;
     m_file = def;

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -298,8 +298,8 @@ bool ActorManager::LoadScene(Ogre::String filename)
     auto actors_changed = false;
     auto player_actor = App::GetGameContext()->GetPlayerActor();
     auto prev_player_actor = App::GetGameContext()->GetPrevPlayerActor();
-    std::vector<Actor*> actors;
-    std::vector<Actor*> x_actors = GetLocalActors();
+    std::vector<ActorPtr> actors;
+    std::vector<ActorPtr> x_actors = GetLocalActors();
     for (rapidjson::Value& j_entry: j_doc["actors"].GetArray())
     {
         String filename = j_entry["filename"].GetString();
@@ -319,7 +319,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
 
         String section_config = j_entry["section_config"].GetString();
 
-        Actor* actor = nullptr;
+        ActorPtr actor = nullptr;
         int index = static_cast<int>(actors.size());
         if (index < x_actors.size())
         {
@@ -335,7 +335,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
                 {
                     App::GetGameContext()->SetPrevPlayerActor(nullptr);
                 }
-                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)x_actors[index]));
+                App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(x_actors[index]))));
                 actors_changed = true;
             }
             else
@@ -380,7 +380,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
         {
             App::GetGameContext()->SetPrevPlayerActor(nullptr);
         }
-        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)x_actors[index]));
+        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(x_actors[index]))));
         actors_changed = true;
     }
 
@@ -390,7 +390,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
         if (actors[index] == nullptr)
             continue;
 
-        Actor* actor = actors[index];
+        ActorPtr actor = actors[index];
         rapidjson::Value& j_entry = j_doc["actors"][index];
 
         this->RestoreSavedState(actor, j_entry);
@@ -407,7 +407,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
 
 bool ActorManager::SaveScene(Ogre::String filename)
 {
-    std::vector<Actor*> x_actors = GetLocalActors();
+    std::vector<ActorPtr> x_actors = GetLocalActors();
 
     if (App::mp_state->getEnum<MpState>() == RoR::MpState::CONNECTED)
     {
@@ -453,10 +453,10 @@ bool ActorManager::SaveScene(Ogre::String filename)
     j_doc.AddMember("player_rotation", App::GetGameContext()->GetPlayerCharacter()->getRotation().valueRadians(), j_doc.GetAllocator());
 
     std::map<int, int> vector_index_lookup;
-    for (auto actor : m_actors)
+    for (ActorPtr& actor : m_actors)
     {
         vector_index_lookup[actor->ar_vector_index] = -1;
-        auto search = std::find_if(x_actors.begin(), x_actors.end(), [actor](Actor* b)
+        auto search = std::find_if(x_actors.begin(), x_actors.end(), [actor](ActorPtr b)
                 { return actor->ar_instance_id == b->ar_instance_id; });
         if (search != x_actors.end())
         {
@@ -466,7 +466,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
 
     // Actors
     rapidjson::Value j_actors(rapidjson::kArrayType);
-    for (auto actor : x_actors)
+    for (ActorPtr actor : x_actors)
     {
         rapidjson::Value j_entry(rapidjson::kObjectType);
 
@@ -720,7 +720,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
             j_beam.PushBack(actor->ar_beams[i].bm_broken, j_doc.GetAllocator());
             j_beam.PushBack(actor->ar_beams[i].bm_disabled, j_doc.GetAllocator());
             j_beam.PushBack(actor->ar_beams[i].bm_inter_actor, j_doc.GetAllocator());
-            Actor* locked_actor = actor->ar_beams[i].bm_locked_actor;
+            ActorPtr locked_actor = actor->ar_beams[i].bm_locked_actor;
             j_beam.PushBack(locked_actor ? vector_index_lookup[locked_actor->ar_vector_index] : -1, j_doc.GetAllocator());
 
             j_beams.PushBack(j_beam, j_doc.GetAllocator());
@@ -749,7 +749,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
     return true;
 }
 
-void ActorManager::RestoreSavedState(Actor* actor, rapidjson::Value const& j_entry)
+void ActorManager::RestoreSavedState(ActorPtr actor, rapidjson::Value const& j_entry)
 {
     actor->m_spawn_rotation = j_entry["spawn_rotation"].GetFloat();
     actor->ar_state = static_cast<ActorState>(j_entry["sim_state"].GetInt());
@@ -757,7 +757,7 @@ void ActorManager::RestoreSavedState(Actor* actor, rapidjson::Value const& j_ent
 
     if (j_entry["player_actor"].GetBool())
     {
-        App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)actor));
+        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
     }
     else if (j_entry["prev_player_actor"].GetBool())
     {
@@ -905,7 +905,7 @@ void ActorManager::RestoreSavedState(Actor* actor, rapidjson::Value const& j_ent
         actor->ar_initial_node_positions[i] = Vector3(data[6].GetFloat(), data[7].GetFloat(), data[8].GetFloat());
     }
 
-    std::vector<Actor*> actors = this->GetLocalActors();
+    std::vector<ActorPtr> actors = this->GetLocalActors();
 
     auto beams = j_entry["beams"].GetArray();
     for (rapidjson::SizeType i = 0; i < beams.Size(); i++)

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -307,7 +307,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
         {
             Str<600> msg; msg << _L("Error while loading scene: Missing content (probably not installed)") << " '" << filename << "'";
             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_ERROR, msg.ToCStr());
-            actors.push_back(nullptr);
+            actors.push_back(ActorPtr());
             continue;
         }
 
@@ -319,7 +319,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
 
         String section_config = j_entry["section_config"].GetString();
 
-        ActorPtr actor = nullptr;
+        ActorPtr actor;
         int index = static_cast<int>(actors.size());
         if (index < x_actors.size())
         {
@@ -333,7 +333,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
                 }
                 else if (x_actors[index] == prev_player_actor)
                 {
-                    App::GetGameContext()->SetPrevPlayerActor(nullptr);
+                    App::GetGameContext()->SetPrevPlayerActor(ActorPtr());
                 }
                 App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(x_actors[index]))));
                 actors_changed = true;
@@ -378,7 +378,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
         }
         else if (x_actors[index] == prev_player_actor)
         {
-            App::GetGameContext()->SetPrevPlayerActor(nullptr);
+            App::GetGameContext()->SetPrevPlayerActor(ActorPtr());
         }
         App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(x_actors[index]))));
         actors_changed = true;

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -61,7 +61,7 @@ std::string GameContext::GetQuicksaveFilename()
 
 void GameContext::LoadScene(std::string const& filename)
 {
-    ROR_ASSERT(App::GetSimTerrain());
+    ROR_ASSERT(App::GetGameContext()->GetTerrain());
     m_actor_manager.LoadScene(filename);
 }
 
@@ -283,7 +283,7 @@ bool ActorManager::LoadScene(Ogre::String filename)
     {
         if (j_doc.HasMember("daytime"))
         {
-            App::GetSimTerrain()->getSkyManager()->SetTime(j_doc["daytime"].GetDouble());
+            App::GetGameContext()->GetTerrain()->getSkyManager()->SetTime(j_doc["daytime"].GetDouble());
         }
     }
 #endif // USE_CAELUM
@@ -436,7 +436,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
 #ifdef USE_CAELUM
     if (App::gfx_sky_mode->getEnum<GfxSkyMode>() == GfxSkyMode::CAELUM)
     {
-        j_doc.AddMember("daytime", App::GetSimTerrain()->getSkyManager()->GetTime(), j_doc.GetAllocator());
+        j_doc.AddMember("daytime", App::GetGameContext()->GetTerrain()->getSkyManager()->GetTime(), j_doc.GetAllocator());
     }
 #endif // USE_CAELUM
 

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -274,6 +274,7 @@ enum class ActorState
     NETWORKED_HIDDEN, //!< not simulated, not updated (remote)
     LOCAL_REPLAY,
     LOCAL_SLEEPING,   //!< sleeping (local) actor
+    DISPOSED          //!< removed from simulation, still in memory to satisfy pointers.
 };
 
 enum class AeroEngineType
@@ -353,7 +354,7 @@ struct beam_t
     SpecialBeam     bounded;
     BeamType        bm_type;
     bool            bm_inter_actor;        //!< in case p2 is on another actor
-    Actor*          bm_locked_actor;       //!< in case p2 is on another actor
+    ActorPtr        bm_locked_actor;       //!< in case p2 is on another actor
     bool            bm_disabled;
     bool            bm_broken;
 
@@ -491,7 +492,7 @@ struct hook_t
     node_t* hk_hook_node;
     node_t* hk_lock_node;
     beam_t* hk_beam;
-    Actor*  hk_locked_actor;
+    ActorPtr  hk_locked_actor;
 };
 
 struct ropable_t
@@ -510,12 +511,12 @@ struct rope_t
     int        rp_group;
     beam_t*    rp_beam;
     ropable_t* rp_locked_ropable;
-    Actor*     rp_locked_actor;
+    ActorPtr     rp_locked_actor;
 };
 
 struct tie_t
 {
-    Actor*     ti_locked_actor;
+    ActorPtr     ti_locked_actor;
     beam_t*    ti_beam;
     ropable_t* ti_locked_ropable;
     int        ti_group;
@@ -784,7 +785,7 @@ struct ActorModifyRequest
         WAKE_UP
     };
 
-    Actor*              amr_actor;
+    ActorPtr            amr_actor;
     Type                amr_type;
     std::shared_ptr<rapidjson::Document>
                         amr_saved_state;

--- a/source/main/physics/SlideNode.cpp
+++ b/source/main/physics/SlideNode.cpp
@@ -26,6 +26,7 @@
 
 #include "SlideNode.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "SimData.h"
 

--- a/source/main/physics/air/AirBrake.cpp
+++ b/source/main/physics/air/AirBrake.cpp
@@ -31,7 +31,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Airbrake::Airbrake(Actor* actor, const char* basename, int num, node_t* ndref, node_t* ndx, node_t* ndy, node_t* nda, Ogre::Vector3 pos, float width, float length, float maxang, std::string const & texname, float tx1, float ty1, float tx2, float ty2, float lift_coef)
+Airbrake::Airbrake(ActorPtr actor, const char* basename, int num, node_t* ndref, node_t* ndx, node_t* ndy, node_t* nda, Ogre::Vector3 pos, float width, float length, float maxang, std::string const & texname, float tx1, float ty1, float tx2, float ty2, float lift_coef)
 {
     snode = 0;
     noderef = ndref;

--- a/source/main/physics/air/AirBrake.h
+++ b/source/main/physics/air/AirBrake.h
@@ -59,7 +59,7 @@ private:
     Ogre::Entity* ec;
 
 public:
-    Airbrake(Actor* actor, const char* basename, int num, node_t* ndref, node_t* ndx, node_t* ndy, node_t* nda, Ogre::Vector3 pos, float width, float length, float maxang, std::string const & texname, float tx1, float tx2, float tx3, float tx4, float lift_coef);
+    Airbrake(ActorPtr actor, const char* basename, int num, node_t* ndref, node_t* ndx, node_t* ndy, node_t* nda, Ogre::Vector3 pos, float width, float length, float maxang, std::string const & texname, float tx1, float tx2, float tx3, float tx4, float lift_coef);
     ~Airbrake() {} // Cleanup of visuals is done by GfxActor
 
     void updatePosition(float amount);

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -33,7 +33,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Turbojet::Turbojet(Actor* actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def)
+Turbojet::Turbojet(ActorPtr actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def)
 {
     m_actor = actor;
 #ifdef USE_OPENAL

--- a/source/main/physics/air/TurboJet.h
+++ b/source/main/physics/air/TurboJet.h
@@ -64,7 +64,7 @@ class Turbojet: public AeroEngine, public ZeroedMemoryAllocator
 
 public:
 
-    Turbojet(Actor* actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def);
+    Turbojet(ActorPtr actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def);
     ~Turbojet();
 
     void flipStart();
@@ -128,7 +128,7 @@ private:
     int m_sound_thr;
 
     // Attachment
-    Actor* m_actor;
+    ActorPtr m_actor;
     NodeNum_t m_node_back;
     NodeNum_t m_node_front;
     NodeNum_t m_node_ref;

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -35,7 +35,7 @@ using namespace Ogre;
 using namespace RoR;
 
 Turboprop::Turboprop(
-    Actor* a,
+    ActorPtr a,
     const char* propname,
     NodeNum_t nr,
     NodeNum_t nb,

--- a/source/main/physics/air/TurboProp.h
+++ b/source/main/physics/air/TurboProp.h
@@ -45,7 +45,7 @@ public:
     float max_torque;
 
     Turboprop(
-        Actor* a,
+        ActorPtr a,
         const char* propname,
         NodeNum_t nr,
         NodeNum_t nb,
@@ -131,7 +131,7 @@ private:
     int thr_id;
 
     // Attachment
-    Actor* m_actor;
+    ActorPtr m_actor;
     NodeNum_t nodeback;
     NodeNum_t noderef;
     NodeNum_t nodep[4];

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -893,7 +893,7 @@ bool Collisions::collisionCorrect(Vector3 *refpos, bool envokeScriptCallbacks)
 
 bool Collisions::permitEvent(CollisionEventFilter filter)
 {
-    Actor *b = App::GetGameContext()->GetPlayerActor();
+    ActorPtr b = App::GetGameContext()->GetPlayerActor();
 
     switch (filter)
     {

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -663,7 +663,7 @@ float Collisions::getSurfaceHeight(float x, float z)
 
 float Collisions::getSurfaceHeightBelow(float x, float z, float height)
 {
-    float surface_height = App::GetSimTerrain()->GetHeightAt(x, z);
+    float surface_height = App::GetGameContext()->GetTerrain()->GetHeightAt(x, z);
 
     // find the correct cell
     int refx = (int)(x / (float)CELL_SIZE);
@@ -1171,13 +1171,13 @@ bool Collisions::isInside(Ogre::Vector3 pos, collision_box_t *cbox, float border
 
 bool Collisions::groundCollision(node_t *node, float dt)
 {
-    Real v = App::GetSimTerrain()->GetHeightAt(node->AbsPosition.x, node->AbsPosition.z);
+    Real v = App::GetGameContext()->GetTerrain()->GetHeightAt(node->AbsPosition.x, node->AbsPosition.z);
     if (v > node->AbsPosition.y)
     {
         ground_model_t* ogm = landuse ? landuse->getGroundModelAt(node->AbsPosition.x, node->AbsPosition.z) : nullptr;
         // when landuse fails or we don't have it, use the default value
         if (!ogm) ogm = defaultgroundgm;
-        Ogre::Vector3 normal = App::GetSimTerrain()->GetNormalAt(node->AbsPosition.x, v, node->AbsPosition.z);
+        Ogre::Vector3 normal = App::GetGameContext()->GetTerrain()->GetNormalAt(node->AbsPosition.x, v, node->AbsPosition.z);
         node->Forces += primitiveCollision(node, node->Velocity, node->mass, normal, dt, ogm, v - node->AbsPosition.y);
         node->nd_last_collision_gm = ogm;
         return true;
@@ -1300,10 +1300,10 @@ void Collisions::createCollisionDebugVisualization(Ogre::SceneNode* root_node, O
                 float z2 = z+CELL_SIZE;
 
                 // find a good ground height for all corners of the cell ...
-                groundheight = std::max(groundheight, App::GetSimTerrain()->GetHeightAt(x, z));
-                groundheight = std::max(groundheight, App::GetSimTerrain()->GetHeightAt(x2, z));
-                groundheight = std::max(groundheight, App::GetSimTerrain()->GetHeightAt(x, z2));
-                groundheight = std::max(groundheight, App::GetSimTerrain()->GetHeightAt(x2, z2));
+                groundheight = std::max(groundheight, App::GetGameContext()->GetTerrain()->GetHeightAt(x, z));
+                groundheight = std::max(groundheight, App::GetGameContext()->GetTerrain()->GetHeightAt(x2, z));
+                groundheight = std::max(groundheight, App::GetGameContext()->GetTerrain()->GetHeightAt(x, z2));
+                groundheight = std::max(groundheight, App::GetGameContext()->GetTerrain()->GetHeightAt(x2, z2));
                 groundheight += 0.1; // 10 cm hover
 
                 float percentd = static_cast<float>(hashtable[hash].size()) / static_cast<float>(CELL_BLOCKSIZE);

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -48,8 +48,8 @@ void PointColDetector::UpdateInterPoint(bool ignorestate)
     m_linked_actors = m_actor->getAllLinkedActors();
 
     int contacters_size = 0;
-    std::vector<Actor*> collision_partners;
-    for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+    std::vector<ActorPtr> collision_partners;
+    for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
         if (actor != m_actor && (ignorestate || actor->ar_update_physics) &&
                 m_actor->ar_bounding_box.intersects(actor->ar_bounding_box))
@@ -94,7 +94,7 @@ void PointColDetector::update_structures_for_contacters(bool ignoreinternal)
 
     // Insert all contacters into the list of points to consider when building the kdtree
     int refi = 0;
-    for (auto actor : m_collision_partners)
+    for (ActorPtr actor : m_collision_partners)
     {
         bool is_linked = std::find(m_linked_actors.begin(), m_linked_actors.end(), actor) != m_linked_actors.end();
         bool internal_collision = !ignoreinternal && ((actor == m_actor) || is_linked);

--- a/source/main/physics/collision/PointColDetector.h
+++ b/source/main/physics/collision/PointColDetector.h
@@ -35,13 +35,13 @@ public:
 
     struct pointid_t
     {
-        Actor* actor;
+        ActorPtr actor;
         short node_id;
     };
 
     std::vector<pointid_t*> hit_list;
 
-    PointColDetector(Actor* actor): m_actor(actor), m_object_list_size(-1) {};
+    PointColDetector(ActorPtr actor): m_actor(actor), m_object_list_size(-1) {};
 
     void UpdateIntraPoint(bool contactables = false);
     void UpdateInterPoint(bool ignorestate = false);
@@ -65,9 +65,9 @@ private:
         int begin;
     };
 
-    Actor*                 m_actor;
-    std::vector<Actor*>    m_linked_actors;
-    std::vector<Actor*>    m_collision_partners;
+    ActorPtr                 m_actor;
+    std::vector<ActorPtr>    m_linked_actors;
+    std::vector<ActorPtr>    m_collision_partners;
     std::vector<refelem_t> m_ref_list;
     std::vector<pointid_t> m_pointid_list;
     std::vector<kdnode_t>  m_kdtree;

--- a/source/main/physics/flex/FlexAirfoil.cpp
+++ b/source/main/physics/flex/FlexAirfoil.cpp
@@ -74,7 +74,7 @@ float refairfoilpos[90]={
 
 using namespace Ogre;
 
-FlexAirfoil::FlexAirfoil(Ogre::String const & name, Actor* actor, NodeNum_t pnfld, NodeNum_t pnfrd, NodeNum_t pnflu, NodeNum_t pnfru, NodeNum_t pnbld, NodeNum_t pnbrd, NodeNum_t pnblu, NodeNum_t pnbru, std::string const & texband, Vector2 texlf, Vector2 texrf, Vector2 texlb, Vector2 texrb, char mtype, float controlratio, float mind, float maxd, Ogre::String const & afname, float lift_coef, bool break_able)
+FlexAirfoil::FlexAirfoil(Ogre::String const & name, ActorPtr actor, NodeNum_t pnfld, NodeNum_t pnfrd, NodeNum_t pnflu, NodeNum_t pnfru, NodeNum_t pnbld, NodeNum_t pnbrd, NodeNum_t pnblu, NodeNum_t pnbru, std::string const & texband, Vector2 texlf, Vector2 texrf, Vector2 texlb, Vector2 texrb, char mtype, float controlratio, float mind, float maxd, Ogre::String const & afname, float lift_coef, bool break_able)
     :nfld(pnfld)
     ,nfrd(pnfrd)
     ,nflu(pnflu)

--- a/source/main/physics/flex/FlexAirfoil.h
+++ b/source/main/physics/flex/FlexAirfoil.h
@@ -33,7 +33,7 @@ namespace RoR {
 class FlexAirfoil : public ZeroedMemoryAllocator
 {
 public:
-    FlexAirfoil(Ogre::String const& wname, Actor* actor,
+    FlexAirfoil(Ogre::String const& wname, ActorPtr actor,
         NodeNum_t pnfld, NodeNum_t pnfrd, NodeNum_t pnflu, NodeNum_t pnfru, NodeNum_t pnbld, NodeNum_t pnbrd, NodeNum_t pnblu, NodeNum_t pnbru,
         std::string const & texname,
         Ogre::Vector2 texlf, Ogre::Vector2 texrf, Ogre::Vector2 texlb, Ogre::Vector2 texrb,

--- a/source/main/physics/water/Buoyance.cpp
+++ b/source/main/physics/water/Buoyance.cpp
@@ -23,6 +23,7 @@
 #include "Application.h"
 #include "SimData.h"
 #include "ActorManager.h"
+#include "GameContext.h"
 #include "GfxScene.h"
 #include "DustPool.h"
 #include "Terrain.h"
@@ -63,9 +64,9 @@ Vector3 Buoyance::computePressureForceSub(Vector3 a, Vector3 b, Vector3 c, Vecto
     if (type != BUOY_DRAGONLY)
     {
         //compute pression prism points
-        Vector3 ap = a + (App::GetSimTerrain()->getWater()->CalcWavesHeight(a) - a.y) * 9810 * normal;
-        Vector3 bp = b + (App::GetSimTerrain()->getWater()->CalcWavesHeight(b) - b.y) * 9810 * normal;
-        Vector3 cp = c + (App::GetSimTerrain()->getWater()->CalcWavesHeight(c) - c.y) * 9810 * normal;
+        Vector3 ap = a + (App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(a) - a.y) * 9810 * normal;
+        Vector3 bp = b + (App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(b) - b.y) * 9810 * normal;
+        Vector3 cp = c + (App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(c) - c.y) * 9810 * normal;
         //find centroid
         Vector3 ctd = (a + b + c + ap + bp + cp) / 6.0;
         //compute volume
@@ -85,7 +86,7 @@ Vector3 Buoyance::computePressureForceSub(Vector3 a, Vector3 b, Vector3 c, Vecto
         //take in account the wave speed
         //compute center
         Vector3 tc = (a + b + c) / 3.0;
-        vel = vel - App::GetSimTerrain()->getWater()->CalcWavesVelocity(tc);
+        vel = vel - App::GetGameContext()->GetTerrain()->getWater()->CalcWavesVelocity(tc);
         float vell = vel.length();
         if (vell > 0.01)
         {
@@ -103,13 +104,13 @@ Vector3 Buoyance::computePressureForceSub(Vector3 a, Vector3 b, Vector3 c, Vecto
                     if (fxdir.y < 0)
                         fxdir.y = -fxdir.y;
 
-                    if (App::GetSimTerrain()->getWater()->CalcWavesHeight(a) - a.y < 0.1)
+                    if (App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(a) - a.y < 0.1)
                         splashp->malloc(a, fxdir);
 
-                    else if (App::GetSimTerrain()->getWater()->CalcWavesHeight(b) - b.y < 0.1)
+                    else if (App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(b) - b.y < 0.1)
                         splashp->malloc(b, fxdir);
 
-                    else if (App::GetSimTerrain()->getWater()->CalcWavesHeight(c) - c.y < 0.1)
+                    else if (App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(c) - c.y < 0.1)
                         splashp->malloc(c, fxdir);
                 }
             }
@@ -124,7 +125,7 @@ Vector3 Buoyance::computePressureForceSub(Vector3 a, Vector3 b, Vector3 c, Vecto
 //compute pressure and drag forces on a random triangle
 Vector3 Buoyance::computePressureForce(Vector3 a, Vector3 b, Vector3 c, Vector3 vel, int type)
 {
-    float wha = App::GetSimTerrain()->getWater()->CalcWavesHeight((a + b + c) / 3.0);
+    float wha = App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight((a + b + c) / 3.0);
     //check if fully emerged
     if (a.y > wha && b.y > wha && c.y > wha)
         return Vector3::ZERO;
@@ -178,9 +179,9 @@ Vector3 Buoyance::computePressureForce(Vector3 a, Vector3 b, Vector3 c, Vector3 
 
 void Buoyance::computeNodeForce(node_t* a, node_t* b, node_t* c, bool doUpdate, int type)
 {
-    if (a->AbsPosition.y > App::GetSimTerrain()->getWater()->CalcWavesHeight(a->AbsPosition) &&
-        b->AbsPosition.y > App::GetSimTerrain()->getWater()->CalcWavesHeight(b->AbsPosition) &&
-        c->AbsPosition.y > App::GetSimTerrain()->getWater()->CalcWavesHeight(c->AbsPosition))
+    if (a->AbsPosition.y > App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(a->AbsPosition) &&
+        b->AbsPosition.y > App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(b->AbsPosition) &&
+        c->AbsPosition.y > App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(c->AbsPosition))
         return;
 
     update = doUpdate;

--- a/source/main/physics/water/ScrewProp.cpp
+++ b/source/main/physics/water/ScrewProp.cpp
@@ -33,7 +33,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Screwprop::Screwprop(Actor* a, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float fullpower) :
+Screwprop::Screwprop(ActorPtr a, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float fullpower) :
     m_actor(a)
     , noderef(noderef)
     , nodeback(nodeback)

--- a/source/main/physics/water/ScrewProp.cpp
+++ b/source/main/physics/water/ScrewProp.cpp
@@ -25,6 +25,7 @@
 #include "SimData.h"
 #include "ActorManager.h"
 #include "DustPool.h"
+#include "GameContext.h"
 #include "GfxScene.h"
 #include "SoundScriptManager.h"
 #include "Terrain.h"
@@ -47,10 +48,10 @@ Screwprop::Screwprop(ActorPtr a, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_
 
 void Screwprop::updateForces(int update)
 {
-    if (!App::GetSimTerrain()->getWater())
+    if (!App::GetGameContext()->GetTerrain()->getWater())
         return;
 
-    float depth = App::GetSimTerrain()->getWater()->CalcWavesHeight(m_actor->ar_nodes[noderef].AbsPosition) - m_actor->ar_nodes[noderef].AbsPosition.y;
+    float depth = App::GetGameContext()->GetTerrain()->getWater()->CalcWavesHeight(m_actor->ar_nodes[noderef].AbsPosition) - m_actor->ar_nodes[noderef].AbsPosition.y;
     if (depth < 0)
         return; //out of water!
     Vector3 dir = m_actor->ar_nodes[nodeback].RelPosition - m_actor->ar_nodes[noderef].RelPosition;

--- a/source/main/physics/water/ScrewProp.h
+++ b/source/main/physics/water/ScrewProp.h
@@ -35,7 +35,7 @@ class Screwprop : public ZeroedMemoryAllocator
 {
 public:
 
-    Screwprop( Actor* actor, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float power);
+    Screwprop( ActorPtr actor, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float power);
 
     void updateForces(int update);
     void setThrottle(float val);
@@ -54,7 +54,7 @@ private:
     float throtle;
 
     // Attachment
-    Actor*    m_actor;
+    ActorPtr    m_actor;
     NodeNum_t nodeback;
     NodeNum_t noderef;
     NodeNum_t nodeup;

--- a/source/main/resources/odef_fileformat/ODefFileFormat.cpp
+++ b/source/main/resources/odef_fileformat/ODefFileFormat.cpp
@@ -19,6 +19,7 @@
 
 #include "ODefFileFormat.h"
 
+#include "Actor.h"
 #include "Utils.h"
 
 using namespace RoR;

--- a/source/main/resources/rig_def_fileformat/RigDef_File.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.cpp
@@ -24,6 +24,8 @@
 /// @date   12/2013
 
 #include "RigDef_File.h"
+
+#include "Actor.h"
 #include "SimConstants.h"
 
 namespace RigDef

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -25,6 +25,7 @@
 
 #include "RigDef_Parser.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "SimConstants.h"
 #include "CacheSystem.h"

--- a/source/main/resources/rig_def_fileformat/RigDef_SequentialImporter.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_SequentialImporter.cpp
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include "RigDef_SequentialImporter.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Console.h"
 #include "RigDef_Parser.h"

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -25,6 +25,7 @@
 
 #include "RigDef_Serializer.h"
 
+#include "Actor.h"
 #include "RigDef_File.h"
 
 #include <fstream>

--- a/source/main/resources/rig_def_fileformat/RigDef_Validator.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Validator.cpp
@@ -25,6 +25,7 @@
 
 #include "RigDef_Validator.h"
 
+#include "Actor.h"
 #include "SimConstants.h"
 #include "Application.h"
 #include "Console.h"

--- a/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
@@ -19,6 +19,7 @@
 
 #include "TObjFileFormat.h"
 
+#include "Actor.h"
 #include "ProceduralRoad.h"
 
 #define LOGSTREAM Ogre::LogManager::getSingleton().stream() << "[RoR|TObj fileformat] "

--- a/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
@@ -62,6 +62,7 @@ void TObjParser::Prepare()
     m_in_procedural_road = false;
     m_in_procedural_road = false;
     m_road2_use_old_mode = false;
+    m_cur_procedural_obj = ProceduralObjectPtr::Bind(new ProceduralObject());
     
     m_def = std::shared_ptr<TObjFile>(new TObjFile());
 }
@@ -108,7 +109,7 @@ bool TObjParser::ProcessCurrentLine()
     }
     if (strncmp("begin_procedural_roads", m_cur_line, 22) == 0)
     {
-        m_cur_procedural_obj = ProceduralObject(); // Hard reset, discarding last "non-procedural" road strip. For backwards compatibility. ~ Petr Ohlidal, 08/2020
+        m_cur_procedural_obj = ProceduralObjectPtr::Bind(new ProceduralObject()); // Hard reset, discarding last "non-procedural" road strip. For backwards compatibility. ~ Petr Ohlidal, 08/2020
         m_in_procedural_road = true;
         m_road2_use_old_mode = true;
         return true;
@@ -118,7 +119,7 @@ bool TObjParser::ProcessCurrentLine()
         if (m_road2_use_old_mode)
         {
             m_def->proc_objects.push_back(m_cur_procedural_obj);
-            m_cur_procedural_obj = ProceduralObject();
+            m_cur_procedural_obj = ProceduralObjectPtr::Bind(new ProceduralObject());
         }
         m_in_procedural_road = false;
         return true;
@@ -197,17 +198,17 @@ void TObjParser::ProcessProceduralLine()
 
     point.rotation = this->CalcRotation(rot);
 
-         if (obj_name == "flat"             ) { point.type = ProceduralRoad::ROAD_FLAT;  }
-    else if (obj_name == "left"             ) { point.type = ProceduralRoad::ROAD_LEFT;  }
-    else if (obj_name == "right"            ) { point.type = ProceduralRoad::ROAD_RIGHT; }
-    else if (obj_name == "both"             ) { point.type = ProceduralRoad::ROAD_BOTH;  }
-    else if (obj_name == "bridge"           ) { point.type = ProceduralRoad::ROAD_BRIDGE;    point.pillartype = 1; }
-    else if (obj_name == "monorail"         ) { point.type = ProceduralRoad::ROAD_MONORAIL;  point.pillartype = 2; }
-    else if (obj_name == "monorail2"        ) { point.type = ProceduralRoad::ROAD_MONORAIL;  point.pillartype = 0; }
-    else if (obj_name == "bridge_no_pillars") { point.type = ProceduralRoad::ROAD_BRIDGE;    point.pillartype = 0; }
-    else                                      { point.type = ProceduralRoad::ROAD_AUTOMATIC; point.pillartype = 0; }
+         if (obj_name == "flat"             ) { point.type = RoadType::ROAD_FLAT;  }
+    else if (obj_name == "left"             ) { point.type = RoadType::ROAD_LEFT;  }
+    else if (obj_name == "right"            ) { point.type = RoadType::ROAD_RIGHT; }
+    else if (obj_name == "both"             ) { point.type = RoadType::ROAD_BOTH;  }
+    else if (obj_name == "bridge"           ) { point.type = RoadType::ROAD_BRIDGE;    point.pillartype = 1; }
+    else if (obj_name == "monorail"         ) { point.type = RoadType::ROAD_MONORAIL;  point.pillartype = 2; }
+    else if (obj_name == "monorail2"        ) { point.type = RoadType::ROAD_MONORAIL;  point.pillartype = 0; }
+    else if (obj_name == "bridge_no_pillars") { point.type = RoadType::ROAD_BRIDGE;    point.pillartype = 0; }
+    else                                      { point.type = RoadType::ROAD_AUTOMATIC; point.pillartype = 0; }
 
-    m_cur_procedural_obj.points.push_back(point);
+    m_cur_procedural_obj->points.push_back(point);
 }
 
 void TObjParser::ProcessGridLine()
@@ -295,7 +296,7 @@ void TObjParser::ProcessRoadObject(const TObjEntry& object)
 
             // finish it and start new object
             m_def->proc_objects.push_back(m_cur_procedural_obj);
-            m_cur_procedural_obj = ProceduralObject();
+            m_cur_procedural_obj = ProceduralObjectPtr::Bind(new ProceduralObject());
         }
         m_road2_use_old_mode = true;
 
@@ -321,10 +322,10 @@ void TObjParser::ImportProceduralPoint(Ogre::Vector3 const& pos, Ogre::Vector3 c
     pp.pillartype = (int)(special != TObj::SpecialObject::ROAD_BRIDGE_NO_PILLARS);
     pp.position   = pos;
     pp.rotation   = this->CalcRotation(rot);
-    pp.type       = (special == TObj::SpecialObject::ROAD) ? ProceduralRoad::ROAD_FLAT : ProceduralRoad::ROAD_AUTOMATIC;
+    pp.type       = (special == TObj::SpecialObject::ROAD) ? RoadType::ROAD_FLAT : RoadType::ROAD_AUTOMATIC;
     pp.width      = 8;
 
-    m_cur_procedural_obj.points.push_back(pp);
+    m_cur_procedural_obj->points.push_back(pp);
 }
 
 Ogre::Quaternion TObjParser::CalcRotation(Ogre::Vector3 const& rot) const

--- a/source/main/resources/tobj_fileformat/TObjFileFormat.h
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.h
@@ -163,7 +163,7 @@ struct TObjFile
     std::vector<TObjGrass>        grass;
     std::vector<TObjVehicle>      vehicles;
     std::vector<TObjEntry>        objects;
-    std::vector<ProceduralObject> proc_objects;
+    std::vector<ProceduralObjectPtr> proc_objects;
 };
 
 // -----------------------------------------------------------------------------
@@ -197,7 +197,7 @@ private:
     bool                       m_road2_use_old_mode; // Old parser: 'int r2oldmode'
     Ogre::Vector3              m_road2_last_pos;
     Ogre::Vector3              m_road2_last_rot;
-    ProceduralObject           m_cur_procedural_obj;
+    ProceduralObjectPtr        m_cur_procedural_obj;
 };
 
 } // namespace RoR

--- a/source/main/resources/tobj_fileformat/TObjFileFormat.h
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.h
@@ -189,8 +189,10 @@ private:
     void                       ImportProceduralPoint(Ogre::Vector3 const& pos, Ogre::Vector3 const& rot, TObj::SpecialObject special);
     Ogre::Quaternion           CalcRotation(Ogre::Vector3 const& rot) const;
     bool                       ParseObjectLine(TObjEntry& object);
+    void                       FlushProceduralObject();
 
     std::shared_ptr<TObjFile>  m_def;
+    std::string                m_filename;
     int                        m_line_number;
     const char*                m_cur_line;
     bool                       m_in_procedural_road; // Old parser: 'bool proroad'
@@ -198,6 +200,7 @@ private:
     Ogre::Vector3              m_road2_last_pos;
     Ogre::Vector3              m_road2_last_rot;
     ProceduralObjectPtr        m_cur_procedural_obj;
+    int                        m_cur_procedural_obj_start_line;
 };
 
 } // namespace RoR

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -907,7 +907,7 @@ VehicleAIPtr GameScript::getCurrentTruckAI()
     {
         return App::GetGameContext()->GetPlayerActor()->getVehicleAI();
     }
-    return nullptr;
+    return VehicleAIPtr();
 }
 
 VehicleAIPtr GameScript::getTruckAIByNum(int num)
@@ -917,7 +917,7 @@ VehicleAIPtr GameScript::getTruckAIByNum(int num)
     {
         return actor->getVehicleAI();
     }
-    return nullptr;
+    return VehicleAIPtr();
 }
 
 ActorPtr GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot)

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -232,7 +232,7 @@ float GameScript::getWaterHeight()
     return result;
 }
 
-Actor* GameScript::getCurrentTruck()
+ActorPtr GameScript::getCurrentTruck()
 {
     return App::GetGameContext()->GetPlayerActor();
 }
@@ -255,7 +255,7 @@ void GameScript::setGravity(float value)
     App::GetSimTerrain()->setGravity(value);
 }
 
-Actor* GameScript::getTruckByNum(int num)
+ActorPtr GameScript::getTruckByNum(int num)
 {
     return App::GetGameContext()->GetActorManager()->GetActorById(num);
 }
@@ -268,7 +268,7 @@ int GameScript::getNumTrucks()
 int GameScript::getNumTrucksByFlag(int flag)
 {
     int result = 0;
-    for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+    for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
         if (!flag || static_cast<int>(actor->ar_state) == flag)
             result++;
@@ -278,7 +278,7 @@ int GameScript::getNumTrucksByFlag(int flag)
 
 int GameScript::getCurrentTruckNumber()
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     return (actor != nullptr) ? actor->ar_instance_id : -1;
 }
 
@@ -372,10 +372,10 @@ void GameScript::repairVehicle(const String& instance, const String& box, bool k
 
 void GameScript::removeVehicle(const String& event_source_instance_name, const String& event_source_box_name)
 {
-    Actor* actor = App::GetGameContext()->FindActorByCollisionBox(event_source_instance_name, event_source_box_name);
+    ActorPtr actor = App::GetGameContext()->FindActorByCollisionBox(event_source_instance_name, event_source_box_name);
     if (actor)
     {
-        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
+        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
     }
 }
 
@@ -761,7 +761,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     if (unit_id == SCRIPTUNITID_INVALID)
         return 2;
 
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
     if (player_actor == nullptr)
         return 1;
@@ -794,7 +794,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     j_doc.AddMember("actor-hash", rapidjson::StringRef(player_actor->ar_filehash.c_str()), j_doc.GetAllocator());
 
     rapidjson::Value j_linked_actors(rapidjson::kArrayType);
-    for (auto actor : player_actor->getAllLinkedActors())
+    for (ActorPtr actor : player_actor->getAllLinkedActors())
     {
         rapidjson::Value j_actor(rapidjson::kObjectType);
         j_actor.AddMember("actor-name", rapidjson::StringRef(actor->ar_design_name.c_str()), j_doc.GetAllocator());
@@ -849,7 +849,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
 
 void GameScript::boostCurrentTruck(float factor)
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (actor && actor->ar_engine)
     {
         float rpm = actor->ar_engine->GetEngineRpm();
@@ -909,7 +909,7 @@ VehicleAI* GameScript::getCurrentTruckAI()
 VehicleAI* GameScript::getTruckAIByNum(int num)
 {
     VehicleAI* result = nullptr;
-    Actor* actor = App::GetGameContext()->GetActorManager()->GetActorById(num);
+    ActorPtr actor = App::GetGameContext()->GetActorManager()->GetActorById(num);
     if (actor != nullptr)
     {
         result = actor->ar_vehicle_ai;
@@ -917,7 +917,7 @@ VehicleAI* GameScript::getTruckAIByNum(int num)
     return result;
 }
 
-Actor* GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot)
+ActorPtr GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot)
 {
     ActorSpawnRequest rq;
     rq.asr_position = pos;
@@ -926,7 +926,7 @@ Actor* GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre:
     return App::GetGameContext()->SpawnActor(rq);
 }
 
-Actor* GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin)
+ActorPtr GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin)
 {
     ActorSpawnRequest rq;
     rq.asr_position = pos;

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -155,9 +155,9 @@ String GameScript::getCaelumTime()
 {
     String result = "";
 #ifdef USE_CAELUM
-    if (App::GetSimTerrain())
+    if (App::GetGameContext()->GetTerrain())
     {
-        result = App::GetSimTerrain()->getSkyManager()->GetPrettyTime();
+        result = App::GetGameContext()->GetTerrain()->getSkyManager()->GetPrettyTime();
     }
 #endif // USE_CAELUM
     return result;
@@ -169,7 +169,7 @@ void GameScript::setCaelumTime(float value)
     if (!this->HaveSimTerrain(__FUNCTION__))
         return;
 
-    App::GetSimTerrain()->getSkyManager()->SetSkyTimeFactor(value);
+    App::GetGameContext()->GetTerrain()->getSkyManager()->SetSkyTimeFactor(value);
 #endif // USE_CAELUM
 }
 
@@ -177,8 +177,8 @@ bool GameScript::getCaelumAvailable()
 {
     bool result = false;
 #ifdef USE_CAELUM
-    if (App::GetSimTerrain())
-        result = App::GetSimTerrain()->getSkyManager() != 0;
+    if (App::GetGameContext()->GetTerrain())
+        result = App::GetGameContext()->GetTerrain()->getSkyManager() != 0;
 #endif // USE_CAELUM
     return result;
 }
@@ -208,9 +208,9 @@ void GameScript::setWaterHeight(float value)
     if (!this->HaveSimTerrain(__FUNCTION__))
         return;
 
-    if (App::GetSimTerrain()->getWater())
+    if (App::GetGameContext()->GetTerrain()->getWater())
     {
-        IWater* water = App::GetSimTerrain()->getWater();
+        IWater* water = App::GetGameContext()->GetTerrain()->getWater();
         water->SetStaticWaterHeight(value);
         water->UpdateWater();
     }
@@ -219,16 +219,16 @@ void GameScript::setWaterHeight(float value)
 float GameScript::getGroundHeight(Vector3& v)
 {
     float result = -1.0f;
-    if (App::GetSimTerrain())
-        result = App::GetSimTerrain()->GetHeightAt(v.x, v.z);
+    if (App::GetGameContext()->GetTerrain())
+        result = App::GetGameContext()->GetTerrain()->GetHeightAt(v.x, v.z);
     return result;
 }
 
 float GameScript::getWaterHeight()
 {
     float result = 0.0f;
-    if (App::GetSimTerrain() && App::GetSimTerrain()->getWater())
-        result = App::GetSimTerrain()->getWater()->GetStaticWaterHeight();
+    if (App::GetGameContext()->GetTerrain() && App::GetGameContext()->GetTerrain()->getWater())
+        result = App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight();
     return result;
 }
 
@@ -240,9 +240,9 @@ ActorPtr GameScript::getCurrentTruck()
 float GameScript::getGravity()
 {
     float result = 0.f;
-    if (App::GetSimTerrain())
+    if (App::GetGameContext()->GetTerrain())
     {
-        result = App::GetSimTerrain()->getGravity();
+        result = App::GetGameContext()->GetTerrain()->getGravity();
     }
     return result;
 }
@@ -252,7 +252,7 @@ void GameScript::setGravity(float value)
     if (!this->HaveSimTerrain(__FUNCTION__))
         return;
 
-    App::GetSimTerrain()->setGravity(value);
+    App::GetGameContext()->GetTerrain()->setGravity(value);
 }
 
 ActorPtr GameScript::getTruckByNum(int num)
@@ -367,7 +367,7 @@ void GameScript::showChooser(const String& type, const String& instance, const S
 
 void GameScript::repairVehicle(const String& instance, const String& box, bool keepPosition)
 {
-    App::GetGameContext()->GetActorManager()->RepairActor(App::GetSimTerrain()->GetCollisions(), instance, box, keepPosition);
+    App::GetGameContext()->GetActorManager()->RepairActor(App::GetGameContext()->GetTerrain()->GetCollisions(), instance, box, keepPosition);
 }
 
 void GameScript::removeVehicle(const String& event_source_instance_name, const String& event_source_box_name)
@@ -384,9 +384,9 @@ void GameScript::destroyObject(const String& instanceName)
     if (!this->HaveSimTerrain(__FUNCTION__))
         return;
 
-    if (App::GetSimTerrain()->getObjectManager())
+    if (App::GetGameContext()->GetTerrain()->getObjectManager())
     {
-        App::GetSimTerrain()->getObjectManager()->unloadObject(instanceName);
+        App::GetGameContext()->GetTerrain()->getObjectManager()->unloadObject(instanceName);
     }
 }
 
@@ -395,9 +395,9 @@ void GameScript::moveObjectVisuals(const String& instanceName, const Vector3& po
     if (!this->HaveSimTerrain(__FUNCTION__))
         return;
 
-    if (App::GetSimTerrain()->getObjectManager())
+    if (App::GetGameContext()->GetTerrain()->getObjectManager())
     {
-        App::GetSimTerrain()->getObjectManager()->MoveObjectVisuals(instanceName, pos);
+        App::GetGameContext()->GetTerrain()->getObjectManager()->MoveObjectVisuals(instanceName, pos);
     }
 }
 
@@ -406,7 +406,7 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
     if (!this->HaveSimTerrain(__FUNCTION__))
         return;
 
-    if ((App::GetSimTerrain()->getObjectManager() == nullptr))
+    if ((App::GetGameContext()->GetTerrain()->getObjectManager() == nullptr))
     {
         this->logFormat("spawnObject(): Cannot spawn object, no terrain loaded!");
         return;
@@ -444,7 +444,7 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
 
         SceneNode* bakeNode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
         const String type = "";
-        App::GetSimTerrain()->getObjectManager()->LoadTerrainObject(objectName, pos, rot, bakeNode, instanceName, type, true, handler_func_id, uniquifyMaterials);
+        App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(objectName, pos, rot, bakeNode, instanceName, type, true, handler_func_id, uniquifyMaterials);
     }
     catch (std::exception& e)
     {
@@ -646,13 +646,18 @@ int GameScript::getLoadedTerrain(String& result)
 {
     String terrainName = "";
 
-    if (App::GetSimTerrain())
+    if (App::GetGameContext()->GetTerrain())
     {
-        terrainName = App::GetSimTerrain()->getTerrainName();
+        terrainName = App::GetGameContext()->GetTerrain()->getTerrainName();
         result = terrainName;
     }
 
     return !terrainName.empty();
+}
+
+RoR::TerrainPtr GameScript::getTerrain()
+{
+    return App::GetGameContext()->GetTerrain();
 }
 
 void GameScript::clearEventCache()
@@ -660,13 +665,13 @@ void GameScript::clearEventCache()
     if (!this->HaveSimTerrain(__FUNCTION__))
         return;
 
-    if (App::GetSimTerrain()->GetCollisions() == nullptr)
+    if (App::GetGameContext()->GetTerrain()->GetCollisions() == nullptr)
     {
         this->logFormat("Cannot execute '%s', collisions not ready", __FUNCTION__);
         return;
     }
 
-    App::GetSimTerrain()->GetCollisions()->clearEventCache();
+    App::GetGameContext()->GetTerrain()->GetCollisions()->clearEventCache();
 }
 
 void GameScript::setCameraPosition(const Vector3& pos)
@@ -771,7 +776,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     std::string user = std::string("RoR-Api-User: ") + App::mp_player_name->getStr();
     std::string token = std::string("RoR-Api-User-Token: ") + hashtok;
 
-    std::string terrain_name = App::GetSimTerrain()->getTerrainName();
+    std::string terrain_name = App::GetGameContext()->GetTerrain()->getTerrainName();
 
     std::string script_name = App::GetScriptEngine()->getScriptUnit(unit_id).scriptName;
     std::string script_hash = App::GetScriptEngine()->getScriptUnit(unit_id).scriptHash;
@@ -1049,7 +1054,7 @@ bool GameScript::getMousePositionOnTerrain(Ogre::Vector3& out_pos)
 
     Ogre::Vector2 mouse_npos = App::GetInputEngine()->getMouseNormalizedScreenPos();
     Ogre::Ray ray = App::GetCameraManager()->GetCamera()->getCameraToViewportRay(mouse_npos.x, mouse_npos.y);
-    Ogre::TerrainGroup::RayResult ray_result = App::GetSimTerrain()->getGeometryManager()->getTerrainGroup()->rayIntersects(ray);
+    Ogre::TerrainGroup::RayResult ray_result = App::GetGameContext()->GetTerrain()->getGeometryManager()->getTerrainGroup()->rayIntersects(ray);
     if (ray_result.hit)
     {
         out_pos = ray_result.position;
@@ -1059,7 +1064,7 @@ bool GameScript::getMousePositionOnTerrain(Ogre::Vector3& out_pos)
 
 bool GameScript::HaveSimTerrain(const char* func_name)
 {
-    if (App::GetSimTerrain() == nullptr)
+    if (App::GetGameContext()->GetTerrain() == nullptr)
     {
         this->logFormat("Cannot execute '%s', terrain not ready", func_name);
         return false;

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -896,25 +896,23 @@ int GameScript::sendGameCmd(const String& message)
     return -11;
 }
 
-VehicleAI* GameScript::getCurrentTruckAI()
+VehicleAIPtr GameScript::getCurrentTruckAI()
 {
-    VehicleAI* result = nullptr;
     if (App::GetGameContext()->GetPlayerActor())
     {
-        result = App::GetGameContext()->GetPlayerActor()->ar_vehicle_ai;
+        return App::GetGameContext()->GetPlayerActor()->getVehicleAI();
     }
-    return result;
+    return nullptr;
 }
 
-VehicleAI* GameScript::getTruckAIByNum(int num)
+VehicleAIPtr GameScript::getTruckAIByNum(int num)
 {
-    VehicleAI* result = nullptr;
     ActorPtr actor = App::GetGameContext()->GetActorManager()->GetActorById(num);
     if (actor != nullptr)
     {
-        result = actor->ar_vehicle_ai;
+        return actor->getVehicleAI();
     }
-    return result;
+    return nullptr;
 }
 
 ActorPtr GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot)

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -362,8 +362,8 @@ public:
 
     int getNumTrucksByFlag(int flag);
 
-    VehicleAI* getCurrentTruckAI();
-    VehicleAI* getTruckAIByNum(int num);
+    VehicleAIPtr getCurrentTruckAI();
+    VehicleAIPtr getTruckAIByNum(int num);
 
     ///@}
 

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -324,13 +324,13 @@ public:
      * returns the current selected truck, 0 if in person mode
      * @return reference to Beam object that is currently in use
      */
-    Actor* getCurrentTruck();
+    ActorPtr getCurrentTruck();
 
     /**
      * returns a truck by index, get max index by calling getNumTrucks
      * @return reference to Beam object that the selected slot
      */
-    Actor* getTruckByNum(int num);
+    ActorPtr getTruckByNum(int num);
 
     /**
      * returns the current amount of loaded trucks
@@ -344,8 +344,8 @@ public:
      */
     int getCurrentTruckNumber();
 
-    Actor* spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot);
-    Actor* spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin);
+    ActorPtr spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot);
+    ActorPtr spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin);
     AngelScript::CScriptArray* getWaypoints();
     int getAIVehicleCount();
     int getAIVehicleDistance();

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -460,6 +460,7 @@ public:
     int setMaterialTextureScale(const Ogre::String& materialName, int techniqueNum, int passNum, int textureUnitNum, float u, float v);
 
     ///@}
+    TerrainPtr getTerrain();
 
 private:
 

--- a/source/main/scripting/LocalStorage.cpp
+++ b/source/main/scripting/LocalStorage.cpp
@@ -21,6 +21,7 @@
 
 #include "LocalStorage.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "ContentManager.h"
 #include "PlatformUtils.h"

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -159,6 +159,7 @@ void ScriptEngine::init()
     RegisterVehicleAi(engine);     // VehicleAIClass, aiEvents, AiValues
     RegisterConsole(engine);       // ConsoleClass, CVarClass, CVarFlags
     RegisterActor(engine);         // BeamClass
+    RegisterProceduralRoad(engine);// procedural_point, ProceduralRoadClass, ProceduralObjectClass, ProceduralManagerClass
     RegisterTerrain(engine);       // TerrainClass
     RegisterGameScript(engine);    // GameScriptClass
     RegisterScriptEvents(engine);  // scriptEvents

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -159,6 +159,7 @@ void ScriptEngine::init()
     RegisterVehicleAi(engine);     // VehicleAIClass, aiEvents, AiValues
     RegisterConsole(engine);       // ConsoleClass, CVarClass, CVarFlags
     RegisterActor(engine);         // BeamClass
+    RegisterTerrain(engine);       // TerrainClass
     RegisterGameScript(engine);    // GameScriptClass
     RegisterScriptEvents(engine);  // scriptEvents
 

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -502,7 +502,7 @@ int ScriptEngine::deleteVariable(const String &arg)
 
 void ScriptEngine::triggerEvent(int eventnum, int value)
 {
-    if (!engine || !context) return;
+    if (!engine || !context || !m_events_enabled) return;
 
     for (auto& pair: m_script_units)
     {

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -117,6 +117,8 @@ public:
      */
     void triggerEvent(int scriptEvents, int value = 0);
 
+    void setEventsEnabled(bool val) { m_events_enabled = val; }
+
     /**
      * executes a string (useful for the console)
      * @param command string to execute
@@ -207,6 +209,7 @@ protected:
     ScriptUnitMap   m_script_units;
     ScriptUnitId_t  m_terrain_script_unit = SCRIPTUNITID_INVALID;
     ScriptUnitId_t  m_currently_executing_script_unit = SCRIPTUNITID_INVALID;
+    bool            m_events_enabled = true; //!< Hack to enable fast shutdown without cleanup
 
     InterThreadStoreVector<Ogre::String> stringExecutionQueue; //!< The string execution queue \see queueStringForExecution
 };

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -47,8 +47,8 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     
 
     // class Actor (historically Beam)
-    result = engine->RegisterObjectType("BeamClass", sizeof(Actor), asOBJ_REF); ROR_ASSERT(result>=0);
-    ActorPtr::RegisterRefCountingObjectPtr("BeamClassPtr", "BeamClass", engine);
+    Actor::RegisterRefCountingObject(engine, "BeamClass");
+    ActorPtr::RegisterRefCountingObjectPtr(engine, "BeamClassPtr", "BeamClass");
     result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", asMETHOD(Actor,scaleTruck), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", asMETHOD(Actor,getTruckName), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", asMETHOD(Actor,getTruckFileName), asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -48,6 +48,7 @@ void RoR::RegisterActor(asIScriptEngine *engine)
 
     // class Actor (historically Beam)
     result = engine->RegisterObjectType("BeamClass", sizeof(Actor), asOBJ_REF); ROR_ASSERT(result>=0);
+    ActorPtr::RegisterRefCountingObjectPtr("BeamClassPtr", "BeamClass", engine);
     result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", asMETHOD(Actor,scaleTruck), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", asMETHOD(Actor,getTruckName), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", asMETHOD(Actor,getTruckFileName), asCALL_THISCALL); ROR_ASSERT(result>=0);
@@ -76,14 +77,8 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "float getWheelSpeed()", asMETHOD(Actor,getWheelSpeed), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "float getSpeed()", asMETHOD(Actor,getSpeed), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "vector3 getGForces()", asMETHOD(Actor,getGForces), asCALL_THISCALL); ROR_ASSERT(result>=0);
-
     result = engine->RegisterObjectMethod("BeamClass", "float getRotation()", asMETHOD(Actor,getRotation), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "vector3 getVehiclePosition()", asMETHOD(Actor,getPosition), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "vector3 getNodePosition(int)", asMETHOD(Actor,getNodePosition), asCALL_THISCALL); ROR_ASSERT(result>=0);
-
     result = engine->RegisterObjectMethod("BeamClass", "VehicleAIClass @getVehicleAI()", asMETHOD(Actor,getVehicleAI), asCALL_THISCALL); ROR_ASSERT(result>=0);
-    
-    result = engine->RegisterObjectBehaviour("BeamClass", asBEHAVE_ADDREF, "void f()", asMETHOD(Actor,addRef), asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectBehaviour("BeamClass", asBEHAVE_RELEASE, "void f()", asMETHOD(Actor,release), asCALL_THISCALL); ROR_ASSERT(result>=0);
-
 }

--- a/source/main/scripting/bindings/AngelScriptBindings.h
+++ b/source/main/scripting/bindings/AngelScriptBindings.h
@@ -64,6 +64,10 @@ void RegisterImGuiBindings(AngelScript::asIScriptEngine* engine);
 /// defined in OgreAngelscript.cpp
 void RegisterOgreObjects(AngelScript::asIScriptEngine* engine);
 
+/// Registers RoR::Terrain, defined in TerrainAngelscript.cpp
+void RegisterTerrain(AngelScript::asIScriptEngine* engine);
+
+
 /// @}   //addtogroup Scripting
 
 } // namespace RoR

--- a/source/main/scripting/bindings/AngelScriptBindings.h
+++ b/source/main/scripting/bindings/AngelScriptBindings.h
@@ -67,6 +67,9 @@ void RegisterOgreObjects(AngelScript::asIScriptEngine* engine);
 /// Registers RoR::Terrain, defined in TerrainAngelscript.cpp
 void RegisterTerrain(AngelScript::asIScriptEngine* engine);
 
+/// defined in ProceduralRoadAngelscript.cpp
+void RegisterProceduralRoad(AngelScript::asIScriptEngine* engine);
+
 
 /// @}   //addtogroup Scripting
 

--- a/source/main/scripting/bindings/GameScriptAngelscript.cpp
+++ b/source/main/scripting/bindings/GameScriptAngelscript.cpp
@@ -31,7 +31,6 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
 
     // class GameScript
     result = engine->RegisterObjectType("GameScriptClass", sizeof(GameScript), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "TerrainClass@ getTerrain()", AngelScript::asMETHOD(GameScript,getTerrain), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     
     // PLEASE maintain the same order as in GameScript.h!
 
@@ -70,6 +69,7 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("GameScriptClass", "int sendGameCmd(const string &in)", asMETHOD(GameScript, sendGameCmd), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 
     // > Terrain
+    result = engine->RegisterObjectMethod("GameScriptClass", "TerrainClassPtr @getTerrain()", AngelScript::asMETHOD(GameScript, getTerrain), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void loadTerrain(const string &in)", asMETHOD(GameScript, loadTerrain), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getLoadedTerrain(string &out)", asMETHOD(GameScript, getLoadedTerrain), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "bool getCaelumAvailable()", asMETHOD(GameScript, getCaelumAvailable), asCALL_THISCALL); ROR_ASSERT(result >= 0);
@@ -96,12 +96,12 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("GameScriptClass", "void activateAllVehicles()", asMETHOD(GameScript,activateAllVehicles), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void setTrucksForcedActive(bool forceActive)", asMETHOD(GameScript,setTrucksForcedAwake), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void boostCurrentTruck(float)", asMETHOD(GameScript, boostCurrentTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @getCurrentTruck()", asMETHOD(GameScript, getCurrentTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @getTruckByNum(int)", asMETHOD(GameScript, getTruckByNum), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @getCurrentTruck()", asMETHOD(GameScript, getCurrentTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @getTruckByNum(int)", asMETHOD(GameScript, getTruckByNum), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getNumTrucks()", asMETHOD(GameScript, getNumTrucks), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getCurrentTruckNumber()", asMETHOD(GameScript, getCurrentTruckNumber), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @spawnTruck(string &in, vector3 &in, vector3 &in)", asMETHOD(GameScript, spawnTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @spawnTruckAI(string &in, vector3 &in, string &in, string &in)", AngelScript::asMETHOD(GameScript, spawnTruckAI), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @spawnTruck(string &in, vector3 &in, vector3 &in)", asMETHOD(GameScript, spawnTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @spawnTruckAI(string &in, vector3 &in, string &in, string &in)", AngelScript::asMETHOD(GameScript, spawnTruckAI), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "array<vector3> @getWaypoints()", AngelScript::asMETHOD(GameScript, getWaypoints), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleCount()", AngelScript::asMETHOD(GameScript, getAIVehicleCount), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleDistance()", AngelScript::asMETHOD(GameScript, getAIVehicleDistance), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
@@ -114,8 +114,8 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("GameScriptClass", "void repairVehicle(const string &in, const string &in, bool)", asMETHOD(GameScript, repairVehicle), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void removeVehicle(const string &in, const string &in)", asMETHOD(GameScript, removeVehicle), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getNumTrucksByFlag(int)", asMETHOD(GameScript, getNumTrucksByFlag), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "VehicleAIClass @getCurrentTruckAI()", asMETHOD(GameScript, getCurrentTruckAI), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "VehicleAIClass @getTruckAIByNum(int)", asMETHOD(GameScript, getTruckAIByNum), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "VehicleAIClassPtr @getCurrentTruckAI()", asMETHOD(GameScript, getCurrentTruckAI), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "VehicleAIClassPtr @getTruckAIByNum(int)", asMETHOD(GameScript, getTruckAIByNum), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 
     // > Camera
     result = engine->RegisterObjectMethod("GameScriptClass", "void setCameraPosition(vector3 &in)", asMETHOD(GameScript, setCameraPosition), asCALL_THISCALL); ROR_ASSERT(result >= 0);

--- a/source/main/scripting/bindings/GameScriptAngelscript.cpp
+++ b/source/main/scripting/bindings/GameScriptAngelscript.cpp
@@ -31,6 +31,7 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
 
     // class GameScript
     result = engine->RegisterObjectType("GameScriptClass", sizeof(GameScript), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "TerrainClass@ getTerrain()", AngelScript::asMETHOD(GameScript,getTerrain), AngelScript::asCALL_THISCALL); ROR_ASSERT(result>=0);
     
     // PLEASE maintain the same order as in GameScript.h!
 

--- a/source/main/scripting/bindings/ProceduralRoadAngelscript.cpp
+++ b/source/main/scripting/bindings/ProceduralRoadAngelscript.cpp
@@ -71,9 +71,9 @@ void RoR::RegisterProceduralRoad(asIScriptEngine* engine)
     result = engine->RegisterEnumValue("TextureFit", "TEXFIT_CONCRETEUNDER", (int)TextureFit::TEXFIT_CONCRETEUNDER); ROR_ASSERT(result >= 0);
 
     // struct ProceduralPoint (ref)
-    result = engine->RegisterObjectType("ProceduralPointClass", sizeof(ProceduralPoint), asOBJ_REF); ROR_ASSERT(result >= 0);
+    ProceduralPoint::RegisterRefCountingObject(engine, "ProceduralPointClass");
+    ProceduralPointPtr::RegisterRefCountingObjectPtr(engine, "ProceduralPointClassPtr", "ProceduralPointClass");
     result = engine->RegisterObjectBehaviour("ProceduralPointClass", asBEHAVE_FACTORY, "ProceduralPointClass@ f()", asFUNCTION(ProceduralPointFactory), asCALL_CDECL); ROR_ASSERT(result >= 0);
-    ProceduralPointPtr::RegisterRefCountingObjectPtr("ProceduralPointClassPtr", "ProceduralPointClass", engine);
     result = engine->RegisterObjectProperty("ProceduralPointClass", "vector3 position", offsetof(ProceduralPoint, position)); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectProperty("ProceduralPointClass", "quaternion rotation", offsetof(ProceduralPoint, rotation)); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectProperty("ProceduralPointClass", "float width", offsetof(ProceduralPoint, width)); ROR_ASSERT(result >= 0);
@@ -83,9 +83,9 @@ void RoR::RegisterProceduralRoad(asIScriptEngine* engine)
     result = engine->RegisterObjectProperty("ProceduralPointClass", "int pillar_type", offsetof(ProceduralPoint, pillartype)); ROR_ASSERT(result >= 0);
 
     // class ProceduralRoad (ref)
-    result = engine->RegisterObjectType("ProceduralRoadClass", sizeof(ProceduralRoad), asOBJ_REF); ROR_ASSERT(result >= 0);
+    ProceduralRoad::RegisterRefCountingObject(engine, "ProceduralRoadClass");
+    ProceduralRoadPtr::RegisterRefCountingObjectPtr(engine, "ProceduralRoadClassPtr", "ProceduralRoadClass");
     result = engine->RegisterObjectBehaviour("ProceduralRoadClass", asBEHAVE_FACTORY, "ProceduralRoadClass@ f()", asFUNCTION(ProceduralRoadFactory), asCALL_CDECL); ROR_ASSERT(result >= 0);
-    ProceduralRoadPtr::RegisterRefCountingObjectPtr("ProceduralRoadClassPtr", "ProceduralRoadClass", engine);
     result = engine->RegisterObjectMethod("ProceduralRoadClass", "void addBlock(vector3 pos, quaternion rot, RoadType type, float width, float border_width, float border_height, int pillar_type = 1)", asMETHOD(RoR::ProceduralRoad, addBlock), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralRoadClass", "void addQuad(vector3 p1, vector3 p2, vector3 p3, vector3 p4, TextureFit texfit, vector3 pos, vector3 lastpos, float width, bool flip = false)", asMETHOD(RoR::ProceduralRoad, addQuad), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralRoadClass", "void addCollisionQuad(vector3 p1, vector3 p2, vector3 p3, vector3 p4, const string&in gm_name, bool flip = false)", asMETHODPR(RoR::ProceduralRoad, addCollisionQuad, (Ogre::Vector3, Ogre::Vector3, Ogre::Vector3, Ogre::Vector3, std::string const&, bool), void), asCALL_THISCALL); ROR_ASSERT(result >= 0);
@@ -94,9 +94,9 @@ void RoR::RegisterProceduralRoad(asIScriptEngine* engine)
     result = engine->RegisterObjectMethod("ProceduralRoadClass", "void setCollisionEnabled(bool v)", asMETHOD(RoR::ProceduralRoad, setCollisionEnabled), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 
     // class ProceduralObject (ref)
-    result = engine->RegisterObjectType("ProceduralObjectClass", sizeof(ProceduralObject), asOBJ_REF); ROR_ASSERT(result>=0);
+    ProceduralObject::RegisterRefCountingObject(engine, "ProceduralObjectClass");
+    ProceduralObjectPtr::RegisterRefCountingObjectPtr(engine, "ProceduralObjectClassPtr", "ProceduralObjectClass");
     result = engine->RegisterObjectBehaviour("ProceduralObjectClass", asBEHAVE_FACTORY, "ProceduralObjectClass@ f()", asFUNCTION(ProceduralObjectFactory), asCALL_CDECL); ROR_ASSERT(result >= 0);
-    ProceduralObjectPtr::RegisterRefCountingObjectPtr("ProceduralObjectClassPtr", "ProceduralObjectClass", engine);
     result = engine->RegisterObjectMethod("ProceduralObjectClass", "string getName()", asMETHOD(RoR::ProceduralObject, getName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralObjectClass", "void setName(const string&in)", asMETHOD(RoR::ProceduralObject, setName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralObjectClass", "void addPoint(ProceduralPointClass @)", asMETHOD(RoR::ProceduralObject, addPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
@@ -107,8 +107,8 @@ void RoR::RegisterProceduralRoad(asIScriptEngine* engine)
     result = engine->RegisterObjectMethod("ProceduralObjectClass", "ProceduralRoadClass @getRoad()", asMETHOD(ProceduralObject, getRoad), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 
     // class ProceduralManager (ref)
-    result = engine->RegisterObjectType("ProceduralManagerClass", sizeof(ProceduralManager), asOBJ_REF); ROR_ASSERT(result >= 0);
-    ProceduralObjectPtr::RegisterRefCountingObjectPtr("ProceduralManagerClassPtr", "ProceduralManagerClass", engine);
+    ProceduralManager::RegisterRefCountingObject(engine, "ProceduralManagerClass");
+    ProceduralManagerPtr::RegisterRefCountingObjectPtr(engine, "ProceduralManagerClassPtr", "ProceduralManagerClass");
     result = engine->RegisterObjectMethod("ProceduralManagerClass", "void addObject(ProceduralObjectClass@)", asMETHOD(ProceduralManager, addObject), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("ProceduralManagerClass", "void removeObject(ProceduralObjectClass@)", asMETHOD(ProceduralManager, removeObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralManagerClass", "int getNumObjects()", asMETHOD(RoR::ProceduralManager, getNumObjects), asCALL_THISCALL); ROR_ASSERT(result >= 0);

--- a/source/main/scripting/bindings/ProceduralRoadAngelscript.cpp
+++ b/source/main/scripting/bindings/ProceduralRoadAngelscript.cpp
@@ -99,18 +99,18 @@ void RoR::RegisterProceduralRoad(asIScriptEngine* engine)
     result = engine->RegisterObjectBehaviour("ProceduralObjectClass", asBEHAVE_FACTORY, "ProceduralObjectClass@ f()", asFUNCTION(ProceduralObjectFactory), asCALL_CDECL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralObjectClass", "string getName()", asMETHOD(RoR::ProceduralObject, getName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralObjectClass", "void setName(const string&in)", asMETHOD(RoR::ProceduralObject, setName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("ProceduralObjectClass", "void addPoint(ProceduralPointClass @)", asMETHOD(RoR::ProceduralObject, addPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("ProceduralObjectClass", "void insertPoint(int pos, ProceduralPointClass @)", asMETHOD(RoR::ProceduralObject, insertPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "void addPoint(ProceduralPointClassPtr @)", asMETHOD(RoR::ProceduralObject, addPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "void insertPoint(int pos, ProceduralPointClassPtr@)", asMETHOD(RoR::ProceduralObject, insertPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralObjectClass", "void deletePoint(int pos)", asMETHOD(RoR::ProceduralObject, deletePoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("ProceduralObjectClass", "ProceduralPointClass @getPoint(int pos)", asMETHOD(RoR::ProceduralObject, getPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "ProceduralPointClassPtr @getPoint(int pos)", asMETHOD(RoR::ProceduralObject, getPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralObjectClass", "int getNumPoints()", asMETHOD(RoR::ProceduralObject, getNumPoints), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("ProceduralObjectClass", "ProceduralRoadClass @getRoad()", asMETHOD(ProceduralObject, getRoad), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "ProceduralRoadClassPtr @getRoad()", asMETHOD(ProceduralObject, getRoad), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 
     // class ProceduralManager (ref)
     ProceduralManager::RegisterRefCountingObject(engine, "ProceduralManagerClass");
     ProceduralManagerPtr::RegisterRefCountingObjectPtr(engine, "ProceduralManagerClassPtr", "ProceduralManagerClass");
-    result = engine->RegisterObjectMethod("ProceduralManagerClass", "void addObject(ProceduralObjectClass@)", asMETHOD(ProceduralManager, addObject), asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("ProceduralManagerClass", "void removeObject(ProceduralObjectClass@)", asMETHOD(ProceduralManager, removeObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralManagerClass", "void addObject(ProceduralObjectClassPtr@)", asMETHOD(ProceduralManager, addObject), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("ProceduralManagerClass", "void removeObject(ProceduralObjectClassPtr@)", asMETHOD(ProceduralManager, removeObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("ProceduralManagerClass", "int getNumObjects()", asMETHOD(RoR::ProceduralManager, getNumObjects), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("ProceduralManagerClass", "ProceduralObjectClass @getObject(int pos)", asMETHOD(ProceduralManager, getObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralManagerClass", "ProceduralObjectClassPtr @getObject(int pos)", asMETHOD(ProceduralManager, getObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 }

--- a/source/main/scripting/bindings/ProceduralRoadAngelscript.cpp
+++ b/source/main/scripting/bindings/ProceduralRoadAngelscript.cpp
@@ -1,0 +1,116 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2022 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+/// @author Petr Ohlidal
+ 
+#include "ProceduralManager.h"
+#include "ProceduralRoad.h"
+#include "ScriptEngine.h"
+
+using namespace RoR;
+using namespace AngelScript;
+
+static ProceduralPoint* ProceduralPointFactory(ProceduralPoint* self)
+{
+    return new(self) ProceduralPoint(); // placement-new syntax
+}
+
+static ProceduralObject* ProceduralObjectFactory(ProceduralObject* self)
+{
+    return new(self) ProceduralObject(); // placement-new syntax
+}
+
+static ProceduralRoad* ProceduralRoadFactory(ProceduralRoad* self)
+{
+    return new(self) ProceduralRoad(); // placement-new syntax
+}
+
+void RoR::RegisterProceduralRoad(asIScriptEngine* engine)
+{
+    int result = 0;
+
+    // enum RoadType
+    result = engine->RegisterEnum("RoadType"); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("RoadType", "ROAD_AUTOMATIC", (int)RoadType::ROAD_AUTOMATIC); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("RoadType", "ROAD_FLAT", (int)RoadType::ROAD_FLAT); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("RoadType", "ROAD_LEFT", (int)RoadType::ROAD_LEFT); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("RoadType", "ROAD_RIGHT", (int)RoadType::ROAD_RIGHT); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("RoadType", "ROAD_BOTH", (int)RoadType::ROAD_BOTH); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("RoadType", "ROAD_BRIDGE", (int)RoadType::ROAD_BRIDGE); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("RoadType", "ROAD_MONORAIL", (int)RoadType::ROAD_MONORAIL); ROR_ASSERT(result >= 0);
+
+    // enum TextureFit
+    result = engine->RegisterEnum("TextureFit"); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_NONE", (int)TextureFit::TEXFIT_NONE); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_BRICKWALL", (int)TextureFit::TEXFIT_BRICKWALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_ROADS1", (int)TextureFit::TEXFIT_ROADS1); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_ROADS2", (int)TextureFit::TEXFIT_ROADS2); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_ROAD", (int)TextureFit::TEXFIT_ROAD); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_ROADS3", (int)TextureFit::TEXFIT_ROADS3); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_ROADS4", (int)TextureFit::TEXFIT_ROADS4); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_CONCRETEWALL", (int)TextureFit::TEXFIT_CONCRETEWALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_CONCRETEWALLI", (int)TextureFit::TEXFIT_CONCRETEWALLI); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_CONCRETETOP", (int)TextureFit::TEXFIT_CONCRETETOP); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("TextureFit", "TEXFIT_CONCRETEUNDER", (int)TextureFit::TEXFIT_CONCRETEUNDER); ROR_ASSERT(result >= 0);
+
+    // struct ProceduralPoint (ref)
+    result = engine->RegisterObjectType("ProceduralPointClass", sizeof(ProceduralPoint), asOBJ_REF); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectBehaviour("ProceduralPointClass", asBEHAVE_FACTORY, "ProceduralPointClass@ f()", asFUNCTION(ProceduralPointFactory), asCALL_CDECL); ROR_ASSERT(result >= 0);
+    ProceduralPointPtr::RegisterRefCountingObjectPtr("ProceduralPointClassPtr", "ProceduralPointClass", engine);
+    result = engine->RegisterObjectProperty("ProceduralPointClass", "vector3 position", offsetof(ProceduralPoint, position)); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectProperty("ProceduralPointClass", "quaternion rotation", offsetof(ProceduralPoint, rotation)); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectProperty("ProceduralPointClass", "float width", offsetof(ProceduralPoint, width)); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectProperty("ProceduralPointClass", "float border_width", offsetof(ProceduralPoint, bwidth)); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectProperty("ProceduralPointClass", "float border_height", offsetof(ProceduralPoint, bheight)); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectProperty("ProceduralPointClass", "RoadType type", offsetof(ProceduralPoint, type)); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectProperty("ProceduralPointClass", "int pillar_type", offsetof(ProceduralPoint, pillartype)); ROR_ASSERT(result >= 0);
+
+    // class ProceduralRoad (ref)
+    result = engine->RegisterObjectType("ProceduralRoadClass", sizeof(ProceduralRoad), asOBJ_REF); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectBehaviour("ProceduralRoadClass", asBEHAVE_FACTORY, "ProceduralRoadClass@ f()", asFUNCTION(ProceduralRoadFactory), asCALL_CDECL); ROR_ASSERT(result >= 0);
+    ProceduralRoadPtr::RegisterRefCountingObjectPtr("ProceduralRoadClassPtr", "ProceduralRoadClass", engine);
+    result = engine->RegisterObjectMethod("ProceduralRoadClass", "void addBlock(vector3 pos, quaternion rot, RoadType type, float width, float border_width, float border_height, int pillar_type = 1)", asMETHOD(RoR::ProceduralRoad, addBlock), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralRoadClass", "void addQuad(vector3 p1, vector3 p2, vector3 p3, vector3 p4, TextureFit texfit, vector3 pos, vector3 lastpos, float width, bool flip = false)", asMETHOD(RoR::ProceduralRoad, addQuad), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralRoadClass", "void addCollisionQuad(vector3 p1, vector3 p2, vector3 p3, vector3 p4, const string&in gm_name, bool flip = false)", asMETHODPR(RoR::ProceduralRoad, addCollisionQuad, (Ogre::Vector3, Ogre::Vector3, Ogre::Vector3, Ogre::Vector3, std::string const&, bool), void), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralRoadClass", "void createMesh()", asMETHOD(RoR::ProceduralRoad, createMesh), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralRoadClass", "void finish()", asMETHOD(RoR::ProceduralRoad, finish), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralRoadClass", "void setCollisionEnabled(bool v)", asMETHOD(RoR::ProceduralRoad, setCollisionEnabled), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+
+    // class ProceduralObject (ref)
+    result = engine->RegisterObjectType("ProceduralObjectClass", sizeof(ProceduralObject), asOBJ_REF); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectBehaviour("ProceduralObjectClass", asBEHAVE_FACTORY, "ProceduralObjectClass@ f()", asFUNCTION(ProceduralObjectFactory), asCALL_CDECL); ROR_ASSERT(result >= 0);
+    ProceduralObjectPtr::RegisterRefCountingObjectPtr("ProceduralObjectClassPtr", "ProceduralObjectClass", engine);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "string getName()", asMETHOD(RoR::ProceduralObject, getName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "void setName(const string&in)", asMETHOD(RoR::ProceduralObject, setName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "void addPoint(ProceduralPointClass @)", asMETHOD(RoR::ProceduralObject, addPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "void insertPoint(int pos, ProceduralPointClass @)", asMETHOD(RoR::ProceduralObject, insertPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "void deletePoint(int pos)", asMETHOD(RoR::ProceduralObject, deletePoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "ProceduralPointClass @getPoint(int pos)", asMETHOD(RoR::ProceduralObject, getPoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "int getNumPoints()", asMETHOD(RoR::ProceduralObject, getNumPoints), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralObjectClass", "ProceduralRoadClass @getRoad()", asMETHOD(ProceduralObject, getRoad), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+
+    // class ProceduralManager (ref)
+    result = engine->RegisterObjectType("ProceduralManagerClass", sizeof(ProceduralManager), asOBJ_REF); ROR_ASSERT(result >= 0);
+    ProceduralObjectPtr::RegisterRefCountingObjectPtr("ProceduralManagerClassPtr", "ProceduralManagerClass", engine);
+    result = engine->RegisterObjectMethod("ProceduralManagerClass", "void addObject(ProceduralObjectClass@)", asMETHOD(ProceduralManager, addObject), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("ProceduralManagerClass", "void removeObject(ProceduralObjectClass@)", asMETHOD(ProceduralManager, removeObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralManagerClass", "int getNumObjects()", asMETHOD(RoR::ProceduralManager, getNumObjects), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("ProceduralManagerClass", "ProceduralObjectClass @getObject(int pos)", asMETHOD(ProceduralManager, getObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+}

--- a/source/main/scripting/bindings/TerrainAngelscript.cpp
+++ b/source/main/scripting/bindings/TerrainAngelscript.cpp
@@ -41,4 +41,5 @@ void RoR::RegisterTerrain(asIScriptEngine* engine)
     result = engine->RegisterObjectMethod("TerrainClass", "int getVersion()", asMETHOD(RoR::Terrain,getVersion), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("TerrainClass", "bool isFlat()", asMETHOD(RoR::Terrain,isFlat), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("TerrainClass", "vector3 getSpawnPos()", asMETHOD(RoR::Terrain,getSpawnPos), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("TerrainClass", "ProceduralManagerClass @getProceduralManager()", asMETHOD(RoR::Terrain, getProceduralManager), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 }

--- a/source/main/scripting/bindings/TerrainAngelscript.cpp
+++ b/source/main/scripting/bindings/TerrainAngelscript.cpp
@@ -33,9 +33,8 @@ void RoR::RegisterTerrain(asIScriptEngine* engine)
 {
     int result = 0;
 
-    result = engine->RegisterObjectType("TerrainClass", sizeof(RoR::Terrain), asOBJ_REF); ROR_ASSERT(result>=0);
-    TerrainPtr::RegisterRefCountingObjectPtr("TerrainClassPtr", "TerrainClass", engine);
-    
+    Terrain::RegisterRefCountingObject(engine, "TerrainClass");
+    TerrainPtr::RegisterRefCountingObjectPtr(engine, "TerrainClassPtr", "TerrainClass");    
     result = engine->RegisterObjectMethod("TerrainClass", "string getTerrainName()", asMETHOD(RoR::Terrain,getTerrainName), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("TerrainClass", "string getGUID()", asMETHOD(RoR::Terrain,getGUID), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("TerrainClass", "int getVersion()", asMETHOD(RoR::Terrain,getVersion), asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/bindings/TerrainAngelscript.cpp
+++ b/source/main/scripting/bindings/TerrainAngelscript.cpp
@@ -40,5 +40,5 @@ void RoR::RegisterTerrain(asIScriptEngine* engine)
     result = engine->RegisterObjectMethod("TerrainClass", "int getVersion()", asMETHOD(RoR::Terrain,getVersion), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("TerrainClass", "bool isFlat()", asMETHOD(RoR::Terrain,isFlat), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("TerrainClass", "vector3 getSpawnPos()", asMETHOD(RoR::Terrain,getSpawnPos), asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectMethod("TerrainClass", "ProceduralManagerClass @getProceduralManager()", asMETHOD(RoR::Terrain, getProceduralManager), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("TerrainClass", "ProceduralManagerClassPtr @getProceduralManager()", asMETHOD(RoR::Terrain, getProceduralManager), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 }

--- a/source/main/scripting/bindings/TerrainAngelscript.cpp
+++ b/source/main/scripting/bindings/TerrainAngelscript.cpp
@@ -1,0 +1,44 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2022 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+/// @author Petr Ohlidal
+ 
+#include "ScriptEngine.h"
+#include "Terrain.h"
+
+#include <angelscript.h>
+
+using namespace AngelScript;
+
+void RoR::RegisterTerrain(asIScriptEngine* engine)
+{
+    int result = 0;
+
+    result = engine->RegisterObjectType("TerrainClass", sizeof(RoR::Terrain), asOBJ_REF); ROR_ASSERT(result>=0);
+    TerrainPtr::RegisterRefCountingObjectPtr("TerrainClassPtr", "TerrainClass", engine);
+    
+    result = engine->RegisterObjectMethod("TerrainClass", "string getTerrainName()", asMETHOD(RoR::Terrain,getTerrainName), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("TerrainClass", "string getGUID()", asMETHOD(RoR::Terrain,getGUID), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("TerrainClass", "int getVersion()", asMETHOD(RoR::Terrain,getVersion), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("TerrainClass", "bool isFlat()", asMETHOD(RoR::Terrain,isFlat), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("TerrainClass", "vector3 getSpawnPos()", asMETHOD(RoR::Terrain,getSpawnPos), asCALL_THISCALL); ROR_ASSERT(result>=0);
+}

--- a/source/main/scripting/bindings/VehicleAiAngelscript.cpp
+++ b/source/main/scripting/bindings/VehicleAiAngelscript.cpp
@@ -40,8 +40,8 @@ void RoR::RegisterVehicleAi(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("AiValues", "AI_SPEED", AI_SPEED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("AiValues", "AI_POWER", AI_POWER); ROR_ASSERT(result >= 0);
 
-    result = engine->RegisterObjectType("VehicleAIClass", sizeof(VehicleAI), asOBJ_REF); ROR_ASSERT(result >= 0);
-    VehicleAIPtr::RegisterRefCountingObjectPtr("VehicleAIClassPtr", "VehicleAIClass", engine);
+    VehicleAI::RegisterRefCountingObject(engine, "VehicleAIClass");
+    VehicleAIPtr::RegisterRefCountingObjectPtr(engine, "VehicleAIClassPtr", "VehicleAIClass");
     result = engine->RegisterObjectMethod("VehicleAIClass", "void addWaypoints(dictionary &in)", asMETHOD(VehicleAI, AddWaypoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("VehicleAIClass", "void setActive(bool)", asMETHOD(VehicleAI, SetActive), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("VehicleAIClass", "void addEvent(string &in,int &in)", asMETHOD(VehicleAI, AddEvent), asCALL_THISCALL); ROR_ASSERT(result >= 0);

--- a/source/main/scripting/bindings/VehicleAiAngelscript.cpp
+++ b/source/main/scripting/bindings/VehicleAiAngelscript.cpp
@@ -41,13 +41,10 @@ void RoR::RegisterVehicleAi(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("AiValues", "AI_POWER", AI_POWER); ROR_ASSERT(result >= 0);
 
     result = engine->RegisterObjectType("VehicleAIClass", sizeof(VehicleAI), asOBJ_REF); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("VehicleAIClass", "void addWaypoint(string &in, vector3 &in)", asMETHOD(VehicleAI, AddWaypoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    VehicleAIPtr::RegisterRefCountingObjectPtr("VehicleAIClassPtr", "VehicleAIClass", engine);
     result = engine->RegisterObjectMethod("VehicleAIClass", "void addWaypoints(dictionary &in)", asMETHOD(VehicleAI, AddWaypoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("VehicleAIClass", "void setActive(bool)", asMETHOD(VehicleAI, SetActive), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("VehicleAIClass", "void addEvent(string &in,int &in)", asMETHOD(VehicleAI, AddEvent), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("VehicleAIClass", "void setValueAtWaypoint(string &in, int &in, float &in)", asMETHOD(VehicleAI, SetValueAtWaypoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("VehicleAIClass", "vector3 getTranslation(int &in, uint &in)", AngelScript::asMETHOD(VehicleAI, getTranslation), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectBehaviour("VehicleAIClass", asBEHAVE_ADDREF, "void f()", asMETHOD(VehicleAI, addRef), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectBehaviour("VehicleAIClass", asBEHAVE_RELEASE, "void f()", asMETHOD(VehicleAI, release), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-
 }

--- a/source/main/system/AppConfig.cpp
+++ b/source/main/system/AppConfig.cpp
@@ -19,6 +19,7 @@
     along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "Actor.h"
 #include "Application.h"
 #include "Console.h"
 #include "ContentManager.h" // RGN_CONFIG

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -69,17 +69,17 @@ public:
         Str<200> reply;
         if (args.size() == 1)
         {
-            reply << _L("Current gravity is: ") << App::GetSimTerrain()->getGravity();
+            reply << _L("Current gravity is: ") << App::GetGameContext()->GetTerrain()->getGravity();
         }
         else
         {
-                 if (args[1] == "earth")    { App::GetSimTerrain()->setGravity(DEFAULT_GRAVITY);    }
-            else if (args[1] == "moon")     { App::GetSimTerrain()->setGravity(-1.62f);             }
-            else if (args[1] == "mars")     { App::GetSimTerrain()->setGravity(-3.711f);            }
-            else if (args[1] == "jupiter")  { App::GetSimTerrain()->setGravity(-24.8f);             }
-            else                            { App::GetSimTerrain()->setGravity(PARSEREAL(args[1])); }
+                 if (args[1] == "earth")    { App::GetGameContext()->GetTerrain()->setGravity(DEFAULT_GRAVITY);    }
+            else if (args[1] == "moon")     { App::GetGameContext()->GetTerrain()->setGravity(-1.62f);             }
+            else if (args[1] == "mars")     { App::GetGameContext()->GetTerrain()->setGravity(-3.711f);            }
+            else if (args[1] == "jupiter")  { App::GetGameContext()->GetTerrain()->setGravity(-24.8f);             }
+            else                            { App::GetGameContext()->GetTerrain()->setGravity(PARSEREAL(args[1])); }
 
-            reply << _L("Gravity set to: ") << App::GetSimTerrain()->getGravity();
+            reply << _L("Gravity set to: ") << App::GetGameContext()->GetTerrain()->getGravity();
         }
 
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_REPLY, reply.ToCStr());
@@ -99,7 +99,7 @@ public:
         Str<200> reply;
         Console::MessageType reply_type;
         reply << m_name << ": ";
-        if (!App::GetSimTerrain()->getWater())
+        if (!App::GetGameContext()->GetTerrain()->getWater())
         {
             reply_type = Console::CONSOLE_SYSTEM_ERROR;
             reply << _L("This terrain does not have water.");
@@ -109,12 +109,12 @@ public:
             reply_type = Console::CONSOLE_SYSTEM_REPLY;
             if (args.size() > 1)
             {
-                IWater* water = App::GetSimTerrain()->getWater();
-                float height = (args[1] == "default") ? App::GetSimTerrain()->getWaterHeight() : PARSEREAL(args[1]);
+                IWater* water = App::GetGameContext()->GetTerrain()->getWater();
+                float height = (args[1] == "default") ? App::GetGameContext()->GetTerrain()->getWaterHeight() : PARSEREAL(args[1]);
                 water->SetStaticWaterHeight(height);
                 water->UpdateWater();
             }
-            reply << _L ("Water level set to: ") << App::GetSimTerrain()->getWater()->GetStaticWaterHeight();
+            reply << _L ("Water level set to: ") << App::GetGameContext()->GetTerrain()->getWater()->GetStaticWaterHeight();
         }
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, reply_type, reply.ToCStr());
     }
@@ -130,7 +130,7 @@ public:
         if (!this->CheckAppState(AppState::SIMULATION))
             return;
 
-        ROR_ASSERT(App::GetSimTerrain());
+        ROR_ASSERT(App::GetGameContext()->GetTerrain());
 
         Str<200> reply;
         reply << m_name << ": ";
@@ -149,7 +149,7 @@ public:
         }
         reply << _L("Terrain height at position: ")
               << "x: " << pos.x << " z: " << pos.z << " = "
-              <<  App::GetSimTerrain()->GetHeightAt(pos.x, pos.z);
+              <<  App::GetGameContext()->GetTerrain()->GetHeightAt(pos.x, pos.z);
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, reply_type, reply.ToCStr());
     }
 };
@@ -165,7 +165,7 @@ public:
             return;
 
         ROR_ASSERT(App::GetGameContext()->GetPlayerCharacter());
-        ROR_ASSERT(App::GetSimTerrain());
+        ROR_ASSERT(App::GetGameContext()->GetTerrain());
 
         Str<200> reply;
         reply << m_name << ": ";
@@ -182,7 +182,7 @@ public:
             {
                 Ogre::Vector3 pos = App::GetGameContext()->GetPlayerCharacter()->getPosition();
                 Ogre::SceneNode* bake_node = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
-                App::GetSimTerrain()->getObjectManager()->LoadTerrainObject(args[1], pos, Ogre::Vector3::ZERO, bake_node, "Console", "");
+                App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(args[1], pos, Ogre::Vector3::ZERO, bake_node, "Console", "");
 
                 reply_type = Console::CONSOLE_SYSTEM_REPLY;
                 reply << _L("Spawned object at position: ") << "x: " << pos.x << " z: " << pos.z;

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -136,7 +136,7 @@ public:
         reply << m_name << ": ";
         Console::MessageType reply_type = Console::CONSOLE_SYSTEM_REPLY;
         Ogre::Vector3 pos;
-        Actor* const actor = App::GetGameContext()->GetPlayerActor();
+        ActorPtr const actor = App::GetGameContext()->GetPlayerActor();
         if (actor)
         {
             pos = actor->getPosition();
@@ -251,7 +251,7 @@ public:
         reply << m_name << ": ";
         Console::MessageType reply_type = Console::CONSOLE_SYSTEM_REPLY;
 
-        Actor* b = App::GetGameContext()->GetPlayerActor();
+        ActorPtr b = App::GetGameContext()->GetPlayerActor();
         if (!b && App::GetGameContext()->GetPlayerCharacter())
         {
             Ogre::Vector3 pos = App::GetGameContext()->GetPlayerCharacter()->getPosition();
@@ -291,7 +291,7 @@ public:
             reply_type = Console::CONSOLE_SYSTEM_REPLY;
             Ogre::Vector3 pos(PARSEREAL(args[1]), PARSEREAL(args[2]), PARSEREAL(args[3]));
 
-            Actor* b = App::GetGameContext()->GetPlayerActor();
+            ActorPtr b = App::GetGameContext()->GetPlayerActor();
             if (!b && App::GetGameContext()->GetPlayerCharacter())
             {
                 App::GetGameContext()->GetPlayerCharacter()->setPosition(pos);

--- a/source/main/terrain/ProceduralManager.cpp
+++ b/source/main/terrain/ProceduralManager.cpp
@@ -52,17 +52,11 @@ void ProceduralManager::deleteObject(ProceduralObjectPtr po)
 
 void ProceduralManager::removeObject(ProceduralObjectPtr po)
 {
-    auto itor = pObjects.begin();
-    while (itor != pObjects.end())
+    for (size_t i = 0; i < pObjects.size(); i++)
     {
-        if (*itor == po)
+        if (pObjects[i] == po)
         {
-            this->deleteObject(*itor);
-            itor = pObjects.erase(itor);
-        }
-        else
-        {
-            itor++;
+            pObjects.erase(pObjects.begin() + i);
         }
     }
 }

--- a/source/main/terrain/ProceduralManager.cpp
+++ b/source/main/terrain/ProceduralManager.cpp
@@ -2,6 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2022 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -28,47 +29,66 @@ using namespace RoR;
 
 ProceduralManager::~ProceduralManager()
 {
-    for (ProceduralObject& po : pObjects)
+    this->removeAllObjects();
+}
+
+void ProceduralManager::removeAllObjects()
+{
+    for (ProceduralObjectPtr obj : pObjects)
     {
-        deleteObject(po);
+        this->deleteObject(obj);
+    }
+    pObjects.clear(); // delete (unreference) all objects.
+}
+
+void ProceduralManager::deleteObject(ProceduralObjectPtr po)
+{
+    if (po->road)
+    {
+        // loaded already, delete (unreference) old object
+        po->road = ProceduralRoadPtr();
     }
 }
 
-int ProceduralManager::deleteObject(ProceduralObject& po)
+void ProceduralManager::removeObject(ProceduralObjectPtr po)
 {
-    if (po.road)
+    auto itor = pObjects.begin();
+    while (itor != pObjects.end())
     {
-        // loaded already, destroy old object
-        delete po.road;
-        po.road = 0;
+        if (*itor == po)
+        {
+            this->deleteObject(*itor);
+            itor = pObjects.erase(itor);
+        }
+        else
+        {
+            itor++;
+        }
     }
-    return 0;
 }
 
-int ProceduralManager::updateObject(ProceduralObject& po)
+void ProceduralManager::updateObject(ProceduralObjectPtr po)
 {
-    if (po.road)
-        deleteObject(po);
-    // create new road2 object
-    po.road = new ProceduralRoad((int)pObjects.size());
+    if (po->road)
+        this->deleteObject(po);
+
+    po->road = ProceduralRoadPtr::Bind(new ProceduralRoad());
     // In diagnostic mode, disable collisions (speeds up terrain loading)
-    po.road->setCollisionEnabled(!App::diag_terrn_log_roads->getBool());
+    po->road->setCollisionEnabled(!App::diag_terrn_log_roads->getBool());
 
     std::vector<ProceduralPoint>::iterator it;
-    for (it = po.points.begin(); it != po.points.end(); it++)
+    for (it = po->points.begin(); it != po->points.end(); it++)
     {
         ProceduralPoint pp = *it;
-        po.road->addBlock(pp.position, pp.rotation, pp.type, pp.width, pp.bwidth, pp.bheight, pp.pillartype);
+        po->road->addBlock(pp.position, pp.rotation, pp.type, pp.width, pp.bwidth, pp.bheight, pp.pillartype);
     }
-    po.road->finish();
-    return 0;
+    po->road->finish();
 }
 
-int ProceduralManager::addObject(ProceduralObject& po)
+void ProceduralManager::addObject(ProceduralObjectPtr po)
 {
     updateObject(po);
     pObjects.push_back(po);
-    return 0;
 }
 
 void ProceduralManager::logDiagnostics()
@@ -79,10 +99,10 @@ void ProceduralManager::logDiagnostics()
     for (int i=0; i< (int) pObjects.size(); ++i)
     {
         LogFormat("~~~~~~ ProceduralObject %d ~~~~~~", i);
-        ProceduralObject& po=pObjects[i];
-        for (int j = 0; j<(int)po.points.size(); ++j)
+        ProceduralObjectPtr& po=pObjects[i];
+        for (int j = 0; j<(int)po->points.size(); ++j)
         {
-            ProceduralPoint& pt = po.points[j];
+            ProceduralPoint& pt = po->points[j];
             LogFormat("\t Point [%d] posXYZ %f %f %f, type %d, width %f, bwidth %f, bheight %f, pillartype %i",
                                 j,   pt.position.x, pt.position.y, pt.position.z,
                                                    pt.type, pt.width, pt.bwidth, pt.bheight, pt.pillartype);

--- a/source/main/terrain/ProceduralManager.h
+++ b/source/main/terrain/ProceduralManager.h
@@ -2,6 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2022 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -18,7 +19,7 @@
     along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
 */
 
-// thomas, 17th of June 2008
+// @author thomas, 17th of June 2008
 #pragma once
 
 #include "Application.h"
@@ -29,38 +30,60 @@ namespace RoR {
 /// @addtogroup Terrain
 /// @{
 
-struct ProceduralPoint
+struct ProceduralPoint: public RefCountingObject<ProceduralPoint>
 {
     Ogre::Vector3 position = Ogre::Vector3::ZERO;
     Ogre::Quaternion rotation = Ogre::Quaternion::IDENTITY;
-    int type = 0;
+    RoadType type = RoadType::ROAD_AUTOMATIC;
     float width = 0.f;
     float bwidth = 0.f;
     float bheight = 0.f;
     int pillartype = 0;
 };
 
-struct ProceduralObject
+struct ProceduralObject: public RefCountingObject<ProceduralObject>
 {
+    // Nice funcs for Angelscript
+    void addPoint(ProceduralPoint const& p) { points.push_back(p); }
+    ProceduralPoint getPoint(int pos) { if (pos < (int)points.size()) { return points[pos]; } else { return ProceduralPoint(); } }
+    void insertPoint(int pos, ProceduralPoint const& p) { if (pos < (int)points.size()) { points.insert(points.begin() + pos, p); } }
+    void deletePoint(int pos) { if (pos < (int)points.size()) { points.erase(points.begin() + pos); } }
+    int getNumPoints() { return (int)points.size(); }
+    ProceduralRoadPtr getRoad() { return road; }
+    std::string getName() { return name; }
+    void setName(std::string const& new_name) { name = new_name; }
+
+    std::string name;
     std::vector<ProceduralPoint> points;
-    ProceduralRoad* road = nullptr;
+    ProceduralRoadPtr road;
 };
 
-class ProceduralManager
+class ProceduralManager: public RefCountingObject<ProceduralManager>
 {
 public:
     ~ProceduralManager();
 
-    int  addObject(ProceduralObject& po);
+    /// Generates road mesh and adds to internal list
+    void addObject(ProceduralObjectPtr po);
 
-    int  deleteObject(ProceduralObject& po);
+    /// Clears road mesh and removes from internal list
+    void removeObject(ProceduralObjectPtr po);
+
+    int getNumObjects() { return (int)pObjects.size(); }
+
+    ProceduralObjectPtr getObject(int pos) { if (pos < (int)pObjects.size()) { return pObjects[pos]; } else return ProceduralObjectPtr(); }
 
     void logDiagnostics();
 
-private:
-    int updateObject(ProceduralObject& po);
+    void removeAllObjects();
 
-    std::vector<ProceduralObject> pObjects;
+private:
+    /// Rebuilds the road mesh
+    void updateObject(ProceduralObjectPtr po);
+    /// Deletes the road mesh
+    void deleteObject(ProceduralObjectPtr po);
+
+    std::vector<ProceduralObjectPtr> pObjects;
 };
 
 /// @} // addtogroup Terrain

--- a/source/main/terrain/ProceduralRoad.cpp
+++ b/source/main/terrain/ProceduralRoad.cpp
@@ -44,7 +44,8 @@ ProceduralRoad::~ProceduralRoad()
 {
     if (snode)
     {
-        snode->removeAndDestroyAllChildren();
+        App::GetGfxScene()->GetSceneManager()->destroySceneNode(snode);
+        snode = nullptr;
     }
     if (!msh.isNull())
     {

--- a/source/main/terrain/ProceduralRoad.cpp
+++ b/source/main/terrain/ProceduralRoad.cpp
@@ -23,6 +23,7 @@
 #include "Actor.h"
 #include "Application.h"
 #include "Collisions.h"
+#include "GameContext.h"
 #include "GfxScene.h"
 #include "Terrain.h"
 
@@ -52,7 +53,7 @@ ProceduralRoad::~ProceduralRoad()
     }
     for (int number : registeredCollTris)
     {
-        App::GetSimTerrain()->GetCollisions()->removeCollisionTri(number);
+        App::GetGameContext()->GetTerrain()->GetCollisions()->removeCollisionTri(number);
     }
 }
 
@@ -71,7 +72,7 @@ void ProceduralRoad::finish()
     snode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
     snode->attachObject(ec);
 
-    App::GetSimTerrain()->GetCollisions()->registerCollisionMesh(
+    App::GetGameContext()->GetTerrain()->GetCollisions()->registerCollisionMesh(
         "RoadSystem", mesh_name, 
         ec->getBoundingBox().getCenter(), ec->getMesh()->getBounds(),
         /*groundmodel:*/nullptr, registeredCollTris[0], (int)registeredCollTris.size());
@@ -87,8 +88,8 @@ void ProceduralRoad::addBlock(Vector3 pos, Quaternion rot, int type, float width
         //define type
         Vector3 leftv = pos + rot * Vector3(0, 0, bwidth + width / 2.0);
         Vector3 rightv = pos + rot * Vector3(0, 0, -bwidth - width / 2.0);
-        float dleft = leftv.y - RoR::App::GetSimTerrain()->GetHeightAt(leftv.x, leftv.z);
-        float dright = rightv.y - RoR::App::GetSimTerrain()->GetHeightAt(rightv.x, rightv.z);
+        float dleft = leftv.y - RoR::App::GetGameContext()->GetTerrain()->GetHeightAt(leftv.x, leftv.z);
+        float dright = rightv.y - RoR::App::GetGameContext()->GetTerrain()->GetHeightAt(rightv.x, rightv.z);
         if (dleft < bheight + 0.1 && dright < bheight + 0.1)
             type = ROAD_FLAT;
         if (dleft < bheight + 0.1 && dright >= bheight + 0.1 && dright < 4.0)
@@ -166,9 +167,9 @@ void ProceduralRoad::addBlock(Vector3 pos, Quaternion rot, int type, float width
             Vector3 rightv = pos + rot * Vector3(0, 0, -bwidth - width / 2.0);
             Vector3 middle = lpts[0] - ((lpts[0] + (pts[1] - lpts[0]) / 2) -
                 (lpts[7] + (pts[6] - lpts[7]) / 2)) * 0.5;
-            float heightleft = RoR::App::GetSimTerrain()->GetHeightAt(leftv.x, leftv.z);
-            float heightright = RoR::App::GetSimTerrain()->GetHeightAt(rightv.x, rightv.z);
-            float heightmiddle = RoR::App::GetSimTerrain()->GetHeightAt(middle.x, middle.z);
+            float heightleft = RoR::App::GetGameContext()->GetTerrain()->GetHeightAt(leftv.x, leftv.z);
+            float heightright = RoR::App::GetGameContext()->GetTerrain()->GetHeightAt(rightv.x, rightv.z);
+            float heightmiddle = RoR::App::GetGameContext()->GetTerrain()->GetHeightAt(middle.x, middle.z);
 
             bool builtpillars = true;
 
@@ -197,7 +198,7 @@ void ProceduralRoad::addBlock(Vector3 pos, Quaternion rot, int type, float width
 
             middle = lpts[0] - ((lpts[0] + (pts[1] - lpts[0]) / 2) -
                 (lpts[7] + (pts[6] - lpts[7]) / 2)) * sidefactor;
-            float len = middle.y - RoR::App::GetSimTerrain()->GetHeightAt(middle.x, middle.z) + 5;
+            float len = middle.y - RoR::App::GetGameContext()->GetTerrain()->GetHeightAt(middle.x, middle.z) + 5;
             float width2 = len / 30;
 
             if (pillartype == 2 && len > 20)
@@ -344,7 +345,7 @@ void ProceduralRoad::computePoints(Vector3* pts, Vector3 pos, Quaternion rot, in
 
 inline Vector3 ProceduralRoad::baseOf(Vector3 p)
 {
-    float y = RoR::App::GetSimTerrain()->GetHeightAt(p.x, p.z) - 0.01;
+    float y = RoR::App::GetGameContext()->GetTerrain()->GetHeightAt(p.x, p.z) - 0.01;
 
     if (y > p.y)
     {
@@ -390,9 +391,9 @@ void ProceduralRoad::addQuad(Vector3 p1, Vector3 p2, Vector3 p3, Vector3 p4, int
     }
     if (collision)
     {
-        ground_model_t* gm = App::GetSimTerrain()->GetCollisions()->getGroundModelByString("concrete");
+        ground_model_t* gm = App::GetGameContext()->GetTerrain()->GetCollisions()->getGroundModelByString("concrete");
         if (texfit == TEXFIT_ROAD || texfit == TEXFIT_ROADS1 || texfit == TEXFIT_ROADS2 || texfit == TEXFIT_ROADS3 || texfit == TEXFIT_ROADS4)
-            gm = App::GetSimTerrain()->GetCollisions()->getGroundModelByString("asphalt");
+            gm = App::GetGameContext()->GetTerrain()->GetCollisions()->getGroundModelByString("asphalt");
         addCollisionQuad(p1, p2, p3, p4, gm, flip);
     }
     tricount += 2;
@@ -539,21 +540,21 @@ void ProceduralRoad::addCollisionQuad(Vector3 p1, Vector3 p2, Vector3 p3, Vector
     int triID = 0;
     if (flip)
     {
-        triID = App::GetSimTerrain()->GetCollisions()->addCollisionTri(p1, p2, p4, gm);
+        triID = App::GetGameContext()->GetTerrain()->GetCollisions()->addCollisionTri(p1, p2, p4, gm);
         if (triID >= 0)
             registeredCollTris.push_back(triID);
 
-        triID = App::GetSimTerrain()->GetCollisions()->addCollisionTri(p4, p2, p3, gm);
+        triID = App::GetGameContext()->GetTerrain()->GetCollisions()->addCollisionTri(p4, p2, p3, gm);
         if (triID >= 0)
             registeredCollTris.push_back(triID);
     }
     else
     {
-        triID = App::GetSimTerrain()->GetCollisions()->addCollisionTri(p1, p2, p3, gm);
+        triID = App::GetGameContext()->GetTerrain()->GetCollisions()->addCollisionTri(p1, p2, p3, gm);
         if (triID >= 0)
             registeredCollTris.push_back(triID);
 
-        triID = App::GetSimTerrain()->GetCollisions()->addCollisionTri(p1, p3, p4, gm);
+        triID = App::GetGameContext()->GetTerrain()->GetCollisions()->addCollisionTri(p1, p3, p4, gm);
         if (triID >= 0)
             registeredCollTris.push_back(triID);
     }

--- a/source/main/terrain/ProceduralRoad.cpp
+++ b/source/main/terrain/ProceduralRoad.cpp
@@ -20,6 +20,7 @@
 
 #include "ProceduralRoad.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Collisions.h"
 #include "GfxScene.h"

--- a/source/main/terrain/ProceduralRoad.h
+++ b/source/main/terrain/ProceduralRoad.h
@@ -23,27 +23,55 @@
 #include <Ogre.h>
 
 #include "Application.h"
+#include "RefCountingObject.h"
 
 namespace RoR {
 
 /// @addtogroup Terrain
 /// @{
 
+enum class RoadType
+{
+    ROAD_AUTOMATIC,
+    ROAD_FLAT,
+    ROAD_LEFT,
+    ROAD_RIGHT,
+    ROAD_BOTH,
+    ROAD_BRIDGE,
+    ROAD_MONORAIL
+};
+
+enum class TextureFit
+{
+    TEXFIT_NONE,
+    TEXFIT_BRICKWALL,
+    TEXFIT_ROADS1,
+    TEXFIT_ROADS2,
+    TEXFIT_ROAD,
+    TEXFIT_ROADS3,
+    TEXFIT_ROADS4,
+    TEXFIT_CONCRETEWALL,
+    TEXFIT_CONCRETEWALLI,
+    TEXFIT_CONCRETETOP,
+    TEXFIT_CONCRETEUNDER
+};
+
 // dynamic roads
-class ProceduralRoad : public ZeroedMemoryAllocator
+class ProceduralRoad : public RefCountingObject<ProceduralRoad>
 {
 public:
 
-    ProceduralRoad(int id);
+    ProceduralRoad();
     ~ProceduralRoad();
 
-    void addBlock(Ogre::Vector3 pos, Ogre::Quaternion rot, int type, float width, float bwidth, float bheight, int pillartype = 1);
+    void addBlock(Ogre::Vector3 pos, Ogre::Quaternion rot, RoadType type, float width, float bwidth, float bheight, int pillartype = 1);
     /**
      * @param p1 Top left point.
      * @param p2 Top right point.
      */
-    void addQuad(Ogre::Vector3 p1, Ogre::Vector3 p2, Ogre::Vector3 p3, Ogre::Vector3 p4, int texfit, Ogre::Vector3 pos, Ogre::Vector3 lastpos, float width, bool flip = false);
+    void addQuad(Ogre::Vector3 p1, Ogre::Vector3 p2, Ogre::Vector3 p3, Ogre::Vector3 p4, TextureFit texfit, Ogre::Vector3 pos, Ogre::Vector3 lastpos, float width, bool flip = false);
     void addCollisionQuad(Ogre::Vector3 p1, Ogre::Vector3 p2, Ogre::Vector3 p3, Ogre::Vector3 p4, ground_model_t* gm, bool flip = false);
+    void addCollisionQuad(Ogre::Vector3 p1, Ogre::Vector3 p2, Ogre::Vector3 p3, Ogre::Vector3 p4, std::string const& gm_name, bool flip = false);
     void createMesh();
     void finish();
     void setCollisionEnabled(bool v) { collision = v; }
@@ -51,37 +79,11 @@ public:
     static const unsigned int MAX_VERTEX = 50000;
     static const unsigned int MAX_TRIS = 50000;
 
-    enum RoadType
-    {
-        ROAD_AUTOMATIC,
-        ROAD_FLAT,
-        ROAD_LEFT,
-        ROAD_RIGHT,
-        ROAD_BOTH,
-        ROAD_BRIDGE,
-        ROAD_MONORAIL
-    };
-
-    enum
-    {
-        TEXFIT_NONE,
-        TEXFIT_BRICKWALL,
-        TEXFIT_ROADS1,
-        TEXFIT_ROADS2,
-        TEXFIT_ROAD,
-        TEXFIT_ROADS3,
-        TEXFIT_ROADS4,
-        TEXFIT_CONCRETEWALL,
-        TEXFIT_CONCRETEWALLI,
-        TEXFIT_CONCRETETOP,
-        TEXFIT_CONCRETEUNDER
-    };
-
 private:
 
     inline Ogre::Vector3 baseOf(Ogre::Vector3 p);
-    void computePoints(Ogre::Vector3* pts, Ogre::Vector3 pos, Ogre::Quaternion rot, int type, float width, float bwidth, float bheight);
-    void textureFit(Ogre::Vector3 p1, Ogre::Vector3 p2, Ogre::Vector3 p3, Ogre::Vector3 p4, int texfit, Ogre::Vector2* texc, Ogre::Vector3 pos, Ogre::Vector3 lastpos, float width);
+    void computePoints(Ogre::Vector3* pts, Ogre::Vector3 pos, Ogre::Quaternion rot, RoadType type, float width, float bwidth, float bheight);
+    void textureFit(Ogre::Vector3 p1, Ogre::Vector3 p2, Ogre::Vector3 p3, Ogre::Vector3 p4, TextureFit texfit, Ogre::Vector2* texc, Ogre::Vector3 pos, Ogre::Vector3 lastpos, float width);
 
     typedef struct
     {
@@ -91,24 +93,24 @@ private:
     } CoVertice_t;
 
     Ogre::MeshPtr msh;
-    Ogre::SubMesh* mainsub;
+    Ogre::SubMesh* mainsub = nullptr;
 
-    Ogre::Vector2 tex[MAX_VERTEX];
-    Ogre::Vector3 vertex[MAX_VERTEX];
-    int tricount;
-    int vertexcount;
-    short tris[MAX_TRIS * 3];
+    Ogre::Vector2 tex[MAX_VERTEX] = {};
+    Ogre::Vector3 vertex[MAX_VERTEX] = {};
+    int tricount = 0;
+    int vertexcount = 0;
+    short tris[MAX_TRIS * 3] = {};
 
     Ogre::Quaternion lastrot;
-    Ogre::SceneNode* snode;
+    Ogre::SceneNode* snode = nullptr;
     Ogre::Vector3 lastpos;
-    bool first;
-    float lastbheight;
-    float lastbwidth;
-    float lastwidth;
-    int lasttype;
-    int mid;
-    bool collision; //!< Register collision triangles?
+    bool first = true;
+    float lastbheight = 0.f;
+    float lastbwidth = 0.f;
+    float lastwidth = 0.f;
+    RoadType lasttype;
+    int mid = 0;
+    bool collision = true; //!< Register collision triangles?
     std::vector<int> registeredCollTris;
 };
 

--- a/source/main/terrain/Terrain.cpp
+++ b/source/main/terrain/Terrain.cpp
@@ -544,3 +544,8 @@ void RoR::Terrain::HandleException(const char* summary)
     }
 }
 
+ProceduralManagerPtr RoR::Terrain::getProceduralManager()
+{
+    return m_object_manager->getProceduralManager();
+}
+

--- a/source/main/terrain/Terrain.h
+++ b/source/main/terrain/Terrain.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "Application.h"
+#include "RefCountingObject.h"
 #include "TerrainEditor.h"
 #include "Terrn2FileFormat.h"
 
@@ -33,34 +34,36 @@ namespace RoR {
 /// @addtogroup Terrain
 /// @{
 
-class Terrain : public ZeroedMemoryAllocator
+class Terrain : public ZeroedMemoryAllocator, public RefCountingObject<Terrain>
 {
 public:
     static const int UNLIMITED_SIGHTRANGE = 4999;
 
-    static Terrain* LoadAndPrepareTerrain(CacheEntry* entry); //!< Factory function
-
-    Terrain(CacheEntry* entry);
+    Terrain(CacheEntry* entry, Terrn2Def def);
     ~Terrain();
+    bool initialize();
+    void dispose();
 
-        // Terrain info
-
+    /// @name Terrain info
+    /// @{
     std::string             getTerrainName() const        { return m_def.name; }
     std::string             getGUID() const               { return m_def.guid; }
     int                     getCategoryID() const         { return m_def.category_id; }
     int                     getVersion() const            { return m_def.version; }
     const CacheEntry*       getCacheEntry()               { return m_cache_entry; }
+    /// @}
 
-        // Terrain properties
-
+    /// @name Terrain properties
+    /// @{
     Terrn2Def&              GetDef()                      { return m_def; }
     Ogre::Vector3           getSpawnPos()                 { return m_def.start_position; }
     float                   getWaterHeight() const        { return m_def.water_height; }
     bool                    isFlat();
     float                   getPagedDetailFactor() const  { return m_paged_detail_factor; }
+    /// @}
 
-        // Subsystems
-
+    /// @name Subsystems
+    /// @{
     TerrainGeometryManager* getGeometryManager()          { return m_geometry_manager; }
     TerrainObjectManager*   getObjectManager()            { return m_object_manager; }
     HydraxWater*            getHydraxManager()            { return m_hydrax_water; }
@@ -70,27 +73,31 @@ public:
     TerrainEditor*          GetTerrainEditor()            { return &m_terrain_editor; }
     Collisions*             GetCollisions()               { return m_collisions; }
     IWater*                 getWater()                    { return m_water.get(); }
+    /// @}
 
-        // Visuals
-
+    /// @name Visuals
+    /// @{
     Ogre::Light*            getMainLight()                { return m_main_light; }
     int                     getFarClip() const            { return m_sight_range; }
+    /// @}
 
-        // Simulation
-
+    /// @name Simulation
+    /// @{
     void                    setGravity(float value);
     float                   getGravity() const            { return m_cur_gravity; }
     float                   GetHeightAt(float x, float z);
     Ogre::Vector3           GetNormalAt(float x, float y, float z);
     Ogre::Vector3           getMaxTerrainSize();
     Ogre::AxisAlignedBox    getTerrainCollisionAAB();
+    /// @}
 
-        // Utility
-
+    /// @name Utility
+    /// @{
     void                    LoadTelepoints();
     void                    LoadPredefinedActors();
     bool                    HasPredefinedActors();
     void                    HandleException(const char* summary);
+    /// @}
 
 private:
 
@@ -132,6 +139,7 @@ private:
 
     Ogre::Light*            m_main_light;
     float                   m_cur_gravity;
+    bool                    m_disposed = false;
 };
 
 /// @} // addtogroup Terrain

--- a/source/main/terrain/Terrain.h
+++ b/source/main/terrain/Terrain.h
@@ -65,6 +65,7 @@ public:
     /// @name Subsystems
     /// @{
     TerrainGeometryManager* getGeometryManager()          { return m_geometry_manager; }
+    ProceduralManagerPtr    getProceduralManager();
     TerrainObjectManager*   getObjectManager()            { return m_object_manager; }
     HydraxWater*            getHydraxManager()            { return m_hydrax_water; }
     SkyManager*             getSkyManager();

--- a/source/main/terrain/TerrainEditor.cpp
+++ b/source/main/terrain/TerrainEditor.cpp
@@ -38,7 +38,7 @@ using namespace Ogre;
 
 void TerrainEditor::UpdateInputEvents(float dt)
 {
-    auto& object_list = App::GetSimTerrain()->getObjectManager()->GetEditorObjects();
+    auto& object_list = App::GetGameContext()->GetTerrain()->getObjectManager()->GetEditorObjects();
     bool update = false;
 
     if (ImGui::IsMouseClicked(2)) // Middle button
@@ -97,7 +97,7 @@ void TerrainEditor::UpdateInputEvents(float dt)
         try
         {
             SceneNode* bakeNode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
-            App::GetSimTerrain()->getObjectManager()->LoadTerrainObject(m_last_object_name, pos, Vector3::ZERO, bakeNode, "Console", "");
+            App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(m_last_object_name, pos, Vector3::ZERO, bakeNode, "Console", "");
 
             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_REPLY, _L("Spawned object at position: ") + String("x: ") + TOSTRING(pos.x) + String("z: ") + TOSTRING(pos.z), "world.png");
         }
@@ -230,7 +230,7 @@ void TerrainEditor::UpdateInputEvents(float dt)
         }
         if (App::GetInputEngine()->getEventBoolValue(EV_COMMON_REMOVE_CURRENT_TRUCK))
         {
-            App::GetSimTerrain()->getObjectManager()->unloadObject(object_list[m_object_index].instance_name);
+            App::GetGameContext()->GetTerrain()->getObjectManager()->unloadObject(object_list[m_object_index].instance_name);
         }
     }
     else
@@ -254,7 +254,7 @@ void TerrainEditor::WriteOutputFile()
             = Ogre::ResourceGroupManager::getSingleton().createResource(
                 editor_logpath, RGN_CONFIG, /*overwrite=*/true);
 
-        for (auto object : App::GetSimTerrain()->getObjectManager()->GetEditorObjects())
+        for (auto object : App::GetGameContext()->GetTerrain()->getObjectManager()->GetEditorObjects())
         {
             SceneNode* sn = object.node;
             if (sn != nullptr)

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -21,6 +21,7 @@
 
 #include "TerrainGeometryManager.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "ContentManager.h"
 #include "Language.h"

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -59,7 +59,7 @@ using namespace Forests;
 //workaround for pagedgeometry
 inline float getTerrainHeight(Real x, Real z, void* unused = 0)
 {
-    return App::GetSimTerrain()->GetHeightAt(x, z);
+    return App::GetGameContext()->GetTerrain()->GetHeightAt(x, z);
 }
 
 TerrainObjectManager::TerrainObjectManager(Terrain* terrainManager) :

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -71,6 +71,8 @@ TerrainObjectManager::TerrainObjectManager(Terrain* terrainManager) :
     // terrain custom group
     m_resource_group = terrainManager->GetDef().name + "-TerrnObjects";
     Ogre::ResourceGroupManager::getSingleton().createResourceGroup(m_resource_group);
+
+    m_procedural_manager = ProceduralManagerPtr::Bind(new ProceduralManager());
 }
 
 TerrainObjectManager::~TerrainObjectManager()
@@ -212,9 +214,9 @@ void TerrainObjectManager::LoadTObjFile(Ogre::String tobj_name)
     }
 
     // Procedural roads
-    for (ProceduralObject po : tobj->proc_objects)
+    for (ProceduralObjectPtr& po : tobj->proc_objects)
     {
-        m_procedural_mgr.addObject(po);
+        m_procedural_manager->addObject(po);
     }
 
     // Vehicles
@@ -252,7 +254,7 @@ void TerrainObjectManager::LoadTObjFile(Ogre::String tobj_name)
 
     if (App::diag_terrn_log_roads->getBool())
     {
-        m_procedural_mgr.logDiagnostics();
+        m_procedural_manager->logDiagnostics();
     }
 }
 

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -120,6 +120,8 @@ public:
 
     std::vector<localizer_t> GetLocalizers() { return localizers; }
 
+    ProceduralManagerPtr& getProceduralManager() { return m_procedural_manager; }
+
 protected:
 
     struct AnimatedObject
@@ -171,7 +173,7 @@ protected:
     std::vector<MapEntity>                m_map_entities;
     Terrain*           terrainManager;
     Ogre::StaticGeometry*     m_staticgeometry;
-    ProceduralManager         m_procedural_mgr;
+    ProceduralManagerPtr      m_procedural_manager;
     Ogre::SceneNode*          m_staticgeometry_bake_node;
     int                       m_entity_counter = 0;
     std::string               m_resource_group;

--- a/source/main/utils/ForceFeedback.cpp
+++ b/source/main/utils/ForceFeedback.cpp
@@ -112,7 +112,7 @@ void ForceFeedback::Update()
         return;
     }
 
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
     if (player_actor && player_actor->ar_driveable == TRUCK)
     {
         Ogre::Vector3 ff_vehicle = player_actor->GetFFbBodyForces();

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -21,6 +21,7 @@
 
 #include "InputEngine.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "Console.h"
 #include "ContentManager.h"

--- a/source/main/utils/MeshObject.cpp
+++ b/source/main/utils/MeshObject.cpp
@@ -24,6 +24,7 @@
 
 #include "MeshObject.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "GfxScene.h"
 #include "MeshLodGenerator/OgreMeshLodGenerator.h"

--- a/source/main/utils/memory/RefCountingObject.h
+++ b/source/main/utils/memory/RefCountingObject.h
@@ -34,7 +34,7 @@ public:
         }
     }
 
-    static void  RegisterRefCountingObject(const char* name, AngelScript::asIScriptEngine *engine)
+    static void  RegisterRefCountingObject(AngelScript::asIScriptEngine* engine, const char* name)
     {
         using namespace AngelScript;
 

--- a/source/main/utils/memory/RefCountingObject.h
+++ b/source/main/utils/memory/RefCountingObject.h
@@ -1,0 +1,75 @@
+
+// RefCountingObject system for AngelScript
+// Copyright (c) 2022 Petr Ohlidal
+// https://github.com/only-a-ptr/RefCountingObject-AngelScript
+
+#pragma once
+
+#include "Application.h"
+#include <angelscript.h>
+
+/// Self reference-counting objects, as requred by AngelScript garbage collector.
+template<class T> class RefCountingObject
+{
+public:
+    RefCountingObject()
+    {
+    }
+
+    virtual ~RefCountingObject()
+    {
+    }
+
+    void AddRef()
+    {
+        m_refcount++;
+    }
+
+    void Release()
+    {
+        m_refcount--;
+        if (m_refcount == 0)
+        {
+            delete this; // commit suicide! This is legit in C++
+        }
+    }
+
+    static void  RegisterRefCountingObject(const char* name, AngelScript::asIScriptEngine *engine)
+    {
+        using namespace AngelScript;
+
+        int r;
+        // Registering the reference type
+        r = engine->RegisterObjectType(name, 0, asOBJ_REF); ROR_ASSERT( r >= 0 );
+
+        // Registering the addref/release behaviours
+        r = engine->RegisterObjectBehaviour(name, asBEHAVE_ADDREF, "void f()", asMETHOD(T,AddRef), asCALL_THISCALL); ROR_ASSERT( r >= 0 );
+        r = engine->RegisterObjectBehaviour(name, asBEHAVE_RELEASE, "void f()", asMETHOD(T,Release), asCALL_THISCALL); ROR_ASSERT( r >= 0 );
+    }
+
+    int m_refcount = 1; // Initial refcount for any angelscript object.
+};
+
+/*
+MIT License
+
+Copyright (c) 2022 Petr Ohlídal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/

--- a/source/main/utils/memory/RefCountingObjectPtr.h
+++ b/source/main/utils/memory/RefCountingObjectPtr.h
@@ -1,0 +1,254 @@
+
+// RefCountingObject system for AngelScript
+// Copyright (c) 2022 Petr Ohlidal
+// https://github.com/only-a-ptr/RefCountingObject-AngelScript
+
+// Adopted from "scripthandle" AngelScript addon, distributed with AngelScript SDK.
+
+#pragma once
+
+#include <angelscript.h>
+
+#ifndef ROR_ASSERT
+#   define ROR_ASSERT(_EXPR)  assert(_EXPR)
+#endif
+
+template<class T>
+class RefCountingObjectPtr
+{
+public:
+    // Constructors
+    RefCountingObjectPtr();
+    RefCountingObjectPtr(const RefCountingObjectPtr<T> &other);
+    RefCountingObjectPtr(T *ref); // Only invoke directly using C++! AngelScript must use a wrapper.
+    ~RefCountingObjectPtr();
+
+    // Assignments
+    RefCountingObjectPtr &operator=(const RefCountingObjectPtr<T> &other);
+    // Intentionally omitting raw-pointer assignment, for simplicity - see raw pointer constructor.
+
+    // Compare equalness
+    bool operator==(const RefCountingObjectPtr<T> &o) const { return m_ref == o.m_ref; }
+    bool operator!=(const RefCountingObjectPtr<T> &o) const { return m_ref != o.m_ref; }
+
+    // Get the reference
+    T *GetRef() { return m_ref; }
+    T* operator->() { return m_ref; }
+    T* operator->() const { return m_ref; }
+
+    // Boolean conversion (classic pointer check)
+    operator bool() const { return (bool)m_ref; }
+
+    // GC callback
+    void EnumReferences(AngelScript::asIScriptEngine *engine);
+    void ReleaseReferences(AngelScript::asIScriptEngine *engine);
+
+    static void RegisterRefCountingObjectPtr(const char* handle_name, const char* obj_name, AngelScript::asIScriptEngine *engine);
+
+protected:
+
+    void Set(T* ref);
+    void ReleaseHandle();
+    void AddRefHandle();
+
+    // Wrapper functions, to be invoked by AngelScript only!
+    static void ConstructDefault(RefCountingObjectPtr<T> *self) { new(self) RefCountingObjectPtr(); }
+    static void ConstructCopy(RefCountingObjectPtr<T> *self, const RefCountingObjectPtr &o) { new(self) RefCountingObjectPtr(o); }
+    static void ConstructRef(RefCountingObjectPtr<T>* self, void** objhandle);
+    static void Destruct(RefCountingObjectPtr<T> *self) { self->~RefCountingObjectPtr(); }
+    static T* OpImplCast(RefCountingObjectPtr<T>* self);
+    static RefCountingObjectPtr & OpAssign(RefCountingObjectPtr<T>* self, void** objhandle);
+    static bool OpEquals(RefCountingObjectPtr<T>* self, void** objhandle);
+    static T* DereferenceHandle(void** objhandle);
+
+    T *m_ref;
+};
+
+template<class T>
+void RefCountingObjectPtr<T>::RegisterRefCountingObjectPtr(const char* handle_name, const char* obj_name, AngelScript::asIScriptEngine *engine)
+{
+    using namespace AngelScript;
+
+    int r;
+    const size_t DECLBUF_MAX = 300;
+    char decl_buf[DECLBUF_MAX];
+
+    // With C++11 it is possible to use asGetTypeTraits to automatically determine the flags that represent the C++ class
+    r = engine->RegisterObjectType(handle_name, sizeof(RefCountingObjectPtr), asOBJ_VALUE | asOBJ_ASHANDLE | asOBJ_GC | asGetTypeTraits<RefCountingObjectPtr>()); ROR_ASSERT( r >= 0 );
+
+    // construct/destruct
+    r = engine->RegisterObjectBehaviour(handle_name, asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(RefCountingObjectPtr::ConstructDefault), asCALL_CDECL_OBJFIRST); ROR_ASSERT( r >= 0 );
+    snprintf(decl_buf, DECLBUF_MAX, "void f(%s @&in)", obj_name);
+    r = engine->RegisterObjectBehaviour(handle_name, asBEHAVE_CONSTRUCT, decl_buf, asFUNCTION(RefCountingObjectPtr::ConstructRef), asCALL_CDECL_OBJFIRST); ROR_ASSERT( r >= 0 );
+    snprintf(decl_buf, DECLBUF_MAX, "void f(const %s &in)", handle_name);
+    r = engine->RegisterObjectBehaviour(handle_name, asBEHAVE_CONSTRUCT, decl_buf, asFUNCTION(RefCountingObjectPtr::ConstructCopy), asCALL_CDECL_OBJFIRST); ROR_ASSERT( r >= 0 );
+    r = engine->RegisterObjectBehaviour(handle_name, asBEHAVE_DESTRUCT, "void f()", asFUNCTION(RefCountingObjectPtr::Destruct), asCALL_CDECL_OBJFIRST); ROR_ASSERT( r >= 0 );
+
+    // GC
+    r = engine->RegisterObjectBehaviour(handle_name, asBEHAVE_ENUMREFS, "void f(int&in)", asMETHOD(RefCountingObjectPtr,EnumReferences), asCALL_THISCALL); ROR_ASSERT(r >= 0);
+    r = engine->RegisterObjectBehaviour(handle_name, asBEHAVE_RELEASEREFS, "void f(int&in)", asMETHOD(RefCountingObjectPtr, ReleaseReferences), asCALL_THISCALL); ROR_ASSERT(r >= 0);
+
+    // Cast
+    snprintf(decl_buf, DECLBUF_MAX, "%s @ opImplCast()", obj_name);
+    r = engine->RegisterObjectMethod(handle_name, decl_buf, asFUNCTION(RefCountingObjectPtr::OpImplCast), asCALL_CDECL_OBJFIRST); ROR_ASSERT( r >= 0 );
+
+    // Assign
+    snprintf(decl_buf, DECLBUF_MAX, "%s &opHndlAssign(const %s &in)", handle_name, handle_name);
+    r = engine->RegisterObjectMethod(handle_name, decl_buf, asMETHOD(RefCountingObjectPtr, operator=), asCALL_THISCALL); ROR_ASSERT( r >= 0 );
+    snprintf(decl_buf, DECLBUF_MAX, "%s &opHndlAssign(const %s @&in)", handle_name, obj_name);
+    r = engine->RegisterObjectMethod(handle_name, decl_buf, asFUNCTION(RefCountingObjectPtr::OpAssign), asCALL_CDECL_OBJFIRST); ROR_ASSERT( r >= 0 );
+
+    // Equals
+    snprintf(decl_buf, DECLBUF_MAX, "bool opEquals(const %s &in) const", handle_name);
+    r = engine->RegisterObjectMethod(handle_name, decl_buf, asMETHODPR(RefCountingObjectPtr, operator==, (const RefCountingObjectPtr &) const, bool), asCALL_THISCALL); ROR_ASSERT( r >= 0 );
+    snprintf(decl_buf, DECLBUF_MAX, "bool opEquals(const %s @&in) const", obj_name);
+    r = engine->RegisterObjectMethod(handle_name, decl_buf, asFUNCTION(RefCountingObjectPtr::OpEquals), asCALL_CDECL_OBJFIRST); ROR_ASSERT( r >= 0 );
+}
+
+
+// ---------------------------- Internals ------------------------------
+
+template<class T>
+T* RefCountingObjectPtr<T>::DereferenceHandle(void** objhandle)
+{
+    // Dereference the handle to get the object itself (see AngelScript SDK, addon 'generic handle', function `Assign()` or `Equals()`).
+    return static_cast<T*>(*objhandle);
+}
+
+template<class T>
+inline void RefCountingObjectPtr<T>::ConstructRef(RefCountingObjectPtr<T>* self, void** objhandle)
+{
+    T* ref = DereferenceHandle(objhandle);
+    new(self)RefCountingObjectPtr(ref);
+
+    // Increase refcount manually because constructor is designed for C++ use only.
+    if (ref)
+        ref->AddRef();
+}
+
+template<class T>
+inline T* RefCountingObjectPtr<T>::OpImplCast(RefCountingObjectPtr<T>* self)
+{
+    T* ref = self->GetRef();
+    ref->AddRef();
+    return ref;
+}
+
+template<class T>
+inline RefCountingObjectPtr<T> & RefCountingObjectPtr<T>::OpAssign(RefCountingObjectPtr<T>* self, void** objhandle)
+{
+    T* ref = DereferenceHandle(objhandle);
+    self->Set(ref);
+    return *self;
+}
+
+template<class T>
+inline bool RefCountingObjectPtr<T>::OpEquals(RefCountingObjectPtr<T>* self, void** objhandle)
+{
+    T* ref = DereferenceHandle(objhandle);
+    return self->GetRef() == ref;
+}
+
+template<class T>
+inline RefCountingObjectPtr<T>::RefCountingObjectPtr()
+    : m_ref(nullptr)
+{
+}
+
+template<class T>
+inline RefCountingObjectPtr<T>::RefCountingObjectPtr(const RefCountingObjectPtr<T> &other)
+{
+    m_ref = other.m_ref;
+    AddRefHandle();
+}
+
+template<class T>
+inline RefCountingObjectPtr<T>::RefCountingObjectPtr(T *ref)
+{
+    // Used directly from C++, DO NOT increase refcount!
+    // It's already been done by constructor/factory/AngelScript (if retrieved from script context).
+    // ------------------------------------------
+    m_ref  = ref;
+}
+
+template<class T>
+inline RefCountingObjectPtr<T>::~RefCountingObjectPtr()
+{
+    ReleaseHandle();
+}
+
+template<class T>
+inline void RefCountingObjectPtr<T>::ReleaseHandle()
+{
+    if( m_ref )
+    {
+        m_ref->Release();
+        m_ref = nullptr;
+    }
+}
+
+template<class T>
+inline void RefCountingObjectPtr<T>::AddRefHandle()
+{
+    if( m_ref )
+    {
+        m_ref->AddRef();
+    }
+}
+
+template<class T>
+inline RefCountingObjectPtr<T> &RefCountingObjectPtr<T>::operator =(const RefCountingObjectPtr<T> &other)
+{
+    Set(other.m_ref);
+    return *this;
+}
+
+template<class T>
+inline void RefCountingObjectPtr<T>::Set(T* ref)
+{
+    if( m_ref == ref )
+        return;
+
+    ReleaseHandle();
+    m_ref  = ref;
+    AddRefHandle();
+}
+
+template<class T>
+inline void RefCountingObjectPtr<T>::EnumReferences(AngelScript::asIScriptEngine *inEngine)
+{
+    // If we're holding a reference, we'll notify the garbage collector of it
+    if (m_ref)
+        inEngine->GCEnumCallback(m_ref);
+}
+
+template<class T>
+inline void RefCountingObjectPtr<T>::ReleaseReferences(AngelScript::asIScriptEngine * /*inEngine*/)
+{
+    // Simply clear the content to release the references
+    Set(nullptr);
+}
+
+/*
+MIT License
+
+Copyright (c) 2022 Petr Ohlídal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/

--- a/source/main/utils/memory/RefCountingObjectPtr.h
+++ b/source/main/utils/memory/RefCountingObjectPtr.h
@@ -50,7 +50,7 @@ public:
     void EnumReferences(AngelScript::asIScriptEngine *engine);
     void ReleaseReferences(AngelScript::asIScriptEngine *engine);
 
-    static void RegisterRefCountingObjectPtr(const char* handle_name, const char* obj_name, AngelScript::asIScriptEngine *engine);
+    static void RegisterRefCountingObjectPtr(AngelScript::asIScriptEngine* engine, const char* handle_name, const char* obj_name);
 
     /// It's CRITICAL that this function gets invoked only once for each object in memory,
     /// and subsequent shared pointers are created from the original shared pointer.
@@ -78,7 +78,7 @@ protected:
 };
 
 template<class T>
-void RefCountingObjectPtr<T>::RegisterRefCountingObjectPtr(const char* handle_name, const char* obj_name, AngelScript::asIScriptEngine *engine)
+void RefCountingObjectPtr<T>::RegisterRefCountingObjectPtr(AngelScript::asIScriptEngine* engine, const char* handle_name, const char* obj_name)
 {
     using namespace AngelScript;
 

--- a/source/main/utils/memory/RefCountingObject_README.md
+++ b/source/main/utils/memory/RefCountingObject_README.md
@@ -1,0 +1,123 @@
+
+# RefCountingObject system for AngelScript
+
+_Created 2022 by Petr Ohlídal_
+
+_https://github.com/only-a-ptr/RefCountingObject-AngelScript_
+
+This mini-framework lets you use a single reference counting mechanism for both
+AngelScript's built-in garbage collection and C++ smart pointers. This allows you to fluently
+pass objects between C++ and script context(s) without caring who created the object and where may
+references be held.
+
+## Motivation
+
+I maintain [a game project](https://github.com/RigsOfRods/rigs-of-rods)
+where AngelScript is an optional dependency
+but at the same time plays an important gameplay role.
+I wanted to expand the scripting interface by exposing
+the internal objects and functions as directly as possible, but I didn't want to do
+AngelScript refcounting manually on the C++ side.
+I wanted a classic C++ smart pointer (like `std::shared_ptr<>`) that would do it for me,
+and which would remain fully functional for C++ even if built without AngelScript.
+
+## How to use
+
+The project was developed against AngelScript 2.35.1; but any reasonably recent version should do.
+
+To install, just copy the 'RefCountingObject\*' files to your project.
+
+Define your C++ classes by implementing `RefCountingObject`
+and calling `RegisterRefCountingObject()` for each type.
+
+```
+class Foo: RefCountingObject<Foo>{}
+Foo::RegisterRefCountingObject("Foo", engine);
+```
+
+Define your C++ smart pointers by qualifying `RefCountingObjectPtr<>`
+and use them in your interfaces. 
+These will become usable interchangeably from both C++ and script.
+
+```
+typedef RefCountingObjectPtr<Foo> FooPtr;
+// demo API:
+static FooPtr gf;
+static void SetFoo(FooPtr f) { gf = f; }
+static FooPtr GetFoo() { return gf; }
+```
+
+Register the smart pointers with `RegisterRefCountingObjectPtr()`
+and use them in your application interface.
+
+```
+FooPtr::RegisterRefCountingObjectPtr("FooPtr", "Foo", engine);
+// ...
+engine->RegisterGlobalFunction("void SetFoo(FooPtr@)", asFUNCTION(SetFoo), asCALL_CDECL);
+engine->RegisterGlobalFunction("FooPtr@ GetFoo()", asFUNCTION(GetFoo), asCALL_CDECL);
+```
+
+In C++, use just the smart pointers and you'll be safe.
+
+```
+FooPtr f1 = new Foo(); // refcount 1
+SetFoo(f1);            // refcount 2
+FooPtr f2 = GetFoo();  // refcount 3
+f2 = nullptr;          // refcount 2
+f1 = nullptr;          // refcount 1
+SetFoo(nullptr);       // refcount 0 -> deleted.
+```
+
+In AngelScript, use the native handles.
+
+```
+Foo@ f1 = new Foo();   // refcount 1
+SetFoo(f1);            // refcount 2
+Foo@ f2 = GetFoo();    // refcount 3
+@f2 = null;            // refcount 2
+@f1 = null;            // refcount 1
+SetFoo(null);          // refcount 0 -> deleted.
+```
+
+## How it works
+
+This part explains the less obvious bits of AngelScript mechanics.
+
+### How the AngelScript refcounting works
+
+ Intuitively, you would call AddRef() every time you obtain a raw pointer to the object, 
+ i.e. when creating a new object or retrieving one from script engine. Well, don't.
+ 
+ * New objects have refcount initialized to 1.
+   You must call Release() to dispose of it, but don't call AddRef() unless you're creating additional pointers.
+ * When passing the object as parameter from script to C++ function, the refcount is already incremented by the script engine.
+   If you don't store the pointer, you must call Release() before the function returns.
+ * When passing the object from C++ to script, you must increase the refcount yourself.
+ 
+Documentation: 
+   https://www.angelcode.com/angelscript/sdk/docs/manual/doc_as_vs_cpp_types.html#doc_as_vs_cpp_types_3
+   https://www.angelcode.com/angelscript/sdk/docs/manual/doc_obj_handle.html#doc_obj_handle_3
+   
+### How RefCountingObject fits into it
+
+RefCountingObject just implements the essential `AddRef()` and `Release()` functions needed by reference types:
+https://www.angelcode.com/angelscript/sdk/docs/manual/doc_reg_basicref.html
+
+RefCountingObjectPtr, for the most part, does the typical smart pointer scheme:
+when created, add ref; when deleted, remove ref.
+
+However, there is one major catch: constructing new objects. Since RefCountingObjectPtr must
+be intuitive in C++, the only acceptable form of creating objects is this:
+```
+FooPtr foo_ptr = new Foo(); // C++ programmer reads "Pointer is taken care of".
+```
+With AngelScript, though, this means a memory leak because the smart pointer added a reference
+while one already existed (the temporary one). The treatment expected by AngelScript is:
+```
+FooPtr foo_ptr = new Foo();
+foo_ptr->Release(); // C++ programmer goes "WTF ?!?"
+```
+**The closure:** RefCountingObjectPtr never increases refcount when assigned a raw pointer (in C++).
+Assignment within AngelScript engine is handled by wrapper interface, not available from C++.
+
+  


### PR DESCRIPTION
## Status (last update 2022-10-14)
Many feats originally developed here got merged in https://github.com/RigsOfRods/rigs-of-rods/pull/2931.
The object ref-counting system, originally created here, got perfected in it's own repo: https://github.com/only-a-ptr/RefCountingObject-AngelScript

## New script features:
* ref types: `TerrainClass, ProceduralRoadClass, ProceduralObjectClass, ProceduralManagerClass, ProceduralPointClass`
* enums: `RoadType, TextureFit`

## Reference counting fix

Previously, if a script kept a pointer (a 'handle' in AngelScript terminology) to `BeamClass` or `VehicleAIClass` after the vehicle was removed, it would crash. I studied how the reference counting system works and added a `RefCountingObject` base class which lets us keep track of the object both inside and outside of the script. It will help registering more objects to the script engine.
