### PR TITLE
Added support for actor scripts (use section 'scripts' in truck file)

### DIFF
--- a/resources/scripts/AI.as
+++ b/resources/scripts/AI.as
@@ -1,9 +1,5 @@
 #include "base.as"
 
-//Stuff that the scripts uses internally. doesn't need to be changed.
-vector3 currentWaypoint(0, 0, 0);
-int waypoint = 0;
-
 void main()
 {
     int offset = 0;
@@ -15,7 +11,17 @@ void main()
     {
         array<vector3> waypoints = game.getWaypoints(x);
 
-        VehicleAIClass @CurrentTruckai = game.spawnTruckAI(game.getAIVehicleName(x), vector3(waypoints[0].x + translation_x, waypoints[0].y, waypoints[0].z + translation_z), game.getAIVehicleSectionConfig(x), game.getAIVehicleSkin(x), x).getVehicleAI();
+        string spawn_vehiclename = game.getAIVehicleName(x);
+        vector3 spawn_pos = vector3(waypoints[0].x + translation_x, waypoints[0].y, waypoints[0].z + translation_z);
+        string spawn_sectionconfig = game.getAIVehicleSectionConfig(x);
+        string spawn_skin = game.getAIVehicleSkin(x);
+        BeamClass@ CurrentTruck = game.spawnTruckAI(spawn_vehiclename, spawn_pos, spawn_sectionconfig, spawn_skin, x);
+        if (@CurrentTruck == null)
+        {
+            game.log("Vehicle AI: Could not spawn vehicle '"+spawn_vehiclename+"' ("+(x+1)+"/"+game.getAIVehicleCount()+"), skipping it...");
+            continue; // Skip this vehicle
+        }
+        VehicleAIClass @CurrentTruckai = CurrentTruck.getVehicleAI();
 
         for (int t = 0; t < game.getAIRepeatTimes(); t++)
         {

--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -192,7 +192,7 @@ void AppContext::windowResized(Ogre::RenderWindow* rw)
     App::GetOverlayWrapper()->windowResized();
     if (App::sim_state->getEnum<AppState>() == RoR::AppState::SIMULATION)
     {
-        for (Actor* actor: App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor: App::GetGameContext()->GetActorManager()->GetActors())
         {
             actor->ar_dashboard->windowResized();
         }

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -96,11 +96,11 @@ enum MsgType
     MSG_SIM_UNLOAD_TERRN_REQUESTED,
     MSG_SIM_SPAWN_ACTOR_REQUESTED,         //!< Payload = RoR::ActorSpawnRequest* (owner)
     MSG_SIM_MODIFY_ACTOR_REQUESTED,        //!< Payload = RoR::ActorModifyRequest* (owner)
-    MSG_SIM_DELETE_ACTOR_REQUESTED,        //!< Payload = RoR::Actor* (weak)
-    MSG_SIM_SEAT_PLAYER_REQUESTED,         //!< Payload = RoR::Actor* (weak) | nullptr
+    MSG_SIM_DELETE_ACTOR_REQUESTED,        //!< Payload = RoR::ActorPtr* (owner)
+    MSG_SIM_SEAT_PLAYER_REQUESTED,         //!< Payload = RoR::ActorPtr (owner) | nullptr
     MSG_SIM_TELEPORT_PLAYER_REQUESTED,     //!< Payload = Ogre::Vector3* (owner)
-    MSG_SIM_HIDE_NET_ACTOR_REQUESTED,      //!< Payload = Actor* (weak)
-    MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED,    //!< Payload = Actor* (weak)
+    MSG_SIM_HIDE_NET_ACTOR_REQUESTED,      //!< Payload = ActorPtr* (owner)
+    MSG_SIM_UNHIDE_NET_ACTOR_REQUESTED,    //!< Payload = ActorPtr* (owner)
     // GUI
     MSG_GUI_OPEN_MENU_REQUESTED,
     MSG_GUI_CLOSE_MENU_REQUESTED,

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -147,6 +147,7 @@ namespace RoR
     struct client_t;
     struct authorinfo_t;
 
+    typedef RefCountingObjectPtr<Actor> ActorPtr;
     typedef RefCountingObjectPtr<LocalStorage> LocalStoragePtr;
     typedef RefCountingObjectPtr<ProceduralPoint> ProceduralPointPtr;
     typedef RefCountingObjectPtr<ProceduralObject> ProceduralObjectPtr;

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -412,6 +412,19 @@ void GameContext::DeleteActor(ActorPtr actor)
 #endif //SOCKETW
 
     TRIGGER_EVENT(SE_GENERIC_DELETED_TRUCK, actor->ar_instance_id);
+
+    // Unload actor's scripts
+    std::vector<ScriptUnitId_t> unload_list;
+    for (auto& pair : App::GetScriptEngine()->getScriptUnits())
+    {
+        if (pair.second.associatedActor == actor)
+            unload_list.push_back(pair.first);
+    }
+    for (ScriptUnitId_t id : unload_list)
+    {
+        App::GetScriptEngine()->unloadScript(id);
+    }
+
     m_actor_manager.DeleteActorInternal(actor);
 }
 

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -170,7 +170,7 @@ void GameContext::UnloadTerrain()
 // --------------------------------
 // Actors (physics and netcode)
 
-Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
+ActorPtr GameContext::SpawnActor(ActorSpawnRequest& rq)
 {
     if (rq.asr_origin == ActorSpawnRequest::Origin::USER)
     {
@@ -232,7 +232,7 @@ Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
     }
 #endif //SOCKETW
 
-    Actor* fresh_actor = m_actor_manager.CreateNewActor(rq, def);
+    ActorPtr fresh_actor = m_actor_manager.CreateNewActor(rq, def);
 
     // lock slide nodes after spawning the actor?
     if (def->slide_nodes_connect_instantly)
@@ -245,7 +245,7 @@ Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
         m_last_spawned_actor = fresh_actor;
         if (fresh_actor->ar_driveable != NOT_DRIVEABLE)
         {
-            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)fresh_actor));
+            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(fresh_actor))));
         }
         if (rq.asr_spawnbox == nullptr)
         {
@@ -259,13 +259,13 @@ Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
             fresh_actor->ar_num_nodes > 0 &&
             App::diag_preset_veh_enter->getBool())
         {
-            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)fresh_actor));
+            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(fresh_actor))));
         }
         if (fresh_actor->ar_driveable != NOT_DRIVEABLE &&
             fresh_actor->ar_num_nodes > 0 &&
             App::cli_preset_veh_enter->getBool())
         {
-            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)fresh_actor));
+            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(fresh_actor))));
         }
     }
     else if (rq.asr_origin == ActorSpawnRequest::Origin::TERRN_DEF)
@@ -307,7 +307,7 @@ Actor* GameContext::SpawnActor(ActorSpawnRequest& rq)
         if (fresh_actor->ar_driveable != NOT_DRIVEABLE &&
             rq.asr_origin != ActorSpawnRequest::Origin::NETWORK)
         {
-            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)fresh_actor));
+            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(fresh_actor))));
         }
     }
 
@@ -366,7 +366,7 @@ void GameContext::ModifyActor(ActorModifyRequest& rq)
     }
 }
 
-void GameContext::DeleteActor(Actor* actor)
+void GameContext::DeleteActor(ActorPtr actor)
 {
     if (actor == m_player_actor)
     {
@@ -415,9 +415,9 @@ void GameContext::DeleteActor(Actor* actor)
     m_actor_manager.DeleteActorInternal(actor);
 }
 
-void GameContext::ChangePlayerActor(Actor* actor)
+void GameContext::ChangePlayerActor(ActorPtr actor)
 {
-    Actor* prev_player_actor = m_player_actor;
+    ActorPtr prev_player_actor = m_player_actor;
     m_player_actor = actor;
 
     // hide any old dashes
@@ -518,12 +518,12 @@ void GameContext::ChangePlayerActor(Actor* actor)
     m_actor_manager.UpdateSleepingState(m_player_actor, 0.f);
 }
 
-Actor* GameContext::FetchPrevVehicleOnList()
+ActorPtr GameContext::FetchPrevVehicleOnList()
 {
     return m_actor_manager.FetchPreviousVehicleOnList(m_player_actor, m_prev_player_actor);
 }
 
-Actor* GameContext::FetchNextVehicleOnList()
+ActorPtr GameContext::FetchNextVehicleOnList()
 {
     return m_actor_manager.FetchNextVehicleOnList(m_player_actor, m_prev_player_actor);
 }
@@ -533,7 +533,7 @@ void GameContext::UpdateActors()
     m_actor_manager.UpdateActors(m_player_actor);
 }
 
-Actor* GameContext::FindActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name)
+ActorPtr GameContext::FindActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name)
 {
     return m_actor_manager.FindActorInsideBox(m_terrain->GetCollisions(),
                                               ev_src_instance_name, box_name);
@@ -594,7 +594,7 @@ void GameContext::ShowLoaderGUI(int type, const Ogre::String& instance, const Og
     if (!(App::mp_state->getEnum<MpState>() == MpState::CONNECTED))
     {
         collision_box_t* spawnbox = m_terrain->GetCollisions()->getBox(instance, box);
-        for (auto actor : this->GetActorManager()->GetActors())
+        for (ActorPtr actor : this->GetActorManager()->GetActors())
         {
             for (int i = 0; i < actor->ar_num_nodes; i++)
             {
@@ -834,7 +834,7 @@ void GameContext::TeleportPlayer(float x, float z)
 
     float src_agl = std::numeric_limits<float>::max(); 
     float dst_agl = std::numeric_limits<float>::max(); 
-    for (auto actor : actors)
+    for (ActorPtr actor : actors)
     {
         for (int i = 0; i < actor->ar_num_nodes; i++)
         {
@@ -847,7 +847,7 @@ void GameContext::TeleportPlayer(float x, float z)
 
     translation += Ogre::Vector3::UNIT_Y * (std::max(0.0f, src_agl) - dst_agl);
 
-    for (auto actor : actors)
+    for (ActorPtr actor : actors)
     {
         actor->resetPosition(actor->ar_nodes[0].AbsPosition + translation, false);
     }
@@ -985,8 +985,8 @@ void GameContext::UpdateSimInputEvents(float dt)
         {
             // find the nearest vehicle
             float mindist = 1000.0;
-            Actor* nearest_actor = nullptr;
-            for (auto actor : this->GetActorManager()->GetActors())
+            ActorPtr nearest_actor = nullptr;
+            for (ActorPtr& actor : this->GetActorManager()->GetActors())
             {
                 if (!actor->ar_driveable)
                     continue;
@@ -1009,7 +1009,7 @@ void GameContext::UpdateSimInputEvents(float dt)
 
             if (mindist < 20.0)
             {
-                this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)nearest_actor));
+                this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(nearest_actor))));
             }
         }
         else // We're in a vehicle -> If moving slowly enough, get out
@@ -1018,7 +1018,7 @@ void GameContext::UpdateSimInputEvents(float dt)
                 this->GetPlayerActor()->ar_state == ActorState::NETWORKED_OK || this->GetPlayerActor()->ar_state == ActorState::NETWORKED_HIDDEN ||
                 this->GetPlayerActor()->ar_driveable == AI)
             {
-                this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, nullptr));
+                this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr())));
             }
         }
     }
@@ -1026,20 +1026,20 @@ void GameContext::UpdateSimInputEvents(float dt)
     // enter next truck
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_NEXT_TRUCK, 0.25f))
     {
-        Actor* actor = this->FetchNextVehicleOnList();
+        ActorPtr actor = this->FetchNextVehicleOnList();
         if (actor != this->GetPlayerActor())
         {
-            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)actor));
+            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
         }
     }
 
     // enter previous truck
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_PREVIOUS_TRUCK, 0.25f))
     {
-        Actor* actor = this->FetchPrevVehicleOnList();
+        ActorPtr actor = this->FetchPrevVehicleOnList();
         if (actor != this->GetPlayerActor())
         {
-            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)actor));
+            this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
         }
     }
 
@@ -1060,9 +1060,9 @@ void GameContext::UpdateSimInputEvents(float dt)
     {
         // Find nearest actor
         const Ogre::Vector3 position = App::GetGameContext()->GetPlayerCharacter()->getPosition();
-        Actor* nearest_actor = nullptr;
+        ActorPtr nearest_actor = nullptr;
         float min_squared_distance = std::numeric_limits<float>::max();
-        for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             float squared_distance = position.squaredDistance(actor->ar_nodes[0].AbsPosition);
             if (squared_distance < min_squared_distance)
@@ -1199,7 +1199,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
     // remove current truck
     if (App::GetInputEngine()->getEventBoolValue(EV_COMMON_REMOVE_CURRENT_TRUCK))
     {
-        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)m_player_actor));
+        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(m_player_actor))));
     }
 
     // Front lights
@@ -1272,7 +1272,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TRUCK_REMOVE))
     {
-        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)m_player_actor));
+        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(m_player_actor))));
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ROPELOCK))
@@ -1305,7 +1305,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_DEBUG_VIEW))
     {
         m_player_actor->GetGfxActor()->ToggleDebugView();
-        for (auto actor : m_player_actor->getAllLinkedActors())
+        for (ActorPtr actor : m_player_actor->getAllLinkedActors())
         {
             actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());
         }
@@ -1314,7 +1314,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_CYCLE_DEBUG_VIEWS))
     {
         m_player_actor->GetGfxActor()->CycleDebugViews();
-        for (auto actor : m_player_actor->getAllLinkedActors())
+        for (ActorPtr actor : m_player_actor->getAllLinkedActors())
         {
             actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());
         }
@@ -1324,8 +1324,8 @@ void GameContext::UpdateCommonInputEvents(float dt)
         App::mp_state->getEnum<MpState>() != MpState::CONNECTED &&
         m_player_actor->ar_driveable != AIRPLANE)
     {
-        Actor* rescuer = nullptr;
-        for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+        ActorPtr rescuer = nullptr;
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             if (actor->ar_rescuer_flag)
             {
@@ -1338,7 +1338,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
         }
         else
         {
-            App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)rescuer));
+            App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(rescuer))));
         }
     }
 
@@ -1376,7 +1376,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
     // toggle physics
     if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_PHYSICS))
     {
-        for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
+        for (ActorPtr actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
         {
             actor->ar_physics_paused = !App::GetGameContext()->GetPlayerActor()->ar_physics_paused;
         }
@@ -1823,7 +1823,7 @@ void GameContext::UpdateTruckInputEvents(float dt)
     }
 
     m_player_actor->UpdatePropAnimInputEvents();
-    for (Actor* linked_actor : m_player_actor->getAllLinkedActors())
+    for (ActorPtr linked_actor : m_player_actor->getAllLinkedActors())
     {
         linked_actor->UpdatePropAnimInputEvents();
     }

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -117,22 +117,22 @@ public:
     /// @name Actors
     /// @{
 
-    Actor*              SpawnActor(ActorSpawnRequest& rq);
+    ActorPtr              SpawnActor(ActorSpawnRequest& rq);
     void                ModifyActor(ActorModifyRequest& rq);
-    void                DeleteActor(Actor* actor);
+    void                DeleteActor(ActorPtr actor);
     void                UpdateActors();
     ActorManager*       GetActorManager() { return &m_actor_manager; }
-    Actor*              FetchPrevVehicleOnList();
-    Actor*              FetchNextVehicleOnList();
-    Actor*              FindActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name);
+    ActorPtr            FetchPrevVehicleOnList();
+    ActorPtr            FetchNextVehicleOnList();
+    ActorPtr            FindActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name);
     void                RespawnLastActor();
     void                SpawnPreselectedActor(std::string const& preset_vehicle, std::string const& preset_veh_config); //!< needs `Character` to exist
 
-    Actor*              GetPlayerActor() { return m_player_actor; }
-    Actor*              GetPrevPlayerActor() { return m_prev_player_actor; }
-    Actor*              GetLastSpawnedActor() { return m_last_spawned_actor; } //!< Last actor spawned by user and still alive.
-    void                SetPrevPlayerActor(Actor* actor) { m_prev_player_actor = actor; }
-    void                ChangePlayerActor(Actor* actor);
+    ActorPtr            GetPlayerActor() { return m_player_actor; }
+    ActorPtr            GetPrevPlayerActor() { return m_prev_player_actor; }
+    ActorPtr            GetLastSpawnedActor() { return m_last_spawned_actor; } //!< Last actor spawned by user and still alive.
+    void                SetPrevPlayerActor(ActorPtr actor) { m_prev_player_actor = actor; }
+    void                ChangePlayerActor(ActorPtr actor);
 
     void                ShowLoaderGUI(int type, const Ogre::String& instance, const Ogre::String& box);
     void                OnLoaderGuiCancel(); //!< GUI callback
@@ -187,9 +187,9 @@ private:
 
     // Actors (physics and netcode)
     ActorManager        m_actor_manager;
-    Actor*              m_player_actor = nullptr;           //!< Actor (vehicle or machine) mounted and controlled by player
-    Actor*              m_prev_player_actor = nullptr;      //!< Previous actor (vehicle or machine) mounted and controlled by player
-    Actor*              m_last_spawned_actor = nullptr;     //!< Last actor spawned by user and still alive.
+    ActorPtr              m_player_actor = nullptr;           //!< Actor (vehicle or machine) mounted and controlled by player
+    ActorPtr              m_prev_player_actor = nullptr;      //!< Previous actor (vehicle or machine) mounted and controlled by player
+    ActorPtr              m_last_spawned_actor = nullptr;     //!< Last actor spawned by user and still alive.
     
     CacheEntry*         m_last_cache_selection = nullptr;   //!< Vehicle/load
     CacheEntry*         m_last_skin_selection = nullptr;

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -98,7 +98,7 @@ SoundScriptManager::~SoundScriptManager()
         delete sound_manager;
 }
 
-void SoundScriptManager::trigOnce(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigOnce(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -126,7 +126,7 @@ void SoundScriptManager::trigOnce(int actor_id, int trig, int linkType, int link
     }
 }
 
-void SoundScriptManager::trigStart(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigStart(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -157,7 +157,7 @@ void SoundScriptManager::trigStart(int actor_id, int trig, int linkType, int lin
     }
 }
 
-void SoundScriptManager::trigStop(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigStop(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -187,7 +187,7 @@ void SoundScriptManager::trigStop(int actor_id, int trig, int linkType, int link
     }
 }
 
-void SoundScriptManager::trigKill(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigKill(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -217,7 +217,7 @@ void SoundScriptManager::trigKill(int actor_id, int trig, int linkType, int link
     }
 }
 
-void SoundScriptManager::trigToggle(Actor* actor, int trig, int linkType, int linkItemID)
+void SoundScriptManager::trigToggle(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return;
@@ -239,7 +239,7 @@ void SoundScriptManager::trigToggle(int actor_id, int trig, int linkType, int li
         trigStart(actor_id, trig, linkType, linkItemID);
 }
 
-bool SoundScriptManager::getTrigState(Actor* actor, int trig, int linkType, int linkItemID)
+bool SoundScriptManager::getTrigState(ActorPtr actor, int trig, int linkType, int linkItemID)
 {
     if (disabled)
         return false;
@@ -258,7 +258,7 @@ bool SoundScriptManager::getTrigState(int actor_id, int trig, int linkType, int 
     return state_map[linkType][linkItemID][actor_id][trig];
 }
 
-void SoundScriptManager::modulate(Actor* actor, int mod, float value, int linkType, int linkItemID)
+void SoundScriptManager::modulate(ActorPtr actor, int mod, float value, int linkType, int linkItemID)
 {
     if (disabled)
         return;

--- a/source/main/audio/SoundScriptManager.h
+++ b/source/main/audio/SoundScriptManager.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "Application.h"
+#include "Actor.h"
 
 #include <OgreScriptLoader.h>
 
@@ -266,19 +267,19 @@ public:
 
     // functions
     void trigOnce    (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void trigOnce    (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void trigOnce    (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void trigStart   (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void trigStart   (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void trigStart   (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void trigStop    (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void trigStop    (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void trigStop    (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void trigToggle  (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void trigToggle  (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void trigToggle  (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void trigKill	 (int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID = -1);
-    void trigKill    (Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID = -1);
+    void trigKill    (ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID = -1);
     bool getTrigState(int actor_id, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
-    bool getTrigState(Actor* actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
+    bool getTrigState(ActorPtr actor, int trig, int linkType = SL_DEFAULT, int linkItemID=-1);
     void modulate    (int actor_id, int mod, float value, int linkType = SL_DEFAULT, int linkItemID=-1);
-    void modulate    (Actor* actor, int mod, float value, int linkType = SL_DEFAULT, int linkItemID=-1);
+    void modulate    (ActorPtr actor, int mod, float value, int linkType = SL_DEFAULT, int linkItemID=-1);
 
     void setEnabled(bool state);
 

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -159,7 +159,7 @@ void Character::update(float dt)
         // Submesh "collision"
         {
             float depth = 0.0f;
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor->ar_bounding_box.contains(position))
                 {
@@ -496,7 +496,7 @@ void Character::receiveStreamData(unsigned int& type, int& source, unsigned int&
         else if (msg->command == CHARACTER_CMD_ATTACH)
         {
             auto* attach_msg = reinterpret_cast<NetCharacterMsgAttach*>(buffer);
-            Actor* beam = App::GetGameContext()->GetActorManager()->GetActorByNetworkLinks(attach_msg->source_id, attach_msg->stream_id);
+            ActorPtr beam = App::GetGameContext()->GetActorManager()->GetActorByNetworkLinks(attach_msg->source_id, attach_msg->stream_id);
             if (beam != nullptr)
             {
                 this->SetActorCoupling(true, beam);
@@ -520,7 +520,7 @@ void Character::receiveStreamData(unsigned int& type, int& source, unsigned int&
 #endif
 }
 
-void Character::SetActorCoupling(bool enabled, Actor* actor)
+void Character::SetActorCoupling(bool enabled, ActorPtr actor)
 {
     m_actor_coupling = actor;
 #ifdef USE_SOCKETW

--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "Actor.h"
 #include "ForwardDeclarations.h"
 
 #include <OgreUTFString.h>
@@ -51,7 +52,7 @@ public:
     std::string const &    GetAnimName() const          { return m_anim_name; }
     float          GetAnimTime() const                  { return m_anim_time; }
     Ogre::Radian   getRotation() const                  { return m_character_rotation; }
-    Actor*         GetActorCoupling()                   { return m_actor_coupling; }
+    ActorPtr       GetActorCoupling()                   { return m_actor_coupling; }
     void           setColour(int color)                 { this->m_color_number = color; }
     Ogre::Vector3  getPosition();
     void           setPosition(Ogre::Vector3 position);
@@ -60,7 +61,7 @@ public:
     void           update(float dt);
     void           updateCharacterRotation();
     void           receiveStreamData(unsigned int& type, int& source, unsigned int& streamid, char* buffer);
-    void           SetActorCoupling(bool enabled, Actor* actor);
+    void           SetActorCoupling(bool enabled, ActorPtr actor);
     GfxCharacter*  SetupGfx();
 
 private:
@@ -70,7 +71,7 @@ private:
     void           SendStreamSetup();
     void           SetAnimState(std::string mode, float time = 0);
 
-    Actor*           m_actor_coupling; //!< The vehicle or machine which the character occupies
+    ActorPtr         m_actor_coupling; //!< The vehicle or machine which the character occupies
     Ogre::Radian     m_character_rotation;
     float            m_character_h_speed;
     float            m_character_v_speed;
@@ -104,7 +105,7 @@ struct GfxCharacter
         Ogre::UTFString    simbuf_net_username;
         bool               simbuf_is_remote;
         int                simbuf_color_number;
-        Actor*             simbuf_actor_coupling;
+        ActorPtr             simbuf_actor_coupling;
         std::string        simbuf_anim_name;
         float              simbuf_anim_time; // Intentionally left empty = forces initial update.
     };

--- a/source/main/gameplay/CharacterFactory.cpp
+++ b/source/main/gameplay/CharacterFactory.cpp
@@ -86,7 +86,7 @@ void CharacterFactory::Update(float dt)
     }
 }
 
-void CharacterFactory::UndoRemoteActorCoupling(Actor* actor)
+void CharacterFactory::UndoRemoteActorCoupling(ActorPtr actor)
 {
     for (auto& c : m_remote_characters)
     {

--- a/source/main/gameplay/CharacterFactory.h
+++ b/source/main/gameplay/CharacterFactory.h
@@ -43,7 +43,7 @@ public:
     Character* CreateLocalCharacter();
     Character* GetLocalCharacter() { return m_local_character.get(); }
     void DeleteAllCharacters();
-    void UndoRemoteActorCoupling(Actor* actor);
+    void UndoRemoteActorCoupling(ActorPtr actor);
     void Update(float dt);
 #ifdef USE_SOCKETW
     void handleStreamData(std::vector<RoR::NetRecvPacket> packet);

--- a/source/main/gameplay/ChatSystem.cpp
+++ b/source/main/gameplay/ChatSystem.cpp
@@ -20,6 +20,7 @@
 
 #include "ChatSystem.h"
 
+#include "Actor.h"
 #include "Console.h"
 #include "GUIManager.h"
 #include "Language.h"

--- a/source/main/gameplay/EngineSim.cpp
+++ b/source/main/gameplay/EngineSim.cpp
@@ -34,7 +34,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-EngineSim::EngineSim(float _min_rpm, float _max_rpm, float torque, std::vector<float> gears, float dratio, Actor* actor) :
+EngineSim::EngineSim(float _min_rpm, float _max_rpm, float torque, std::vector<float> gears, float dratio, ActorPtr actor) :
     m_air_pressure(0.0f)
     , m_auto_cur_acc(0.0f)
     , m_auto_mode(AUTOMATIC)

--- a/source/main/gameplay/EngineSim.h
+++ b/source/main/gameplay/EngineSim.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "Application.h"
+#include "Actor.h"
 
 namespace RoR {
 
@@ -38,7 +39,7 @@ class EngineSim : public ZeroedMemoryAllocator
 
 public:
 
-    EngineSim(float min_rpm, float max_rpm, float torque, std::vector<float> gears, float dratio, Actor* actor);
+    EngineSim(float min_rpm, float max_rpm, float torque, std::vector<float> gears, float dratio, ActorPtr actor);
     ~EngineSim();
 
     /// Sets current engine state;
@@ -153,7 +154,7 @@ private:
     };
 
     // Vehicle
-    Actor*         m_actor;
+    ActorPtr         m_actor;
 
     // Gearbox
     float          m_ref_wheel_revolutions; //!< Gears; estimated wheel revolutions based on current vehicle speed along the longi. axis

--- a/source/main/gameplay/Landusemap.cpp
+++ b/source/main/gameplay/Landusemap.cpp
@@ -20,6 +20,7 @@
 
 #include "Landusemap.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Collisions.h"
 #include "Console.h"

--- a/source/main/gameplay/RecoveryMode.cpp
+++ b/source/main/gameplay/RecoveryMode.cpp
@@ -115,7 +115,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
 
             if (App::sim_soft_reset_mode->getBool())
             {
-                for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
+                for (ActorPtr actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
                 {
                     actor->requestRotation(rotation, rotation_center);
                     actor->requestTranslation(translation);
@@ -129,7 +129,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
             App::GetGameContext()->GetPlayerActor()->requestAngleSnap(45);
             if (App::sim_soft_reset_mode->getBool())
             {
-                for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
+                for (ActorPtr actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
                 {
                     actor->requestAngleSnap(45);
                 }
@@ -144,7 +144,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
         if (App::sim_soft_reset_mode->getBool())
         {
             reset_type = ActorModifyRequest::Type::SOFT_RESET;
-            for (auto actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
+            for (ActorPtr actor : App::GetGameContext()->GetPlayerActor()->getAllLinkedActors())
             {
                 ActorModifyRequest* rq = new ActorModifyRequest;
                 rq->amr_actor = actor;

--- a/source/main/gameplay/Replay.cpp
+++ b/source/main/gameplay/Replay.cpp
@@ -32,7 +32,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Replay::Replay(Actor* actor, int _numFrames)
+Replay::Replay(ActorPtr actor, int _numFrames)
 {
     m_actor = actor;
     numFrames = _numFrames;
@@ -48,7 +48,9 @@ Replay::Replay(Actor* actor, int _numFrames)
 
     outOfMemory = false;
 
-    unsigned long bsize = (actor->ar_num_nodes * numFrames * sizeof(node_simple_t) + actor->ar_num_beams * numFrames * sizeof(beam_simple_t) + numFrames * sizeof(unsigned long)) / 1024.0f;
+    const int numNodes = actor->ar_num_nodes;
+    const int numBeams = actor->ar_num_beams;
+    unsigned long bsize = (numNodes * numFrames * sizeof(node_simple_t) + numBeams * numFrames * sizeof(beam_simple_t) + numFrames * sizeof(unsigned long)) / 1024.0f;
     LOG("replay buffer size: " + TOSTRING(bsize) + " kB");
 
     writeIndex = 0;

--- a/source/main/gameplay/Replay.h
+++ b/source/main/gameplay/Replay.h
@@ -39,7 +39,7 @@ struct beam_simple_t
 class Replay : public ZeroedMemoryAllocator
 {
 public:
-    Replay(Actor* b, int nframes);
+    Replay(ActorPtr b, int nframes);
     ~Replay();
 
     void*               getWriteBuffer(int type);
@@ -56,7 +56,7 @@ public:
     void                UpdateInputEvents();
 
 protected:
-    Actor*              m_actor = nullptr;
+    ActorPtr              m_actor = nullptr;
     float               m_replay_timer = 0.f;
     float               ar_replay_precision = 1.f;
     int                 ar_replay_pos = 0;

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -126,7 +126,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
         // walk all trucks
         minnode = NODENUM_INVALID;
         grab_truck = NULL;
-        for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             if (actor->ar_state == ActorState::LOCAL_SIMULATED)
             {
@@ -236,13 +236,13 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
             return true;
         }
 
-        Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+        ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
         // Reselect the player actor
         {
             Real nearest_ray_distance = std::numeric_limits<float>::max();
 
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor != player_actor)
                 {
@@ -254,7 +254,7 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
                         if (ray_distance < nearest_ray_distance)
                         {
                             nearest_ray_distance = ray_distance;
-                            App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, (void*)actor));
+                            App::GetGameContext()->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                         }
                     }
                 }

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -58,7 +58,7 @@ protected:
 
     NodeNum_t minnode = NODENUM_INVALID;
     float mindist;
-    Actor* grab_truck;
+    ActorPtr grab_truck;
     Ogre::Vector3 lastgrabpos;
     int lastMouseX, lastMouseY;
 

--- a/source/main/gameplay/TyrePressure.h
+++ b/source/main/gameplay/TyrePressure.h
@@ -41,7 +41,7 @@ namespace RoR {
 class TyrePressure
 {
 public:
-    TyrePressure(Actor* a): m_actor(a) {}
+    TyrePressure(ActorPtr a): m_actor(a) {}
 
     void                AddBeam(int beam_id) { m_pressure_beams.push_back(beam_id); }
     bool                IsEnabled() const { return m_pressure_beams.size() != 0; }
@@ -51,7 +51,7 @@ public:
     bool                IsPressurizing() const { return m_pressure_pressed; }
 
 private:
-    Actor*              m_actor;
+    ActorPtr              m_actor;
     std::vector<int>    m_pressure_beams;
     bool                m_pressure_pressed = false;
     float               m_pressure_pressed_timer = 0.f;

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -39,7 +39,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-VehicleAI::VehicleAI(Actor* b) :
+VehicleAI::VehicleAI(ActorPtr b) :
     is_waiting(false),
     wait_time(0.0f)
 {
@@ -419,7 +419,7 @@ void VehicleAI::update(float dt, int doUpdate)
             }
 
             // Collision avoidance with other actors
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor->ar_driveable == NOT_DRIVEABLE) // Ignore objects that may be actors
                     continue;
@@ -490,7 +490,7 @@ void VehicleAI::update(float dt, int doUpdate)
             }
 
             // Collision avoidance with other actors
-            for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+            for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
             {
                 if (actor->ar_driveable == NOT_DRIVEABLE) // Ignore objects that may be actors
                     continue;

--- a/source/main/gameplay/VehicleAI.h
+++ b/source/main/gameplay/VehicleAI.h
@@ -63,7 +63,7 @@ class VehicleAI : public RefCountingObject<VehicleAI>
     // PLEASE maintain the same order as in 'bindings/VehicleAiAngelscript.cpp' and 'doc/../VehicleAIClass.h'
 
 public:
-    VehicleAI(Actor* b);
+    VehicleAI(ActorPtr b);
     ~VehicleAI();
 
     /**
@@ -138,7 +138,7 @@ private:
     float wait_time=0.f;//!<(seconds) The amount of time the AI has to wait.
 
     float maxspeed = 50;//!<(KM/H) The max speed the AI is allowed to drive.
-    Actor* beam = nullptr;//!< The verhicle the AI is driving.
+    ActorPtr beam;//!< The verhicle the AI is driving.
     bool is_enabled = false;//!< True if the AI is driving.
     Ogre::Vector3 current_waypoint = Ogre::Vector3::ZERO;//!< The coordinates of the waypoint that the AI is driving to.
     Ogre::Vector3 prev_waypoint = Ogre::Vector3::ZERO;;//!< The coordinates of the previous waypoint.

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -56,7 +56,7 @@
 
 using namespace RoR;
 
-RoR::GfxActor::GfxActor(Actor* actor, ActorSpawner* spawner, std::string ogre_resource_group,
+RoR::GfxActor::GfxActor(ActorPtr actor, ActorSpawner* spawner, std::string ogre_resource_group,
                         RoR::Renderdash* renderdash):
     m_actor(actor),
     m_custom_resource_group(ogre_resource_group),
@@ -1799,7 +1799,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
 
     // Linked Actors
     m_linked_gfx_actors.clear();
-    for (auto actor : m_actor->getAllLinkedActors())
+    for (ActorPtr actor : m_actor->getAllLinkedActors())
     {
         m_linked_gfx_actors.insert(actor->GetGfxActor());
     }

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -55,7 +55,7 @@ class GfxActor
 
 public:
 
-    GfxActor(Actor* actor, ActorSpawner* spawner, std::string ogre_resource_group,
+    GfxActor(ActorPtr actor, ActorSpawner* spawner, std::string ogre_resource_group,
         RoR::Renderdash* renderdash);
 
     ~GfxActor();
@@ -139,7 +139,7 @@ public:
     DebugViewType        GetDebugView() const { return m_debug_view; }
     std::set<GfxActor*>  GetLinkedGfxActors() { return m_linked_gfx_actors; }
     Ogre::String         GetResourceGroup() { return m_custom_resource_group; }
-    Actor*               GetActor() { return m_actor; } // Watch out for multithreading with this!
+    ActorPtr             GetActor() { return m_actor; } // Watch out for multithreading with this!
     Ogre::TexturePtr     GetHelpTex() { return m_help_tex; }
     Ogre::MaterialPtr    GetHelpMat() { return m_help_mat; }
     int                  FetchNumBeams() const ;
@@ -156,7 +156,7 @@ private:
     static Ogre::Quaternion SpecialGetRotationTo(const Ogre::Vector3& src, const Ogre::Vector3& dest);
 
     // Static info
-    Actor*                      m_actor = nullptr;
+    ActorPtr                      m_actor = nullptr;
     std::string                 m_custom_resource_group;
     int                         m_driverseat_prop_index = -1;
     Ogre::SceneNode*            m_gfx_beams_parent_scenenode = nullptr;

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -253,7 +253,7 @@ struct BeamGfx
 
     NodeNum_t        rod_node1           = NODENUM_INVALID;  //!< Node index - may change during simulation!
     NodeNum_t        rod_node2           = NODENUM_INVALID;  //!< Node index - may change during simulation!
-    Actor*           rod_target_actor    = nullptr;
+    ActorPtr           rod_target_actor    = nullptr;
     bool             rod_is_visible      = false;
 };
 

--- a/source/main/gfx/HydraxWater.cpp
+++ b/source/main/gfx/HydraxWater.cpp
@@ -20,6 +20,7 @@
 
 #include "HydraxWater.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
 #include "GameContext.h"

--- a/source/main/gfx/Renderdash.cpp
+++ b/source/main/gfx/Renderdash.cpp
@@ -20,6 +20,7 @@
 
 #include "Renderdash.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "GfxScene.h"
 #include "GUIManager.h"

--- a/source/main/gfx/ShadowManager.cpp
+++ b/source/main/gfx/ShadowManager.cpp
@@ -20,6 +20,7 @@
 
 #include "ShadowManager.h"
 
+#include "Actor.h"
 #include "CameraManager.h"
 #include "GfxScene.h"
 

--- a/source/main/gfx/SimBuffers.h
+++ b/source/main/gfx/SimBuffers.h
@@ -194,7 +194,7 @@ struct ActorSB
 
 struct GameContextSB
 {
-    Actor*            simbuf_player_actor             = nullptr;
+    ActorPtr          simbuf_player_actor;
     Ogre::Vector3     simbuf_character_pos            = Ogre::Vector3::ZERO;
     bool              simbuf_sim_paused               = false;
     float             simbuf_sim_speed                = 1.f;

--- a/source/main/gfx/Skidmark.cpp
+++ b/source/main/gfx/Skidmark.cpp
@@ -20,6 +20,7 @@
 
 #include "Skidmark.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "SimData.h"
 #include "ContentManager.h" // RGN_CONFIG

--- a/source/main/gfx/SkyManager.cpp
+++ b/source/main/gfx/SkyManager.cpp
@@ -23,6 +23,7 @@
 
 #include "SkyManager.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
 #include "GameContext.h"

--- a/source/main/gfx/SkyXManager.cpp
+++ b/source/main/gfx/SkyXManager.cpp
@@ -21,6 +21,7 @@
 
 #include "SkyXManager.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
 #include "GameContext.h"

--- a/source/main/gfx/SurveyMapTextureCreator.cpp
+++ b/source/main/gfx/SurveyMapTextureCreator.cpp
@@ -20,6 +20,7 @@
 
 #include "SurveyMapTextureCreator.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "GameContext.h"
 #include "GfxScene.h"

--- a/source/main/gfx/Water.cpp
+++ b/source/main/gfx/Water.cpp
@@ -21,6 +21,7 @@
 
 #include "Water.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "CameraManager.h"
 #include "GfxScene.h"

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -507,7 +507,7 @@ void CameraManager::switchBehavior(CameraBehaviors new_behavior)
     this->ActivateNewBehavior(new_behavior, true);
 }
 
-void CameraManager::SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, Actor* new_vehicle)
+void CameraManager::SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, ActorPtr new_vehicle)
 {
     if (new_behavior == m_current_behavior)
     {
@@ -626,7 +626,7 @@ void CameraManager::NotifyContextChange()
     }
 }
 
-void CameraManager::NotifyVehicleChanged(Actor* new_vehicle)
+void CameraManager::NotifyVehicleChanged(ActorPtr new_vehicle)
 {
     // Getting out of vehicle
     if (new_vehicle == nullptr)
@@ -1249,7 +1249,7 @@ void CameraManager::CameraBehaviorVehicleSplineCreateSpline()
 
     if (m_splinecam_num_linked_beams > 0)
     {
-        for (auto actor : linkedBeams)
+        for (ActorPtr actor : linkedBeams)
         {
             if (actor->ar_num_camera_rails <= 0)
                 continue;

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -64,7 +64,7 @@ public:
     Ogre::Camera*     GetCamera()                 { return m_camera; }
 
     void NotifyContextChange();
-    void NotifyVehicleChanged(Actor* new_vehicle);
+    void NotifyVehicleChanged(ActorPtr new_vehicle);
 
     void CameraBehaviorOrbitReset();
     bool CameraBehaviorOrbitMouseMoved(const OIS::MouseEvent& _arg);
@@ -82,7 +82,7 @@ public:
 protected:
 
     void switchBehavior(CameraBehaviors new_behavior);
-    void SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, Actor* new_vehicle);
+    void SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, ActorPtr new_vehicle);
     void ToggleCameraBehavior(CameraBehaviors new_behavior); //!< Only accepts FREE and FREEFIX modes
     void ActivateNewBehavior(CameraBehaviors new_behavior, bool reset);
     void UpdateCurrentBehavior();
@@ -110,7 +110,7 @@ protected:
     CameraBehaviors      m_cam_before_toggled;  //!< Toggled modes (FREE, FREEFIX) remember original state.
     CameraBehaviors      m_prev_toggled_cam;    //!< Switching toggled modes (FREE, FREEFIX) keeps 1-slot history.
     // Old `CameraContext`
-    Actor*               m_cct_player_actor; // TODO: duplicates `GameContext::m_player_actor`
+    ActorPtr             m_cct_player_actor; // TODO: duplicates `GameContext::m_player_actor`
     Ogre::Degree         m_cct_rot_scale;
     Ogre::Real           m_cct_dt;
     Ogre::Real           m_cct_trans_scale;

--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -19,6 +19,8 @@
 
 #include "GUIUtils.h"
 
+#include "Actor.h"
+
 #include "imgui_internal.h" // ImTextCharFromUtf8
 #include <regex>
 #include <stdio.h> // sscanf

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -370,12 +370,12 @@ void OverlayWrapper::showPressureOverlay(bool show)
     }
 }
 
-void OverlayWrapper::ToggleDashboardOverlays(Actor* actor)
+void OverlayWrapper::ToggleDashboardOverlays(ActorPtr actor)
 {
     showDashboardOverlays(!m_dashboard_visible, actor);
 }
 
-void OverlayWrapper::showDashboardOverlays(bool show, Actor* actor)
+void OverlayWrapper::showDashboardOverlays(bool show, ActorPtr actor)
 {
     m_dashboard_visible = show;
 
@@ -500,7 +500,7 @@ bool OverlayWrapper::mouseMoved(const OIS::MouseEvent& _arg)
     bool res = false;
     const OIS::MouseState ms = _arg.state;
     
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
     if (!player_actor)
         return res;
@@ -919,7 +919,7 @@ void OverlayWrapper::UpdateAerialHUD(RoR::GfxActor* gfx_actor)
         m_aerial_dashboard.vs_trim.DisplayFormat("+%i00", simbuf.simbuf_ap_vs_value / 100);
 }
 
-void OverlayWrapper::UpdateMarineHUD(Actor* vehicle)
+void OverlayWrapper::UpdateMarineHUD(ActorPtr vehicle)
 {
     // throttles
     bthro1->setTop(thrtop + thrheight * (0.5 - vehicle->ar_screwprops[0]->getThrottle() / 2.0) - 1.0);

--- a/source/main/gui/OverlayWrapper.h
+++ b/source/main/gui/OverlayWrapper.h
@@ -122,9 +122,9 @@ public:
         Ogre::Overlay *o;
     };
 
-    void ToggleDashboardOverlays(Actor *actor);
+    void ToggleDashboardOverlays(ActorPtr actor);
 
-    void showDashboardOverlays(bool show, Actor *actor);
+    void showDashboardOverlays(bool show, ActorPtr actor);
 
     void windowResized();
     void resizeOverlay(LoadedOverlay & overlay);
@@ -138,7 +138,7 @@ public:
     void update(float dt);
     void UpdateLandVehicleHUD(RoR::GfxActor* ga);
     void UpdateAerialHUD(RoR::GfxActor* ga);
-    void UpdateMarineHUD(Actor * vehicle);
+    void UpdateMarineHUD(ActorPtr vehicle);
 
     void ShowRacingOverlay();
     void HideRacingOverlay();

--- a/source/main/gui/imgui/OgreImGui.cpp
+++ b/source/main/gui/imgui/OgreImGui.cpp
@@ -25,6 +25,7 @@
 
 #include "OgreImGui.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "ContentManager.h"
 #include "OgreImGuiOverlay.h"

--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -22,6 +22,7 @@
 
 #include "GUI_ConsoleView.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Console.h"
 #include "GUIManager.h"

--- a/source/main/gui/panels/GUI_ConsoleWindow.cpp
+++ b/source/main/gui/panels/GUI_ConsoleWindow.cpp
@@ -95,7 +95,7 @@ void ConsoleWindow::Draw()
 
         if (ImGui::BeginMenu(_LC("Console", "Script Monitor")))
         {
-            ImGui::Dummy(ImVec2(340.f, 1.f)); // Manually resize width (DearIMGUI bug workaround)
+            ImGui::Dummy(ImVec2(440.f, 1.f)); // Manually resize width (DearIMGUI bug workaround)
             m_script_monitor.Draw();
             ImGui::EndMenu();
         }

--- a/source/main/gui/panels/GUI_ConsoleWindow.cpp
+++ b/source/main/gui/panels/GUI_ConsoleWindow.cpp
@@ -21,6 +21,8 @@
 
 
 #include "GUI_ConsoleWindow.h"
+
+#include "Actor.h"
 #include "GUIManager.h"
 #include "GUI_AngelScriptExamples.h"
 

--- a/source/main/gui/panels/GUI_FlexbodyDebug.cpp
+++ b/source/main/gui/panels/GUI_FlexbodyDebug.cpp
@@ -42,7 +42,7 @@ void FlexbodyDebug::Draw()
     bool keep_open = true;
     ImGui::Begin(_LC("FlexbodyDebug", "Flexbody/Prop debug"), &keep_open, win_flags);
 
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (!actor)
     {
         ImGui::Text("%s", _LC("FlexbodyDebug", "You are on foot."));
@@ -178,7 +178,7 @@ void FlexbodyDebug::AnalyzeFlexbodies()
     int num_combo_items = 0;
 
     // Analyze flexbodies
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (actor && actor->GetGfxActor()->GetFlexbodies().size() > 0)
     {
         for (FlexBody* fb : actor->GetGfxActor()->GetFlexbodies())
@@ -425,7 +425,7 @@ void FlexbodyDebug::DrawDebugView(FlexBody* flexbody, Prop* prop, NodeNum_t node
 
 void FlexbodyDebug::UpdateVisibility()
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (!actor)
     {
         return;

--- a/source/main/gui/panels/GUI_GameAbout.cpp
+++ b/source/main/gui/panels/GUI_GameAbout.cpp
@@ -25,6 +25,7 @@
 
 #include "GUI_GameAbout.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "GUIManager.h"
 #include "Language.h"

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -21,6 +21,7 @@
 
 #include "GUI_GameChatBox.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "ChatSystem.h"
 #include "Console.h"

--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -21,6 +21,7 @@
 
 #include "GUI_GameControls.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Language.h"
 #include "OgreImGui.h"

--- a/source/main/gui/panels/GUI_LoadingWindow.cpp
+++ b/source/main/gui/panels/GUI_LoadingWindow.cpp
@@ -21,6 +21,7 @@
 #include "GUI_LoadingWindow.h"
 #include <fmt/format.h>
 
+#include "Actor.h"
 #include "GUIManager.h"
 #include "GUIUtils.h"
 #include "OgreImGui.h"

--- a/source/main/gui/panels/GUI_NodeBeamUtils.cpp
+++ b/source/main/gui/panels/GUI_NodeBeamUtils.cpp
@@ -31,7 +31,7 @@ using namespace GUI;
 
 void NodeBeamUtils::Draw()
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (!actor)
     {
         this->SetVisible(false);

--- a/source/main/gui/panels/GUI_ScriptMonitor.cpp
+++ b/source/main/gui/panels/GUI_ScriptMonitor.cpp
@@ -32,7 +32,7 @@ void ScriptMonitor::Draw()
     ImGui::Columns(3);
     ImGui::SetColumnWidth(0, 30);
     ImGui::SetColumnWidth(1, 200);
-    ImGui::SetColumnWidth(2, 100);
+    ImGui::SetColumnWidth(2, 200);
 
     // Header
     ImGui::TextDisabled("ID");
@@ -57,6 +57,10 @@ void ScriptMonitor::Draw()
         ImGui::NextColumn();
         switch (unit.scriptCategory)
         {
+        case ScriptCategory::ACTOR:
+            ImGui::Text("(actor [%u] '%s')", unit.associatedActor->ar_vector_index, unit.associatedActor->getTruckName().c_str());
+            break;
+
         case ScriptCategory::TERRAIN:
             ImGui::Text("(terrain)");
             break;

--- a/source/main/gui/panels/GUI_ScriptMonitor.cpp
+++ b/source/main/gui/panels/GUI_ScriptMonitor.cpp
@@ -16,6 +16,7 @@
 
 #include "GUI_ScriptMonitor.h"
 
+#include "Actor.h"
 #include "ContentManager.h"
 #include "ScriptEngine.h"
 

--- a/source/main/gui/panels/GUI_SimActorStats.cpp
+++ b/source/main/gui/panels/GUI_SimActorStats.cpp
@@ -225,7 +225,7 @@ void SimActorStats::Draw(RoR::GfxActor* actorx)
     ImGui::PopStyleColor(1); // WindowBg
 }
 
-void SimActorStats::UpdateStats(float dt, Actor* actor)
+void SimActorStats::UpdateStats(float dt, ActorPtr actor)
 {
     //taken from TruckHUD.cpp (now removed)
     beam_t* beam = actor->ar_beams;

--- a/source/main/gui/panels/GUI_SimActorStats.h
+++ b/source/main/gui/panels/GUI_SimActorStats.h
@@ -36,7 +36,7 @@ public:
     void SetVisible(bool vis) { m_is_visible = vis; }
     bool IsVisible() const { return m_is_visible; }
 
-    void UpdateStats(float dt, Actor* actor); //!< Caution: touches live data, must be synced with sim. thread
+    void UpdateStats(float dt, ActorPtr actor); //!< Caution: touches live data, must be synced with sim. thread
     void Draw(RoR::GfxActor* actorx);
 
 private:

--- a/source/main/gui/panels/GUI_SimPerfStats.cpp
+++ b/source/main/gui/panels/GUI_SimPerfStats.cpp
@@ -21,6 +21,7 @@
 
 #include "GUI_SimPerfStats.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "GUIManager.h"
 #include "Language.h"

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -138,7 +138,7 @@ void SurveyMap::Draw()
         // Calc. view center
         smallmap_size = mTerrainSize * (1.0f - mMapZoom);
         Ogre::Vector2 player_map_pos;
-        Actor* actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
+        ActorPtr actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
         if (actor)
         {
             auto& actor_data = actor->GetGfxActor()->GetSimDataBuffer();
@@ -422,7 +422,7 @@ void SurveyMap::setMapZoomRelative(float delta)
 }
 
 
-const char* SurveyMap::getTypeByDriveable(ActorType driveable, Actor* actor)
+const char* SurveyMap::getTypeByDriveable(ActorType driveable, ActorPtr actor)
 {
     switch (driveable)
     {
@@ -443,7 +443,7 @@ const char* SurveyMap::getTypeByDriveable(ActorType driveable, Actor* actor)
     }
 }
 
-const char* SurveyMap::getAIType(Actor* actor)
+const char* SurveyMap::getAIType(ActorPtr actor)
 {
     if (actor->ar_engine)
     {

--- a/source/main/gui/panels/GUI_SurveyMap.h
+++ b/source/main/gui/panels/GUI_SurveyMap.h
@@ -72,8 +72,8 @@ protected:
 
     void setMapZoom(float zoom);
     void setMapZoomRelative(float dt_sec);
-    const char* getTypeByDriveable(ActorType driveable, Actor* actor);
-    const char* getAIType(Actor* actor);
+    const char* getTypeByDriveable(ActorType driveable, ActorPtr actor);
+    const char* getAIType(ActorPtr actor);
 
     void DrawMapIcon(ImVec2 view_pos, ImVec2 view_size, Ogre::Vector2 view_origin,
                      std::string const& filename, std::string const& caption, 

--- a/source/main/gui/panels/GUI_TextureToolWindow.cpp
+++ b/source/main/gui/panels/GUI_TextureToolWindow.cpp
@@ -23,6 +23,7 @@
 
 #include <Ogre.h>
 
+#include "Actor.h"
 #include "Application.h"
 #include "Console.h"
 #include "GUIManager.h"

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -627,7 +627,7 @@ void VehicleButtons::DrawActorPhysicsButton(RoR::GfxActor* actorx)
 
     if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(m_actor_physics_icon->getHandle()), ImVec2(24, 24)))
     {
-        for (auto actor : actorx->GetActor()->getAllLinkedActors())
+        for (ActorPtr actor : actorx->GetActor()->getAllLinkedActors())
         {
             actor->ar_physics_paused = !actorx->GetActor()->ar_physics_paused;
         }

--- a/source/main/gui/panels/GUI_VehicleDescription.cpp
+++ b/source/main/gui/panels/GUI_VehicleDescription.cpp
@@ -40,7 +40,7 @@ using namespace GUI;
 
 void VehicleDescription::Draw()
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (!actor)
     {
         m_is_visible = false;

--- a/source/main/network/OutGauge.cpp
+++ b/source/main/network/OutGauge.cpp
@@ -100,7 +100,7 @@ void OutGauge::Connect()
 #endif // _WIN32
 }
 
-bool OutGauge::Update(float dt, Actor* truck)
+bool OutGauge::Update(float dt, ActorPtr truck)
 {
 #if defined(_WIN32) && defined(USE_SOCKETW)
     if (!working)

--- a/source/main/network/OutGauge.h
+++ b/source/main/network/OutGauge.h
@@ -49,7 +49,7 @@ public:
     OutGauge(void);
 
     void Connect();
-    bool Update(float dt, Actor* truck);
+    bool Update(float dt, ActorPtr truck);
     void Close();
 
 private:

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -67,7 +67,7 @@ void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
 
 void Actor::CalcForceFeedback(bool doUpdate)
 {
-    if (this == App::GetGameContext()->GetPlayerActor())
+    if (this == App::GetGameContext()->GetPlayerActor().GetRef())
     {
         if (doUpdate)
         {
@@ -988,7 +988,7 @@ void Actor::CalcCommands(bool doUpdate)
             ar_engine->SetEnginePriming(requested);
         }
 
-        if (doUpdate && this == App::GetGameContext()->GetPlayerActor())
+        if (doUpdate && this == App::GetGameContext()->GetPlayerActor().GetRef())
         {
 #ifdef USE_OPENAL
             if (active > 0)
@@ -1693,7 +1693,7 @@ void Actor::CalcHooks()
             {
                 //enable beam if not enabled yet between those 2 nodes
                 it->hk_beam->p2 = it->hk_lock_node;
-                it->hk_beam->bm_inter_actor = it->hk_locked_actor != 0;
+                it->hk_beam->bm_inter_actor = (it->hk_locked_actor != nullptr);
                 it->hk_beam->L = (it->hk_hook_node->AbsPosition - it->hk_lock_node->AbsPosition).length();
                 it->hk_beam->bm_disabled = false;
                 AddInterActorBeam(it->hk_beam, this, it->hk_locked_actor);

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -317,6 +317,12 @@ ActorPtr ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr 
         actor->m_replay_handler = new Replay(actor, App::sim_replay_length->getInt());
     }
 
+    // Launch scripts (FIXME: ignores sectionconfig)
+    for (RigDef::Script const& script_def : def->root_module->scripts)
+    {
+        App::GetScriptEngine()->loadScript(script_def.filename, ScriptCategory::ACTOR, actor);
+    }
+
     LOG(" ===== DONE LOADING VEHICLE");
 
     if (App::diag_actor_dump->getBool())

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -74,9 +74,9 @@ ActorManager::~ActorManager()
     this->SyncWithSimThread(); // Wait for sim task to finish
 }
 
-Actor* ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr def)
+ActorPtr ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr def)
 {
-    Actor* actor = new Actor(m_actor_counter++, static_cast<int>(m_actors.size()), def, rq);
+    ActorPtr actor = new Actor(m_actor_counter++, static_cast<int>(m_actors.size()), def, rq);
 
     if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED && rq.asr_origin != ActorSpawnRequest::Origin::NETWORK)
     {
@@ -324,7 +324,7 @@ Actor* ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr de
         actor->WriteDiagnosticDump(actor->ar_filename + "_dump_recalc.txt"); // Saves file to 'logs'
     }
 
-    m_actors.push_back(actor);
+    m_actors.push_back(ActorPtr(actor));
 
     return actor;
 }
@@ -333,14 +333,14 @@ void ActorManager::RemoveStreamSource(int sourceid)
 {
     m_stream_mismatches.erase(sourceid);
 
-    for (auto actor : m_actors)
+    for (ActorPtr& actor : m_actors)
     {
         if (actor->ar_state != ActorState::NETWORKED_OK)
             continue;
 
         if (actor->ar_net_source_id == sourceid)
         {
-            App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
+            App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
         }
     }
 }
@@ -435,7 +435,7 @@ void ActorManager::HandleActorStreamData(std::vector<RoR::NetRecvPacket> packet_
         else if (packet.header.command == RoRnet::MSG2_STREAM_REGISTER_RESULT)
         {
             RoRnet::StreamRegister* reg = (RoRnet::StreamRegister *)packet.buffer;
-            for (auto actor : m_actors)
+            for (ActorPtr& actor: m_actors)
             {
                 if (actor->ar_net_source_id == reg->origin_sourceid && actor->ar_net_stream_id == reg->origin_streamid)
                 {
@@ -457,12 +457,12 @@ void ActorManager::HandleActorStreamData(std::vector<RoR::NetRecvPacket> packet_
         }
         else if (packet.header.command == RoRnet::MSG2_STREAM_UNREGISTER)
         {
-            Actor* b = this->GetActorByNetworkLinks(packet.header.source, packet.header.streamid);
+            ActorPtr b = this->GetActorByNetworkLinks(packet.header.source, packet.header.streamid);
             if (b)
             {
                 if (b->ar_state == ActorState::NETWORKED_OK || b->ar_state == ActorState::NETWORKED_HIDDEN)
                 {
-                    App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)b));
+                    App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(b))));
                 }
             }
             m_stream_mismatches[packet.header.source].erase(packet.header.streamid);
@@ -473,7 +473,7 @@ void ActorManager::HandleActorStreamData(std::vector<RoR::NetRecvPacket> packet_
         }
         else if (packet.header.command == RoRnet::MSG2_STREAM_DATA)
         {
-            for (auto actor : m_actors)
+            for (ActorPtr& actor: m_actors)
             {
                 if (actor->ar_state != ActorState::NETWORKED_OK)
                     continue;
@@ -511,7 +511,7 @@ int ActorManager::CheckNetworkStreamsOk(int sourceid)
     if (!m_stream_mismatches[sourceid].empty())
         return 0;
 
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         if (actor->ar_state != ActorState::NETWORKED_OK)
             continue;
@@ -529,7 +529,7 @@ int ActorManager::CheckNetRemoteStreamsOk(int sourceid)
 {
     int result = 2;
 
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         if (actor->ar_state == ActorState::NETWORKED_OK)
             continue;
@@ -544,9 +544,9 @@ int ActorManager::CheckNetRemoteStreamsOk(int sourceid)
     return result;
 }
 
-Actor* ActorManager::GetActorByNetworkLinks(int source_id, int stream_id)
+ActorPtr ActorManager::GetActorByNetworkLinks(int source_id, int stream_id)
 {
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         if (actor->ar_net_source_id == source_id && actor->ar_net_stream_id == stream_id)
         {
@@ -640,13 +640,13 @@ void ActorManager::RecursiveActivation(int j, std::vector<bool>& visited)
     }
 }
 
-void ActorManager::ForwardCommands(Actor* source_actor)
+void ActorManager::ForwardCommands(ActorPtr source_actor)
 {
     if (source_actor->ar_forward_commands)
     {
         auto linked_actors = source_actor->getAllLinkedActors();
 
-        for (auto actor : this->GetActors())
+        for (ActorPtr& actor : this->GetActors())
         {
             if (actor != source_actor && actor->ar_import_commands &&
                     (actor->getPosition().distance(source_actor->getPosition()) < 
@@ -700,11 +700,11 @@ void ActorManager::ForwardCommands(Actor* source_actor)
     }
 }
 
-void ActorManager::UpdateSleepingState(Actor* player_actor, float dt)
+void ActorManager::UpdateSleepingState(ActorPtr player_actor, float dt)
 {
     if (!m_forced_awake)
     {
-        for (auto actor : m_actors)
+        for (ActorPtr& actor: m_actors)
         {
             if (actor->ar_state != ActorState::LOCAL_SIMULATED)
                 continue;
@@ -747,7 +747,7 @@ void ActorManager::UpdateSleepingState(Actor* player_actor, float dt)
 
 void ActorManager::WakeUpAllActors()
 {
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         if (actor->ar_state == ActorState::LOCAL_SLEEPING)
         {
@@ -760,7 +760,7 @@ void ActorManager::WakeUpAllActors()
 void ActorManager::SendAllActorsSleeping()
 {
     m_forced_awake = false;
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         if (actor->ar_state == ActorState::LOCAL_SIMULATED)
         {
@@ -769,11 +769,11 @@ void ActorManager::SendAllActorsSleeping()
     }
 }
 
-Actor* ActorManager::FindActorInsideBox(Collisions* collisions, const Ogre::String& inst, const Ogre::String& box)
+ActorPtr ActorManager::FindActorInsideBox(Collisions* collisions, const Ogre::String& inst, const Ogre::String& box)
 {
     // try to find the desired actor (the one in the box)
-    Actor* ret = nullptr;
-    for (auto actor : m_actors)
+    ActorPtr ret = nullptr;
+    for (ActorPtr& actor: m_actors)
     {
         if (collisions->isInside(actor->ar_nodes[0].AbsPosition, inst, box))
         {
@@ -790,7 +790,7 @@ Actor* ActorManager::FindActorInsideBox(Collisions* collisions, const Ogre::Stri
 
 void ActorManager::RepairActor(Collisions* collisions, const Ogre::String& inst, const Ogre::String& box, bool keepPosition)
 {
-    Actor* actor = this->FindActorInsideBox(collisions, inst, box);
+    ActorPtr actor = this->FindActorInsideBox(collisions, inst, box);
     if (actor != nullptr)
     {
         SOUND_PLAY_ONCE(actor, SS_TRIG_REPAIR);
@@ -804,7 +804,7 @@ void ActorManager::RepairActor(Collisions* collisions, const Ogre::String& inst,
 
 void ActorManager::MuteAllActors()
 {
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         actor->muteAllSounds();
     }
@@ -812,17 +812,17 @@ void ActorManager::MuteAllActors()
 
 void ActorManager::UnmuteAllActors()
 {
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         actor->unmuteAllSounds();
     }
 }
 
-std::pair<Actor*, float> ActorManager::GetNearestActor(Vector3 position)
+std::pair<ActorPtr, float> ActorManager::GetNearestActor(Vector3 position)
 {
-    Actor* nearest_actor = nullptr;
+    ActorPtr nearest_actor = nullptr;
     float min_squared_distance = std::numeric_limits<float>::max();
-    for (auto actor : m_actors)
+    for (ActorPtr& actor : m_actors)
     {
         float squared_distance = position.squaredDistance(actor->ar_nodes[0].AbsPosition);
         if (squared_distance < min_squared_distance)
@@ -836,9 +836,10 @@ std::pair<Actor*, float> ActorManager::GetNearestActor(Vector3 position)
 
 void ActorManager::CleanUpSimulation() // Called after simulation finishes
 {
-    for (auto actor : m_actors)
+    for (ActorPtr& actor : m_actors)
     {
-        delete actor;
+        // Only dispose(), do not `delete`; a script may still hold pointer to the object.
+        actor->dispose();
     }
     m_actors.clear();
 
@@ -848,9 +849,9 @@ void ActorManager::CleanUpSimulation() // Called after simulation finishes
     m_simulation_speed = 1.f;
 }
 
-void ActorManager::DeleteActorInternal(Actor* actor)
+void ActorManager::DeleteActorInternal(ActorPtr actor)
 {
-    if (actor == 0)
+    if (actor == nullptr)
         return;
 
     this->SyncWithSimThread();
@@ -862,7 +863,7 @@ void ActorManager::DeleteActorInternal(Actor* actor)
         {
             App::GetNetwork()->AddPacket(actor->ar_net_stream_id, RoRnet::MSG2_STREAM_UNREGISTER, 0, 0);
         }
-        else if (std::count_if(m_actors.begin(), m_actors.end(), [actor](Actor* b)
+        else if (std::count_if(m_actors.begin(), m_actors.end(), [actor](ActorPtr& b)
                     { return b->ar_net_source_id == actor->ar_net_source_id; }) == 1)
         {
             // We're deleting the last actor from this stream source, reset the stream time offset
@@ -871,15 +872,28 @@ void ActorManager::DeleteActorInternal(Actor* actor)
     }
 #endif // USE_SOCKETW
 
-    m_actors.erase(std::remove(m_actors.begin(), m_actors.end(), actor), m_actors.end());
-    delete actor;
+    auto actor_i = m_actors.begin();
+    while (actor_i != m_actors.end())
+    {
+        if (actor == actor_i->GetRef())
+        {
+            actor_i = m_actors.erase(actor_i);
+        }
+        else
+        {
+            actor_i++;
+        }
+    }
+
+    // Only dispose(), do not `delete`; a script may still hold pointer to the object.
+    actor->dispose();
 
     // Upate actor indices
     for (unsigned int i = 0; i < m_actors.size(); i++)
         m_actors[i]->ar_vector_index = i;
 }
 
-int FindPivotActorId(Actor* player, Actor* prev_player)
+int FindPivotActorId(ActorPtr player, ActorPtr prev_player)
 {
     if (player != nullptr)
         return player->ar_vector_index;
@@ -888,7 +902,7 @@ int FindPivotActorId(Actor* player, Actor* prev_player)
     return -1;
 }
 
-Actor* ActorManager::FetchNextVehicleOnList(Actor* player, Actor* prev_player)
+ActorPtr ActorManager::FetchNextVehicleOnList(ActorPtr player, ActorPtr prev_player)
 {
     int pivot_index = FindPivotActorId(player, prev_player);
 
@@ -896,7 +910,7 @@ Actor* ActorManager::FetchNextVehicleOnList(Actor* player, Actor* prev_player)
     {
         if (m_actors[i]->ar_state != ActorState::NETWORKED_OK && !m_actors[i]->isPreloadedWithTerrain())
         {
-            return m_actors[i];
+            return m_actors[i].GetRef();
         }
     }
 
@@ -904,19 +918,19 @@ Actor* ActorManager::FetchNextVehicleOnList(Actor* player, Actor* prev_player)
     {
         if (m_actors[i]->ar_state != ActorState::NETWORKED_OK && !m_actors[i]->isPreloadedWithTerrain())
         {
-            return m_actors[i];
+            return m_actors[i].GetRef();
         }
     }
 
     if (pivot_index >= 0 && m_actors[pivot_index]->ar_state != ActorState::NETWORKED_OK && !m_actors[pivot_index]->isPreloadedWithTerrain())
     {
-        return m_actors[pivot_index];
+        return m_actors[pivot_index].GetRef();
     }
 
     return nullptr;
 }
 
-Actor* ActorManager::FetchPreviousVehicleOnList(Actor* player, Actor* prev_player)
+ActorPtr ActorManager::FetchPreviousVehicleOnList(ActorPtr player, ActorPtr prev_player)
 {
     int pivot_index = FindPivotActorId(player, prev_player);
 
@@ -924,7 +938,7 @@ Actor* ActorManager::FetchPreviousVehicleOnList(Actor* player, Actor* prev_playe
     {
         if (m_actors[i]->ar_state != ActorState::NETWORKED_OK && !m_actors[i]->isPreloadedWithTerrain())
         {
-            return m_actors[i];
+            return m_actors[i].GetRef();
         }
     }
 
@@ -932,21 +946,21 @@ Actor* ActorManager::FetchPreviousVehicleOnList(Actor* player, Actor* prev_playe
     {
         if (m_actors[i]->ar_state != ActorState::NETWORKED_OK && !m_actors[i]->isPreloadedWithTerrain())
         {
-            return m_actors[i];
+            return m_actors[i].GetRef();
         }
     }
 
     if (pivot_index >= 0 && m_actors[pivot_index]->ar_state != ActorState::NETWORKED_OK && !m_actors[pivot_index]->isPreloadedWithTerrain())
     {
-        return m_actors[pivot_index];
+        return m_actors[pivot_index].GetRef();
     }
 
     return nullptr;
 }
 
-Actor* ActorManager::FetchRescueVehicle()
+ActorPtr ActorManager::FetchRescueVehicle()
 {
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         if (actor->ar_rescuer_flag)
         {
@@ -956,7 +970,7 @@ Actor* ActorManager::FetchRescueVehicle()
     return nullptr;
 }
 
-void ActorManager::UpdateActors(Actor* player_actor)
+void ActorManager::UpdateActors(ActorPtr player_actor)
 {
     float dt = m_simulation_time;
 
@@ -979,7 +993,7 @@ void ActorManager::UpdateActors(Actor* player_actor)
 
     this->UpdateSleepingState(player_actor, dt);
 
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         actor->HandleInputEvents(dt);
         actor->HandleAngelScriptEvents(dt);
@@ -1060,9 +1074,9 @@ void ActorManager::UpdateActors(Actor* player_actor)
         m_sim_task->join();
 }
 
-Actor* ActorManager::GetActorById(int actor_id)
+ActorPtr ActorManager::GetActorById(int actor_id)
 {
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         if (actor->ar_instance_id == actor_id)
         {
@@ -1074,7 +1088,7 @@ Actor* ActorManager::GetActorById(int actor_id)
 
 void ActorManager::UpdatePhysicsSimulation()
 {
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         actor->UpdatePhysicsOrigin();
     }
@@ -1082,19 +1096,20 @@ void ActorManager::UpdatePhysicsSimulation()
     {
         {
             std::vector<std::function<void()>> tasks;
-            for (auto actor : m_actors)
+            for (ActorPtr& actor: m_actors)
             {
                 if (actor->ar_update_physics = actor->CalcForcesEulerPrepare(i == 0))
                 {
-                    auto func = std::function<void()>([this, i, actor]()
+                    ActorPtr actor_raw = actor;
+                    auto func = std::function<void()>([this, i, actor_raw]()
                         {
-                            actor->CalcForcesEulerCompute(i == 0, m_physics_steps);
+                            actor_raw->CalcForcesEulerCompute(i == 0, m_physics_steps);
                         });
                     tasks.push_back(func);
                 }
             }
             App::GetThreadPool()->Parallelize(tasks);
-            for (auto actor : m_actors)
+            for (ActorPtr& actor: m_actors)
             {
                 if (actor->ar_update_physics)
                 {
@@ -1104,25 +1119,26 @@ void ActorManager::UpdatePhysicsSimulation()
         }
         {
             std::vector<std::function<void()>> tasks;
-            for (auto actor : m_actors)
+            for (ActorPtr& actor: m_actors)
             {
                 if (actor->m_inter_point_col_detector != nullptr && (actor->ar_update_physics ||
                         (App::mp_pseudo_collisions->getBool() && actor->ar_state == ActorState::NETWORKED_OK)))
                 {
-                    auto func = std::function<void()>([this, actor]()
+                    ActorPtr actor_raw = actor;
+                    auto func = std::function<void()>([this, actor_raw]()
                         {
-                            actor->m_inter_point_col_detector->UpdateInterPoint();
-                            if (actor->ar_collision_relevant)
+                            actor_raw->m_inter_point_col_detector->UpdateInterPoint();
+                            if (actor_raw->ar_collision_relevant)
                             {
                                 ResolveInterActorCollisions(PHYSICS_DT,
-                                    *actor->m_inter_point_col_detector,
-                                    actor->ar_num_collcabs,
-                                    actor->ar_collcabs,
-                                    actor->ar_cabs,
-                                    actor->ar_inter_collcabrate,
-                                    actor->ar_nodes,
-                                    actor->ar_collision_range,
-                                    *actor->ar_submesh_ground_model);
+                                   *actor_raw->m_inter_point_col_detector,
+                                    actor_raw->ar_num_collcabs,
+                                    actor_raw->ar_collcabs,
+                                    actor_raw->ar_cabs,
+                                    actor_raw->ar_inter_collcabrate,
+                                    actor_raw->ar_nodes,
+                                    actor_raw->ar_collision_range,
+                                   *actor_raw->ar_submesh_ground_model);
                             }
                         });
                     tasks.push_back(func);
@@ -1131,7 +1147,7 @@ void ActorManager::UpdatePhysicsSimulation()
             App::GetThreadPool()->Parallelize(tasks);
         }
     }
-    for (auto actor : m_actors)
+    for (ActorPtr& actor: m_actors)
     {
         actor->m_ongoing_reset = false;
         if (actor->ar_update_physics && m_physics_steps > 0)
@@ -1254,10 +1270,10 @@ RigDef::DocumentPtr ActorManager::FetchActorDef(std::string filename, bool prede
     }
 }
 
-std::vector<Actor*> ActorManager::GetLocalActors()
+std::vector<ActorPtr> ActorManager::GetLocalActors()
 {
-    std::vector<Actor*> actors;
-    for (auto actor : m_actors)
+    std::vector<ActorPtr> actors;
+    for (ActorPtr& actor: m_actors)
     {
         if (actor->ar_state != ActorState::NETWORKED_OK)
             actors.push_back(actor);
@@ -1355,7 +1371,7 @@ void ActorManager::UpdateInputEvents(float dt)
     }
 }
 
-void ActorManager::UpdateTruckFeatures(Actor* vehicle, float dt)
+void ActorManager::UpdateTruckFeatures(ActorPtr vehicle, float dt)
 {
     if (vehicle->isBeingReset() || vehicle->ar_physics_paused)
         return;

--- a/source/main/physics/ActorSlideNode.cpp
+++ b/source/main/physics/ActorSlideNode.cpp
@@ -53,10 +53,10 @@ void Actor::toggleSlideNodeLock()
         }
 
         // check all the slide rail on all the other trucks :(
-        for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
         {
             // make sure this truck is allowed
-            if ((this != actor && !itNode->sn_attach_foreign) || (this == actor && !itNode->sn_attach_self))
+            if ((this != actor.GetRef() && !itNode->sn_attach_foreign) || (this == actor.GetRef() && !itNode->sn_attach_self))
                 continue;
 
             current = GetClosestRailOnActor(actor, (*itNode));
@@ -70,7 +70,7 @@ void Actor::toggleSlideNodeLock()
     m_slidenodes_locked = !m_slidenodes_locked;
 } // is ugly....
 
-std::pair<RailGroup*, Ogre::Real> Actor::GetClosestRailOnActor(Actor* actor, const SlideNode& node)
+std::pair<RailGroup*, Ogre::Real> Actor::GetClosestRailOnActor(ActorPtr actor, const SlideNode& node)
 {
     std::pair<RailGroup*, Ogre::Real> closest((RailGroup*)NULL, std::numeric_limits<Ogre::Real>::infinity());
 

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -1127,14 +1127,14 @@ void ActorSpawner::ProcessSoundSource2(RigDef::SoundSource2 & def)
 #endif // USE_OPENAL
 }
 
-void ActorSpawner::AddSoundSourceInstance(Actor *vehicle, Ogre::String const & sound_script_name, int node_index, int type)
+void ActorSpawner::AddSoundSourceInstance(ActorPtr const& vehicle, Ogre::String const & sound_script_name, int node_index, int type)
 {
 #ifdef USE_OPENAL
     AddSoundSource(vehicle, App::GetSoundScriptManager()->createInstance(sound_script_name, vehicle->ar_instance_id, nullptr), (NodeNum_t)node_index);
 #endif // USE_OPENAL
 }
 
-void ActorSpawner::AddSoundSource(Actor *vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type)
+void ActorSpawner::AddSoundSource(ActorPtr const& vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type)
 {
     if (! CheckSoundScriptLimit(vehicle, 1))
     {
@@ -6005,7 +6005,7 @@ bool ActorSpawner::CheckTexcoordLimit(unsigned int count)
 }
 
 /* Static version */
-bool ActorSpawner::CheckSoundScriptLimit(Actor *vehicle, unsigned int count)
+bool ActorSpawner::CheckSoundScriptLimit(ActorPtr const& vehicle, unsigned int count)
 {
     if ((vehicle->ar_num_soundsources + count) > MAX_SOUNDSCRIPTS_PER_TRUCK)
     {
@@ -6122,7 +6122,7 @@ void ActorSpawner::SetBeamDamping(beam_t & beam, float damping)
     beam.d = damping;
 }
 
-void ActorSpawner::SetupDefaultSoundSources(Actor *vehicle)
+void ActorSpawner::SetupDefaultSoundSources(ActorPtr const& vehicle)
 {
     int trucknum = vehicle->ar_instance_id;
     int ar_exhaust_pos_node = vehicle->ar_exhaust_pos_node;

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -96,13 +96,13 @@ public:
     /// @name Processing
     /// @{
     void                           ConfigureSections(Ogre::String const & sectionconfig, RigDef::DocumentPtr def);
-    void                           ProcessNewActor(Actor *actor, ActorSpawnRequest rq, RigDef::DocumentPtr def);
-    static void                    SetupDefaultSoundSources(Actor *actor);
+    void                           ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef::DocumentPtr def);
+    static void                    SetupDefaultSoundSources(ActorPtr const& actor);
     /// @}
 
     /// @name Utility
     /// @{
-    Actor*                         GetActor() { return m_actor; }
+    ActorPtr                       GetActor() { return m_actor; }
     ActorMemoryRequirements const& GetMemoryRequirements() { return m_memory_requirements; }
     std::string                    GetSubmeshGroundmodelName();
     /// @}
@@ -364,7 +364,7 @@ private:
     bool                          CheckTexcoordLimit(unsigned int count);
     bool                          CheckCabLimit(unsigned int count);
     bool                          CheckCameraRailLimit(unsigned int count);
-    static bool                   CheckSoundScriptLimit(Actor *vehicle, unsigned int count);
+    static bool                   CheckSoundScriptLimit(ActorPtr const& vehicle, unsigned int count);
     bool                          CheckAeroEngineLimit(unsigned int count);
     bool                          CheckScrewpropLimit(unsigned int count);
     /// @}
@@ -418,8 +418,8 @@ private:
 
     /// @name Audio setup
     /// @{
-    static void                   AddSoundSource(Actor *vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type = -2);
-    static void                   AddSoundSourceInstance(Actor *vehicle, Ogre::String const & sound_script_name, int node_index, int type = -2);
+    static void                   AddSoundSource(ActorPtr const& vehicle, SoundScriptInstance *sound_script, NodeNum_t node_index, int type = -2);
+    static void                   AddSoundSourceInstance(ActorPtr const& vehicle, Ogre::String const & sound_script_name, int node_index, int type = -2);
     /// @}
 
     /// Maintenance
@@ -437,7 +437,7 @@ private:
 
     /// @name Settings
     /// @{
-    Actor*                   m_actor;
+    ActorPtr                 m_actor;
     RigDef::DocumentPtr      m_file;
     std::list<std::shared_ptr<RigDef::Document::Module>>
                              m_selected_modules;

--- a/source/main/physics/ActorSpawnerFlow.cpp
+++ b/source/main/physics/ActorSpawnerFlow.cpp
@@ -54,7 +54,7 @@ using namespace RoR;
     this->SetCurrentKeyword(RigDef::Keyword::INVALID);                  \
 }
 
-void ActorSpawner::ProcessNewActor(Actor* actor, ActorSpawnRequest rq, RigDef::DocumentPtr def)
+void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef::DocumentPtr def)
 {
     m_actor = actor;
     m_file = def;

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -281,6 +281,7 @@ enum class ActorState
     NETWORKED_HIDDEN, //!< not simulated, not updated (remote)
     LOCAL_REPLAY,
     LOCAL_SLEEPING,   //!< sleeping (local) actor
+    DISPOSED          //!< removed from simulation, still in memory to satisfy pointers.
 };
 
 enum class AeroEngineType
@@ -360,7 +361,7 @@ struct beam_t
     SpecialBeam     bounded;
     BeamType        bm_type;
     bool            bm_inter_actor;        //!< in case p2 is on another actor
-    Actor*          bm_locked_actor;       //!< in case p2 is on another actor
+    ActorPtr        bm_locked_actor;       //!< in case p2 is on another actor
     bool            bm_disabled;
     bool            bm_broken;
 
@@ -498,7 +499,7 @@ struct hook_t
     node_t* hk_hook_node;
     node_t* hk_lock_node;
     beam_t* hk_beam;
-    Actor*  hk_locked_actor;
+    ActorPtr  hk_locked_actor;
 };
 
 struct ropable_t
@@ -517,12 +518,12 @@ struct rope_t
     int        rp_group;
     beam_t*    rp_beam;
     ropable_t* rp_locked_ropable;
-    Actor*     rp_locked_actor;
+    ActorPtr     rp_locked_actor;
 };
 
 struct tie_t
 {
-    Actor*     ti_locked_actor;
+    ActorPtr     ti_locked_actor;
     beam_t*    ti_beam;
     ropable_t* ti_locked_ropable;
     int        ti_group;
@@ -794,7 +795,7 @@ struct ActorModifyRequest
         WAKE_UP
     };
 
-    Actor*              amr_actor;
+    ActorPtr            amr_actor;
     Type                amr_type;
     std::shared_ptr<rapidjson::Document>
                         amr_saved_state;

--- a/source/main/physics/SlideNode.cpp
+++ b/source/main/physics/SlideNode.cpp
@@ -26,6 +26,7 @@
 
 #include "SlideNode.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "SimData.h"
 

--- a/source/main/physics/air/AirBrake.cpp
+++ b/source/main/physics/air/AirBrake.cpp
@@ -31,7 +31,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Airbrake::Airbrake(Actor* actor, const char* basename, int num, node_t* ndref, node_t* ndx, node_t* ndy, node_t* nda, Ogre::Vector3 pos, float width, float length, float maxang, std::string const & texname, float tx1, float ty1, float tx2, float ty2, float lift_coef)
+Airbrake::Airbrake(ActorPtr actor, const char* basename, int num, node_t* ndref, node_t* ndx, node_t* ndy, node_t* nda, Ogre::Vector3 pos, float width, float length, float maxang, std::string const & texname, float tx1, float ty1, float tx2, float ty2, float lift_coef)
 {
     snode = 0;
     noderef = ndref;

--- a/source/main/physics/air/AirBrake.h
+++ b/source/main/physics/air/AirBrake.h
@@ -59,7 +59,7 @@ private:
     Ogre::Entity* ec;
 
 public:
-    Airbrake(Actor* actor, const char* basename, int num, node_t* ndref, node_t* ndx, node_t* ndy, node_t* nda, Ogre::Vector3 pos, float width, float length, float maxang, std::string const & texname, float tx1, float tx2, float tx3, float tx4, float lift_coef);
+    Airbrake(ActorPtr actor, const char* basename, int num, node_t* ndref, node_t* ndx, node_t* ndy, node_t* nda, Ogre::Vector3 pos, float width, float length, float maxang, std::string const & texname, float tx1, float tx2, float tx3, float tx4, float lift_coef);
     ~Airbrake() {} // Cleanup of visuals is done by GfxActor
 
     void updatePosition(float amount);

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -33,7 +33,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Turbojet::Turbojet(Actor* actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def)
+Turbojet::Turbojet(ActorPtr actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def)
 {
     m_actor = actor;
 #ifdef USE_OPENAL

--- a/source/main/physics/air/TurboJet.h
+++ b/source/main/physics/air/TurboJet.h
@@ -64,7 +64,7 @@ class Turbojet: public AeroEngine, public ZeroedMemoryAllocator
 
 public:
 
-    Turbojet(Actor* actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def);
+    Turbojet(ActorPtr actor, NodeNum_t tnodefront, NodeNum_t tnodeback, NodeNum_t tnoderef, RigDef::Turbojet & def);
     ~Turbojet();
 
     void flipStart();
@@ -128,7 +128,7 @@ private:
     int m_sound_thr;
 
     // Attachment
-    Actor* m_actor;
+    ActorPtr m_actor;
     NodeNum_t m_node_back;
     NodeNum_t m_node_front;
     NodeNum_t m_node_ref;

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -35,7 +35,7 @@ using namespace Ogre;
 using namespace RoR;
 
 Turboprop::Turboprop(
-    Actor* a,
+    ActorPtr a,
     const char* propname,
     NodeNum_t nr,
     NodeNum_t nb,

--- a/source/main/physics/air/TurboProp.h
+++ b/source/main/physics/air/TurboProp.h
@@ -45,7 +45,7 @@ public:
     float max_torque;
 
     Turboprop(
-        Actor* a,
+        ActorPtr a,
         const char* propname,
         NodeNum_t nr,
         NodeNum_t nb,
@@ -131,7 +131,7 @@ private:
     int thr_id;
 
     // Attachment
-    Actor* m_actor;
+    ActorPtr m_actor;
     NodeNum_t nodeback;
     NodeNum_t noderef;
     NodeNum_t nodep[4];

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -900,7 +900,7 @@ bool Collisions::collisionCorrect(Vector3 *refpos, bool envokeScriptCallbacks)
     return contacted;
 }
 
-bool Collisions::permitEvent(Actor* b, CollisionEventFilter filter)
+bool Collisions::permitEvent(ActorPtr b, CollisionEventFilter filter)
 {
     switch (filter)
     {

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -149,7 +149,7 @@ private:
     eventsource_t eventsources[MAX_EVENT_SOURCE];
     int free_eventsource;
 
-    bool permitEvent(Actor* actor, CollisionEventFilter filter);
+    bool permitEvent(ActorPtr actor, CollisionEventFilter filter);
 
     Landusemap* landuse;
     int collision_version;

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -48,8 +48,8 @@ void PointColDetector::UpdateInterPoint(bool ignorestate)
     m_linked_actors = m_actor->getAllLinkedActors();
 
     int contacters_size = 0;
-    std::vector<Actor*> collision_partners;
-    for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+    std::vector<ActorPtr> collision_partners;
+    for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
         if (actor != m_actor && (ignorestate || actor->ar_update_physics) &&
                 m_actor->ar_bounding_box.intersects(actor->ar_bounding_box))
@@ -94,7 +94,7 @@ void PointColDetector::update_structures_for_contacters(bool ignoreinternal)
 
     // Insert all contacters into the list of points to consider when building the kdtree
     int refi = 0;
-    for (auto actor : m_collision_partners)
+    for (ActorPtr actor : m_collision_partners)
     {
         bool is_linked = std::find(m_linked_actors.begin(), m_linked_actors.end(), actor) != m_linked_actors.end();
         bool internal_collision = !ignoreinternal && ((actor == m_actor) || is_linked);

--- a/source/main/physics/collision/PointColDetector.h
+++ b/source/main/physics/collision/PointColDetector.h
@@ -35,13 +35,13 @@ public:
 
     struct pointid_t
     {
-        Actor* actor;
+        ActorPtr actor;
         short node_id;
     };
 
     std::vector<pointid_t*> hit_list;
 
-    PointColDetector(Actor* actor): m_actor(actor), m_object_list_size(-1) {};
+    PointColDetector(ActorPtr actor): m_actor(actor), m_object_list_size(-1) {};
 
     void UpdateIntraPoint(bool contactables = false);
     void UpdateInterPoint(bool ignorestate = false);
@@ -65,9 +65,9 @@ private:
         int begin;
     };
 
-    Actor*                 m_actor;
-    std::vector<Actor*>    m_linked_actors;
-    std::vector<Actor*>    m_collision_partners;
+    ActorPtr                 m_actor;
+    std::vector<ActorPtr>    m_linked_actors;
+    std::vector<ActorPtr>    m_collision_partners;
     std::vector<refelem_t> m_ref_list;
     std::vector<pointid_t> m_pointid_list;
     std::vector<kdnode_t>  m_kdtree;

--- a/source/main/physics/flex/FlexAirfoil.cpp
+++ b/source/main/physics/flex/FlexAirfoil.cpp
@@ -74,7 +74,7 @@ float refairfoilpos[90]={
 
 using namespace Ogre;
 
-FlexAirfoil::FlexAirfoil(Ogre::String const & name, Actor* actor, NodeNum_t pnfld, NodeNum_t pnfrd, NodeNum_t pnflu, NodeNum_t pnfru, NodeNum_t pnbld, NodeNum_t pnbrd, NodeNum_t pnblu, NodeNum_t pnbru, std::string const & texband, Vector2 texlf, Vector2 texrf, Vector2 texlb, Vector2 texrb, char mtype, float controlratio, float mind, float maxd, Ogre::String const & afname, float lift_coef, bool break_able)
+FlexAirfoil::FlexAirfoil(Ogre::String const & name, ActorPtr actor, NodeNum_t pnfld, NodeNum_t pnfrd, NodeNum_t pnflu, NodeNum_t pnfru, NodeNum_t pnbld, NodeNum_t pnbrd, NodeNum_t pnblu, NodeNum_t pnbru, std::string const & texband, Vector2 texlf, Vector2 texrf, Vector2 texlb, Vector2 texrb, char mtype, float controlratio, float mind, float maxd, Ogre::String const & afname, float lift_coef, bool break_able)
     :nfld(pnfld)
     ,nfrd(pnfrd)
     ,nflu(pnflu)

--- a/source/main/physics/flex/FlexAirfoil.h
+++ b/source/main/physics/flex/FlexAirfoil.h
@@ -33,7 +33,7 @@ namespace RoR {
 class FlexAirfoil : public ZeroedMemoryAllocator
 {
 public:
-    FlexAirfoil(Ogre::String const& wname, Actor* actor,
+    FlexAirfoil(Ogre::String const& wname, ActorPtr actor,
         NodeNum_t pnfld, NodeNum_t pnfrd, NodeNum_t pnflu, NodeNum_t pnfru, NodeNum_t pnbld, NodeNum_t pnbrd, NodeNum_t pnblu, NodeNum_t pnbru,
         std::string const & texname,
         Ogre::Vector2 texlf, Ogre::Vector2 texrf, Ogre::Vector2 texlb, Ogre::Vector2 texrb,

--- a/source/main/physics/water/ScrewProp.cpp
+++ b/source/main/physics/water/ScrewProp.cpp
@@ -34,7 +34,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-Screwprop::Screwprop(Actor* a, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float fullpower) :
+Screwprop::Screwprop(ActorPtr a, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float fullpower) :
     m_actor(a)
     , noderef(noderef)
     , nodeback(nodeback)

--- a/source/main/physics/water/ScrewProp.h
+++ b/source/main/physics/water/ScrewProp.h
@@ -35,7 +35,7 @@ class Screwprop : public ZeroedMemoryAllocator
 {
 public:
 
-    Screwprop( Actor* actor, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float power);
+    Screwprop( ActorPtr actor, NodeNum_t noderef, NodeNum_t nodeback, NodeNum_t nodeup, float power);
 
     void updateForces(int update);
     void setThrottle(float val);
@@ -54,7 +54,7 @@ private:
     float throtle;
 
     // Attachment
-    Actor*    m_actor;
+    ActorPtr    m_actor;
     NodeNum_t nodeback;
     NodeNum_t noderef;
     NodeNum_t nodeup;

--- a/source/main/resources/odef_fileformat/ODefFileFormat.cpp
+++ b/source/main/resources/odef_fileformat/ODefFileFormat.cpp
@@ -19,6 +19,7 @@
 
 #include "ODefFileFormat.h"
 
+#include "Actor.h"
 #include "Utils.h"
 
 using namespace RoR;

--- a/source/main/resources/rig_def_fileformat/RigDef_File.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.cpp
@@ -24,6 +24,8 @@
 /// @date   12/2013
 
 #include "RigDef_File.h"
+
+#include "Actor.h"
 #include "SimConstants.h"
 
 namespace RigDef

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -145,6 +145,7 @@ enum class Keyword
     ROTATORS,
     ROTATORS2,
     SCREWPROPS,
+    SCRIPTS,
     SECTION,
     SECTIONCONFIG,
     SET_BEAM_DEFAULTS,
@@ -1158,6 +1159,11 @@ struct Screwprop
     float power = 0.f;
 };
 
+struct Script
+{
+    std::string filename;
+};
+
 struct ShadowOptions
 {
     int shadow_mode = 0;
@@ -1610,6 +1616,7 @@ struct Document
         std::vector<Rotator>               rotators;
         std::vector<Rotator2>              rotators2;
         std::vector<Screwprop>             screwprops;
+        std::vector<Script>                scripts;
         std::vector<Shock>                 shocks;
         std::vector<Shock2>                shocks2;
         std::vector<Shock3>                shocks3;

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -275,6 +275,7 @@ void Parser::ProcessCurrentLine()
         case Keyword::ROTATORS:
         case Keyword::ROTATORS2:            this->ParseRotatorsUnified();         return;
         case Keyword::SCREWPROPS:           this->ParseScrewprops();              return;
+        case Keyword::SCRIPTS:              this->ParseScripts();                 return;
         case Keyword::SHOCKS:               this->ParseShock();                   return;
         case Keyword::SHOCKS2:              this->ParseShock2();                  return;
         case Keyword::SHOCKS3:              this->ParseShock3();                  return;
@@ -2098,6 +2099,17 @@ void Parser::ParseScrewprops()
     screwprop.power     = this->GetArgFloat  (3);
 
     m_current_module->screwprops.push_back(screwprop);
+}
+
+void Parser::ParseScripts()
+{
+    if (!this->CheckNumArguments(1)) { return; }
+
+    Script script;
+
+    script.filename = this->GetArgStr(0);
+
+    m_current_module->scripts.push_back(script);
 }
 
 void Parser::ParseRotatorsUnified()

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -25,6 +25,7 @@
 
 #include "RigDef_Parser.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "SimConstants.h"
 #include "CacheSystem.h"

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.h
@@ -161,6 +161,7 @@ private:
     void ParseRopes();
     void ParseRotatorsUnified();
     void ParseScrewprops();
+    void ParseScripts();
     void ParseSetCollisionRange();
     void ParseSetSkeletonSettings();
     void ParseShock();

--- a/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
@@ -194,6 +194,7 @@ namespace Regexes
     E_KEYWORD_BLOCK("rotators")                                   \
     E_KEYWORD_BLOCK("rotators2")                                  \
     E_KEYWORD_BLOCK("screwprops")                                 \
+    E_KEYWORD_BLOCK("scripts")                                    \
     E_KEYWORD_INLINE("section")                                   \
     E_KEYWORD_INLINE("sectionconfig")                             \
     E_KEYWORD_INLINE("set_beam_defaults")                         \

--- a/source/main/resources/rig_def_fileformat/RigDef_SequentialImporter.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_SequentialImporter.cpp
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include "RigDef_SequentialImporter.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Console.h"
 #include "RigDef_Parser.h"

--- a/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Serializer.cpp
@@ -25,6 +25,7 @@
 
 #include "RigDef_Serializer.h"
 
+#include "Actor.h"
 #include "RigDef_File.h"
 
 #include <fstream>

--- a/source/main/resources/rig_def_fileformat/RigDef_Validator.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Validator.cpp
@@ -25,6 +25,7 @@
 
 #include "RigDef_Validator.h"
 
+#include "Actor.h"
 #include "SimConstants.h"
 #include "Application.h"
 #include "Console.h"

--- a/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
@@ -19,6 +19,7 @@
 
 #include "TObjFileFormat.h"
 
+#include "Actor.h"
 #include "ProceduralRoad.h"
 
 #define LOGSTREAM Ogre::LogManager::getSingleton().stream() << "[RoR|TObj fileformat] "

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -234,7 +234,7 @@ float GameScript::getWaterHeight()
     return result;
 }
 
-Actor* GameScript::getCurrentTruck()
+ActorPtr GameScript::getCurrentTruck()
 {
     return App::GetGameContext()->GetPlayerActor();
 }
@@ -257,7 +257,7 @@ void GameScript::setGravity(float value)
     App::GetGameContext()->GetTerrain()->setGravity(value);
 }
 
-Actor* GameScript::getTruckByNum(int num)
+ActorPtr GameScript::getTruckByNum(int num)
 {
     return App::GetGameContext()->GetActorManager()->GetActorById(num);
 }
@@ -270,7 +270,7 @@ int GameScript::getNumTrucks()
 int GameScript::getNumTrucksByFlag(int flag)
 {
     int result = 0;
-    for (auto actor : App::GetGameContext()->GetActorManager()->GetActors())
+    for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
     {
         if (!flag || static_cast<int>(actor->ar_state) == flag)
             result++;
@@ -280,7 +280,7 @@ int GameScript::getNumTrucksByFlag(int flag)
 
 int GameScript::getCurrentTruckNumber()
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     return (actor != nullptr) ? actor->ar_instance_id : -1;
 }
 
@@ -374,10 +374,10 @@ void GameScript::repairVehicle(const String& instance, const String& box, bool k
 
 void GameScript::removeVehicle(const String& event_source_instance_name, const String& event_source_box_name)
 {
-    Actor* actor = App::GetGameContext()->FindActorByCollisionBox(event_source_instance_name, event_source_box_name);
+    ActorPtr actor = App::GetGameContext()->FindActorByCollisionBox(event_source_instance_name, event_source_box_name);
     if (actor)
     {
-        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, (void*)actor));
+        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
     }
 }
 
@@ -767,7 +767,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     if (unit_id == SCRIPTUNITID_INVALID)
         return 2;
 
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
     if (player_actor == nullptr)
         return 1;
@@ -800,7 +800,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     j_doc.AddMember("actor-hash", rapidjson::StringRef(player_actor->ar_filehash.c_str()), j_doc.GetAllocator());
 
     rapidjson::Value j_linked_actors(rapidjson::kArrayType);
-    for (auto actor : player_actor->getAllLinkedActors())
+    for (ActorPtr actor : player_actor->getAllLinkedActors())
     {
         rapidjson::Value j_actor(rapidjson::kObjectType);
         j_actor.AddMember("actor-name", rapidjson::StringRef(actor->ar_design_name.c_str()), j_doc.GetAllocator());
@@ -855,7 +855,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
 
 void GameScript::boostCurrentTruck(float factor)
 {
-    Actor* actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr actor = App::GetGameContext()->GetPlayerActor();
     if (actor && actor->ar_engine)
     {
         float rpm = actor->ar_engine->GetEngineRpm();
@@ -915,7 +915,7 @@ VehicleAIPtr GameScript::getCurrentTruckAI()
 VehicleAIPtr GameScript::getTruckAIByNum(int num)
 {
     VehicleAIPtr result = nullptr;
-    Actor* actor = App::GetGameContext()->GetActorManager()->GetActorById(num);
+    ActorPtr actor = App::GetGameContext()->GetActorManager()->GetActorById(num);
     if (actor != nullptr)
     {
         result = actor->ar_vehicle_ai;
@@ -923,7 +923,7 @@ VehicleAIPtr GameScript::getTruckAIByNum(int num)
     return result;
 }
 
-Actor* GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot)
+ActorPtr GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot)
 {
     ActorSpawnRequest rq;
     rq.asr_position = pos;
@@ -932,7 +932,7 @@ Actor* GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre:
     return App::GetGameContext()->SpawnActor(rq);
 }
 
-Actor* GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x)
+ActorPtr GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x)
 {
     ActorSpawnRequest rq;
     rq.asr_position = pos;

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -934,25 +934,33 @@ ActorPtr GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogr
 
 ActorPtr GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x)
 {
-    ActorSpawnRequest rq;
-    rq.asr_position = pos;
-
-    // Set rotation based on first two waypoints
-    std::vector<Ogre::Vector3> waypoints = App::GetGuiManager()->SurveyMap.ai_waypoints;
-    if (App::GetGuiManager()->TopMenubar.ai_mode == 3 && x == 1) // Crash driving mode
+    try
     {
-        std::reverse(waypoints.begin(), waypoints.end());
+        ActorSpawnRequest rq;
+        rq.asr_position = pos;
+
+        // Set rotation based on first two waypoints
+        std::vector<Ogre::Vector3> waypoints = App::GetGuiManager()->SurveyMap.ai_waypoints;
+        if (App::GetGuiManager()->TopMenubar.ai_mode == 3 && x == 1) // Crash driving mode
+        {
+            std::reverse(waypoints.begin(), waypoints.end());
+        }
+
+        Ogre::Vector3 dir = waypoints[0] - waypoints[1];
+        dir.y = 0;
+        rq.asr_rotation = Ogre::Vector3::UNIT_X.getRotationTo(dir, Ogre::Vector3::UNIT_Y);
+
+        rq.asr_filename = truckName;
+        rq.asr_config = truckSectionConfig;
+        rq.asr_skin_entry = App::GetCacheSystem()->FetchSkinByName(truckSkin);
+        rq.asr_origin = ActorSpawnRequest::Origin::AI;
+        return App::GetGameContext()->SpawnActor(rq);
     }
-
-    Ogre::Vector3 dir = waypoints[0] - waypoints[1];
-    dir.y = 0;
-    rq.asr_rotation = Ogre::Vector3::UNIT_X.getRotationTo(dir, Ogre::Vector3::UNIT_Y);
-
-    rq.asr_filename = truckName;
-    rq.asr_config = truckSectionConfig;
-    rq.asr_skin_entry = App::GetCacheSystem()->FetchSkinByName(truckSkin);
-    rq.asr_origin = ActorSpawnRequest::Origin::AI;
-    return App::GetGameContext()->SpawnActor(rq);
+    catch (std::exception& ex)
+    {
+        this->log(fmt::format("Error running `spawnTruckAI()` - got exception '{}'", ex.what()));
+        return ActorPtr();
+    }
 }
 
 AngelScript::CScriptArray* GameScript::getWaypoints(int x)

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -326,13 +326,13 @@ public:
      * returns the current selected truck, 0 if in person mode
      * @return reference to Beam object that is currently in use
      */
-    Actor* getCurrentTruck();
+    ActorPtr getCurrentTruck();
 
     /**
      * returns a truck by index, get max index by calling getNumTrucks
      * @return reference to Beam object that the selected slot
      */
-    Actor* getTruckByNum(int num);
+    ActorPtr getTruckByNum(int num);
 
     /**
      * returns the current amount of loaded trucks
@@ -346,8 +346,8 @@ public:
      */
     int getCurrentTruckNumber();
 
-    Actor* spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot);
-    Actor* spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x);
+    ActorPtr spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::Vector3& rot);
+    ActorPtr spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x);
     AngelScript::CScriptArray* getWaypoints(int x);
     void addWaypoint(const Ogre::Vector3& pos);
     int getAIVehicleCount();

--- a/source/main/scripting/LocalStorage.cpp
+++ b/source/main/scripting/LocalStorage.cpp
@@ -21,6 +21,7 @@
 
 #include "LocalStorage.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "ContentManager.h"
 #include "PlatformUtils.h"

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -503,7 +503,7 @@ int ScriptEngine::deleteVariable(const String &arg)
 
 void ScriptEngine::triggerEvent(int eventnum, int value)
 {
-    if (!engine || !context) return;
+    if (!engine || !context || !m_events_enabled) return;
 
     for (auto& pair: m_script_units)
     {

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -51,7 +51,8 @@ namespace RoR {
 enum class ScriptCategory
 {
     INVALID,
-    TERRAIN,
+    ACTOR,   //!< Defined in truck file under 'scripts', contains global variable `BeamClass@ thisActor`.
+    TERRAIN, //!< Defined in terrn2 file under '[Scripts]', receives terrain eventbox notifications.
     CUSTOM
 };
 
@@ -70,6 +71,7 @@ struct ScriptUnit
     AngelScript::asIScriptFunction* frameStepFunctionPtr = nullptr; //!< script function pointer to the frameStep function
     AngelScript::asIScriptFunction* eventCallbackFunctionPtr = nullptr; //!< script function pointer to the event callback function
     AngelScript::asIScriptFunction* defaultEventCallbackFunctionPtr = nullptr; //!< script function pointer for spawner events
+    ActorPtr associatedActor; //!< For ScriptCategory::ACTOR
     Ogre::String scriptName;
     Ogre::String scriptHash;
 };
@@ -94,7 +96,7 @@ public:
      * @param scriptname filename to load
      * @return Unique ID of the script unit (because one script file can be loaded multiple times).
      */
-    ScriptUnitId_t loadScript(Ogre::String scriptname, ScriptCategory category = ScriptCategory::TERRAIN);
+    ScriptUnitId_t loadScript(Ogre::String scriptname, ScriptCategory category = ScriptCategory::TERRAIN, ActorPtr associatedActor = nullptr);
 
     /**
      * Unloads a script

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -117,6 +117,8 @@ public:
      */
     void triggerEvent(int scriptEvents, int value = 0);
 
+    void setEventsEnabled(bool val) { m_events_enabled = val; }
+
     /**
      * executes a string (useful for the console)
      * @param command string to execute
@@ -207,6 +209,7 @@ protected:
     ScriptUnitMap   m_script_units;
     ScriptUnitId_t  m_terrain_script_unit = SCRIPTUNITID_INVALID;
     ScriptUnitId_t  m_currently_executing_script_unit = SCRIPTUNITID_INVALID;
+    bool            m_events_enabled = true; //!< Hack to enable fast shutdown without cleanup
 
     InterThreadStoreVector<Ogre::String> stringExecutionQueue; //!< The string execution queue \see queueStringForExecution
 };

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -69,7 +69,8 @@ void RoR::RegisterActor(asIScriptEngine *engine)
 
 
     // class Actor (historically Beam)
-    result = engine->RegisterObjectType("BeamClass", sizeof(Actor), asOBJ_REF); ROR_ASSERT(result>=0);
+    Actor::RegisterRefCountingObject(engine, "BeamClass");
+    ActorPtr::RegisterRefCountingObjectPtr(engine, "BeamClassPtr", "BeamClass");
 
     // - physics state (PLEASE maintain the same order as 'Actor.h' and 'doc/angelscript/.../BeamClass.h')
     result = engine->RegisterObjectMethod("BeamClass", "TruckState getTruckState()", asMETHOD(Actor,getTruckState), asCALL_THISCALL); ROR_ASSERT(result>=0);
@@ -96,7 +97,6 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "void toggleCustomParticles()", asMETHOD(Actor,toggleCustomParticles), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool getCustomParticleMode()", asMETHOD(Actor,getCustomParticleMode), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool isLocked()", asMETHOD(Actor,isLocked), asCALL_THISCALL); ROR_ASSERT(result>=0);
-
     // - subsystems (PLEASE maintain the same order as 'Actor.h' and 'doc/angelscript/.../BeamClass.h')
     result = engine->RegisterObjectMethod("BeamClass", "VehicleAIClassPtr @getVehicleAI()", asMETHOD(Actor,getVehicleAI), asCALL_THISCALL); ROR_ASSERT(result>=0);
 
@@ -118,9 +118,4 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "string getTruckFileResourceGroup()", asMETHOD(Actor, getTruckFileResourceGroup), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "int  getTruckType()", asMETHOD(Actor,getTruckType), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "string getSectionConfig()", asMETHOD(Actor, getSectionConfig), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-
-    // - refcount
-    result = engine->RegisterObjectBehaviour("BeamClass", asBEHAVE_ADDREF, "void f()", asMETHOD(Actor,addRef), asCALL_THISCALL); ROR_ASSERT(result>=0);
-    result = engine->RegisterObjectBehaviour("BeamClass", asBEHAVE_RELEASE, "void f()", asMETHOD(Actor,release), asCALL_THISCALL); ROR_ASSERT(result>=0);
-
 }

--- a/source/main/scripting/bindings/GameScriptAngelscript.cpp
+++ b/source/main/scripting/bindings/GameScriptAngelscript.cpp
@@ -96,12 +96,12 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("GameScriptClass", "void activateAllVehicles()", asMETHOD(GameScript,activateAllVehicles), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void setTrucksForcedActive(bool forceActive)", asMETHOD(GameScript,setTrucksForcedAwake), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void boostCurrentTruck(float)", asMETHOD(GameScript, boostCurrentTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @getCurrentTruck()", asMETHOD(GameScript, getCurrentTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @getTruckByNum(int)", asMETHOD(GameScript, getTruckByNum), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @getCurrentTruck()", asMETHOD(GameScript, getCurrentTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @getTruckByNum(int)", asMETHOD(GameScript, getTruckByNum), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getNumTrucks()", asMETHOD(GameScript, getNumTrucks), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getCurrentTruckNumber()", asMETHOD(GameScript, getCurrentTruckNumber), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @spawnTruck(string &in, vector3 &in, vector3 &in)", asMETHOD(GameScript, spawnTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClass @spawnTruckAI(string &in, vector3 &in, string &in, string &in, int x)", AngelScript::asMETHOD(GameScript, spawnTruckAI), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @spawnTruck(string &in, vector3 &in, vector3 &in)", asMETHOD(GameScript, spawnTruck), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @spawnTruckAI(string &in, vector3 &in, string &in, string &in, int x)", AngelScript::asMETHOD(GameScript, spawnTruckAI), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "array<vector3> @getWaypoints(int x)", AngelScript::asMETHOD(GameScript, getWaypoints), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void addWaypoint(vector3 &in)", asMETHOD(GameScript, addWaypoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleCount()", AngelScript::asMETHOD(GameScript, getAIVehicleCount), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);

--- a/source/main/system/AppConfig.cpp
+++ b/source/main/system/AppConfig.cpp
@@ -19,6 +19,7 @@
     along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "Actor.h"
 #include "Application.h"
 #include "Console.h"
 #include "ContentManager.h" // RGN_CONFIG

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -136,7 +136,7 @@ public:
         reply << m_name << ": ";
         Console::MessageType reply_type = Console::CONSOLE_SYSTEM_REPLY;
         Ogre::Vector3 pos;
-        Actor* const actor = App::GetGameContext()->GetPlayerActor();
+        ActorPtr const actor = App::GetGameContext()->GetPlayerActor();
         if (actor)
         {
             pos = actor->getPosition();
@@ -256,7 +256,7 @@ public:
         reply << m_name << ": ";
         Console::MessageType reply_type = Console::CONSOLE_SYSTEM_REPLY;
 
-        Actor* b = App::GetGameContext()->GetPlayerActor();
+        ActorPtr b = App::GetGameContext()->GetPlayerActor();
         if (!b && App::GetGameContext()->GetPlayerCharacter())
         {
             Ogre::Vector3 pos = App::GetGameContext()->GetPlayerCharacter()->getPosition();
@@ -296,7 +296,7 @@ public:
             reply_type = Console::CONSOLE_SYSTEM_REPLY;
             Ogre::Vector3 pos(PARSEREAL(args[1]), PARSEREAL(args[2]), PARSEREAL(args[3]));
 
-            Actor* b = App::GetGameContext()->GetPlayerActor();
+            ActorPtr b = App::GetGameContext()->GetPlayerActor();
             if (!b && App::GetGameContext()->GetPlayerCharacter())
             {
                 App::GetGameContext()->GetPlayerCharacter()->setPosition(pos);

--- a/source/main/terrain/ProceduralRoad.cpp
+++ b/source/main/terrain/ProceduralRoad.cpp
@@ -20,6 +20,7 @@
 
 #include "ProceduralRoad.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "Collisions.h"
 #include "Console.h"

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -21,6 +21,7 @@
 
 #include "TerrainGeometryManager.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "ContentManager.h"
 #include "Language.h"

--- a/source/main/utils/ForceFeedback.cpp
+++ b/source/main/utils/ForceFeedback.cpp
@@ -112,7 +112,7 @@ void ForceFeedback::Update()
         return;
     }
 
-    Actor* player_actor = App::GetGameContext()->GetPlayerActor();
+    ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
     if (player_actor && player_actor->ar_driveable == TRUCK)
     {
         Ogre::Vector3 ff_vehicle = player_actor->GetFFbBodyForces();

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -21,6 +21,7 @@
 
 #include "InputEngine.h"
 
+#include "Actor.h"
 #include "AppContext.h"
 #include "Console.h"
 #include "ContentManager.h"

--- a/source/main/utils/MeshObject.cpp
+++ b/source/main/utils/MeshObject.cpp
@@ -24,6 +24,7 @@
 
 #include "MeshObject.h"
 
+#include "Actor.h"
 #include "Application.h"
 #include "GfxScene.h"
 #include "MeshLodGenerator/OgreMeshLodGenerator.h"


### PR DESCRIPTION
The scripts work the same as terrain/custom scripts but they have an extra global variable `thisActor` pointing to the associated actor.

![obrazek](https://user-images.githubusercontent.com/491088/210435963-1832c013-f85d-4aaf-b00b-10fdee716b3e.png)

![obrazek](https://user-images.githubusercontent.com/491088/210436311-2d40a74b-5613-474c-bfb5-a043338b6f36.png)

Elementary test vehicle:
[dafsemi-scripttest.zip](https://github.com/RigsOfRods/rigs-of-rods/files/10339592/dafsemi-scripttest.zip)



