### PR TITLE
AI: Added Drag Race and Crash driving modes, fixes and UI improvements

### DIFF
--- a/resources/scripts/AI.as
+++ b/resources/scripts/AI.as
@@ -15,7 +15,7 @@ void main()
 
     for (int x = 0; x < game.getAIVehicleCount(); x++)
     {
-        VehicleAIClass @CurrentTruckai = game.spawnTruckAI(game.getAIVehicleName(), vector3(waypoints[0].x + translation_x, waypoints[0].y, waypoints[0].z + translation_z), game.getAIVehicleSectionConfig(), game.getAIVehicleSkin()).getVehicleAI();
+        VehicleAIClass @CurrentTruckai = game.spawnTruckAI(game.getAIVehicleName(x), vector3(waypoints[0].x + translation_x, waypoints[0].y, waypoints[0].z + translation_z), game.getAIVehicleSectionConfig(x), game.getAIVehicleSkin(x)).getVehicleAI();
 
         for (int t = 0; t < game.getAIRepeatTimes(); t++)
         {

--- a/resources/scripts/AI.as
+++ b/resources/scripts/AI.as
@@ -1,7 +1,5 @@
 #include "base.as"
 
-array<vector3> waypoints = game.getWaypoints();
-
 //Stuff that the scripts uses internally. doesn't need to be changed.
 vector3 currentWaypoint(0, 0, 0);
 int waypoint = 0;
@@ -15,7 +13,9 @@ void main()
 
     for (int x = 0; x < game.getAIVehicleCount(); x++)
     {
-        VehicleAIClass @CurrentTruckai = game.spawnTruckAI(game.getAIVehicleName(x), vector3(waypoints[0].x + translation_x, waypoints[0].y, waypoints[0].z + translation_z), game.getAIVehicleSectionConfig(x), game.getAIVehicleSkin(x)).getVehicleAI();
+        array<vector3> waypoints = game.getWaypoints(x);
+
+        VehicleAIClass @CurrentTruckai = game.spawnTruckAI(game.getAIVehicleName(x), vector3(waypoints[0].x + translation_x, waypoints[0].y, waypoints[0].z + translation_z), game.getAIVehicleSectionConfig(x), game.getAIVehicleSkin(x), x).getVehicleAI();
 
         for (int t = 0; t < game.getAIRepeatTimes(); t++)
         {
@@ -35,6 +35,10 @@ void main()
                 else if (position_scheme == 1) // Vehicle parallel to vehicle, offset all waypoints
                 {
                     CurrentTruckai.addWaypoint("way"+i, vector3(waypoints[i].x + CurrentTruckai.getTranslation(offset, i).x, waypoints[i].y, waypoints[i].z + CurrentTruckai.getTranslation(offset, i).z));
+                }
+                else if (position_scheme == 2) // Vehicle opposite to vehicle, add the reversed waypoints
+                {
+                    CurrentTruckai.addWaypoint("way"+i, vector3(waypoints[i].x, waypoints[i].y, waypoints[i].z));
                 }
             }
         }

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -631,6 +631,14 @@ void GameContext::OnLoaderGuiApply(LoaderType type, CacheEntry* entry, std::stri
     case LT_AllBeam:
         m_current_selection.asr_cache_entry = entry;
         m_current_selection.asr_config = sectionconfig;
+        if (App::GetGuiManager()->TopMenubar.ai_select)
+        {
+            App::GetGuiManager()->TopMenubar.ai_sectionconfig = sectionconfig;
+        }
+        if (App::GetGuiManager()->TopMenubar.ai_select2)
+        {
+            App::GetGuiManager()->TopMenubar.ai_sectionconfig2 = sectionconfig;
+        }
         m_current_selection.asr_origin = ActorSpawnRequest::Origin::USER;
         // Look for extra skins
         if (!entry->guid.empty())
@@ -662,7 +670,6 @@ void GameContext::OnLoaderGuiApply(LoaderType type, CacheEntry* entry, std::stri
         {
             App::GetGuiManager()->TopMenubar.ai_fname = m_current_selection.asr_cache_entry->fname;
             App::GetGuiManager()->TopMenubar.ai_dname = m_current_selection.asr_cache_entry->dname;
-            App::GetGuiManager()->TopMenubar.ai_sectionconfig = sectionconfig;
             App::GetGuiManager()->TopMenubar.ai_select = false;
             App::GetGuiManager()->TopMenubar.ai_menu = true;
         }
@@ -670,7 +677,6 @@ void GameContext::OnLoaderGuiApply(LoaderType type, CacheEntry* entry, std::stri
         {
             App::GetGuiManager()->TopMenubar.ai_fname2 = m_current_selection.asr_cache_entry->fname;
             App::GetGuiManager()->TopMenubar.ai_dname2 = m_current_selection.asr_cache_entry->dname;
-            App::GetGuiManager()->TopMenubar.ai_sectionconfig2 = sectionconfig;
             App::GetGuiManager()->TopMenubar.ai_select2 = false;
             App::GetGuiManager()->TopMenubar.ai_menu = true;
         }

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -594,6 +594,11 @@ void GameContext::OnLoaderGuiCancel()
         App::GetGuiManager()->TopMenubar.ai_select = false;
         App::GetGuiManager()->TopMenubar.ai_menu = true;
     }
+    if (App::GetGuiManager()->TopMenubar.ai_select2)
+    {
+        App::GetGuiManager()->TopMenubar.ai_select2 = false;
+        App::GetGuiManager()->TopMenubar.ai_menu = true;
+    }
 }
 
 void GameContext::OnLoaderGuiApply(LoaderType type, CacheEntry* entry, std::string sectionconfig)
@@ -606,6 +611,10 @@ void GameContext::OnLoaderGuiApply(LoaderType type, CacheEntry* entry, std::stri
         if (App::GetGuiManager()->TopMenubar.ai_select)
         {
             App::GetGuiManager()->TopMenubar.ai_skin = entry->dname;
+        }
+        if (App::GetGuiManager()->TopMenubar.ai_select2)
+        {
+            App::GetGuiManager()->TopMenubar.ai_skin2 = entry->dname;
         }
         spawn_now = true;
         break;
@@ -655,6 +664,14 @@ void GameContext::OnLoaderGuiApply(LoaderType type, CacheEntry* entry, std::stri
             App::GetGuiManager()->TopMenubar.ai_dname = m_current_selection.asr_cache_entry->dname;
             App::GetGuiManager()->TopMenubar.ai_sectionconfig = sectionconfig;
             App::GetGuiManager()->TopMenubar.ai_select = false;
+            App::GetGuiManager()->TopMenubar.ai_menu = true;
+        }
+        else if (App::GetGuiManager()->TopMenubar.ai_select2)
+        {
+            App::GetGuiManager()->TopMenubar.ai_fname2 = m_current_selection.asr_cache_entry->fname;
+            App::GetGuiManager()->TopMenubar.ai_dname2 = m_current_selection.asr_cache_entry->dname;
+            App::GetGuiManager()->TopMenubar.ai_sectionconfig2 = sectionconfig;
+            App::GetGuiManager()->TopMenubar.ai_select2 = false;
             App::GetGuiManager()->TopMenubar.ai_menu = true;
         }
         else

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -254,7 +254,7 @@ void VehicleAI::update(float dt, int doUpdate)
         angle_deg = dir1.angleBetween(dir2.normalisedCopy()).valueDegrees(); // Degrees 0 - 180
     }
 
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 3) // Chase driving mode
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 4) // Chase driving mode
     {
         if (App::GetGameContext()->GetPlayerActor()) // We are in vehicle
         {
@@ -476,7 +476,7 @@ void VehicleAI::update(float dt, int doUpdate)
                 }
             }
         }
-        else if (App::GetGuiManager()->TopMenubar.ai_mode == 3) // Chase driving mode
+        else if (App::GetGuiManager()->TopMenubar.ai_mode == 4) // Chase driving mode
         {
             if (App::GetGameContext()->GetPlayerActor())
             {

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -254,7 +254,7 @@ void VehicleAI::update(float dt, int doUpdate)
         angle_deg = dir1.angleBetween(dir2.normalisedCopy()).valueDegrees(); // Degrees 0 - 180
     }
 
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 2) // Chase driving mode
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 3) // Chase driving mode
     {
         if (App::GetGameContext()->GetPlayerActor()) // We are in vehicle
         {
@@ -476,7 +476,7 @@ void VehicleAI::update(float dt, int doUpdate)
                 }
             }
         }
-        else if (App::GetGuiManager()->TopMenubar.ai_mode == 2) // Chase driving mode
+        else if (App::GetGuiManager()->TopMenubar.ai_mode == 3) // Chase driving mode
         {
             if (App::GetGameContext()->GetPlayerActor())
             {

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -791,12 +791,25 @@ void TopMenubar::Update()
             if (ai_num < 1)
                 ai_num = 1;
 
+
+            if (ai_mode == 2)
+            {
+                ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+            }
+
             ImGui::InputInt(_LC("TopMenubar", "Vehicle count"), &ai_num, 1, 100);
             if (ImGui::IsItemHovered())
             {
                 ImGui::BeginTooltip();
                 ImGui::Text(_LC("TopMenubar", "Number of vehicles"));
                 ImGui::EndTooltip();
+            }
+
+            if (ai_mode == 2)
+            {
+                ImGui::PopItemFlag();
+                ImGui::PopStyleVar();
             }
 
             if (ai_num < 2)
@@ -817,6 +830,12 @@ void TopMenubar::Update()
             if (ai_position_scheme == 1)
             {
                 label1 = "Parallel";
+            }
+
+            if (ai_mode == 2)
+            {
+                ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
             }
 
             if (ImGui::BeginCombo("Position", label1.c_str()))
@@ -850,12 +869,30 @@ void TopMenubar::Update()
             if (ai_times < 1)
                 ai_times = 1;
 
+            if (ai_mode == 3)
+            {
+                ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+            }
+
             ImGui::InputInt(_LC("TopMenubar", "Repeat times"), &ai_times, 1, 100);
             if (ImGui::IsItemHovered())
             {
                 ImGui::BeginTooltip();
                 ImGui::Text(_LC("TopMenubar", "How many times to loop the path"));
                 ImGui::EndTooltip();
+            }
+
+            if (ai_mode == 3)
+            {
+                ImGui::PopItemFlag();
+                ImGui::PopStyleVar();
+            }
+
+            if (ai_mode == 2)
+            {
+                ImGui::PopItemFlag();
+                ImGui::PopStyleVar();
             }
 
             ImGui::Separator();
@@ -879,6 +916,10 @@ void TopMenubar::Update()
             }
             else if (ai_mode == 2)
             {
+                label2 = "Drag Race";
+            }
+            else if (ai_mode == 3)
+            {
                 label2 = "Chase";
             }
 
@@ -887,14 +928,54 @@ void TopMenubar::Update()
                 if (ImGui::Selectable("Normal"))
                 {
                     ai_mode = 0;
+
+                    if (ai_mode_prev == 2)
+                    {
+                        ai_num = ai_num_prev;
+                        ai_speed = ai_speed_prev;
+                        ai_position_scheme = ai_position_scheme_prev;
+                        ai_times = ai_times_prev;
+                    }
+                    ai_mode_prev = ai_mode;
                 }
                 if (ImGui::Selectable("Race"))
                 {
                     ai_mode = 1;
+
+                    if (ai_mode_prev == 2)
+                    {
+                        ai_num = ai_num_prev;
+                        ai_speed = ai_speed_prev;
+                        ai_position_scheme = ai_position_scheme_prev;
+                        ai_times = ai_times_prev;
+                    }
+                    ai_mode_prev = ai_mode;
+                }
+                if (ImGui::Selectable("Drag Race"))
+                {
+                    ai_mode = 2;
+                    ai_mode_prev = ai_mode;
+                    ai_num_prev = ai_num;
+                    ai_speed_prev = ai_speed;
+                    ai_position_scheme_prev = ai_position_scheme;
+                    ai_times_prev = ai_times;
+                    ai_num = 2;
+                    ai_speed = 1000;
+                    ai_position_scheme = 1;
+                    ai_times = 1;
                 }
                 if (ImGui::Selectable("Chase"))
                 {
-                    ai_mode = 2;
+                    ai_mode = 3;
+
+                    if (ai_mode_prev == 2)
+                    {
+                        ai_num = ai_num_prev;
+                        ai_speed = ai_speed_prev;
+                        ai_position_scheme = ai_position_scheme_prev;
+                        ai_times = ai_times_prev;
+                    }
+                    ai_mode_prev = ai_mode;
                 }
                 ImGui::EndCombo();
             }
@@ -937,6 +1018,26 @@ void TopMenubar::Update()
                 ImGui::EndTooltip();
             }
 
+            if (ai_mode == 2)
+            {
+                ImGui::PushID("vehicle2");
+                if (ImGui::Button(StripColorMarksFromText(ai_dname2).c_str(), ImVec2(250, 0)))
+                {
+                    ai_select2 = true;
+
+                    RoR::Message m(MSG_GUI_OPEN_SELECTOR_REQUESTED);
+                    m.payload = reinterpret_cast<void*>(new LoaderType(LT_AllBeam));
+                    App::GetGameContext()->PushMessage(m);
+                }
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::BeginTooltip();
+                    ImGui::Text(_LC("TopMenubar", "Land vehicles, boats and airplanes"));
+                    ImGui::EndTooltip();
+                }
+                ImGui::PopID();
+            }
+
             ImGui::Separator();
 
             if (ai_rec)
@@ -945,14 +1046,14 @@ void TopMenubar::Update()
                 ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
             }
 
-            if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 2)
+            if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 3)
             {
                 ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyle().Colors[ImGuiCol_ButtonActive]);
             }
 
             if (ImGui::Button(_LC("TopMenubar", "Start"), ImVec2(80, 0)))
             {
-                if (ai_mode == 2)
+                if (ai_mode == 3)
                 {
                     App::GetGuiManager()->SurveyMap.ai_waypoints.clear();
                     if (App::GetGameContext()->GetPlayerActor()) // We are in vehicle
@@ -980,7 +1081,7 @@ void TopMenubar::Update()
                 }
             }
 
-            if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 2)
+            if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 3)
             {
                 ImGui::PopStyleColor();
             }
@@ -989,7 +1090,7 @@ void TopMenubar::Update()
 
             if (ImGui::Button(_LC("TopMenubar", "Stop"), ImVec2(80, 0)))
             {
-                if (ai_mode == 2)
+                if (ai_mode == 3)
                 {
                     App::GetGuiManager()->SurveyMap.ai_waypoints.clear();
                 }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -912,10 +912,14 @@ void TopMenubar::Update()
                 label2 = "Chase";
             }
 
-            if (ai_start)
+            for (auto actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
             {
-                ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+                if (actor->ar_driveable == AI)
+                {
+                    ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+                    break;
+                }
             }
 
             if (ImGui::BeginCombo("Mode", label2.c_str()))
@@ -986,10 +990,14 @@ void TopMenubar::Update()
                 ImGui::EndTooltip();
             }
 
-            if (ai_start)
+            for (auto actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
             {
-                ImGui::PopItemFlag();
-                ImGui::PopStyleVar();
+                if (actor->ar_driveable == AI)
+                {
+                    ImGui::PopItemFlag();
+                    ImGui::PopStyleVar();
+                    break;
+                }
             }
 
             if (ai_speed < 1)
@@ -1092,11 +1100,6 @@ void TopMenubar::Update()
                         App::GetScriptEngine()->loadScript("AI.as", ScriptCategory::CUSTOM);
                     }
                 }
-
-                if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty())
-                {
-                    ai_start = true;
-                }
             }
 
             if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 3)
@@ -1120,8 +1123,6 @@ void TopMenubar::Update()
                         App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
                     }
                 }
-
-                ai_start = false;
             }
 
             if (ai_rec)

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -1224,7 +1224,7 @@ void TopMenubar::Update()
                 int count = 0;
                 for (size_t i = 0; i < num_rows; i++)
                 {
-                    rapidjson::Value& j_row =  j_doc[static_cast<rapidjson::SizeType>(i)];
+                    rapidjson::Value& j_row = j_doc[static_cast<rapidjson::SizeType>(i)];
 
                     if (j_row.HasMember("terrain") && App::sim_terrain_name->getStr() == j_row["terrain"].GetString())
                     {
@@ -1253,7 +1253,7 @@ void TopMenubar::Update()
 
                     for (size_t i = 0; i < num_rows; i++)
                     {
-                        rapidjson::Value& j_row_terrains =  j_doc[static_cast<rapidjson::SizeType>(i)];
+                        rapidjson::Value& j_row_terrains = j_doc[static_cast<rapidjson::SizeType>(i)];
                         if (j_row_terrains.HasMember("terrains"))
                         {
                             for (size_t i = 0; i < j_row_terrains["terrains"].Size(); i++)

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -792,7 +792,7 @@ void TopMenubar::Update()
                 ai_num = 1;
 
 
-            if (ai_mode == 2)
+            if (ai_mode == 2 || ai_mode == 3) // Drag Race or Crash driving mode
             {
                 ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                 ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
@@ -806,13 +806,19 @@ void TopMenubar::Update()
                 ImGui::EndTooltip();
             }
 
-            if (ai_mode == 2)
+            if (ai_mode == 2 || ai_mode == 3) // Drag Race or Crash driving mode
             {
                 ImGui::PopItemFlag();
                 ImGui::PopStyleVar();
             }
 
             if (ai_num < 2)
+            {
+                ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+            }
+
+            if (ai_mode == 3) // Crash driving mode
             {
                 ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                 ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
@@ -826,13 +832,23 @@ void TopMenubar::Update()
                 ImGui::EndTooltip();
             }
 
+            if (ai_mode == 3) // Crash driving mode
+            {
+                ImGui::PopItemFlag();
+                ImGui::PopStyleVar();
+            }
+
             std::string label1 = "Behind";
             if (ai_position_scheme == 1)
             {
                 label1 = "Parallel";
             }
+            else if (ai_position_scheme == 2)
+            {
+                label1 = "Opposite";
+            }
 
-            if (ai_mode == 2)
+            if (ai_mode == 2 || ai_mode == 3) // Drag Race or Crash driving mode
             {
                 ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                 ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
@@ -869,7 +885,7 @@ void TopMenubar::Update()
             if (ai_times < 1)
                 ai_times = 1;
 
-            if (ai_mode == 3)
+            if (ai_mode == 4) // Chase driving mode
             {
                 ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                 ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
@@ -883,13 +899,13 @@ void TopMenubar::Update()
                 ImGui::EndTooltip();
             }
 
-            if (ai_mode == 3)
+            if (ai_mode == 4) // Chase driving mode
             {
                 ImGui::PopItemFlag();
                 ImGui::PopStyleVar();
             }
 
-            if (ai_mode == 2)
+            if (ai_mode == 2 || ai_mode == 3) // Drag Race or Crash driving mode
             {
                 ImGui::PopItemFlag();
                 ImGui::PopStyleVar();
@@ -908,6 +924,10 @@ void TopMenubar::Update()
                 label2 = "Drag Race";
             }
             else if (ai_mode == 3)
+            {
+                label2 = "Crash";
+            }
+            else if (ai_mode == 4)
             {
                 label2 = "Chase";
             }
@@ -928,7 +948,7 @@ void TopMenubar::Update()
                 {
                     ai_mode = 0;
 
-                    if (ai_mode_prev == 2)
+                    if (ai_mode_prev == 2 || ai_mode_prev == 3)
                     {
                         ai_num = ai_num_prev;
                         ai_speed = ai_speed_prev;
@@ -941,7 +961,7 @@ void TopMenubar::Update()
                 {
                     ai_mode = 1;
 
-                    if (ai_mode_prev == 2)
+                    if (ai_mode_prev == 2 || ai_mode_prev == 3)
                     {
                         ai_num = ai_num_prev;
                         ai_speed = ai_speed_prev;
@@ -953,21 +973,41 @@ void TopMenubar::Update()
                 if (ImGui::Selectable("Drag Race"))
                 {
                     ai_mode = 2;
+
+                    if (ai_mode_prev != 3)
+                    {
+                        ai_num_prev = ai_num;
+                        ai_speed_prev = ai_speed;
+                        ai_position_scheme_prev = ai_position_scheme;
+                        ai_times_prev = ai_times;
+                    }
                     ai_mode_prev = ai_mode;
-                    ai_num_prev = ai_num;
-                    ai_speed_prev = ai_speed;
-                    ai_position_scheme_prev = ai_position_scheme;
-                    ai_times_prev = ai_times;
                     ai_num = 2;
                     ai_speed = 1000;
                     ai_position_scheme = 1;
                     ai_times = 1;
                 }
-                if (ImGui::Selectable("Chase"))
+                if (ImGui::Selectable("Crash"))
                 {
                     ai_mode = 3;
+                    if (ai_mode_prev != 2)
+                    {
+                        ai_num_prev = ai_num;
+                        ai_speed_prev = ai_speed;
+                        ai_position_scheme_prev = ai_position_scheme;
+                        ai_times_prev = ai_times;
+                    }
+                    ai_mode_prev = ai_mode;
+                    ai_num = 2;
+                    ai_speed = 100;
+                    ai_position_scheme = 2;
+                    ai_times = 1;
+                }
+                if (ImGui::Selectable("Chase"))
+                {
+                    ai_mode = 4;
 
-                    if (ai_mode_prev == 2)
+                    if (ai_mode_prev == 2 || ai_mode_prev == 3)
                     {
                         ai_num = ai_num_prev;
                         ai_speed = ai_speed_prev;
@@ -986,6 +1026,7 @@ void TopMenubar::Update()
                 ImGui::Text(_LC("TopMenubar", "Normal: Modify speed according to turns, other vehicles and character"));
                 ImGui::Text(_LC("TopMenubar", "Race: Always keep defined speed"));
                 ImGui::Text(_LC("TopMenubar", "Drag Race: Two vehicles performing a drag race"));
+                ImGui::Text(_LC("TopMenubar", "Crash: Two vehicles driving in opposite direction"));
                 ImGui::Text(_LC("TopMenubar", "Chase: Follow character and player vehicle"));
                 ImGui::EndTooltip();
             }
@@ -1039,7 +1080,7 @@ void TopMenubar::Update()
                 ImGui::EndTooltip();
             }
 
-            if (ai_mode == 2)
+            if (ai_mode == 2 || ai_mode == 3) // Drag Race or Crash driving mode
             {
                 ImGui::PushID("vehicle2");
                 if (ImGui::Button(StripColorMarksFromText(ai_dname2).c_str(), ImVec2(250, 0)))
@@ -1067,14 +1108,14 @@ void TopMenubar::Update()
                 ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
             }
 
-            if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 3)
+            if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 4) // Waypoints provided or Chase driving mode
             {
                 ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyle().Colors[ImGuiCol_ButtonActive]);
             }
 
             if (ImGui::Button(_LC("TopMenubar", "Start"), ImVec2(80, 0)))
             {
-                if (ai_mode == 3)
+                if (ai_mode == 4) // Chase driving mode
                 {
                     App::GetGuiManager()->SurveyMap.ai_waypoints.clear();
                     if (App::GetGameContext()->GetPlayerActor()) // We are in vehicle
@@ -1102,7 +1143,7 @@ void TopMenubar::Update()
                 }
             }
 
-            if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 3)
+            if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 4) // Waypoints provided or Chase driving mode
             {
                 ImGui::PopStyleColor();
             }
@@ -1111,7 +1152,7 @@ void TopMenubar::Update()
 
             if (ImGui::Button(_LC("TopMenubar", "Stop"), ImVec2(80, 0)))
             {
-                if (ai_mode == 3)
+                if (ai_mode == 4) // Chase driving mode
                 {
                     App::GetGuiManager()->SurveyMap.ai_waypoints.clear();
                 }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -898,17 +898,6 @@ void TopMenubar::Update()
             ImGui::Separator();
             ImGui::TextColored(GRAY_HINT_TEXT, _LC("TopMenubar", "Vehicle options:"));
 
-            if (ai_speed < 1)
-                ai_speed = 1;
-
-            ImGui::InputInt(_LC("TopMenubar", "Speed"), &ai_speed, 1, 100);
-            if (ImGui::IsItemHovered())
-            {
-                ImGui::BeginTooltip();
-                ImGui::Text(_LC("TopMenubar", "Speed in km/h for land vehicles or knots/s for boats"));
-                ImGui::EndTooltip();
-            }
-
             std::string label2 = "Normal";
             if (ai_mode == 1)
             {
@@ -988,6 +977,17 @@ void TopMenubar::Update()
                 ImGui::Text(_LC("TopMenubar", "Race: Always keep defined speed"));
                 ImGui::Text(_LC("TopMenubar", "Drag Race: Two vehicles performing a drag race"));
                 ImGui::Text(_LC("TopMenubar", "Chase: Follow character and player vehicle"));
+                ImGui::EndTooltip();
+            }
+
+            if (ai_speed < 1)
+                ai_speed = 1;
+
+            ImGui::InputInt(_LC("TopMenubar", "Speed"), &ai_speed, 1, 100);
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::BeginTooltip();
+                ImGui::Text(_LC("TopMenubar", "Speed in km/h for land vehicles or knots/s for boats"));
                 ImGui::EndTooltip();
             }
 

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -986,6 +986,7 @@ void TopMenubar::Update()
                 ImGui::Separator();
                 ImGui::Text(_LC("TopMenubar", "Normal: Modify speed according to turns, other vehicles and character"));
                 ImGui::Text(_LC("TopMenubar", "Race: Always keep defined speed"));
+                ImGui::Text(_LC("TopMenubar", "Drag Race: Two vehicles performing a drag race"));
                 ImGui::Text(_LC("TopMenubar", "Chase: Follow character and player vehicle"));
                 ImGui::EndTooltip();
             }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -1160,8 +1160,14 @@ void TopMenubar::Update()
             bool is_open = ImGui::CollapsingHeader(_LC("TopMenubar", "Presets"));
             if (ImGui::IsItemActivated() && !is_open && j_doc.Empty()) // Fetch once
             {
-                this->GetPresets();
-                //App::GetContentManager()->LoadAndParseJson("waypoints.json", RGN_SAVEGAMES, j_doc);
+                if (FileExists(PathCombine(App::sys_savegames_dir->getStr(), "waypoints.json")))
+                {
+                    App::GetContentManager()->LoadAndParseJson("waypoints.json", RGN_SAVEGAMES, j_doc);
+                }
+                else
+                {
+                    this->GetPresets();
+                }
             }
 
             if (is_open && j_doc.Empty())

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -1178,7 +1178,7 @@ void TopMenubar::Update()
                 {
                     rapidjson::Value& j_row =  j_doc[static_cast<rapidjson::SizeType>(i)];
 
-                    if (App::sim_terrain_name->getStr() == j_row["terrain"].GetString())
+                    if (j_row.HasMember("terrain") && App::sim_terrain_name->getStr() == j_row["terrain"].GetString())
                     {
                         count++;
                         if (ImGui::Button(j_row["preset"].GetString(), ImVec2(250, 0)))
@@ -1198,6 +1198,24 @@ void TopMenubar::Update()
                 if (count == 0)
                 {
                     ImGui::Text(_LC("TopMenubar", "No presets found for this terrain :("));
+                    ImGui::Text(_LC("TopMenubar", "Supported terrains:"));
+                    ImGui::Separator();
+
+                    ImGui::BeginChild("terrains-scrolling", ImVec2(0.f, 200), false);
+
+                    for (size_t i = 0; i < num_rows; i++)
+                    {
+                        rapidjson::Value& j_row_terrains =  j_doc[static_cast<rapidjson::SizeType>(i)];
+                        if (j_row_terrains.HasMember("terrains"))
+                        {
+                            for (size_t i = 0; i < j_row_terrains["terrains"].Size(); i++)
+                            {
+                                ImGui::Text(j_row_terrains["terrains"][i].GetString());
+                            }
+                        }
+                    }
+
+                    ImGui::EndChild();
                 }
             }
 

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -912,6 +912,12 @@ void TopMenubar::Update()
                 label2 = "Chase";
             }
 
+            if (ai_start)
+            {
+                ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+                ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+            }
+
             if (ImGui::BeginCombo("Mode", label2.c_str()))
             {
                 if (ImGui::Selectable("Normal"))
@@ -978,6 +984,12 @@ void TopMenubar::Update()
                 ImGui::Text(_LC("TopMenubar", "Drag Race: Two vehicles performing a drag race"));
                 ImGui::Text(_LC("TopMenubar", "Chase: Follow character and player vehicle"));
                 ImGui::EndTooltip();
+            }
+
+            if (ai_start)
+            {
+                ImGui::PopItemFlag();
+                ImGui::PopStyleVar();
             }
 
             if (ai_speed < 1)
@@ -1080,6 +1092,11 @@ void TopMenubar::Update()
                         App::GetScriptEngine()->loadScript("AI.as", ScriptCategory::CUSTOM);
                     }
                 }
+
+                if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty())
+                {
+                    ai_start = true;
+                }
             }
 
             if (!App::GetGuiManager()->SurveyMap.ai_waypoints.empty() || ai_mode == 3)
@@ -1103,6 +1120,8 @@ void TopMenubar::Update()
                         App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
                     }
                 }
+
+                ai_start = false;
             }
 
             if (ai_rec)

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -82,7 +82,6 @@ public:
     int ai_position_scheme_prev = 0;
     int ai_times_prev = 1;
     int ai_mode_prev = 0;
-    bool ai_start = false;
 
     void Refresh(std::string payload);
 

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -70,7 +70,7 @@ public:
     int ai_mode = 0;
     bool ai_menu = false;
 
-    // Second selections for Drag Race Mode
+    // Secondary selections for Drag Race mode
     bool ai_select2 = false;
     Ogre::String ai_fname2 = "95bbUID-agoras.truck";
     Ogre::String ai_dname2 = "Bus RVI Agora S";

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -70,6 +70,19 @@ public:
     int ai_mode = 0;
     bool ai_menu = false;
 
+    // Second selections for Drag Race Mode
+    bool ai_select2 = false;
+    Ogre::String ai_fname2 = "95bbUID-agoras.truck";
+    Ogre::String ai_dname2 = "Bus RVI Agora S";
+    Ogre::String ai_sectionconfig2 = "";
+    std::string ai_skin2 = "";
+
+    int ai_num_prev = 1;
+    int ai_speed_prev = 50;
+    int ai_position_scheme_prev = 0;
+    int ai_times_prev = 1;
+    int ai_mode_prev = 0;
+
     void Refresh(std::string payload);
 
 private:

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -82,6 +82,7 @@ public:
     int ai_position_scheme_prev = 0;
     int ai_times_prev = 1;
     int ai_mode_prev = 0;
+    bool ai_start = false;
 
     void Refresh(std::string payload);
 

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -70,7 +70,7 @@ public:
     int ai_mode = 0;
     bool ai_menu = false;
 
-    // Secondary selections for Drag Race mode
+    // Secondary selections for Drag Race and Crash driving modes
     bool ai_select2 = false;
     Ogre::String ai_fname2 = "95bbUID-agoras.truck";
     Ogre::String ai_dname2 = "Bus RVI Agora S";

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -983,7 +983,7 @@ int GameScript::getAIVehicleSpeed()
 
 Ogre::String GameScript::getAIVehicleName(int x)
 {
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race Mode
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race mode
     {
         Ogre::String name = App::GetGuiManager()->TopMenubar.ai_fname2;
         return name;
@@ -997,7 +997,7 @@ Ogre::String GameScript::getAIVehicleName(int x)
 
 Ogre::String GameScript::getAIVehicleSectionConfig(int x)
 {
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race Mode
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race mode
     {
         Ogre::String config = App::GetGuiManager()->TopMenubar.ai_sectionconfig2;
         return config;
@@ -1011,7 +1011,7 @@ Ogre::String GameScript::getAIVehicleSectionConfig(int x)
 
 std::string GameScript::getAIVehicleSkin(int x)
 {
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race Mode
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race mode
     {
         std::string skin = App::GetGuiManager()->TopMenubar.ai_skin2;
         return skin;

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -981,22 +981,46 @@ int GameScript::getAIVehicleSpeed()
     return speed;
 }
 
-Ogre::String GameScript::getAIVehicleName()
+Ogre::String GameScript::getAIVehicleName(int x)
 {
-    Ogre::String name = App::GetGuiManager()->TopMenubar.ai_fname;
-    return name;
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race Mode
+    {
+        Ogre::String name = App::GetGuiManager()->TopMenubar.ai_fname2;
+        return name;
+    }
+    else
+    {
+        Ogre::String name = App::GetGuiManager()->TopMenubar.ai_fname;
+        return name;
+    }
 }
 
-Ogre::String GameScript::getAIVehicleSectionConfig()
+Ogre::String GameScript::getAIVehicleSectionConfig(int x)
 {
-    Ogre::String config = App::GetGuiManager()->TopMenubar.ai_sectionconfig;
-    return config;
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race Mode
+    {
+        Ogre::String config = App::GetGuiManager()->TopMenubar.ai_sectionconfig2;
+        return config;
+    }
+    else
+    {
+        Ogre::String config = App::GetGuiManager()->TopMenubar.ai_sectionconfig;
+        return config;
+    }
 }
 
-std::string GameScript::getAIVehicleSkin()
+std::string GameScript::getAIVehicleSkin(int x)
 {
-    std::string skin = App::GetGuiManager()->TopMenubar.ai_skin;
-    return skin;
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race Mode
+    {
+        std::string skin = App::GetGuiManager()->TopMenubar.ai_skin2;
+        return skin;
+    }
+    else
+    {
+        std::string skin = App::GetGuiManager()->TopMenubar.ai_skin;
+        return skin;
+    }
 }
 
 int GameScript::getAIRepeatTimes()

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -926,13 +926,19 @@ Actor* GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre:
     return App::GetGameContext()->SpawnActor(rq);
 }
 
-Actor* GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin)
+Actor* GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x)
 {
     ActorSpawnRequest rq;
     rq.asr_position = pos;
 
     // Set rotation based on first two waypoints
-    Ogre::Vector3 dir = App::GetGuiManager()->SurveyMap.ai_waypoints[0] - App::GetGuiManager()->SurveyMap.ai_waypoints[1];
+    std::vector<Ogre::Vector3> waypoints = App::GetGuiManager()->SurveyMap.ai_waypoints;
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 3 && x == 1) // Crash driving mode
+    {
+        std::reverse(waypoints.begin(), waypoints.end());
+    }
+
+    Ogre::Vector3 dir = waypoints[0] - waypoints[1];
     dir.y = 0;
     rq.asr_rotation = Ogre::Vector3::UNIT_X.getRotationTo(dir, Ogre::Vector3::UNIT_Y);
 
@@ -943,9 +949,14 @@ Actor* GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogr
     return App::GetGameContext()->SpawnActor(rq);
 }
 
-AngelScript::CScriptArray* GameScript::getWaypoints()
+AngelScript::CScriptArray* GameScript::getWaypoints(int x)
 {
     std::vector<Ogre::Vector3> vec = App::GetGuiManager()->SurveyMap.ai_waypoints;
+    if (App::GetGuiManager()->TopMenubar.ai_mode == 3 && x == 1) // Crash driving mode
+    {
+        std::reverse(vec.begin(), vec.end());
+    }
+
     AngelScript::CScriptArray* arr = AngelScript::CScriptArray::Create(AngelScript::asGetActiveContext()->GetEngine()->GetTypeInfoByDecl("array<vector3>"), vec.size());
 
     for(AngelScript::asUINT i = 0; i < arr->GetSize(); i++)
@@ -983,7 +994,7 @@ int GameScript::getAIVehicleSpeed()
 
 Ogre::String GameScript::getAIVehicleName(int x)
 {
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race mode
+    if ((App::GetGuiManager()->TopMenubar.ai_mode == 2 || App::GetGuiManager()->TopMenubar.ai_mode == 3) && x == 1) // Drag Race or Crash driving mode
     {
         Ogre::String name = App::GetGuiManager()->TopMenubar.ai_fname2;
         return name;
@@ -997,7 +1008,7 @@ Ogre::String GameScript::getAIVehicleName(int x)
 
 Ogre::String GameScript::getAIVehicleSectionConfig(int x)
 {
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race mode
+    if ((App::GetGuiManager()->TopMenubar.ai_mode == 2 || App::GetGuiManager()->TopMenubar.ai_mode == 3) && x == 1) // Drag Race or Crash driving mode
     {
         Ogre::String config = App::GetGuiManager()->TopMenubar.ai_sectionconfig2;
         return config;
@@ -1011,7 +1022,7 @@ Ogre::String GameScript::getAIVehicleSectionConfig(int x)
 
 std::string GameScript::getAIVehicleSkin(int x)
 {
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 2 && x == 1) // Drag Race mode
+    if ((App::GetGuiManager()->TopMenubar.ai_mode == 2 || App::GetGuiManager()->TopMenubar.ai_mode == 3) && x == 1) // Drag Race or Crash driving mode
     {
         std::string skin = App::GetGuiManager()->TopMenubar.ai_skin2;
         return skin;

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -345,8 +345,8 @@ public:
     int getCurrentTruckNumber();
 
     Actor* spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot);
-    Actor* spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin);
-    AngelScript::CScriptArray* getWaypoints();
+    Actor* spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x);
+    AngelScript::CScriptArray* getWaypoints(int x);
     int getAIVehicleCount();
     int getAIVehicleDistance();
     int getAIVehiclePositionScheme();

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -351,9 +351,9 @@ public:
     int getAIVehicleDistance();
     int getAIVehiclePositionScheme();
     int getAIVehicleSpeed();
-    Ogre::String getAIVehicleName();
-    Ogre::String getAIVehicleSectionConfig();
-    std::string getAIVehicleSkin();
+    Ogre::String getAIVehicleName(int x);
+    Ogre::String getAIVehicleSectionConfig(int x);
+    std::string getAIVehicleSkin(int x);
     int getAIRepeatTimes();
 
     void repairVehicle(const Ogre::String& instance, const Ogre::String& box, bool keepPosition);

--- a/source/main/scripting/bindings/GameScriptAngelscript.cpp
+++ b/source/main/scripting/bindings/GameScriptAngelscript.cpp
@@ -106,9 +106,9 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleDistance()", AngelScript::asMETHOD(GameScript, getAIVehicleDistance), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehiclePositionScheme()", AngelScript::asMETHOD(GameScript, getAIVehiclePositionScheme), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleSpeed()", AngelScript::asMETHOD(GameScript, getAIVehicleSpeed), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "string getAIVehicleName()", AngelScript::asMETHOD(GameScript, getAIVehicleName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "string getAIVehicleSectionConfig()", AngelScript::asMETHOD(GameScript, getAIVehicleSectionConfig), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "string getAIVehicleSkin()", AngelScript::asMETHOD(GameScript, getAIVehicleSkin), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "string getAIVehicleName(int x)", AngelScript::asMETHOD(GameScript, getAIVehicleName), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "string getAIVehicleSectionConfig(int x)", AngelScript::asMETHOD(GameScript, getAIVehicleSectionConfig), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "string getAIVehicleSkin(int x)", AngelScript::asMETHOD(GameScript, getAIVehicleSkin), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIRepeatTimes()", AngelScript::asMETHOD(GameScript, getAIRepeatTimes), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void repairVehicle(const string &in, const string &in, bool)", asMETHOD(GameScript, repairVehicle), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void removeVehicle(const string &in, const string &in)", asMETHOD(GameScript, removeVehicle), asCALL_THISCALL); ROR_ASSERT(result >= 0);

--- a/source/main/scripting/bindings/GameScriptAngelscript.cpp
+++ b/source/main/scripting/bindings/GameScriptAngelscript.cpp
@@ -100,8 +100,8 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("GameScriptClass", "int getNumTrucks()", asMETHOD(GameScript, getNumTrucks), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getCurrentTruckNumber()", asMETHOD(GameScript, getCurrentTruckNumber), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @spawnTruck(string &in, vector3 &in, vector3 &in)", asMETHOD(GameScript, spawnTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @spawnTruckAI(string &in, vector3 &in, string &in, string &in)", AngelScript::asMETHOD(GameScript, spawnTruckAI), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "array<vector3> @getWaypoints()", AngelScript::asMETHOD(GameScript, getWaypoints), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @spawnTruckAI(string &in, vector3 &in, string &in, string &in, int x)", AngelScript::asMETHOD(GameScript, spawnTruckAI), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "array<vector3> @getWaypoints(int x)", AngelScript::asMETHOD(GameScript, getWaypoints), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleCount()", AngelScript::asMETHOD(GameScript, getAIVehicleCount), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleDistance()", AngelScript::asMETHOD(GameScript, getAIVehicleDistance), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehiclePositionScheme()", AngelScript::asMETHOD(GameScript, getAIVehiclePositionScheme), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);


### PR DESCRIPTION
- A new Drag Race mode added which auto configures the settings and makes possible to select two vehicles to perform a drag race. Returning to other modes preserves the previous selections.

![kk](https://user-images.githubusercontent.com/2660424/195370251-17c97492-b2f7-47a1-970d-07bd5d23c88b.png)

Just two waypoints making a line are enough for this mode.

- A new Crash driving mode added which auto configures the settings and makes possible to select two vehicles to perform a crash. Returning to other modes preserves the previous selections.

![kk](https://user-images.githubusercontent.com/2660424/197919665-7cef3b98-1e89-4a6f-abbe-a13a80152cc0.png)

Again just two waypoints making a line are enough for this mode.

- Fixed setting sectionconfig when skin is also available

- Moved driving mode on top

- Don't allow changing mode when AI is running

- If no preset found, show supported terrains list also (fetchable from json)

![gg](https://user-images.githubusercontent.com/2660424/196301179-42e6db39-e36f-4f74-9488-82f0a0a16002.png)

- Prefer local file `savegames/waypoints.json` if exists
