### PR TITLE
Only display terrain object errors if it's user's fault

### DIFF
--- a/source/main/utils/ConfigFile.cpp
+++ b/source/main/utils/ConfigFile.cpp
@@ -124,6 +124,5 @@ bool ConfigFile::HasSection(std::string const & name)
 void ConfigFile::logMessage(std::string const & msg)
 {
     // If filename is specified, log "filename: message", otherwise just "message".
-    App::GetConsole()->putMessage(m_log_area, Console::CONSOLE_SYSTEM_WARNING,
-        fmt::format("{}{}{}", m_log_filename, (m_log_filename == "" ? "" : ": "), msg));
+    LOG(fmt::format("{}{}{}", m_log_filename, (m_log_filename == "" ? "" : ": "), msg));
 }


### PR DESCRIPTION
When the map is flawed, there's no point in throwing that errors on the player - I made a bypass where the errors display only during simulation (ODEFs loaded from script or console), not during map loading.