### PR TITLE
Any node now activates script event boxes

### DIFF
--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -402,6 +402,8 @@ public:
     float             ar_collision_range;             //!< Physics attr
     float             ar_top_speed;                   //!< Sim state
     ground_model_t*   ar_last_fuzzy_ground_model;     //!< GUI state
+    CollisionBoxPtrVec m_potential_eventboxes;
+    std::vector<std::pair<collision_box_t*, NodeNum_t>> m_active_eventboxes;
 
     // Gameplay state
     ActorState        ar_state;
@@ -455,7 +457,8 @@ private:
     void              CalcHooks();                         
     void              CalcHydros();                        
     void              CalcMouse();                         
-    void              CalcNodes();                         
+    void              CalcNodes();
+    void              CalcEventBoxes();
     void              CalcReplay();                        
     void              CalcRopes();                         
     void              CalcShocks(bool doUpdate, int num_steps); 

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -697,6 +697,7 @@ struct collision_box_t
     Ogre::Vector3 campos;       //!< camera position
     Ogre::Vector3 debug_verts[8];//!< box corners in absolute world position
 };
+typedef std::vector<collision_box_t*> CollisionBoxPtrVec;
 
 /// Surface friction properties.
 struct ground_model_t

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -130,7 +130,7 @@ private:
 
     // collision boxes pool
     CollisionBoxVec m_collision_boxes; // Formerly MAX_COLLISION_BOXES = 5000
-    std::vector<collision_box_t*> m_last_called_cboxes;
+    std::vector<collision_box_t*> m_last_called_cboxes; // Only used for character, actors have their own cache `Actor::m_active_eventboxes`
 
     // collision tris pool
     CollisionTriVec m_collision_tris; // Formerly MAX_COLLISION_TRIS = 100000
@@ -150,7 +150,6 @@ private:
     int free_eventsource;
 
     bool permitEvent(CollisionEventFilter filter);
-    void envokeScriptCallback(collision_box_t* cbox, node_t* node = 0);
 
     Landusemap* landuse;
     int collision_version;
@@ -188,7 +187,9 @@ public:
     bool groundCollision(node_t* node, float dt);
     bool isInside(Ogre::Vector3 pos, const Ogre::String& inst, const Ogre::String& box, float border = 0);
     bool isInside(Ogre::Vector3 pos, collision_box_t* cbox, float border = 0);
-    bool nodeCollision(node_t* node, float dt, bool envokeScriptCallbacks = true);
+    bool nodeCollision(node_t* node, float dt);
+    void findPotentialEventBoxes(Ogre::AxisAlignedBox const& aabb, CollisionBoxPtrVec& out_boxes);
+    void envokeScriptCallback(collision_box_t* cbox, node_t* node = 0);
 
     void finishLoadingTerrain();
 


### PR DESCRIPTION
Previously only the main camera node activated eventboxes. This was a bad fit for i.e. races vs. the finishing line.

The process of invoking the event boxes was inverted - instead of searching an event box for the camera node, all event boxes close to the actor are searched for a hit with any node. Hits are recorded and next time the recorded colliding node is checked first.

I checked performance impact on Auriga race under Debug. There seems to be no noticeable FPS drop.

Code changes:
* Actor::CalcForcesEulerCompute() - call to UpdateBoundingBoxes() moved here from CalcNodes(). Added call to CalcEventBoxes().
* Actor::CalcEventBoxes() - searches and records hits with eventboxes, as described above.
* Collisions::nodeCollision() - no longer processes event boxes, the parameter was removed.