### PR TITLE
Prop anims with 'eventlock' now remain active if player leaves vehicle (+multiplayer).

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1684,5 +1684,11 @@ void GameContext::UpdateTruckInputEvents(float dt)
     {
         m_player_actor->getTyrePressure().UpdateInputEvents(dt);
     }
+
+    m_player_actor->UpdatePropAnimInputEvents();
+    for (Actor* linked_actor : m_player_actor->getAllLinkedActors())
+    {
+        linked_actor->UpdatePropAnimInputEvents();
+    }
 }
 

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -105,7 +105,7 @@ public:
     void                 UpdateWingMeshes();
     void                 UpdateBeaconFlare(Prop & prop, float dt, bool is_player_actor);
     void                 UpdateProps(float dt, bool is_player_actor);
-    void                 UpdatePropAnimations(float dt, bool is_player_connected);
+    void                 UpdatePropAnimations(float dt);
     void                 UpdateAirbrakes();
     void                 UpdateCParticles();
     void                 UpdateAeroEngines();

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -118,9 +118,6 @@ struct PropAnim
     PropAnimMode animMode     = {};
     float        animOpt3     = 0;  //!< Various purposes
     float        animOpt5     = 0;
-    int          animKey      = 0;
-    int          animKeyState = 0;
-    int          lastanimKS   = 0;
     float        lower_limit  = 0;  //!< The lower limit for the animation
     float        upper_limit  = 0;  //!< The upper limit for the animation
 };

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -98,11 +98,9 @@ void GfxScene::UpdateScene(float dt_sec)
 
     // Var
     GfxActor* player_gfx_actor = nullptr;
-    std::set<GfxActor*> player_connected_gfx_actors;
     if (m_simbuf.simbuf_player_actor != nullptr)
     {
         player_gfx_actor = m_simbuf.simbuf_player_actor->GetGfxActor();
-        player_connected_gfx_actors = player_gfx_actor->GetLinkedGfxActors();
     }
 
     // FOV
@@ -211,7 +209,6 @@ void GfxScene::UpdateScene(float dt_sec)
     // Actors - update misc visuals
     for (GfxActor* gfx_actor: m_all_gfx_actors)
     {
-        bool is_player_connected = (player_connected_gfx_actors.find(gfx_actor) != player_connected_gfx_actors.end());
         if (gfx_actor->IsActorLive())
         {
             gfx_actor->UpdateRods();
@@ -220,7 +217,7 @@ void GfxScene::UpdateScene(float dt_sec)
             gfx_actor->UpdateAirbrakes();
             gfx_actor->UpdateCParticles();
             gfx_actor->UpdateAeroEngines();
-            gfx_actor->UpdatePropAnimations(dt_sec, (gfx_actor == player_gfx_actor) || is_player_connected);
+            gfx_actor->UpdatePropAnimations(dt_sec);
             gfx_actor->UpdateRenderdashRTT();
         }
         // Beacon flares must always be updated

--- a/source/main/gfx/SimBuffers.h
+++ b/source/main/gfx/SimBuffers.h
@@ -82,6 +82,11 @@ struct CommandKeySB
     float             simbuf_cmd_value;
 };
 
+struct PropAnimKeySB
+{
+    bool              simbuf_anim_active;
+};
+
 struct AeroEngineSB
 {
     AeroEngineType    simbuf_ae_type;
@@ -129,6 +134,7 @@ struct ActorSB
     std::vector<NodeSB>       simbuf_nodes;
     std::vector<ScrewpropSB>  simbuf_screwprops;
     std::vector<CommandKeySB> simbuf_commandkey;
+    std::vector<PropAnimKeySB> simbuf_prop_anim_keys;
     std::vector<AeroEngineSB> simbuf_aeroengines;
     std::vector<AirbrakeSB>   simbuf_airbrakes;
 

--- a/source/main/network/RoRnet.h
+++ b/source/main/network/RoRnet.h
@@ -32,7 +32,7 @@ namespace RoRnet {
 #define RORNET_LAN_BROADCAST_PORT   13000  //!< port used to send the broadcast announcement in LAN mode
 #define RORNET_MAX_USERNAME_LEN     40     //!< port used to send the broadcast announcement in LAN mode
 
-#define RORNET_VERSION              "RoRnet_2.43"
+#define RORNET_VERSION              "RoRnet_2.44"
 
 enum MessageType
 {

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4606,3 +4606,25 @@ void Actor::WriteDiagnosticDump(std::string const& fileName)
     outStream->write(text.c_str(), text.length());
     Ogre::ResourceGroupManager::getSingleton().destroyResourceGroup(rgName);
 }
+
+void Actor::UpdatePropAnimInputEvents()
+{
+    for (PropAnimKeyState& state : m_prop_anim_key_states)
+    {
+        bool ev_active = App::GetInputEngine()->getEventValue(state.event_id);
+        if (state.eventlock_present)
+        {
+            // Toggle-mode
+            if (ev_active && (ev_active != state.event_active_prev))
+            {
+                state.anim_active = !state.anim_active;
+            }
+        }
+        else
+        {
+            // Direct-mode
+            state.anim_active = ev_active;
+        }
+        state.event_active_prev = ev_active;
+    }
+}

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -493,8 +493,6 @@ private:
     Ogre::Vector3     m_mouse_grab_pos;
     float             m_mouse_grab_move_force;
     float             m_spawn_rotation;
-    Ogre::UTFString   m_net_username;
-    int               m_net_color_num;
     Ogre::Timer       m_reset_timer;
     Ogre::Vector3     m_rotation_request_center;
     float             m_rotation_request;         //!< Accumulator
@@ -511,10 +509,6 @@ private:
     Differential*     m_wheel_diffs[MAX_WHEELS/2];//!< Physics
     int               m_num_wheel_diffs;          //!< Physics attr
     TransferCase*     m_transfer_case;            //!< Physics
-    float             m_net_node_compression;  //!< Sim attr;
-    int               m_net_first_wheel_node;  //!< Network attr; Determines data buffer layout
-    int               m_net_node_buf_size;     //!< Network attr; buffer size
-    int               m_net_buffer_size;       //!< Network attr; buffer size
     int               m_wheel_node_count;      //!< Static attr; filled at spawn
     int               m_previous_gear;         //!< Sim state; land vehicle shifting
     float             m_handbrake_force;       //!< Physics attr; defined in truckfile
@@ -538,6 +532,19 @@ private:
     TyrePressure      m_tyre_pressure;
     std::vector<std::string>  m_description;
     std::vector<PropAnimKeyState> m_prop_anim_key_states;
+
+    /// @name Networking
+    /// @{
+    size_t            m_net_node_buf_size;        //!< For incoming/outgoing traffic; calculated on spawn
+    size_t            m_net_wheel_buf_size;       //!< For incoming/outgoing traffic; calculated on spawn
+    size_t            m_net_propanimkey_buf_size; //!< For incoming/outgoing traffic; calculated on spawn
+    size_t            m_net_total_buffer_size;    //!< For incoming/outgoing traffic; calculated on spawn
+    float             m_net_node_compression;     //!< For incoming/outgoing traffic; calculated on spawn
+    int               m_net_first_wheel_node;     //!< Network attr; Determines data buffer layout; calculated on spawn
+
+    Ogre::UTFString   m_net_username;
+    int               m_net_color_num;
+    /// @}
 
     /// @name Light states
     /// @{

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -148,7 +148,7 @@ public:
     void              toggleBlinkType(BlinkType blink);
     BlinkType         getBlinkType();
     void              setBlinkType(BlinkType blink);
-    std::vector<Actor*> getAllLinkedActors() { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
+    std::vector<Actor*>& getAllLinkedActors() { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
     //! @}
 
     /// @name Visual state updates
@@ -218,6 +218,7 @@ public:
     Ogre::Real        getMinimalCameraRadius();
     float             GetFFbHydroForces() const         { return m_force_sensors.out_hydros_forces; }
     bool              isBeingReset() const              { return m_ongoing_reset; };
+    void              UpdatePropAnimInputEvents();
 #ifdef USE_ANGELSCRIPT
     // we have to add this to be able to use the class as reference inside scripts
     void              addRef()                          {};
@@ -536,6 +537,7 @@ private:
     bool              m_has_axles_section;     //!< Temporary (legacy parsing helper) until central diffs are implemented
     TyrePressure      m_tyre_pressure;
     std::vector<std::string>  m_description;
+    std::vector<PropAnimKeyState> m_prop_anim_key_states;
 
     /// @name Light states
     /// @{

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -22,7 +22,10 @@
 /// @file
 /// @author Thomas Fischer
 /// @date   30th of April 2010
-/// @brief Core data structures for simulation.
+/// @brief Core data structures for simulation; Everything affected by by either physics, network or user interaction is here.
+///
+/// Note that simulation state and gfx state is separated; For example,
+/// light states (on/off) are here while the actual lights (renderer objects) are in 'GfxData.h' :)
 
 #pragma once
 
@@ -30,6 +33,7 @@
 #include "SimConstants.h"
 #include "BitFlags.h"
 #include "CmdKeyInertia.h"
+#include "InputEngine.h"
 
 #include <memory>
 #include <Ogre.h>
@@ -639,6 +643,15 @@ struct cparticle_t
     bool active;
     Ogre::SceneNode *snode;
     Ogre::ParticleSystem* psys;
+};
+
+/// User input state for animated props with 'source:event'.
+struct PropAnimKeyState
+{
+    bool eventlock_present = false;
+    bool event_active_prev = false;
+    bool anim_active = false;
+    events event_id = EV_MODE_LAST; // invalid
 };
 
 /// @}

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -535,10 +535,7 @@ struct Animation
     BitMask_t source = 0;
     std::list<MotorSource> motor_sources;
     BitMask_t mode = 0;
-
-    // NOTE: MSVC highlights 'event' as keyword: http://msdn.microsoft.com/en-us/library/4b612y2s%28v=vs.100%29.aspx
-    // But it's ok to use as identifier in this context: http://msdn.microsoft.com/en-us/library/8d7y7wz6%28v=vs.100%29.aspx
-    Ogre::String event;
+    Ogre::String event_name;
 
     void AddMotorSource(BitMask_t source, unsigned int motor);
 };

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -1091,9 +1091,9 @@ void Parser::ParseDirectiveAddAnimation()
             }
             else if (entry[0] == "event")
             {
-                animation.event = entry[1];
-                Ogre::StringUtil::trim(animation.event);
-                Ogre::StringUtil::toUpperCase(animation.event);
+                animation.event_name = entry[1];
+                Ogre::StringUtil::trim(animation.event_name);
+                Ogre::StringUtil::toUpperCase(animation.event_name);
             }
             else if (entry[0] == "source")
             {

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -591,7 +591,7 @@ void Serializer::ProcessDirectiveAddAnimation(RigDef::Animation & anim)
             
     if (BITMASK_IS_1(src_flags, RigDef::Animation::SOURCE_EVENT))
     {
-        m_stream << ", event: " << anim.event;
+        m_stream << ", event: " << anim.event_name;
     }
 }
 


### PR DESCRIPTION
Kindly requested from Discord by Flip889#6304 and BRobinson#9257

As a bonus, key-triggered prop animations now propagate over network:
![busHeadsUnite](https://user-images.githubusercontent.com/491088/194809264-5e6b3077-647f-479f-a48d-e91d8d8075fc.gif)

RoRnet was bumped to .44