### PR TITLE
:sparkles: Added polygon mode (aka render mode) as cvar

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -202,6 +202,7 @@ CVar* audio_menu_music;
 
 // Graphics
 CVar* gfx_flares_mode;
+CVar* gfx_polygon_mode;
 CVar* gfx_shadow_type;
 CVar* gfx_extcam_mode;
 CVar* gfx_sky_mode;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -395,6 +395,7 @@ extern CVar* audio_menu_music;
 
 // Graphics
 extern CVar* gfx_flares_mode;
+extern CVar* gfx_polygon_mode;
 extern CVar* gfx_shadow_type;
 extern CVar* gfx_extcam_mode;
 extern CVar* gfx_sky_mode;

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -845,6 +845,14 @@ void GameContext::UpdateGlobalInputEvents()
             this->PushMessage(Message(MSG_APP_DISPLAY_FULLSCREEN_REQUESTED));
     }
 
+    // render mode
+    switch (App::gfx_polygon_mode->getEnum<Ogre::PolygonMode>())
+    {
+    case 3: App::GetCameraManager()->GetCamera()->setPolygonMode(Ogre::PM_SOLID);       break;
+    case 2: App::GetCameraManager()->GetCamera()->setPolygonMode(Ogre::PM_WIREFRAME);   break;
+    case 1: App::GetCameraManager()->GetCamera()->setPolygonMode(Ogre::PM_POINTS);      break;
+    }
+
     // Write player position to log
     if (App::app_state->getEnum<AppState>() == AppState::SIMULATION &&
         App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_OUTPUT_POSITION))

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -146,6 +146,7 @@ void Console::cVarSetupBuiltins()
     App::audio_menu_music        = this->cVarCreate("audio_menu_music",        "MainMenuMusic",              CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
 
     App::gfx_flares_mode         = this->cVarCreate("gfx_flares_mode",         "Lights",                     CVAR_ARCHIVE | CVAR_TYPE_INT,     "4"/*(int)GfxFlaresMode::ALL_VEHICLES_ALL_LIGHTS*/);
+    App::gfx_polygon_mode        = this->cVarCreate("gfx_polygon_mode",        "Polygon mode",                              CVAR_TYPE_INT,     "3"/*(int)Ogre::PM_SOLID*/);
     App::gfx_shadow_type         = this->cVarCreate("gfx_shadow_type",         "Shadow technique",           CVAR_ARCHIVE | CVAR_TYPE_INT,     "1"/*(int)GfxShadowType::PSSM*/);
     App::gfx_extcam_mode         = this->cVarCreate("gfx_extcam_mode",         "External Camera Mode",       CVAR_ARCHIVE | CVAR_TYPE_INT,     "2"/*(int)GfxExtCamMode::PITCHING*/);
     App::gfx_sky_mode            = this->cVarCreate("gfx_sky_mode",            "Sky effects",                CVAR_ARCHIVE | CVAR_TYPE_INT,     "1"/*(int)GfxSkyMode::CAELUM*/);


### PR DESCRIPTION
Resolves #2957 

`PM_SOLID` is the default when rendering, `setint gfx_polygon_mode 3`
`PM_WIREFRAME` to show the wireframe `setint gfx_polygon_mode 2`
`PM_POINTS` to show the points of each wireframe `setint gfx_polygon_mode 1`