### PR TITLE
Added 'default_skin' directive to truck file format

### DIFF
--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -27,6 +27,7 @@
 
 #include "Actor.h"
 #include "ActorManager.h"
+#include "CacheSystem.h"
 #include "CharacterFactory.h"
 #include "RaceSystem.h"
 #include "RecoveryMode.h"
@@ -194,6 +195,7 @@ private:
     CacheEntry*         m_last_skin_selection = nullptr;
     Ogre::String        m_last_section_config;
     ActorSpawnRequest   m_current_selection;                //!< Context of the loader UI
+    CacheEntry          m_dummy_cache_selection;
 
     // Characters (simplified physics and netcode)
     CharacterFactory    m_character_factory;

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -41,7 +41,7 @@ public:
     const float LEFT_PANE_WIDTH = 250.f;
     const float PREVIEW_SIZE_RATIO = 0.7f;
 
-    void Show(LoaderType type, std::string const& filter_guid = "");
+    void Show(LoaderType type, std::string const& filter_guid = "", CacheEntry* advertised_entry = nullptr);
     bool IsVisible() { return m_loader_type != LT_None; };
     bool IsHovered() { return IsVisible() && m_is_hovered; }
     bool m_kb_focused = true;
@@ -91,7 +91,7 @@ private:
     Str<500>           m_search_input;
     bool               m_show_details = false;
     bool               m_searchbox_was_active = false;
-    CacheEntry         m_dummy_skin;
+    CacheEntry*        m_advertised_entry = nullptr; //!< Always shown on top, even if not existing in modcache (i.e. dummy default skin)
     bool               m_is_hovered = false;
 
     int                m_selected_category = 0;    //!< Combobox position (uses display list)

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -258,6 +258,7 @@ void CacheSystem::ImportEntryFromJson(rapidjson::Value& j_entry, CacheEntry & ou
     // Vehicle details
     out_entry.description =       j_entry["description"].GetString();
     out_entry.tags =              j_entry["tags"].GetString();
+    out_entry.default_skin =      j_entry["default_skin"].GetString();
     out_entry.fileformatversion = j_entry["fileformatversion"].GetInt();
     out_entry.hasSubmeshs =       j_entry["hasSubmeshs"].GetBool();
     out_entry.nodecount =         j_entry["nodecount"].GetInt();
@@ -517,6 +518,7 @@ void CacheSystem::ExportEntryToJson(rapidjson::Value& j_entries, rapidjson::Docu
     // Vehicle details
     j_entry.AddMember("description",         rapidjson::StringRef(entry.description.c_str()),       j_doc.GetAllocator());
     j_entry.AddMember("tags",                rapidjson::StringRef(entry.tags.c_str()),              j_doc.GetAllocator());
+    j_entry.AddMember("default_skin",        rapidjson::StringRef(entry.default_skin.c_str()),      j_doc.GetAllocator());
     j_entry.AddMember("fileformatversion",   entry.fileformatversion, j_doc.GetAllocator());
     j_entry.AddMember("hasSubmeshs",         entry.hasSubmeshs,       j_doc.GetAllocator());
     j_entry.AddMember("nodecount",           entry.nodecount,         j_doc.GetAllocator());
@@ -742,6 +744,12 @@ void CacheSystem::FillTruckDetailInfo(CacheEntry& entry, Ogre::DataStreamPtr str
         author.type = author_itor->type;
 
         entry.authors.push_back(author);
+    }
+
+    /* Default skin */
+    if (def->root_module->default_skin.size() > 0)
+    {
+        entry.default_skin = def->root_module->default_skin.back().skin_name;
     }
 
     /* Modules (previously called "sections") */

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -36,7 +36,7 @@
 #include <string>
 
 #define CACHE_FILE "mods.cache"
-#define CACHE_FILE_FORMAT 11
+#define CACHE_FILE_FORMAT 12
 #define CACHE_FILE_FRESHNESS 86400 // 60*60*24 = one day
 
 namespace RoR {
@@ -88,6 +88,7 @@ public:
     // following all TRUCK detail information:
     Ogre::String description;
     Ogre::String tags;
+    std::string default_skin;
     int fileformatversion;
     bool hasSubmeshs;
     int nodecount;

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -85,6 +85,7 @@ enum class Keyword
     COMMENT,
     CONTACTERS,
     CRUISECONTROL,
+    DEFAULT_SKIN,
     DESCRIPTION,
     DETACHER_GROUP,
     DISABLEDEFAULTSOUNDS,
@@ -785,6 +786,11 @@ struct CruiseControl
 struct DefaultMinimass
 {
     float min_mass_Kg = DEFAULT_MINIMASS; //!< minimum node mass in Kg
+};
+
+struct DefaultSkin
+{
+    std::string skin_name;
 };
 
 struct Engine
@@ -1566,6 +1572,7 @@ struct Document
         std::vector<Command2>              commands2; // 'commands' are auto-imported as 'commands2' (only 1 extra argument)
         std::vector<CruiseControl>         cruisecontrol;
         std::vector<Node::Ref>             contacters;
+        std::vector<DefaultSkin>           default_skin;
         std::vector<Ogre::String>          description;
         std::vector<Engine>                engine;
         std::vector<Engoption>             engoption;

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -38,6 +38,8 @@
 #include <OgreStringVector.h>
 #include <OgreStringConverter.h>
 
+#include <algorithm>
+
 using namespace RoR;
 
 namespace RigDef
@@ -132,6 +134,9 @@ void Parser::ProcessCurrentLine()
             return;
         case Keyword::CRUISECONTROL:
             this->ParseCruiseControl();
+            return;
+        case Keyword::DEFAULT_SKIN:
+            this->ParseDirectiveDefaultSkin();
             return;
         case Keyword::DETACHER_GROUP:
             this->ParseDirectiveDetacherGroup();
@@ -1036,6 +1041,17 @@ void Parser::ParseFileFormatVersion()
 
     m_current_module->fileformatversion.push_back(ffv);
     m_current_block = Keyword::INVALID;
+}
+
+void Parser::ParseDirectiveDefaultSkin()
+{
+    if (!this->CheckNumArguments(2)) { return; } // 2 items: keyword, param
+
+    DefaultSkin data;
+    data.skin_name = this->GetArgStr(1);
+    std::replace(data.skin_name.begin(), data.skin_name.end(), '_', ' ');
+
+    m_current_module->default_skin.push_back(data);
 }
 
 void Parser::ParseDirectiveDetacherGroup()

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.h
@@ -90,6 +90,7 @@ private:
     void ProcessGlobalDirective(Keyword keyword); //!< Directives that should only appear in root module
     void ParseDirectiveAddAnimation();
     void ParseDirectiveBackmesh();
+    void ParseDirectiveDefaultSkin();
     void ParseDirectiveDetacherGroup();
     void ParseDirectiveFlexbodyCameraMode();
     void ParseDirectiveForset();

--- a/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
@@ -134,6 +134,7 @@ namespace Regexes
     E_KEYWORD_BLOCK("comment")                                    \
     E_KEYWORD_BLOCK("contacters")                                 \
     E_KEYWORD_INLINE("cruisecontrol")                             \
+    E_KEYWORD_INLINE("default_skin")                              \
     E_KEYWORD_BLOCK("description")                                \
     E_KEYWORD_INLINE("detacher_group")                            \
     E_KEYWORD_BLOCK("disabledefaultsounds")                       \


### PR DESCRIPTION
Syntax: default_skin <skin_name_with_underscores_for_spaces>
Example: `default_skin Viper_Yellow/Black_Stripe`

This works with classic .skin files (which may be in the mod ZIP itself or separate SKINZIP). When used, the game will display that skin on top of skin selector, instead of the dummy "Default skin" entry. If no other skins are found, the game will apply this skin automatically and won't display the selector at all.

Closes #2990 
Closes #2909

Cache file version was bumped from 11 to 12 because it must remember the skin name.
The selector UI displays the default skin in the details.

![obrazek](https://user-images.githubusercontent.com/491088/210479995-bccc7541-f616-4170-b493-b206bf2df632.png)
![obrazek](https://user-images.githubusercontent.com/491088/210480062-428a1f37-e5cc-440e-9161-3f558e314fde.png)
