### PR TITLE
Fixed white managedmat if specular/damage texture missing

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2261,17 +2261,19 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
         this->AddMessage(Message::TYPE_WARNING, "Skipping managed material, missing texture file: " + def.diffuse_map);
         return;
     }
+
     if (def.damaged_diffuse_map != "" &&
         !rgm.resourceExists(m_custom_resource_group, def.damaged_diffuse_map))
     {
-        this->AddMessage(Message::TYPE_WARNING, "Skipping managed material, missing texture file: " + def.damaged_diffuse_map);
-        return;
+        this->AddMessage(Message::TYPE_WARNING, "Damage texture not found: " + def.damaged_diffuse_map);
+        def.damaged_diffuse_map = "";
     }
+
     if (def.specular_map != "" &&
         !rgm.resourceExists(m_custom_resource_group, def.specular_map))
     {
-        this->AddMessage(Message::TYPE_WARNING, "Skipping managed material, missing texture file: " + def.specular_map);
-        return;
+        this->AddMessage(Message::TYPE_WARNING, "Specular texture not found: " + def.specular_map);
+        def.specular_map = "";
     }
 
     // Create temporary placeholder


### PR DESCRIPTION
This was a bug introduced with 0e8e64644c685ccdd1904c53260269d1473406a0 - managedmaterial processing got refactored and new logic didn't match the old logic - new checks for missing textures were overzealous and disabled the entire material instead of disabling just the related effect.

Fixes #3005