### PR TITLE
Ηeadlights: ignore already attached objects

### DIFF
--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2944,7 +2944,16 @@ void Actor::lightsToggle()
                     ar_flares[i].light->setVisible(true);
                 ar_flares[i].isVisible = true;
                 if (ar_flares[i].bbs)
-                    ar_flares[i].snode->attachObject(ar_flares[i].bbs);
+                {
+                    try
+                    {
+                        ar_flares[i].snode->attachObject(ar_flares[i].bbs);
+                    }
+                    catch (...)
+                    {
+                        // Already attached
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
https://forum.rigsofrods.org/resources/coca-cola-t600-dry-van-trailer.86/

Load trailer, press N to open lights
Load the truck, press L to lock with the trailer and press N, it tries to re attach trailer's flares (because main vehicle lights trigger trailer lights also) so crash:

```
InvalidParametersException: Object already attached to a SceneNode or a Bone in SceneNode::attachObject at /home/babis/Downloads/ror-dependencies/Source/ogre/OgreMain/src/OgreSceneNode.cpp (line 105)
```