### PR TITLE
Fixed crash when reloading actor during race

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -373,6 +373,8 @@ void GameContext::DeleteActor(Actor* actor)
         Ogre::Vector3 center = m_player_actor->getRotationCenter();
         this->ChangePlayerActor(nullptr); // Get out of the vehicle
         this->GetPlayerCharacter()->setPosition(center);
+        // Update scene SimBuffer immediatelly to prevent having dangling pointer.
+        App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor = nullptr;
     }
 
     if (actor == m_prev_player_actor)


### PR DESCRIPTION
Reported on Discord by The Jesser#8202

Problem: Race display in top menubar tries to access Actor which was already deleted.

Cause: the top menubar is rendered in between removing the actor and updating the simbuffer, so it draws a dangling Actor pointer from the simbuffer.

Broken by: 547227575fa58a5ed9a2218fa78d6297c8906f42 where the race display was moved to top menubar.

Fix: Update simbuffer immediately after removing actor.