### PR TITLE
Parser: Ignore 'v' beam option

### DIFF
--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -317,6 +317,7 @@ enum class TriggerOption: char
 
 enum class BeamOption: char
 {
+    v_DUMMY                  = 'v',
     i_INVISIBLE              = 'i',
     r_ROPE                   = 'r',
     s_SUPPORT                = 's',

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -3101,6 +3101,8 @@ BitMask_t Parser::GetArgBeamOptions(int index)
             case (char)BeamOption::r_ROPE     : ret |= Beam::OPTION_r_ROPE     ; break;
             case (char)BeamOption::s_SUPPORT  : ret |= Beam::OPTION_s_SUPPORT  ; break;
 
+            case (char)BeamOption::v_DUMMY: break;
+
             default:
                 this->LogMessage(Console::CONSOLE_SYSTEM_WARNING,
                     fmt::format("ignoring invalid option '{}'", c));


### PR DESCRIPTION
Quite a few mods use the 'v' beam option to make beams visible, even though they're actually visible by default. This prevents the console from getting spammed by warnings:
![image](https://user-images.githubusercontent.com/46073351/200156322-0d6c8f70-8605-4264-802d-6c5f3a948505.png)
I don't really know how the parser works but this seems to do the job.