### PR TITLE
Fixed script LocalStorage data (race times etc...) not being written

### DIFF
--- a/source/main/scripting/LocalStorage.cpp
+++ b/source/main/scripting/LocalStorage.cpp
@@ -44,9 +44,8 @@ LocalStorage::LocalStorage(AngelScript::asIScriptEngine *engine_in, std::string 
 
     sectionName = sectionName_in.substr(0, sectionName_in.find(".", 0));
     
-    this->filename = fileName_in + ".asdata";
+    m_filename = fileName_in + ".asdata";
     this->separators = "=";
-    this->resource_group_name = RGN_CACHE;
     loadDict();
     
     saved = true;
@@ -101,7 +100,7 @@ void LocalStorage::ReleaseAllReferences(AngelScript::asIScriptEngine * /*engine*
 
 LocalStorage &LocalStorage::operator =(LocalStorage &other)
 {
-    filename = other.getFilename();
+    m_filename = other.getFilename();
     sectionName = other.getSection();
     SettingsBySection::iterator secIt;
     SettingsBySection osettings = other.getSettings();
@@ -251,14 +250,14 @@ void LocalStorage::saveDict()
 
     try
     {
-        this->saveImprovedCfg();
+        this->saveImprovedCfg(m_filename, RGN_CACHE);
         this->saved = true;
     }
     catch (std::exception& e)
     {
         RoR::LogFormat("[RoR|Scripting|LocalStorage]"
                        "Error saving file '%s' (resource group '%s'), message: '%s'",
-                        this->filename, RGN_CACHE, e.what());
+                        m_filename, RGN_CACHE, e.what());
     }
 }
 
@@ -266,13 +265,13 @@ bool LocalStorage::loadDict()
 {
     try
     {
-        this->loadImprovedCfg();
+        this->loadImprovedCfg(m_filename, RGN_CACHE);
     }
     catch (std::exception& e)
     {
         RoR::LogFormat("[RoR|Scripting|LocalStorage]"
                        "Error reading file '%s' (resource group '%s'), message: '%s'",
-                        this->filename, RGN_CACHE, e.what());
+                        m_filename, RGN_CACHE, e.what());
         return false;
     }
     saved = true;

--- a/source/main/scripting/LocalStorage.h
+++ b/source/main/scripting/LocalStorage.h
@@ -93,10 +93,11 @@ public:
     void ReleaseAllReferences(AngelScript::asIScriptEngine* engine);
 
     SettingsBySection getSettings() { return mSettingsPtr; }
-    std::string getFilename() { return filename; }
+    std::string getFilename() { return m_filename; }
     std::string getSection() { return sectionName; }
 
 protected:
+    std::string m_filename;
     bool saved; //!< Inverted 'dirty flag'
     std::string sectionName;
 

--- a/source/main/utils/ImprovedConfigFile.h
+++ b/source/main/utils/ImprovedConfigFile.h
@@ -36,7 +36,7 @@
 class ImprovedConfigFile : public RoR::ConfigFile
 {
 public:
-    ImprovedConfigFile() : separators("="), filename()
+    ImprovedConfigFile() : separators("=")
     {
         ConfigFile();
     }
@@ -45,9 +45,9 @@ public:
     {
     }
 
-    void loadImprovedCfg()
+    void loadImprovedCfg(std::string const& filename, std::string const& resource_group_name)
     {
-        ConfigFile::load(this->filename, this->resource_group_name, this->separators, /*trimWhitespace*/true);
+        ConfigFile::load(filename, resource_group_name, this->separators, /*trimWhitespace*/true);
     }
 
     bool hasSetting(Ogre::String key, Ogre::String section = "")
@@ -55,11 +55,11 @@ public:
         return (mSettingsPtr.find(section) != mSettingsPtr.end() && mSettingsPtr[section]->find(key) != mSettingsPtr[section]->end());
     }
 
-    bool saveImprovedCfg()
+    bool saveImprovedCfg(std::string const& filename, std::string const& resource_group_name)
     {
         Ogre::DataStreamPtr stream
             = Ogre::ResourceGroupManager::getSingleton().createResource(
-                this->filename, this->resource_group_name, /*overwrite=*/true);
+                filename, resource_group_name, /*overwrite=*/true);
 
         const size_t BUF_LEN = 2000;
         char buf[BUF_LEN];
@@ -231,6 +231,4 @@ public:
 
 protected:
     Ogre::String separators;
-    Ogre::String filename;
-    Ogre::String resource_group_name;
 };


### PR DESCRIPTION
**Problem:** resource group mixup.

**Fix:** Removed filename+RG name fields from ImprovedConfigFile. Now keeping filename in LocalStorage and using RGN_CACHE constant directly.

Fixes #2962