### PR TITLE
Vehicle spawning fixes

### DIFF
--- a/source/main/gui/panels/GUI_FlexbodyDebug.cpp
+++ b/source/main/gui/panels/GUI_FlexbodyDebug.cpp
@@ -79,7 +79,8 @@ void FlexbodyDebug::Draw()
     Ogre::MaterialPtr mat; // Assume one submesh (=> subentity)
     NodeNum_t node_ref = NODENUM_INVALID, node_x = NODENUM_INVALID, node_y = NODENUM_INVALID;
     std::string mesh_name;
-    if (m_combo_selection >= m_combo_props_start)
+    if (actor->GetGfxActor()->getProps().size() > 0
+        && m_combo_selection >= m_combo_props_start)
     {
         prop = &actor->GetGfxActor()->getProps()[m_combo_selection - m_combo_props_start];
         mat = prop->pp_mesh_obj->getEntity()->getSubEntity(0)->getMaterial();

--- a/source/main/gui/panels/GUI_FlexbodyDebug.cpp
+++ b/source/main/gui/panels/GUI_FlexbodyDebug.cpp
@@ -589,13 +589,5 @@ void FlexbodyDebug::DrawMeshInfo(Prop* prop)
         ImGui::Separator();
         ImGui::Text("%s", RoR::PrintMeshInfo("Special: steering wheel", prop->pp_wheel_mesh_obj->getEntity()->getMesh()).c_str());
     }
-    for (int i = 0; i < 4; i++)
-    {
-        if (prop->pp_beacon_scene_node[i])
-        {
-            ImGui::Separator();
-            Ogre::Entity* entity = static_cast<Ogre::Entity*>(prop->pp_beacon_scene_node[i]->getAttachedObject(0));
-            ImGui::Text("%s", RoR::PrintMeshInfo(fmt::format("Special: beacon #{}", i), entity->getMesh()).c_str());
-        }
-    }
+    // NOTE: `prop->pp_beacon_scene_node` has only billboards attached, not meshes.
 }

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -1587,6 +1587,13 @@ void ActorSpawner::ProcessProp(RigDef::Prop & def)
     prop.pp_scene_node = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
     const std::string instance_name = this->ComposeName("PropEntity", prop_index);
     prop.pp_mesh_obj = new MeshObject(def.mesh_name, m_custom_resource_group, instance_name, prop.pp_scene_node);
+    if (!prop.pp_mesh_obj->getLoadedMesh())
+    {
+        AddMessage(Message::TYPE_WARNING, fmt::format("Skipping prop because mesh '{}' could not be loaded", def.mesh_name));
+        delete prop.pp_mesh_obj;
+        return; // No mercy
+    }
+
     prop.pp_mesh_obj->setCastShadows(true); // Orig code {{ prop.pp_mesh_obj->setCastShadows(shadowmode != 0); }}, shadowmode has default value 1 and changes with undocumented directive 'set_shadows'
 
     if (def.special == RigDef::SpecialProp::AERO_PROP_SPIN)
@@ -1989,6 +1996,7 @@ void ActorSpawner::ProcessProp(RigDef::Prop & def)
 
         prop.pp_animations.push_back(anim);
     }
+
     m_actor->m_gfx_actor->m_props.push_back(prop);
 }
 

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -880,6 +880,8 @@ void ActorSpawner::ProcessWing(RigDef::Wing & def)
         return;
     }
 
+    m_actor->GetGfxActor()->UpdateSimDataBuffer(); // fill all current nodes - needed to setup flexing meshes
+
     NodeNum_t node1 = this->GetNodeIndexOrThrow(def.nodes[1]);
 
     const std::string wing_name = this->ComposeName("Wing", m_actor->ar_num_wings);

--- a/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
@@ -77,6 +77,8 @@ namespace Regexes
 
 #define E_DELIMITER_SPACE "[[:blank:]]+"
 
+#define E_DELIMITER_CLASSIC "[[:blank:],:|]+" // Separators: space/comma/colon/pipe, see also `IsSeparator()` in RigDef_Parser.cpp. This is what original parser did.
+
 #define E_NODE_ID "[[:alnum:]_-]+"
 
 // --------------------------------------------------------------------------
@@ -94,13 +96,11 @@ namespace Regexes
 /// A keyword which should be on it's own line. Used in IDENTIFY_KEYWORD.
 #define E_KEYWORD_BLOCK(_NAME_) \
     "(^" _NAME_ "[[:blank:]]*$)?"
+
 /// A keyword which should have values following it. Used in IDENTIFY_KEYWORD.
 #define E_KEYWORD_INLINE(_NAME_) \
-    "(^" _NAME_ E_DELIMITER_SPACE ".*$)?"
-    
-/// Inline keyword, tolerant version: keyword and values can be delimited by either space or comma
-#define E_KEYWORD_INLINE_TOLERANT(_NAME_) \
-    "(^" _NAME_ "[[:blank:],]+" ".*$)?"
+    "(^" _NAME_ E_DELIMITER_CLASSIC ".*$)?"
+
 /// Actual regex definition macro.
 #define DEFINE_REGEX(_NAME_,_REGEXP_) \
     const std::regex _NAME_ = std::regex( _REGEXP_, std::regex::ECMAScript);
@@ -115,7 +115,7 @@ namespace Regexes
 // IMPORTANT! If you add a value here, you must also modify File::Keywords enum, it relies on positions in this regex
 #define IDENTIFY_KEYWORD_REGEX_STRING                             \
     /* E_KEYWORD_BLOCK("advdrag") ~~ Not supported yet */         \
-    E_KEYWORD_INLINE_TOLERANT("add_animation")  /* Position 1 */  \
+    E_KEYWORD_INLINE("add_animation")  /* Position 1 */           \
     E_KEYWORD_BLOCK("airbrakes")       /* Position 2 */           \
     E_KEYWORD_BLOCK("animators")       /* Position 3 etc... */    \
     E_KEYWORD_INLINE("AntiLockBrakes")                            \

--- a/source/main/utils/MeshObject.cpp
+++ b/source/main/utils/MeshObject.cpp
@@ -31,48 +31,48 @@
 using namespace Ogre;
 using namespace RoR;
 
-MeshObject::MeshObject(Ogre::String meshName, Ogre::String entityRG, Ogre::String entityName, Ogre::SceneNode* sceneNode)
-    : sceneNode(sceneNode)
-    , ent(nullptr)
-    , castshadows(true)
+MeshObject::MeshObject(Ogre::String meshName, Ogre::String entityRG, Ogre::String entityName, Ogre::SceneNode* m_scene_node)
+    : m_scene_node(m_scene_node)
+    , m_entity(nullptr)
+    , m_cast_shadows(true)
 {
     this->createEntity(meshName, entityRG, entityName);
 }
 
 void MeshObject::setMaterialName(Ogre::String m)
 {
-    if (ent)
+    if (m_entity)
     {
-        ent->setMaterialName(m);
+        m_entity->setMaterialName(m);
     }
 }
 
 void MeshObject::setCastShadows(bool b)
 {
-    castshadows = b;
-    if (sceneNode && sceneNode->numAttachedObjects())
+    m_cast_shadows = b;
+    if (m_scene_node && m_scene_node->numAttachedObjects())
     {
-        sceneNode->getAttachedObject(0)->setCastShadows(b);
+        m_scene_node->getAttachedObject(0)->setCastShadows(b);
     }
 }
 
 void MeshObject::setVisible(bool b)
 {
     // Workaround: if the scenenode is not used (entity not attached) for some reason, try hiding the entity directly.
-    if (sceneNode && sceneNode->getAttachedObjects().size() > 0)
-        sceneNode->setVisible(b);
-    else if (ent)
-        ent->setVisible(b);
+    if (m_scene_node && m_scene_node->getAttachedObjects().size() > 0)
+        m_scene_node->setVisible(b);
+    else if (m_entity)
+        m_entity->setVisible(b);
 }
 
 void MeshObject::createEntity(Ogre::String meshName, Ogre::String entityRG, Ogre::String entityName)
 {
-    if (!sceneNode)
+    if (!m_scene_node)
         return;
 
     try
     {
-        Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().load(meshName, entityRG);
+        m_mesh = Ogre::MeshManager::getSingleton().load(meshName, entityRG);
 
         // important: you need to add the LODs before creating the entity
         // now find possible LODs, needs to be done before calling createEntity()
@@ -109,11 +109,11 @@ void MeshObject::createEntity(Ogre::String meshName, Ogre::String entityRG, Ogre
 
         // now create an entity around the mesh and attach it to the scene graph
 
-        ent = App::GetGfxScene()->GetSceneManager()->createEntity(entityName, meshName, entityRG);
-        ent->setCastShadows(castshadows);
+        m_entity = App::GetGfxScene()->GetSceneManager()->createEntity(entityName, meshName, entityRG);
+        m_entity->setCastShadows(m_cast_shadows);
 
-        sceneNode->attachObject(ent);
-        sceneNode->setVisible(true);
+        m_scene_node->attachObject(m_entity);
+        m_scene_node->setVisible(true);
     }
     catch (Ogre::Exception& e)
     {

--- a/source/main/utils/MeshObject.h
+++ b/source/main/utils/MeshObject.h
@@ -32,7 +32,7 @@
 /// @addtogroup Gfx
 /// @{
 
-class MeshObject : public Ogre::Resource::Listener, public ZeroedMemoryAllocator
+class MeshObject
 {
 public:
     MeshObject(Ogre::String meshName, Ogre::String entityRG, Ogre::String entityName, Ogre::SceneNode* sceneNode);
@@ -40,15 +40,15 @@ public:
     void setMaterialName(Ogre::String m);
     void setCastShadows(bool b);
     void setVisible(bool b);
-    inline Ogre::Entity*    getEntity() { return ent; };
-    inline Ogre::SceneNode* GetSceneNode() { return sceneNode; }
+    inline Ogre::Entity*    getEntity() { return m_entity; };
+    inline Ogre::SceneNode* GetSceneNode() { return m_scene_node; }
+    inline Ogre::MeshPtr    getLoadedMesh() { return m_mesh; }
 
 protected:
-    Ogre::SceneNode* sceneNode;
-    Ogre::Entity* ent;
-    Ogre::MeshPtr mesh;
-
-    bool castshadows;
+    Ogre::SceneNode* m_scene_node = nullptr;
+    Ogre::Entity* m_entity = nullptr;
+    Ogre::MeshPtr m_mesh;
+    bool m_cast_shadows = false;
 
     void createEntity(Ogre::String meshName, Ogre::String entityRG, Ogre::String entityName);
 };


### PR DESCRIPTION
Fixes:
* https://forum.rigsofrods.org/resources/mercedes-benz-atego-1318-comax.344/ - some flexbodies were missing because truckfile parser was too strict on syntax. Restored to original.
* https://forum.rigsofrods.org/resources/c1-offshore.182/ - segfault due to missing simbuffer update when procesing 'wings'. Only hapenned for vehicles without 'flexbodies' or 'wheels'.