### PR TITLE
Terrain editing fixes

### DIFF
--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -442,9 +442,8 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
             }
         }
 
-        SceneNode* bakeNode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
         const String type = "";
-        App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(objectName, pos, rot, bakeNode, instanceName, type, true, handler_func_id, uniquifyMaterials);
+        App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(objectName, pos, rot, instanceName, type, true, handler_func_id, uniquifyMaterials);
     }
     catch (std::exception& e)
     {

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -181,8 +181,7 @@ public:
             else
             {
                 Ogre::Vector3 pos = App::GetGameContext()->GetPlayerCharacter()->getPosition();
-                Ogre::SceneNode* bake_node = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
-                App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(args[1], pos, Ogre::Vector3::ZERO, bake_node, "Console", "");
+                App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(args[1], pos, Ogre::Vector3::ZERO, "Console", "");
 
                 reply_type = Console::CONSOLE_SYSTEM_REPLY;
                 reply << _L("Spawned object at position: ") << "x: " << pos.x << " z: " << pos.z;

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -181,10 +181,16 @@ public:
             else
             {
                 Ogre::Vector3 pos = App::GetGameContext()->GetPlayerCharacter()->getPosition();
-                App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(args[1], pos, Ogre::Vector3::ZERO, "Console", "");
-
-                reply_type = Console::CONSOLE_SYSTEM_REPLY;
-                reply << _L("Spawned object at position: ") << "x: " << pos.x << " z: " << pos.z;
+                if (App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(args[1], pos, Ogre::Vector3::ZERO, "Console", ""))
+                {
+                    reply_type = Console::CONSOLE_SYSTEM_REPLY;
+                    reply << _L("Spawned object at position: ") << "x: " << pos.x << " z: " << pos.z;
+                }
+                else
+                {
+                    reply_type = Console::CONSOLE_SYSTEM_ERROR;
+                    reply << _L("Could not spawn object");
+                }
             }
         }
         catch (std::exception& e)

--- a/source/main/terrain/Terrain.cpp
+++ b/source/main/terrain/Terrain.cpp
@@ -430,8 +430,6 @@ void RoR::Terrain::loadTerrainObjects()
     {
         m_object_manager->LoadTObjFile(tobj_filename);
     }
-
-    m_object_manager->PostLoadTerrain(); // bakes the geometry and things
 }
 
 void RoR::Terrain::initTerrainCollisions()

--- a/source/main/terrain/TerrainEditor.cpp
+++ b/source/main/terrain/TerrainEditor.cpp
@@ -96,8 +96,7 @@ void TerrainEditor::UpdateInputEvents(float dt)
 
         try
         {
-            SceneNode* bakeNode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
-            App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(m_last_object_name, pos, Vector3::ZERO, bakeNode, "Console", "");
+            App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(m_last_object_name, pos, Vector3::ZERO, "Console", "");
 
             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_REPLY, _L("Spawned object at position: ") + String("x: ") + TOSTRING(pos.x) + String("z: ") + TOSTRING(pos.z), "world.png");
         }

--- a/source/main/terrain/TerrainEditor.cpp
+++ b/source/main/terrain/TerrainEditor.cpp
@@ -108,13 +108,19 @@ void TerrainEditor::UpdateInputEvents(float dt)
     }
     else if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_NEXT_TRUCK, 0.25f))
     {
-        m_object_index = (m_object_index + 1 + (int)object_list.size()) % object_list.size();
-        update = true;
+        if (object_list.size() > 0)
+        {
+            m_object_index = (m_object_index + 1 + (int)object_list.size()) % object_list.size();
+            update = true;
+        }
     }
     else if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_PREVIOUS_TRUCK, 0.25f))
     {
-        m_object_index = (m_object_index - 1 + (int)object_list.size()) % object_list.size();
-        update = true;
+        if (object_list.size() > 0)
+        {
+            m_object_index = (m_object_index - 1 + (int)object_list.size()) % object_list.size();
+            update = true;
+        }
     }
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESCUE_TRUCK))
     {

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -79,7 +79,7 @@ public:
     std::vector<EditorObject>& GetEditorObjects() { return m_editor_objects; }
     std::vector<MapEntity>& GetMapEntities() { return m_map_entities; }
     void           LoadTObjFile(Ogre::String filename);
-    void           LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, bool enable_collisions = true, int scripthandler = -1, bool uniquifyMaterial = false);
+    bool           LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, bool enable_collisions = true, int scripthandler = -1, bool uniquifyMaterial = false);
     void           MoveObjectVisuals(const Ogre::String& instancename, const Ogre::Vector3& pos);
     void           unloadObject(const Ogre::String& instancename);
     void           LoadTelepoints();

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -79,13 +79,12 @@ public:
     std::vector<EditorObject>& GetEditorObjects() { return m_editor_objects; }
     std::vector<MapEntity>& GetMapEntities() { return m_map_entities; }
     void           LoadTObjFile(Ogre::String filename);
-    void           LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, Ogre::SceneNode* m_staticgeometry_bake_node, const Ogre::String& instancename, const Ogre::String& type, bool enable_collisions = true, int scripthandler = -1, bool uniquifyMaterial = false);
+    void           LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, bool enable_collisions = true, int scripthandler = -1, bool uniquifyMaterial = false);
     void           MoveObjectVisuals(const Ogre::String& instancename, const Ogre::Vector3& pos);
     void           unloadObject(const Ogre::String& instancename);
     void           LoadTelepoints();
     void           LoadPredefinedActors();
     bool           HasPredefinedActors() { return !m_predefined_actors.empty(); };
-    void           PostLoadTerrain();
     bool           UpdateTerrainObjects(float dt);
 
     void ProcessTree(
@@ -172,9 +171,7 @@ protected:
     std::vector<MeshObject*>              m_mesh_objects;
     std::vector<MapEntity>                m_map_entities;
     Terrain*           terrainManager;
-    Ogre::StaticGeometry*     m_staticgeometry;
     ProceduralManagerPtr      m_procedural_manager;
-    Ogre::SceneNode*          m_staticgeometry_bake_node;
     int                       m_entity_counter = 0;
     std::string               m_resource_group;
 


### PR DESCRIPTION
* Terrain editor: fixed crash when terrain has no objects and user presses `{` or `}` hotkeys. Found by CuriousMike on Discord.
* Console: command `spawnobject` now correctly reports error if file isn't found. Previously it always responded "success, spawned object at..."