### PR TITLE
Main selector improvements

### DIFF
--- a/source/main/gui/imgui/OgreImGui.cpp
+++ b/source/main/gui/imgui/OgreImGui.cpp
@@ -73,6 +73,7 @@ void OgreImGui::Init()
     io.KeyMap[ImGuiKey_KeyPad7] = OIS::KC_NUMPAD7;
     io.KeyMap[ImGuiKey_KeyPad8] = OIS::KC_NUMPAD8;
     io.KeyMap[ImGuiKey_KeyPad9] = OIS::KC_NUMPAD9;
+    io.KeyMap[ImGuiKey_Slash] = OIS::KC_SLASH;
 
     // Load font
     m_imgui_overlay->addFont("rigsofrods/fonts/Roboto-Medium",

--- a/source/main/gui/imgui/imgui.h
+++ b/source/main/gui/imgui/imgui.h
@@ -960,14 +960,14 @@ enum ImGuiKey_
     ImGuiKey_KeyPad7,
     ImGuiKey_KeyPad8,
     ImGuiKey_KeyPad9,
+    ImGuiKey_Slash,
     ImGuiKey_A,         // for text edit CTRL+A: select all
     ImGuiKey_C,         // for text edit CTRL+C: copy
     ImGuiKey_V,         // for text edit CTRL+V: paste
     ImGuiKey_X,         // for text edit CTRL+X: cut
     ImGuiKey_Y,         // for text edit CTRL+Y: redo
     ImGuiKey_Z,         // for text edit CTRL+Z: undo
-    ImGuiKey_COUNT,
-    ImGuiKey_Slash
+    ImGuiKey_COUNT
 };
 
 // Gamepad/Keyboard directional navigation

--- a/source/main/gui/imgui/imgui.h
+++ b/source/main/gui/imgui/imgui.h
@@ -966,7 +966,8 @@ enum ImGuiKey_
     ImGuiKey_X,         // for text edit CTRL+X: cut
     ImGuiKey_Y,         // for text edit CTRL+Y: redo
     ImGuiKey_Z,         // for text edit CTRL+Z: undo
-    ImGuiKey_COUNT
+    ImGuiKey_COUNT,
+    ImGuiKey_Slash
 };
 
 // Gamepad/Keyboard directional navigation

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -90,7 +90,7 @@ void MainSelector::Draw()
 
     // category keyboard control
     const int num_categories = static_cast<int>(m_display_categories.size());
-    if (m_search_input == "")
+    if (!m_searchbox_was_active || m_search_input == "")
     {
         if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_RightArrow)))
         {

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -90,7 +90,7 @@ void MainSelector::Draw()
 
     // category keyboard control
     const int num_categories = static_cast<int>(m_display_categories.size());
-    if (!m_searchbox_was_active)
+    if (m_search_input == "")
     {
         if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_RightArrow)))
         {
@@ -140,7 +140,8 @@ void MainSelector::Draw()
     }
     if (ImGui::InputText("##SelectorSearch", m_search_input.GetBuffer(), m_search_input.GetCapacity()))
     {
-        // `m_last_selected_category` intentionally not updated
+        m_selected_category = 0; // 'All'
+        m_selected_cid = CID_All;
         this->UpdateSearchParams();
         this->UpdateDisplayLists();
     }

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -134,7 +134,7 @@ void MainSelector::Draw()
         m_kb_focused = false;
     }
 
-    if (!m_searchbox_was_active && ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Tab)))
+    if (!m_searchbox_was_active && (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Tab)) || ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_Slash))))
     {
         ImGui::SetKeyboardFocusHere();
     }


### PR DESCRIPTION
- Slash (/) now focus the search bar in main selector.
- Right/Left arrows now switch categories if search input is empty, no need to unfocus search bar to use them.
- Properly search all categories.

Requested from discord.