### PR TITLE
Created unified text file tokenizer

### DIFF
--- a/doc/angelscript/Script2Game/GenericDocReaderClass.h
+++ b/doc/angelscript/Script2Game/GenericDocReaderClass.h
@@ -1,0 +1,55 @@
+namespace Script2Game {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */   
+
+enum TokenType
+{
+    TOKEN_TYPE_NONE,
+    TOKEN_TYPE_LINEBREAK,
+    TOKEN_TYPE_COMMENT,
+    TOKEN_TYPE_STRING,
+    TOKEN_TYPE_NUMBER,
+    TOKEN_TYPE_BOOL,
+    TOKEN_TYPE_KEYWORD
+};
+
+/**
+ * @brief Binding of RoR::GenericDocReader; Traverses document tokens; See 'demo_script.as' for an example.
+ */
+class GenericDocReaderClass
+{
+    GenericDocReader(GenericDocumentPtr@ d);
+
+    bool MoveNext();
+    uint GetPos();
+    bool SeekNextLine();
+    int CountLineArgs();
+    bool EndOfFile(int offset = 0);
+
+    TokenType GetTokType(int offset = 0);
+    string GetStringData(int offset = 0);
+    float GetFloatData(int offset = 0);
+
+    string GetTokString(int offset = 0);
+    float GetTokFloat(int offset = 0);
+    bool GetTokBool(int offset = 0);
+    string GetTokKeyword(int offset = 0);
+    string GetTokComment(int offset = 0);
+
+    bool IsTokString(int offset = 0);
+    bool IsTokFloat(int offset = 0);
+    bool IsTokBool(int offset = 0);
+    bool IsTokKeyword(int offset = 0);
+    bool IsTokComment(int offset = 0);
+};
+
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Game

--- a/doc/angelscript/Script2Game/GenericDocumentClass.h
+++ b/doc/angelscript/Script2Game/GenericDocumentClass.h
@@ -14,7 +14,10 @@ enum GenericDocumentOptions
     GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS, //!< Allow comments starting with `//`. 
     GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE, //!< First non-empty & non-comment line is a naked string with spaces. 
     GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON, //!< Allow ':' as separator between tokens.
-    GENERIC_DOCUMENT_OPTION_PARENTHESES_CAPTURE_SPACES //!< If non-empty NAKED string encounters '(', following spaces will be captured until matching ')' is found.    
+    GENERIC_DOCUMENT_OPTION_PARENTHESES_CAPTURE_SPACES, //!< If non-empty NAKED string encounters '(', following spaces will be captured until matching ')' is found.    
+    GENERIC_DOCUMENT_OPTION_ALLOW_BRACED_KEYWORDS, //!< Allow INI-like '[keyword]' tokens.
+    GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_EQUALS, //!< Allow '=' as separator between tokens.
+    GENERIC_DOCUMENT_OPTION_ALLOW_HASH_COMMENTS //!< Allow comments starting with `#`.     
 };
 
 /**

--- a/doc/angelscript/Script2Game/GenericDocumentClass.h
+++ b/doc/angelscript/Script2Game/GenericDocumentClass.h
@@ -1,0 +1,39 @@
+namespace Script2Game {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */   
+
+enum GenericDocumentOptions
+{
+    GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS, //!< Allow strings without quotes, for backwards compatibility.
+    GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS, //!< Allow comments starting with `//`. 
+    GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE, //!< First non-empty & non-comment line is a naked string with spaces. 
+    GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON, //!< Allow ':' as separator between tokens.
+    GENERIC_DOCUMENT_OPTION_PARENTHESES_CAPTURE_SPACES //!< If non-empty NAKED string encounters '(', following spaces will be captured until matching ')' is found.    
+};
+
+/**
+ * @brief Binding of RoR::GenericDocument; Parses TRUCK/TOBJ/ODEF/CHARACTER file formats.
+ */
+class GenericDocumentClass
+{
+    /**
+    * Loads and parses a document from OGRE resource system.
+    */
+    bool LoadFromResource(string resource_name, string resource_group_name, int options = 0);
+    
+    /**
+    * Saves the document to OGRE resource system.
+    */
+    bool SaveToResource(string resource_name, string resource_group_name);
+};
+
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Game

--- a/doc/angelscript/Script2Game/TerrainClass.h
+++ b/doc/angelscript/Script2Game/TerrainClass.h
@@ -22,6 +22,16 @@ public:
     string getTerrainName();
     
     /**
+     * @return File name of the terrain definition (TERRN2 format).
+     */
+    string getTerrainFileName(); 
+    
+    /**
+     * @return OGRE resource group of the terrain bundle (ZIP/directory under 'mods/') where definition files live.
+     */
+    string getTerrainFileResourceGroup();    
+    
+    /**
      * @return GUID (global unique ID) of the terrain, or empty string if not specified.
      */
     string getGUID();

--- a/resources/scripts/demo_script.as
+++ b/resources/scripts/demo_script.as
@@ -112,7 +112,9 @@ void frameStep(float dt)
                 if (ImGui::Button("View document"))
                 {
                     GenericDocumentClass@ doc = GenericDocumentClass();
-                    int flags = GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS | GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS;
+                    int flags = GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS
+                              | GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS
+                              | GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE;
                     if (doc.LoadFromResource(actor.getTruckFileName(), actor.getTruckFileResourceGroup(), flags))
                     {
                         @g_displayed_document = @doc;
@@ -213,7 +215,7 @@ void drawDocumentWindow()
 
         // Other tokens come anywhere - delimiting logic is needed
         default:
-            if (reader.GetTokType(-1) != TOKEN_TYPE_LINEBREAK)
+            if (reader.GetPos() != 0 && reader.GetTokType(-1) != TOKEN_TYPE_LINEBREAK)
             {
                 ImGui::SameLine();
                 string delimiter = (reader.GetTokType(-1) == TOKEN_TYPE_KEYWORD) ? " " : ", ";

--- a/resources/scripts/demo_script.as
+++ b/resources/scripts/demo_script.as
@@ -114,7 +114,8 @@ void frameStep(float dt)
                     int flags = GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS
                               | GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS
                               | GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE
-                              | GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON;
+                              | GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON
+                              | GENERIC_DOCUMENT_OPTION_PARENTHESES_CAPTURE_SPACES;
                     if (doc.LoadFromResource(actor.getTruckFileName(), actor.getTruckFileResourceGroup(), flags))
                     {
                         @g_displayed_document = @doc;

--- a/resources/scripts/demo_script.as
+++ b/resources/scripts/demo_script.as
@@ -9,6 +9,7 @@
      * Collect and show stats (i.e. frame count, total time)
      * Read/Write cvars (RoR.cfg values, cli args, game state...)
      * View and update game state (current vehicle...)
+     * Parse and display definition files with syntax highlighting.
      
     There are 3 ways of invoking a script:
      1. By defining it with terrain, see terrn2 fileformat, section '[Scripts]':
@@ -21,12 +22,12 @@
     
     For introduction to game events, read
     https://docs.rigsofrods.org/terrain-creation/scripting/.
-
-    For reference manual of the interface, see
-    https://github.com/RigsOfRods/rigs-of-rods/tree/master/doc/angelscript.
+    
+    Scripting documentation:
+    https://developer.rigsofrods.org/d4/d07/group___script2_game.html
+     
     ---------------------------------------------------------------------------
 */
-
 
 /*
     ---------------------------------------------------------------------------
@@ -38,6 +39,7 @@ CVarClass@  g_app_state = console.cVarFind("app_state"); // 0=bootstrap, 1=main 
 CVarClass@  g_sim_state = console.cVarFind("sim_state"); // 0=off, 1=running, 2=paused, 3=terrain editor, see SimState in Application.h
 CVarClass@  g_mp_state = console.cVarFind("mp_state"); // 0=disabled, 1=connecting, 2=connected, see MpState in Application.h
 CVarClass@  g_io_arcade_controls = console.cVarFind("io_arcade_controls"); // bool
+GenericDocumentClass@ g_displayed_document = null;
 
 /*
     ---------------------------------------------------------------------------
@@ -100,9 +102,31 @@ void frameStep(float dt)
         ImGui::Text("Toggle fixed camera: " + inputs.getEventCommandTrimmed(EV_CAMERA_FREE_MODE_FIX));              
         
         BeamClass@ actor = game.getCurrentTruck();
-        if (actor != null)
+        if (@actor != null)
         {
+            ImGui::AlignTextToFramePadding();
             ImGui::Text("You are driving " + actor.getTruckName());
+            ImGui::SameLine();
+            if (@g_displayed_document == null)
+            {
+                if (ImGui::Button("View document"))
+                {
+                    GenericDocumentClass@ doc = GenericDocumentClass();
+                    int flags = GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS | GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS;
+                    if (doc.LoadFromResource(actor.getTruckFileName(), actor.getTruckFileResourceGroup(), flags))
+                    {
+                        @g_displayed_document = @doc;
+                    }
+                }
+            }
+            else
+            {
+                if (ImGui::Button("Close document"))
+                {
+                    @g_displayed_document = null;
+                }
+            }
+            
             ImGui::TextDisabled("Vehicle controls:");
 
             ImGui::Text("Accelerate/Brake: "
@@ -157,4 +181,63 @@ void frameStep(float dt)
     // Update global counters
     g_total_frames++;
     g_total_seconds += dt;
+    
+    // Draw document window
+    if (@g_displayed_document != null)
+    {
+        drawDocumentWindow();
+    }
+}
+
+void drawDocumentWindow()
+{
+    ImGui::PushID("document view");
+    ImGui::Begin("Document view", /*open:*/true, /*flags:*/0);
+
+    GenericDocReaderClass reader(g_displayed_document);
+    while (!reader.EndOfFile())
+    {
+        switch (reader.GetTokType())
+        {
+        // These tokens are always at start of line
+        case TOKEN_TYPE_KEYWORD:
+            ImGui::TextColored(color(1.f, 1.f, 0.f, 1.f), reader.GetTokKeyword());
+            break;
+        case TOKEN_TYPE_COMMENT:
+            ImGui::TextDisabled(";" + reader.GetTokComment());
+            break;
+            
+        // Linebreak is implicit in DearIMGUI, no action needed
+        case TOKEN_TYPE_LINEBREAK:
+            break;
+
+        // Other tokens come anywhere - delimiting logic is needed
+        default:
+            if (reader.GetTokType(-1) != TOKEN_TYPE_LINEBREAK)
+            {
+                ImGui::SameLine();
+                string delimiter = (reader.GetTokType(-1) == TOKEN_TYPE_KEYWORD) ? " " : ", ";
+                ImGui::Text(delimiter);
+                ImGui::SameLine();
+            }
+
+            switch (reader.GetTokType())
+            {
+            case TOKEN_TYPE_STRING:
+                ImGui::TextColored(color(0.f, 1.f, 1.f, 1.f), "\"" + reader.GetTokString() + "\"");
+                break;
+            case TOKEN_TYPE_NUMBER:
+                ImGui::Text("" + reader.GetTokFloat());
+                break;
+            case TOKEN_TYPE_BOOL:
+                ImGui::TextColored(color(1.f, 0.f, 1.f, 1.f), ""+reader.GetTokBool());
+                break;
+            }
+        }
+        
+        reader.MoveNext();
+    }
+    
+    ImGui::End();
+    ImGui::PopID(); //"document view"
 }

--- a/resources/scripts/demo_script.as
+++ b/resources/scripts/demo_script.as
@@ -58,8 +58,7 @@ void main()
 void frameStep(float dt)
 {
     // Open demo window
-    ImGui::SetNextWindowSize(vector2(400, 320));
-    ImGui::Begin("Demo Script", /*open:*/true, /*flags:*/0);
+    ImGui::Begin("Demo Script", /*open:*/true, ImGuiWindowFlags_AlwaysAutoResize);
     
     // show some stats
     ImGui::Text("Total frames: " + g_total_frames);
@@ -114,7 +113,8 @@ void frameStep(float dt)
                     GenericDocumentClass@ doc = GenericDocumentClass();
                     int flags = GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS
                               | GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS
-                              | GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE;
+                              | GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE
+                              | GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON;
                     if (doc.LoadFromResource(actor.getTruckFileName(), actor.getTruckFileResourceGroup(), flags))
                     {
                         @g_displayed_document = @doc;

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -230,6 +230,7 @@ if (USE_ANGELSCRIPT)
             scripting/bindings/ActorAngelscript.cpp
             scripting/bindings/ConsoleAngelscript.cpp
             scripting/bindings/GameScriptAngelscript.cpp
+            scripting/bindings/GenericFileFormatAngelscript.cpp
             scripting/bindings/ImGuiAngelscript.cpp
             scripting/bindings/InputEngineAngelscript.cpp
             scripting/bindings/LocalStorageAngelscript.cpp

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -207,6 +207,7 @@ set(SOURCE_FILES
         utils/ConfigFile.{h,cpp}
         utils/ErrorUtils.{h,cpp}
         utils/ForceFeedback.{h,cpp}
+        utils/GenericFileFormat.{h,cpp}
         utils/ImprovedConfigFile.h
         utils/InputEngine.{h,cpp}
         utils/InterThreadStoreVector.h

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4614,3 +4614,7 @@ void Actor::UpdatePropAnimInputEvents()
     }
 }
 
+std::string Actor::getTruckFileResourceGroup()
+{
+    return m_gfx_actor->GetResourceGroup();
+}

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -197,6 +197,7 @@ public:
     /// @{
     std::string       getTruckName() { return ar_design_name; }
     std::string       getTruckFileName() { return ar_filename; }
+    std::string       getTruckFileResourceGroup();
     int               getTruckType() { return ar_driveable; }
     Ogre::String      getSectionConfig() { return m_section_config; }
     CacheEntry*       getUsedSkin() { return m_used_skin_entry; }

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -163,6 +163,7 @@ void ScriptEngine::init()
     RegisterTerrain(engine);       // TerrainClass
     RegisterGameScript(engine);    // GameScriptClass
     RegisterScriptEvents(engine);  // scriptEvents
+    RegisterGenericFileFormat(engine); // TokenType, GenericDocumentClass, GenericDocReaderClass
 
     // now the global instances
     result = engine->RegisterGlobalProperty("GameScriptClass game", &m_game_script); ROR_ASSERT(result>=0);

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -66,6 +66,7 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", asMETHOD(Actor,scaleTruck), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckName()", asMETHOD(Actor,getTruckName), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileName()", asMETHOD(Actor,getTruckFileName), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileResourceGroup()", asMETHOD(Actor, getTruckFileResourceGroup), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "string getSectionConfig()", asMETHOD(Actor, getSectionConfig), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", asMETHOD(Actor,getTruckType), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void reset(bool)", asMETHOD(Actor,reset), asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/bindings/AngelScriptBindings.h
+++ b/source/main/scripting/bindings/AngelScriptBindings.h
@@ -70,6 +70,9 @@ void RegisterTerrain(AngelScript::asIScriptEngine* engine);
 /// defined in ProceduralRoadAngelscript.cpp
 void RegisterProceduralRoad(AngelScript::asIScriptEngine* engine);
 
+/// defined in GenericFileFormatAngelscript.cpp
+void RegisterGenericFileFormat(AngelScript::asIScriptEngine* engine);
+
 
 /// @}   //addtogroup Scripting
 

--- a/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
+++ b/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
@@ -76,6 +76,7 @@ void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
     engine->RegisterEnum("GenericDocumentOptions");
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS", GenericDocument::OPTION_ALLOW_NAKED_STRINGS);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS", GenericDocument::OPTION_ALLOW_SLASH_COMMENTS);
+    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE", GenericDocument::OPTION_FIRST_LINE_IS_TITLE);
 
 
     // class GenericDocument
@@ -93,6 +94,7 @@ void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("GenericDocReaderClass", asBEHAVE_FACTORY, "GenericDocReaderClass@ f(GenericDocumentClassPtr @)", asFUNCTION(GenericDocReaderFactory), asCALL_CDECL);
 
     engine->RegisterObjectMethod("GenericDocReaderClass", "bool MoveNext()", asMETHOD(GenericDocReader, MoveNext), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "uint GetPos()", asMETHOD(GenericDocReader, GetPos), asCALL_THISCALL);
     engine->RegisterObjectMethod("GenericDocReaderClass", "bool SeekNextLine()", asMETHOD(GenericDocReader, SeekNextLine), asCALL_THISCALL);
     engine->RegisterObjectMethod("GenericDocReaderClass", "uint CountLineArgs()", asMETHOD(GenericDocReader, CountLineArgs), asCALL_THISCALL);
     engine->RegisterObjectMethod("GenericDocReaderClass", "bool EndOfFile(int offset = 0)", asMETHOD(GenericDocReader, EndOfFile), asCALL_THISCALL);

--- a/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
+++ b/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
@@ -77,6 +77,7 @@ void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS", GenericDocument::OPTION_ALLOW_NAKED_STRINGS);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS", GenericDocument::OPTION_ALLOW_SLASH_COMMENTS);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE", GenericDocument::OPTION_FIRST_LINE_IS_TITLE);
+    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON", GenericDocument::OPTION_ALLOW_SEPARATOR_COLON);
 
 
     // class GenericDocument

--- a/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
+++ b/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
@@ -1,0 +1,113 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2022 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+/// @author Petr Ohlidal
+/// @date   12-2022
+
+#include "AngelScriptBindings.h"
+#include "GenericFileFormat.h"
+
+using namespace RoR;
+using namespace AngelScript;
+
+// Wrappers
+static std::string GenericDocReader_GetTokString(GenericDocReader* reader, uint32_t offset)
+{
+    const char* val = reader->GetTokString(offset);
+    return (val) ? val : "";
+}
+
+static std::string GenericDocReader_GetTokKeyword(GenericDocReader* reader, uint32_t offset)
+{
+    const char* val = reader->GetTokKeyword(offset);
+    return (val) ? val : "";
+}
+
+static std::string GenericDocReader_GetTokComment(GenericDocReader* reader, uint32_t offset)
+{
+    const char* val = reader->GetTokComment(offset);
+    return (val) ? val : "";
+}
+
+// Factories
+static GenericDocument* GenericDocumentFactory()
+{
+    return new GenericDocument();
+}
+
+static GenericDocReader* GenericDocReaderFactory(GenericDocumentPtr doc)
+{
+    return new GenericDocReader(doc);
+}
+
+void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
+{
+    // enum TokenType
+    engine->RegisterEnum("TokenType");
+    engine->RegisterEnumValue("TokenType", "TOKEN_TYPE_NONE", (int)TokenType::NONE);
+    engine->RegisterEnumValue("TokenType", "TOKEN_TYPE_LINEBREAK", (int)TokenType::LINEBREAK);
+    engine->RegisterEnumValue("TokenType", "TOKEN_TYPE_COMMENT", (int)TokenType::COMMENT);
+    engine->RegisterEnumValue("TokenType", "TOKEN_TYPE_STRING", (int)TokenType::STRING);
+    engine->RegisterEnumValue("TokenType", "TOKEN_TYPE_NUMBER", (int)TokenType::NUMBER);
+    engine->RegisterEnumValue("TokenType", "TOKEN_TYPE_BOOL", (int)TokenType::BOOL);
+    engine->RegisterEnumValue("TokenType", "TOKEN_TYPE_KEYWORD", (int)TokenType::KEYWORD);
+
+
+    // GenericDocument constants
+    engine->RegisterEnum("GenericDocumentOptions");
+    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS", GenericDocument::OPTION_ALLOW_NAKED_STRINGS);
+    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS", GenericDocument::OPTION_ALLOW_SLASH_COMMENTS);
+
+
+    // class GenericDocument
+    GenericDocument::RegisterRefCountingObject(engine, "GenericDocumentClass");
+    GenericDocumentPtr::RegisterRefCountingObjectPtr(engine, "GenericDocumentClassPtr", "GenericDocumentClass");
+    engine->RegisterObjectBehaviour("GenericDocumentClass", asBEHAVE_FACTORY, "GenericDocumentClass@ f()", asFUNCTION(GenericDocumentFactory), asCALL_CDECL);
+
+    engine->RegisterObjectMethod("GenericDocumentClass", "bool LoadFromResource(string,string,int)", asMETHOD(GenericDocument, LoadFromResource), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocumentClass", "bool SaveToResource(string,string)", asMETHOD(GenericDocument, SaveToResource), asCALL_THISCALL);
+
+
+    // class GenericDocReader
+    GenericDocReader::RegisterRefCountingObject(engine, "GenericDocReaderClass");
+    GenericDocReaderPtr::RegisterRefCountingObjectPtr(engine, "GenericDocReaderClassPtr", "GenericDocReaderClass");
+    engine->RegisterObjectBehaviour("GenericDocReaderClass", asBEHAVE_FACTORY, "GenericDocReaderClass@ f(GenericDocumentClassPtr @)", asFUNCTION(GenericDocReaderFactory), asCALL_CDECL);
+
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool MoveNext()", asMETHOD(GenericDocReader, MoveNext), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool SeekNextLine()", asMETHOD(GenericDocReader, SeekNextLine), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "uint CountLineArgs()", asMETHOD(GenericDocReader, CountLineArgs), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool EndOfFile(int offset = 0)", asMETHOD(GenericDocReader, EndOfFile), asCALL_THISCALL);
+
+    engine->RegisterObjectMethod("GenericDocReaderClass", "TokenType GetTokType(int offset = 0)", asMETHOD(GenericDocReader, GetTokType), asCALL_THISCALL);
+
+    engine->RegisterObjectMethod("GenericDocReaderClass", "string GetTokString(int offset = 0)", asFUNCTION(GenericDocReader_GetTokString), asCALL_CDECL_OBJFIRST);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "float GetTokFloat(int offset = 0)", asMETHOD(GenericDocReader, GetTokFloat), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool GetTokBool(int offset = 0)", asMETHOD(GenericDocReader, GetTokBool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "string GetTokKeyword(int offset = 0)", asFUNCTION(GenericDocReader_GetTokKeyword), asCALL_CDECL_OBJFIRST);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "string GetTokComment(int offset = 0)", asFUNCTION(GenericDocReader_GetTokComment), asCALL_CDECL_OBJFIRST);
+    
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool IsTokString(int offset = 0)", asMETHOD(GenericDocReader, IsTokString), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool IsTokFloat(int offset = 0)", asMETHOD(GenericDocReader, IsTokFloat), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool IsTokBool(int offset = 0)", asMETHOD(GenericDocReader, IsTokBool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool IsTokKeyword(int offset = 0)", asMETHOD(GenericDocReader, IsTokKeyword), asCALL_THISCALL);
+    engine->RegisterObjectMethod("GenericDocReaderClass", "bool IsTokComment(int offset = 0)", asMETHOD(GenericDocReader, IsTokComment), asCALL_THISCALL);
+}

--- a/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
+++ b/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
@@ -79,6 +79,9 @@ void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE", GenericDocument::OPTION_FIRST_LINE_IS_TITLE);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON", GenericDocument::OPTION_ALLOW_SEPARATOR_COLON);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_PARENTHESES_CAPTURE_SPACES", GenericDocument::OPTION_PARENTHESES_CAPTURE_SPACES);
+    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_BRACED_KEYWORDS", GenericDocument::OPTION_ALLOW_BRACED_KEYWORDS);
+    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_EQUALS", GenericDocument::OPTION_ALLOW_SEPARATOR_EQUALS);
+    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_HASH_COMMENTS", GenericDocument::OPTION_ALLOW_HASH_COMMENTS);
 
 
     // class GenericDocument

--- a/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
+++ b/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
@@ -78,6 +78,7 @@ void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS", GenericDocument::OPTION_ALLOW_SLASH_COMMENTS);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE", GenericDocument::OPTION_FIRST_LINE_IS_TITLE);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON", GenericDocument::OPTION_ALLOW_SEPARATOR_COLON);
+    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_PARENTHESES_CAPTURE_SPACES", GenericDocument::OPTION_PARENTHESES_CAPTURE_SPACES);
 
 
     // class GenericDocument

--- a/source/main/scripting/bindings/ImGuiAngelscript.cpp
+++ b/source/main/scripting/bindings/ImGuiAngelscript.cpp
@@ -179,7 +179,7 @@ void RoR::RegisterImGuiBindings(AngelScript::asIScriptEngine* engine)
     engine->RegisterGlobalFunction("vector2 GetCursorStartPos()", asFUNCTIONPR([]() { auto v = ImGui::GetCursorStartPos(); return Vector2(v.x, v.y); }, (), Vector2), asCALL_CDECL);
     engine->RegisterGlobalFunction("vector2 GetCursorScreenPos()", asFUNCTIONPR([]() { auto v = ImGui::GetCursorScreenPos(); return Vector2(v.x, v.y); }, (), Vector2), asCALL_CDECL);
     engine->RegisterGlobalFunction("void SetCursorScreenPos(vector2)", asFUNCTIONPR([](Vector2 v) { ImGui::SetCursorScreenPos(ImVec2(v.x, v.y)); }, (Vector2), void), asCALL_CDECL);
-  //  engine->RegisterGlobalFunction("void AlignTextToFramePadding()", asFUNCTIONPR(ImGui::AlignTextToFramePadding, (), void), asCALL_CDECL);
+    engine->RegisterGlobalFunction("void AlignTextToFramePadding()", asFUNCTIONPR(ImGui::AlignTextToFramePadding, (), void), asCALL_CDECL);
     engine->RegisterGlobalFunction("float GetTextLineHeight()", asFUNCTIONPR(ImGui::GetTextLineHeight, (), float), asCALL_CDECL);
     engine->RegisterGlobalFunction("float GetTextLineHeightWithSpacing()", asFUNCTIONPR(ImGui::GetTextLineHeightWithSpacing, (), float), asCALL_CDECL);
   //  engine->RegisterGlobalFunction("float GetFrameHeight()", asFUNCTIONPR(ImGui::GetFrameHeight, (), float), asCALL_CDECL);

--- a/source/main/scripting/bindings/TerrainAngelscript.cpp
+++ b/source/main/scripting/bindings/TerrainAngelscript.cpp
@@ -36,6 +36,8 @@ void RoR::RegisterTerrain(asIScriptEngine* engine)
 
     int result = 0;
     result = engine->RegisterObjectMethod("TerrainClass", "string getTerrainName()", asMETHOD(RoR::Terrain,getTerrainName), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("TerrainClass", "string getTerrainFileName()", asMETHOD(RoR::Terrain, getTerrainFileName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("TerrainClass", "string getTerrainFileResourceGroup()", asMETHOD(RoR::Terrain, getTerrainFileResourceGroup), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("TerrainClass", "string getGUID()", asMETHOD(RoR::Terrain,getGUID), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("TerrainClass", "int getVersion()", asMETHOD(RoR::Terrain,getVersion), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("TerrainClass", "bool isFlat()", asMETHOD(RoR::Terrain,isFlat), asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/terrain/Terrain.cpp
+++ b/source/main/terrain/Terrain.cpp
@@ -550,3 +550,12 @@ ProceduralManagerPtr RoR::Terrain::getProceduralManager()
     return m_object_manager->getProceduralManager();
 }
 
+std::string RoR::Terrain::getTerrainFileName()
+{
+    return m_cache_entry->fname;
+}
+
+std::string RoR::Terrain::getTerrainFileResourceGroup()
+{
+    return m_cache_entry->resource_group;
+}

--- a/source/main/terrain/Terrain.h
+++ b/source/main/terrain/Terrain.h
@@ -47,6 +47,8 @@ public:
     /// @name Terrain info
     /// @{
     std::string             getTerrainName() const        { return m_def.name; }
+    std::string             getTerrainFileName();
+    std::string             getTerrainFileResourceGroup();
     std::string             getGUID() const               { return m_def.guid; }
     int                     getCategoryID() const         { return m_def.category_id; }
     int                     getVersion() const            { return m_def.version; }

--- a/source/main/utils/GenericFileFormat.cpp
+++ b/source/main/utils/GenericFileFormat.cpp
@@ -37,7 +37,7 @@ enum class PartialToken
     TITLE_STRING,      // A whole-line string, with spaces
     NUMBER,            // Number with digits and optionally leading '-'
     NUMBER_DOT,        // Like NUMBER but already containing '.'
-    KEYWORD,           // Unqoted string at the start of line
+    KEYWORD,           // Unqoted string at the start of line. Accepted characters: alphanumeric and underscore
     BOOL_TRUE,         // Partial 'true'
     BOOL_FALSE,        // Partial 'false'
     GARBAGE,           // Text not fitting any above category, will be discarded
@@ -533,6 +533,11 @@ void DocumentParser::UpdateKeyword(const char c)
         doc.tokens.push_back({ TokenType::LINEBREAK, 0.f });
         line_num++;
         line_pos = 0;
+        break;
+
+    case '_':
+        tok.push_back(c);
+        line_pos++;
         break;
 
     default:

--- a/source/main/utils/GenericFileFormat.cpp
+++ b/source/main/utils/GenericFileFormat.cpp
@@ -433,13 +433,13 @@ void DocumentParser::UpdateBool(const char c)
         break;
 
     case 'e':
-        if (partial_tok_type == PartialToken::BOOL_TRUE || tok.size() == 3)
+        if (partial_tok_type == PartialToken::BOOL_TRUE && tok.size() == 3)
         {
             doc.tokens.push_back({ TokenType::BOOL, 1.f });
             tok.clear();
             partial_tok_type = PartialToken::NONE;
         }
-        else if (partial_tok_type == PartialToken::BOOL_FALSE || tok.size() == 4)
+        else if (partial_tok_type == PartialToken::BOOL_FALSE && tok.size() == 4)
         {
             doc.tokens.push_back({ TokenType::BOOL, 0.f });
             tok.clear();

--- a/source/main/utils/GenericFileFormat.cpp
+++ b/source/main/utils/GenericFileFormat.cpp
@@ -328,12 +328,6 @@ void DocumentParser::UpdateNumber(const char c)
         line_pos = 0;
         break;
 
-    case '-':
-        partial_tok_type = PartialToken::GARBAGE;
-        tok.push_back(c);
-        line_pos++;
-        break;
-
     case '.':
         if (partial_tok_type == PartialToken::NUMBER)
         {
@@ -347,6 +341,37 @@ void DocumentParser::UpdateNumber(const char c)
         }
         line_pos++;
         break;
+
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case '-': // For scientific notation
+    case '+': // For scientific notation
+    case 'e': // For scientific notation
+        tok.push_back(c);
+        line_pos++;
+        break;
+
+    default:
+        if (options & GenericDocument::OPTION_ALLOW_NAKED_STRINGS)
+        {
+            partial_tok_type = PartialToken::STRING_NAKED;
+        }
+        else
+        {
+            partial_tok_type = PartialToken::GARBAGE;
+        }
+        tok.push_back(c);
+        line_pos++;
+        break;
+
     }
 
     if (partial_tok_type == PartialToken::GARBAGE)

--- a/source/main/utils/GenericFileFormat.cpp
+++ b/source/main/utils/GenericFileFormat.cpp
@@ -1,0 +1,695 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2022 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "GenericFileFormat.h"
+
+#include "Application.h"
+#include "Console.h"
+
+#include <algorithm>
+
+using namespace RoR;
+using namespace Ogre;
+
+enum class PartialToken
+{
+    NONE,
+    COMMENT_SEMICOLON, // Comment starting with ';'
+    COMMENT_SLASH,     // Comment starting with '//'
+    STRING_QUOTED,     // String starting/ending with '"'
+    STRING_NAKED,      // String without '"' on either end
+    NUMBER,            // Number with digits and optionally leading '-'
+    NUMBER_DOT,        // Like NUMBER but already containing '.'
+    KEYWORD,           // Unqoted string at the start of line
+    BOOL_TRUE,         // Partial 'true'
+    BOOL_FALSE,        // Partial 'false'
+    GARBAGE,           // Text not fitting any above category, will be discarded
+};
+
+struct DocumentParser
+{
+    DocumentParser(Document& d, const BitMask_t opt, Ogre::DataStreamPtr ds)
+        : doc(d), options(opt), datastream(ds) {}
+
+    // Config
+    Document& doc;
+    const BitMask_t options;
+    Ogre::DataStreamPtr datastream;
+
+    // State
+    std::vector<char> tok;
+    size_t line_num = 0;
+    size_t line_pos = 0;
+    PartialToken partial_tok_type = PartialToken::NONE;
+
+    void BeginToken(const char c);
+    void UpdateComment(const char c);
+    void UpdateString(const char c);
+    void UpdateNumber(const char c);
+    void UpdateBool(const char c);
+    void UpdateKeyword(const char c);
+    void UpdateGarbage(const char c);
+};
+
+void DocumentParser::BeginToken(const char c)
+{
+    switch (c)
+    {
+    case '\r':
+        break;
+
+    case ' ':
+    case ',':
+    case '\t':
+        line_pos++;
+        break;
+
+    case '\n':
+        doc.tokens.push_back({ TokenType::LINEBREAK, 0.f });
+        line_num++;
+        line_pos = 0;
+        break;
+
+    case ';':
+        partial_tok_type = PartialToken::COMMENT_SEMICOLON;
+        line_pos++;
+        break;
+
+    case '/':
+        if (options & Document::OPTION_ALLOW_SLASH_COMMENTS)
+        {
+            partial_tok_type = PartialToken::COMMENT_SLASH;
+        }
+        else if (options & Document::OPTION_ALLOW_NAKED_STRINGS &&
+            (doc.tokens.size() != 0 && doc.tokens.back().type != TokenType::LINEBREAK)) // not first on line?
+        {
+            tok.push_back(c);
+            partial_tok_type = PartialToken::STRING_NAKED;
+        }
+        else
+        {
+            partial_tok_type = PartialToken::GARBAGE;
+            tok.push_back(c);
+        }
+        line_pos++;
+        break;
+
+    case '"':
+        partial_tok_type = PartialToken::STRING_QUOTED;
+        line_pos++;
+        break;
+
+    case '.':
+        tok.push_back(c);
+        partial_tok_type = PartialToken::NUMBER_DOT;
+        line_pos++;
+        break;
+
+    case '-':
+        tok.push_back(c);
+        partial_tok_type = PartialToken::NUMBER;
+        line_pos++;
+        break;
+
+    case 't':
+        tok.push_back(c);
+        partial_tok_type = PartialToken::BOOL_TRUE;
+        line_pos++;
+        break;
+
+    case 'f':
+        tok.push_back(c);
+        partial_tok_type = PartialToken::BOOL_FALSE;
+        line_pos++;
+        break;
+
+    default:
+        if (isdigit(c))
+        {
+            tok.push_back(c);
+            partial_tok_type = PartialToken::NUMBER;
+        }
+        else if (isalpha(c) &&
+            (doc.tokens.size() == 0 || doc.tokens.back().type == TokenType::LINEBREAK)) // on line start?
+        {
+            tok.push_back(c);
+            partial_tok_type = PartialToken::KEYWORD;
+        }
+        else if (options & Document::OPTION_ALLOW_NAKED_STRINGS)
+        {
+            tok.push_back(c);
+            partial_tok_type = PartialToken::STRING_NAKED;
+        }
+        else
+        {
+            partial_tok_type = PartialToken::GARBAGE;
+            tok.push_back(c);
+        }
+        line_pos++;
+        break;
+    }
+
+    if (partial_tok_type == PartialToken::GARBAGE)
+    {
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format("{}, line {}, pos {}: stray character '{}'", datastream->getName(), line_num, line_pos, c));
+    }
+}
+
+void DocumentParser::UpdateComment(const char c)
+{
+    switch (c)
+    {
+    case '\r':
+        break;
+
+    case '\n':
+        // Flush comment
+        doc.tokens.push_back({ TokenType::COMMENT, (float)doc.string_pool.size() });
+        tok.push_back('\0');
+        std::copy(tok.begin(), tok.end(), std::back_inserter(doc.string_pool));
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        // Break line
+        doc.tokens.push_back({ TokenType::LINEBREAK, 0.f });
+        line_num++;
+        line_pos = 0;
+        break;
+
+    case '/':
+        if (partial_tok_type != PartialToken::COMMENT_SLASH || tok.size() > 0) // With COMMENT_SLASH, skip any number of leading '/'
+        {
+            tok.push_back(c);
+        }
+        line_pos++;
+        break;
+
+    default:
+        tok.push_back(c);
+        line_pos++;
+        break;
+    }
+}
+
+void DocumentParser::UpdateString(const char c)
+{
+    switch (c)
+    {
+    case '\r':
+        break;
+
+    case ' ':
+    case ',':
+    case '\t':
+        if (partial_tok_type == PartialToken::STRING_QUOTED)
+        {
+            tok.push_back('\0');
+        }
+        else // (partial_tok_type == PartialToken::STRING_NAKED)
+        {
+            // Flush string
+            doc.tokens.push_back({ TokenType::STRING, (float)doc.string_pool.size() });
+            tok.push_back('\0');
+            std::copy(tok.begin(), tok.end(), std::back_inserter(doc.string_pool));
+            tok.clear();
+            partial_tok_type = PartialToken::NONE;
+        }
+        line_pos++;
+        break;
+
+    case '\n':
+        if (partial_tok_type == PartialToken::STRING_QUOTED)
+        {
+            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+                fmt::format("{}, line {}, pos {}: quoted string interrupted by newline", datastream->getName(), line_num, line_pos));
+        }
+        // Flush string
+        doc.tokens.push_back({ TokenType::STRING, (float)doc.string_pool.size() });
+        tok.push_back('\0');
+        std::copy(tok.begin(), tok.end(), std::back_inserter(doc.string_pool));
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        // Break line
+        doc.tokens.push_back({ TokenType::LINEBREAK, 0.f });
+        line_num++;
+        line_pos = 0;
+        break;
+
+    case '"':
+        if (partial_tok_type == PartialToken::STRING_QUOTED)
+        {
+            // Flush string
+            doc.tokens.push_back({ TokenType::STRING, (float)doc.string_pool.size() });
+            tok.push_back('\0');
+            std::copy(tok.begin(), tok.end(), std::back_inserter(doc.string_pool));
+            tok.clear();
+            partial_tok_type = PartialToken::NONE;
+        }
+        else // (partial_tok_type == PartialToken::STRING_NAKED)
+        {
+            partial_tok_type = PartialToken::GARBAGE;
+            tok.push_back(c);
+        }
+        line_pos++;
+        break;
+
+    default:
+        tok.push_back(c);
+        line_pos++;
+        break;
+    }
+
+    if (partial_tok_type == PartialToken::GARBAGE)
+    {
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format("{}, line {}, pos {}: stray character '{}' in string", datastream->getName(), line_num, line_pos, c));
+    }
+}
+
+void DocumentParser::UpdateNumber(const char c)
+{
+    switch (c)
+    {
+    case '\r':
+        break;
+
+    case ' ':
+    case ',':
+    case '\t':
+        // Flush number
+        tok.push_back('\0');
+        doc.tokens.push_back({ TokenType::NUMBER, (float)Ogre::StringConverter::parseReal(tok.data()) });
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        line_pos++;
+        break;
+
+    case '\n':
+        // Flush number
+        tok.push_back('\0');
+        doc.tokens.push_back({ TokenType::NUMBER, (float)Ogre::StringConverter::parseReal(tok.data()) });
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        // Break line
+        doc.tokens.push_back({ TokenType::LINEBREAK, 0.f });
+        line_num++;
+        line_pos = 0;
+        break;
+
+    case '-':
+        partial_tok_type = PartialToken::GARBAGE;
+        tok.push_back(c);
+        line_pos++;
+        break;
+
+    case '.':
+        if (partial_tok_type == PartialToken::NUMBER)
+        {
+            tok.push_back(c);
+            partial_tok_type = PartialToken::NUMBER_DOT;
+        }
+        else // (partial_tok_type == PartialToken::NUMBER_DOT)
+        {
+            partial_tok_type = PartialToken::GARBAGE;
+            tok.push_back(c);
+        }
+        line_pos++;
+        break;
+    }
+
+    if (partial_tok_type == PartialToken::GARBAGE)
+    {
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format("{}, line {}, pos {}: stray character '{}' in number", datastream->getName(), line_num, line_pos, c));
+    }
+}
+
+void DocumentParser::UpdateBool(const char c)
+{
+    switch (c)
+    {
+    case '\r':
+        break;
+
+    case ' ':
+    case ',':
+    case '\t':
+        // Discard token
+        tok.push_back('\0');
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format("{}, line {}, pos {}: discarding incomplete boolean token '{}'", datastream->getName(), line_num, line_pos, tok.data()));
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        line_pos++;
+        break;
+
+    case '\n':
+        // Discard token
+        tok.push_back('\0');
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format("{}, line {}, pos {}: discarding incomplete boolean token '{}'", datastream->getName(), line_num, line_pos, tok.data()));
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        // Break line
+        doc.tokens.push_back({ TokenType::LINEBREAK, 0.f });
+        line_num++;
+        line_pos = 0;
+        break;
+
+    case 'r':
+        if (partial_tok_type != PartialToken::BOOL_TRUE || tok.size() != 1)
+        {
+            if (options & Document::OPTION_ALLOW_NAKED_STRINGS)
+                partial_tok_type = PartialToken::STRING_NAKED;
+            else
+                partial_tok_type = PartialToken::GARBAGE;
+        }
+        tok.push_back(c);
+        line_pos++;
+        break;
+
+    case 'u':
+        if (partial_tok_type != PartialToken::BOOL_TRUE || tok.size() != 2)
+        {
+            if (options & Document::OPTION_ALLOW_NAKED_STRINGS)
+                partial_tok_type = PartialToken::STRING_NAKED;
+            else
+                partial_tok_type = PartialToken::GARBAGE;
+        }
+        tok.push_back(c);
+        line_pos++;
+        break;
+
+    case 'a':
+        if (partial_tok_type != PartialToken::BOOL_FALSE || tok.size() != 1)
+        {
+            if (options & Document::OPTION_ALLOW_NAKED_STRINGS)
+                partial_tok_type = PartialToken::STRING_NAKED;
+            else
+                partial_tok_type = PartialToken::GARBAGE;
+        }
+        tok.push_back(c);
+        line_pos++;
+        break;
+
+    case 'l':
+        if (partial_tok_type != PartialToken::BOOL_FALSE || tok.size() != 2)
+        {
+            if (options & Document::OPTION_ALLOW_NAKED_STRINGS)
+                partial_tok_type = PartialToken::STRING_NAKED;
+            else
+                partial_tok_type = PartialToken::GARBAGE;
+        }
+        tok.push_back(c);
+        line_pos++;
+        break;
+
+    case 's':
+        if (partial_tok_type != PartialToken::BOOL_FALSE || tok.size() != 3)
+        {
+            if (options & Document::OPTION_ALLOW_NAKED_STRINGS)
+                partial_tok_type = PartialToken::STRING_NAKED;
+            else
+                partial_tok_type = PartialToken::GARBAGE;
+        }
+        tok.push_back(c);
+        line_pos++;
+        break;
+
+    case 'e':
+        if (partial_tok_type == PartialToken::BOOL_TRUE || tok.size() == 3)
+        {
+            doc.tokens.push_back({ TokenType::BOOL, 1.f });
+            tok.clear();
+            partial_tok_type = PartialToken::NONE;
+        }
+        else if (partial_tok_type == PartialToken::BOOL_FALSE || tok.size() == 4)
+        {
+            doc.tokens.push_back({ TokenType::BOOL, 0.f });
+            tok.clear();
+            partial_tok_type = PartialToken::NONE;
+        }
+        else
+        {
+            if (options & Document::OPTION_ALLOW_NAKED_STRINGS)
+                partial_tok_type = PartialToken::STRING_NAKED;
+            else
+                partial_tok_type = PartialToken::GARBAGE;
+            tok.push_back(c);
+        }
+        line_pos++;
+        break;
+
+    default:
+        if (options & Document::OPTION_ALLOW_NAKED_STRINGS)
+            partial_tok_type = PartialToken::STRING_NAKED;
+        else
+            partial_tok_type = PartialToken::GARBAGE;
+        tok.push_back(c);
+        break;
+    }
+
+    if (partial_tok_type == PartialToken::GARBAGE)
+    {
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format("{}, line {}, pos {}: stray character '{}' in boolean", datastream->getName(), line_num, line_pos, c));
+    }
+}
+
+void DocumentParser::UpdateKeyword(const char c)
+{
+    switch (c)
+    {
+    case '\r':
+        break;
+
+    case ' ':
+    case ',':
+    case '\t':
+        // Flush keyword
+        doc.tokens.push_back({ TokenType::KEYWORD, (float)doc.string_pool.size() });
+        tok.push_back('\0');
+        std::copy(tok.begin(), tok.end(), std::back_inserter(doc.string_pool));
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        line_pos++;
+        break;
+
+    case '\n':
+        // Flush keyword
+        doc.tokens.push_back({ TokenType::KEYWORD, (float)doc.string_pool.size() });
+        tok.push_back('\0');
+        std::copy(tok.begin(), tok.end(), std::back_inserter(doc.string_pool));
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        // Break line
+        doc.tokens.push_back({ TokenType::LINEBREAK, 0.f });
+        line_num++;
+        line_pos = 0;
+        break;
+
+    default:
+        if (!isalnum(c))
+        {
+            partial_tok_type = PartialToken::GARBAGE;
+        }
+        tok.push_back(c);
+        line_pos++;
+        break;
+    }
+
+    if (partial_tok_type == PartialToken::GARBAGE)
+    {
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format("{}, line {}, pos {}: stray character '{}' in keyword", datastream->getName(), line_num, line_pos, c));
+    }
+}
+
+void DocumentParser::UpdateGarbage(const char c)
+{
+    switch (c)
+    {
+    case '\r':
+        break;
+
+    case ' ':
+    case ',':
+    case '\t':
+    case '\n':
+        tok.push_back('\0');
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format("{}, line {}, pos {}: discarding garbage token '{}'", datastream->getName(), line_num, line_pos, tok.data()));
+        tok.clear();
+        partial_tok_type = PartialToken::NONE;
+        line_pos++;
+        break;
+
+    default:
+        tok.push_back(c);
+        line_pos++;
+        break;
+    }
+}   
+
+void Document::Load(Ogre::DataStreamPtr datastream, const BitMask_t options)
+{
+    // Reset the document
+    tokens.clear();
+    string_pool.clear();
+
+    // Prepare context
+    DocumentParser parser(*this, options, datastream);
+    const size_t LINE_BUF_MAX = 10 * 1024; // 10Kb
+    char buf[LINE_BUF_MAX];
+
+    // Parse the text
+    while (!datastream->eof())
+    {
+        size_t buf_len = datastream->read(buf, LINE_BUF_MAX);
+        for (size_t i = 0; i < buf_len; i++)
+        {
+            const char c = buf[i];
+
+            switch (parser.partial_tok_type)
+            {
+            case PartialToken::NONE:
+                parser.BeginToken(c);
+                break;
+
+            case PartialToken::COMMENT_SEMICOLON:
+            case PartialToken::COMMENT_SLASH:
+                parser.UpdateComment(c);
+                break;
+
+            case PartialToken::STRING_QUOTED:
+            case PartialToken::STRING_NAKED:
+                parser.UpdateString(c);
+                break;
+
+            case PartialToken::NUMBER:
+            case PartialToken::NUMBER_DOT:
+                parser.UpdateNumber(c);
+                break;
+
+            case PartialToken::BOOL_TRUE:
+            case PartialToken::BOOL_FALSE:
+                parser.UpdateBool(c);
+                break;
+
+            case PartialToken::KEYWORD:
+                parser.UpdateKeyword(c);
+                break;
+
+            case PartialToken::GARBAGE:
+                parser.UpdateGarbage(c);
+                break;
+            }
+        }
+    }
+
+    // Ensure newline at end of file
+    if (tokens.size() == 0 || tokens.back().type != TokenType::LINEBREAK)
+    {
+        tokens.push_back({ TokenType::LINEBREAK, 0.f });
+    }
+}
+
+#if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+    const char* EOL_STR = "\r\n"; // CR+LF
+#else
+    const char* EOL_STR = "\n"; // "LF"
+#endif
+
+void Document::Save(Ogre::DataStreamPtr datastream)
+{
+    std::string separator;
+    const char* pool_str = nullptr;
+    const size_t BUF_MAX = 100;
+    char buf[BUF_MAX];
+
+    for (Token& tok : tokens)
+    {
+        switch (tok.type)
+        {
+        case TokenType::LINEBREAK:
+            datastream->write(EOL_STR, strlen(EOL_STR));
+            separator = "";
+            break;
+
+        case TokenType::COMMENT:
+            datastream->write(";", 1);
+            pool_str = string_pool.data() + (size_t)tok.data;
+            datastream->write(pool_str, strlen(pool_str));
+            break;
+
+        case TokenType::STRING:
+            datastream->write(separator.data(), separator.size());
+            pool_str = string_pool.data() + (size_t)tok.data;
+            datastream->write(pool_str, strlen(pool_str));
+            separator = ",";
+            break;
+
+        case TokenType::NUMBER:
+            datastream->write(separator.data(), separator.size());
+            snprintf(buf, BUF_MAX, "%f", tok.data);
+            datastream->write(buf, strlen(buf));
+            separator = ",";
+            break;
+
+        case TokenType::BOOL:
+            datastream->write(separator.data(), separator.size());
+            snprintf(buf, BUF_MAX, "%s", tok.data == 1.f ? "true" : "false");
+            datastream->write(buf, strlen(buf));
+            separator = ",";
+            break;
+
+        case TokenType::KEYWORD:
+            pool_str = string_pool.data() + (size_t)tok.data;
+            datastream->write(pool_str, strlen(pool_str));
+            separator = " ";
+            break;
+        }
+    }
+}
+
+bool Reader::SeekNextLine()
+{
+    // Skip current line
+    while (!this->EndOfFile() && this->GetType() != TokenType::LINEBREAK)
+    {
+        this->MoveNext();
+    }
+
+    // Skip comments
+    while (!this->EndOfFile() && !this->IsArgString() && !this->IsArgFloat() && !this->IsArgBool() && !this->IsArgKeyword())
+    {
+        this->MoveNext();
+    }
+
+    return this->EndOfFile();
+}
+
+size_t Reader::CountLineArgs()
+{
+    size_t count = 0;
+    while (!EndOfFile(count) && this->GetType(count) != TokenType::LINEBREAK)
+        count++;
+    return count;
+}
+

--- a/source/main/utils/GenericFileFormat.h
+++ b/source/main/utils/GenericFileFormat.h
@@ -61,6 +61,7 @@ struct GenericDocument: public RefCountingObject<GenericDocument>
 {
     static const BitMask_t OPTION_ALLOW_NAKED_STRINGS = BITMASK(1); //!< Allow strings without quotes, for backwards compatibility.
     static const BitMask_t OPTION_ALLOW_SLASH_COMMENTS = BITMASK(2); //!< Allow comments starting with `//`. 
+    static const BitMask_t OPTION_FIRST_LINE_IS_TITLE = BITMASK(3); //!< First non-empty & non-comment line is a naked string with spaces.
 
     virtual ~GenericDocument() {};
 
@@ -86,6 +87,7 @@ struct GenericDocReader: public RefCountingObject<GenericDocument>
     uint32_t line_num = 0;
 
     bool MoveNext() { token_pos++; return EndOfFile(); }
+    uint32_t GetPos() const { return token_pos; }
     bool SeekNextLine();
     int CountLineArgs();
     bool EndOfFile(int offset = 0) const { return token_pos + offset >= doc->tokens.size(); }

--- a/source/main/utils/GenericFileFormat.h
+++ b/source/main/utils/GenericFileFormat.h
@@ -63,6 +63,7 @@ struct GenericDocument: public RefCountingObject<GenericDocument>
     static const BitMask_t OPTION_ALLOW_SLASH_COMMENTS = BITMASK(2); //!< Allow comments starting with `//`. 
     static const BitMask_t OPTION_FIRST_LINE_IS_TITLE = BITMASK(3); //!< First non-empty & non-comment line is a naked string with spaces.
     static const BitMask_t OPTION_ALLOW_SEPARATOR_COLON = BITMASK(4); //!< Allow ':' as separator between tokens.
+    static const BitMask_t OPTION_PARENTHESES_CAPTURE_SPACES = BITMASK(5); //!< If non-empty NAKED string encounters '(', following spaces will be captured until matching ')' is found.
 
     virtual ~GenericDocument() {};
 

--- a/source/main/utils/GenericFileFormat.h
+++ b/source/main/utils/GenericFileFormat.h
@@ -62,6 +62,7 @@ struct GenericDocument: public RefCountingObject<GenericDocument>
     static const BitMask_t OPTION_ALLOW_NAKED_STRINGS = BITMASK(1); //!< Allow strings without quotes, for backwards compatibility.
     static const BitMask_t OPTION_ALLOW_SLASH_COMMENTS = BITMASK(2); //!< Allow comments starting with `//`. 
     static const BitMask_t OPTION_FIRST_LINE_IS_TITLE = BITMASK(3); //!< First non-empty & non-comment line is a naked string with spaces.
+    static const BitMask_t OPTION_ALLOW_SEPARATOR_COLON = BITMASK(4); //!< Allow ':' as separator between tokens.
 
     virtual ~GenericDocument() {};
 

--- a/source/main/utils/GenericFileFormat.h
+++ b/source/main/utils/GenericFileFormat.h
@@ -64,6 +64,9 @@ struct GenericDocument: public RefCountingObject<GenericDocument>
     static const BitMask_t OPTION_FIRST_LINE_IS_TITLE = BITMASK(3); //!< First non-empty & non-comment line is a naked string with spaces.
     static const BitMask_t OPTION_ALLOW_SEPARATOR_COLON = BITMASK(4); //!< Allow ':' as separator between tokens.
     static const BitMask_t OPTION_PARENTHESES_CAPTURE_SPACES = BITMASK(5); //!< If non-empty NAKED string encounters '(', following spaces will be captured until matching ')' is found.
+    static const BitMask_t OPTION_ALLOW_BRACED_KEYWORDS = BITMASK(6); //!< Allow INI-like '[keyword]' tokens.
+    static const BitMask_t OPTION_ALLOW_SEPARATOR_EQUALS = BITMASK(7); //!< Allow '=' as separator between tokens.
+    static const BitMask_t OPTION_ALLOW_HASH_COMMENTS = BITMASK(8); //!< Allow comments starting with `#`. 
 
     virtual ~GenericDocument() {};
 

--- a/source/main/utils/GenericFileFormat.h
+++ b/source/main/utils/GenericFileFormat.h
@@ -1,0 +1,102 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2022 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+/// @brief Generic text file parser
+/// 
+/// Syntax:
+///  - Lines starting with semicolon (;) (ignoring leading whitespace) are comments
+///  - Separators are space, tabulator or comma (,)
+///  - All strings must be in double quotes (except if OPTION_ALLOW_NAKED_STRINGS is used).
+///  - If the first argument on line is an unqoted string, it's considered KEYWORD token type.
+///  - Reserved keywords are 'true' and 'false' for the BOOL token type.
+/// 
+/// Remarks:
+///  - Strings cannot be multiline. Linebreak within string ends the string.
+///  - KEYWORD tokens cannot start with a digit or special character.
+
+#include <vector>
+#include <string>
+
+#include <Ogre.h>
+
+namespace RoR {
+
+enum class TokenType
+{
+    NONE,
+    LINEBREAK,    // Input: LF (CR is ignored); Output: platform-specific.
+    COMMENT,      // Line starting with ; (skipping whitespace). Data: offset in string pool.
+    STRING,       // Quoted string. Data: offset in string pool.
+    NUMBER,       // Float.
+    BOOL,         // Lowercase 'true'/'false'. Data: 1.0 for true, 0.0 for false.
+    KEYWORD,      // Unquoted string at start of line (skipping whitespace). Data: offset in string pool.
+};
+
+struct Token
+{
+    TokenType type;
+    float     data;
+};
+
+struct Document
+{
+    static const BitMask_t OPTION_ALLOW_NAKED_STRINGS = BITMASK(1); //!< Allow strings without quotes, for backwards compatibility.
+    static const BitMask_t OPTION_ALLOW_SLASH_COMMENTS = BITMASK(2); //!< Allow comments starting with `//`. 
+
+    virtual ~Document() {};
+
+    std::vector<char> string_pool; // Data of COMMENT/KEYWORD/STRING tokens; NUL-terminated strings.
+    std::vector<Token> tokens;
+    
+    virtual void Load(Ogre::DataStreamPtr datastream, BitMask_t options = 0);
+    virtual void Save(Ogre::DataStreamPtr datastream);
+};
+
+struct Reader
+{
+    Reader(Document& d) : doc(d) {}
+    virtual ~Reader() {};
+
+    Document& doc;
+    size_t token_pos = 0;
+    size_t line_num = 0;
+
+    bool MoveNext() { token_pos++; return EndOfFile(); }
+    bool SeekNextLine();
+    size_t CountLineArgs();
+    bool EndOfFile(size_t offset = 0) const { return token_pos + offset >= doc.tokens.size(); }
+
+    TokenType GetType(size_t offset = 0) const { return !EndOfFile(offset) ? doc.tokens[token_pos + offset].type : TokenType::NONE; }
+    const char* GetStringData(size_t offset = 0) const { return !EndOfFile(offset) ? (doc.string_pool.data() + (size_t)doc.tokens[token_pos + offset].data) : nullptr; }
+    float GetFloatData(size_t offset = 0) const { return !EndOfFile(offset) ? doc.tokens[token_pos + offset].data : 0.f; }
+
+    const char* GetArgString(size_t offset = 0) const { ROR_ASSERT(IsArgString(offset)); return GetStringData(offset); }
+    float GetArgFloat(size_t offset = 0) const { ROR_ASSERT(IsArgFloat(offset)); return GetFloatData(offset); }
+    bool GetArgBool(size_t offset = 0) const { ROR_ASSERT(IsArgBool(offset)); return GetFloatData(offset) == 1.f; }
+    const char* GetArgKeyword(size_t offset = 0) const { ROR_ASSERT(IsArgKeyword(offset)); return GetStringData(offset); }
+
+    bool IsArgString(size_t offset = 0) const { return GetType(offset) == TokenType::STRING; };
+    bool IsArgFloat(size_t offset = 0) const { return GetType(offset) == TokenType::NUMBER; };
+    bool IsArgBool(size_t offset = 0) const { return GetType(offset) == TokenType::BOOL; };
+    bool IsArgKeyword(size_t offset = 0) const { return GetType(offset) == TokenType::KEYWORD; };
+
+};
+
+} // namespace RoR


### PR DESCRIPTION
We have multiple formats with very similar syntax: rig def (truck), odef, tobj, character (see #2942). This new parser supports all these formats and adds new features:
 - **Support for "quoted strings with spaces"**. I first implemented them in the new .character fileformat and I decided I want them everywhere, notably .tobj so that procedural roads can have custom names and descriptions for a GPS-like navigation system.
 - **Simple editing in memory**. The document is a vector of Tokens (types: linebreak, comment, keyword, string, number, boolean.) which keeps the exact sequence as in the file. Tokens can be easily added/modified/removed without writing any extra custom code.
 - **Serializability** - saving the (possibly modified) file is as simple as looping through the Tokens array and writing them to a file. No custom code needs to be written for any file format.
 - **Ease of binding to AngelScript**: a single API can modify any fileformat. All the operations the user needs is 1. insert token 2. modify token 3. delete token.

Update: I added AngelScript bindings and extended the bundled 'demo_script.as' to showcase them. There's a new button "View document" (changes to "Close document" after pressing) which opens separate window with a syntax highlighted truck file. Update2: all glitches were fixed. It's ready for review.

**New script API:**
* class GenericDocumentClass - loads/saves a document from OGRE resource system
* class GenericDocReaderClass - traverses document tokens
* enum TokenType (TOKEN_TYPE_*)
* enum GenericDocumentOptions (GENERIC_DOCUMENT_OPTION_*)
* void ImGui::AlignTextToFramePadding()
* string Terran::getTerrainFileName()
* string Terrain::getTerrainFileResourceGroup() 

To test, open game console and say `loadscript demo_script.as`.
![obrazek](https://user-images.githubusercontent.com/491088/206774416-1ab7ce40-7d1e-46d1-9d6e-41f57ecdf068.png)
