### PR TITLE
Fixed ControlsUI not showing built-in defaults

### DIFF
--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -160,7 +160,7 @@ void GameControls::DrawEvent(RoR::events ev_code)
 
     // Check if we have anything to show
     int display_count = 0;
-    for (event_trigger_t& trig: triggers)
+    for (event_trigger_t& trig : triggers)
     {
         display_count += (int)this->ShouldDisplay(trig);
     }
@@ -179,11 +179,20 @@ void GameControls::DrawEvent(RoR::events ev_code)
 
     // Command column
 
+    int num_visible_commands = 0; // Count visible commands ahead of time
+    for (event_trigger_t& trig : triggers)
+    {
+        num_visible_commands += this->ShouldDisplay(trig);
+    }
+
+    int num_drawn_commands = 0;
     for (event_trigger_t& trig: triggers)
     {
         if (!this->ShouldDisplay(trig)) continue;
 
         ImGui::PushID(&trig);
+
+        ImVec2 cursor_before_command = ImGui::GetCursorScreenPos();
 
         if (ImGui::Button(App::GetInputEngine()->getTriggerCommand(trig).c_str(), ImVec2(ImGui::GetColumnWidth() - 2*ImGui::GetStyle().ItemSpacing.x, 0)))
         {
@@ -194,6 +203,15 @@ void GameControls::DrawEvent(RoR::events ev_code)
             m_active_buffer.Clear();
             m_interactive_keybinding_active = true;
             m_interactive_keybinding_expl = trig.explicite;
+        }
+
+        // If there's more than 1 commands, add numbering at the left side of the buttons
+        num_drawn_commands++;
+        if (num_visible_commands > 1)
+        {
+            ImVec2 text_pos = cursor_before_command + ImGui::GetStyle().FramePadding;
+            ImU32 text_color = ImColor(ImGui::GetStyle().Colors[ImGuiCol_TextDisabled]);
+            ImGui::GetWindowDrawList()->AddText(text_pos, text_color, fmt::format("{}.", num_drawn_commands).c_str());
         }
 
         ImGui::PopID(); // &trig

--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -408,6 +408,7 @@ bool GameControls::ShouldDisplay(event_trigger_t& trig)
 {
     // display only keyboard items from "input.map" or defaults
     return trig.eventtype == eventtypes::ET_Keyboard &&
-            (trig.configDeviceID == MAPFILE_ID_DEFAULT); // input.map
+            (trig.configDeviceID == InputEngine::DEFAULT_MAPFILE_DEVICEID ||
+                (trig.configDeviceID == InputEngine::BUILTIN_MAPPING_DEVICEID));
 }
 

--- a/source/main/gui/panels/GUI_GameControls.h
+++ b/source/main/gui/panels/GUI_GameControls.h
@@ -29,7 +29,6 @@ class GameControls
 {
 public:
     const ImVec4      GRAY_HINT_TEXT = ImVec4(0.62f, 0.62f, 0.61f, 1.f);
-    const int         MAPFILE_ID_DEFAULT = -1;
 
     void SetVisible(bool visible);
     bool IsVisible() const { return m_is_visible; }
@@ -58,7 +57,7 @@ private:
     float m_colum_widths[3] = {}; //!< body->header width sync
 
     // Mode/config file selection
-    int m_active_mapping_file = MAPFILE_ID_DEFAULT; //!< Negative values = MAPFILE_ID_*, 0+ = device specific map file.
+    int m_active_mapping_file = InputEngine::DEFAULT_MAPFILE_DEVICEID;
     bool m_unsaved_changes = false;
 
     // Editing context

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -450,9 +450,9 @@ public:
     typedef std::vector<event_trigger_t> TriggerVec;
     typedef std::map<int, TriggerVec> EventMap;
 
-    static const std::string DEFAULT_MAPFILE; // = "input.map";
-    static const int         DEFAULT_MAPFILE_DEVICEID = -1;
-    static const int         BUILTIN_MAPPING_DEVICEID = -2;
+    static const std::string DEFAULT_MAPFILE; //!< = "input.map";
+    static const int         DEFAULT_MAPFILE_DEVICEID = -1; //!< virtual device ID for "input.map" entries
+    static const int         BUILTIN_MAPPING_DEVICEID = -2; //!< virtual device ID for builtin defaults
 
     InputEngine();
     ~InputEngine();


### PR DESCRIPTION
only entries actually present in 'input.map' were shown, other controls were missing.

If you edit an entry which wasn't present in 'input.map' before, it will be added.