### PR TITLE
Added setting to use alternative vehicle materials

### DIFF
--- a/resources/managed_materials/managed_mats_vehicles.material
+++ b/resources/managed_materials/managed_mats_vehicles.material
@@ -1,14 +1,12 @@
-import * from "shadows.material"
 import * from "texture_manager.material"
 
 material managed/flexmesh_standard/simple
 {
-	technique BaseTechnique: Shadows/managed/base_receiver //Include shadows
+	technique BaseTechnique
 	{
 	//Texture is rendred here
 		pass BaseRender
 		{
-			depth_bias -0.1 -0.1
 			texture_unit Diffuse_Map
 			{
 				texture_alias unknown.dds
@@ -19,12 +17,11 @@ material managed/flexmesh_standard/simple
 
 material managed/flexmesh_standard/damageonly
 {
-	technique BaseTechnique: Shadows/managed/base_receiver //Include shadows
+	technique BaseTechnique
 	{
 	//Texture is rendred here
 		pass BaseRender
 		{
-			depth_bias -0.1 -0.1
 			diffuse vertexcolour
 			texture_unit Diffuse_Map
 			{
@@ -43,12 +40,11 @@ material managed/flexmesh_standard/damageonly
 
 material managed/flexmesh_standard/specularonly
 {
-	technique BaseTechnique: Shadows/managed/base_receiver //Include shadows
+	technique BaseTechnique
 	{
 	//Texture is rendred here
 		pass BaseRender
 		{
-			depth_bias -0.1 -0.1
 			texture_unit Diffuse_Map
 			{
 				texture_alias unknown.dds
@@ -63,12 +59,11 @@ material managed/flexmesh_standard/specularonly
 
 material managed/flexmesh_standard/speculardamage
 {
-	technique BaseTechnique: Shadows/managed/base_receiver //Include shadows
+	technique BaseTechnique
 	{
 	//Texture is rendred here
 		pass BaseRender
 		{
-			depth_bias -0.1 -0.1
 			diffuse vertexcolour
 			texture_unit Diffuse_Map
 			{
@@ -90,12 +85,11 @@ material managed/flexmesh_standard/speculardamage
 
 material managed/mesh_standard/simple
 {
-	technique BaseTechnique: Shadows/managed/base_receiver //Include shadows
+	technique BaseTechnique
 	{
 	//Texture is rendred here
 		pass BaseRender
 		{
-			depth_bias -0.1 -0.1
 			texture_unit Diffuse_Map
 			{
 				texture_alias unknown.dds
@@ -111,7 +105,6 @@ material managed/mesh_standard/specular
 	//Texture is rendred here
 		pass BaseRender
 		{
-			depth_bias -0.1 -0.1
 			texture_unit Diffuse_Map
 			{
 				texture_alias unknown.dds

--- a/resources/managed_materials/shadows/pssm/on/shadows.material
+++ b/resources/managed_materials/shadows/pssm/on/shadows.material
@@ -4,7 +4,6 @@ abstract technique Shadows/managed/base_receiver
 	{
 			ambient 1 1 1 1
 			diffuse 1 1 1 1
-			depth_bias 0.1 0.1
 			
 			vertex_program_ref PSSM/shadow_receiver_vs {}
 			fragment_program_ref PSSM/shadow_receiver_ps {}

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -236,6 +236,7 @@ CVar* gfx_speedo_imperial;
 CVar* gfx_flexbody_cache;
 CVar* gfx_reduce_shadows;
 CVar* gfx_enable_rtshaders;
+CVar* gfx_alt_actor_materials;
 
 // Flexbodies
 CVar* flexbody_defrag_enabled;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -429,6 +429,7 @@ extern CVar* gfx_speedo_imperial;
 extern CVar* gfx_flexbody_cache;
 extern CVar* gfx_reduce_shadows;
 extern CVar* gfx_enable_rtshaders;
+extern CVar* gfx_alt_actor_materials;
 
 // Flexbodies
 extern CVar* flexbody_defrag_enabled;

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -362,6 +362,7 @@ void GameSettings::DrawGraphicsSettings()
         DrawGCheckbox(App::gfx_declutter_map,  _LC("GameSettings", "Declutter overview map"));
     }
     DrawGCheckbox(App::gfx_water_waves,      _LC("GameSettings", "Waves on water"));
+    DrawGCheckbox(App::gfx_alt_actor_materials,      _LC("GameSettings", "Use alternate vehicle materials"));
 
     DrawGCombo(App::gfx_extcam_mode, "Exterior camera mode",
         m_combo_items_extcam_mode.c_str());

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2302,17 +2302,33 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
             if (def.specular_map != "")
             {
                 /* FLEXMESH, damage, specular */
-                material = this->InstantiateManagedMaterial(mat_name_base + "/speculardamage_nicemetal", custom_name);
+                if (App::gfx_alt_actor_materials->getBool())
+                {
+                    material = this->InstantiateManagedMaterial(mat_name_base + "/speculardamage", custom_name);
+                }
+                else
+                {
+                    material = this->InstantiateManagedMaterial(mat_name_base + "/speculardamage_nicemetal", custom_name);
+                }
 
                 if (material.isNull())
                 {
                     return;
                 }
 
-                material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
-                material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Dmg_Diffuse_Map")->setTextureName(def.damaged_diffuse_map);
-                material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
-                material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+                if (App::gfx_alt_actor_materials->getBool())
+                {
+                    material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
+                    material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Dmg_Diffuse_Map")->setTextureName(def.damaged_diffuse_map);
+                    material->getTechnique("BaseTechnique")->getPass("SpecularMapping1")->getTextureUnitState("SpecularMapping1_Tex")->setTextureName(def.specular_map);
+                }
+                else
+                {
+                    material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
+                    material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Dmg_Diffuse_Map")->setTextureName(def.damaged_diffuse_map);
+                    material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+                    material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+                }
             }
             else
             {
@@ -2331,16 +2347,31 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
             if (def.specular_map != "")
             {
                 /* FLEXMESH, no_damage, specular */
-                material = this->InstantiateManagedMaterial(mat_name_base + "/specularonly_nicemetal", custom_name);
+                if (App::gfx_alt_actor_materials->getBool())
+                {
+                    material = this->InstantiateManagedMaterial(mat_name_base + "/specularonly", custom_name);
+                }
+                else
+                {
+                    material = this->InstantiateManagedMaterial(mat_name_base + "/specularonly_nicemetal", custom_name);
+                }
 
                 if (material.isNull())
                 {
                     return;
                 }
 
-                material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
-                material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
-                material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+                if (App::gfx_alt_actor_materials->getBool())
+                {
+                    material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
+                    material->getTechnique("BaseTechnique")->getPass("SpecularMapping1")->getTextureUnitState("SpecularMapping1_Tex")->setTextureName(def.specular_map);
+                }
+                else
+                {
+                    material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
+                    material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+                    material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+                }
             }
             else
             {
@@ -2364,16 +2395,31 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
         if (def.specular_map != "")
         {
             /* MESH, specular */
-            material = this->InstantiateManagedMaterial(mat_name_base + "/specular_nicemetal", custom_name);
+            if (App::gfx_alt_actor_materials->getBool())
+            {
+                material = this->InstantiateManagedMaterial(mat_name_base + "/specular", custom_name);
+            }
+            else
+            {
+                material = this->InstantiateManagedMaterial(mat_name_base + "/specular_nicemetal", custom_name);
+            }
 
             if (material.isNull())
             {
                 return;
             }
 
-            material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
-            material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
-            material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+            if (App::gfx_alt_actor_materials->getBool())
+            {
+                material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
+                material->getTechnique("BaseTechnique")->getPass("SpecularMapping1")->getTextureUnitState("SpecularMapping1_Tex")->setTextureName(def.specular_map);
+            }
+            else
+            {
+                material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map")->setTextureName(def.diffuse_map);
+                material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+                material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map")->setTextureName(def.specular_map);
+            }
         }
         else
         {
@@ -2395,7 +2441,14 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
             material->getTechnique("BaseTechnique")->getPass("BaseRender")->setCullingMode(Ogre::CULL_NONE);
             if (def.specular_map != "")
             {
-                material->getTechnique("BaseTechnique")->getPass("Specular")->setCullingMode(Ogre::CULL_NONE);
+                if (App::gfx_alt_actor_materials->getBool())
+                {
+                    material->getTechnique("BaseTechnique")->getPass("SpecularMapping1")->setCullingMode(Ogre::CULL_NONE);
+                }
+                else
+                {
+                    material->getTechnique("BaseTechnique")->getPass("Specular")->setCullingMode(Ogre::CULL_NONE);
+                }
             }
         }
     }

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -180,6 +180,7 @@ void Console::cVarSetupBuiltins()
     App::gfx_flexbody_cache      = this->cVarCreate("gfx_flexbody_cache",      "Flexbody_UseCache",          CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::gfx_reduce_shadows      = this->cVarCreate("gfx_reduce_shadows",      "Shadow optimizations",       CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
     App::gfx_enable_rtshaders    = this->cVarCreate("gfx_enable_rtshaders",    "Use RTShader System",        CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
+    App::gfx_alt_actor_materials = this->cVarCreate("gfx_alt_actor_materials", "Use alternate vehicle materials", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "false");
 
     App::flexbody_defrag_enabled           = this->cVarCreate("flexbody_defrag_enabled",           "", CVAR_TYPE_BOOL);
     App::flexbody_defrag_const_penalty     = this->cVarCreate("flexbody_defrag_const_penalty",     "", CVAR_TYPE_INT, "7");


### PR DESCRIPTION
After the release of 2022.12, some players apparently prefer the other vehicle materials instead of the current NiceMetal-based materials. This brings those back by adding "Use alternative vehicle materials" to the graphics settings.

~PR is currently a draft as~ I'd like to also fix the slight flickering the materials have, introduced after 2020.01: 
https://streamable.com/3unrvg
After tinkering with the materials a little, I managed to stop the flickering by commenting out all `depth_bias` lines in `managed_mats_vehicles.material` and changing the value in `shadows.material` to `depth_bias -20`. However, with this change vehicles now look like this when the camera is far away:
![image](https://user-images.githubusercontent.com/46073351/209902889-fb01c8a7-fab6-4091-ba9f-410a00cd2a95.png)
(Lowered FOV)
