### PR TITLE
Don't show top menu bar and vehicle buttons when rotating camera

### DIFF
--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -1360,6 +1360,11 @@ bool TopMenubar::ShouldDisplay(ImVec2 window_pos)
         return false;
     }
 
+    if (ImGui::IsMouseDown(1))
+    {
+        return false;
+    }
+
     if (ai_menu)
     {
         m_open_menu = TopMenu::TOPMENU_AI;

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -71,7 +71,7 @@ void VehicleButtons::Draw(RoR::GfxActor* actorx)
 
     // Show when mouse is on the left of screen
     if (App::GetGuiManager()->AreStaticMenusAllowed() &&
-        (ImGui::GetIO().MousePos.x <= window_pos.x + ImGui::GetStyle().WindowPadding.x) && ImGui::GetIO().MousePos.y <= ImGui::GetIO().DisplaySize.y)
+        (ImGui::GetIO().MousePos.x <= window_pos.x + ImGui::GetStyle().WindowPadding.x) && ImGui::GetIO().MousePos.y <= ImGui::GetIO().DisplaySize.y && !ImGui::IsMouseDown(1))
     {
         is_visible = true;
     }


### PR DESCRIPTION
Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/2998