### PR TITLE
TOBJ fileformat: added `set_default_rendering_distance`

### DIFF
--- a/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
@@ -63,6 +63,7 @@ void TObjParser::Prepare()
     m_cur_procedural_obj = new ProceduralObject();
     m_cur_procedural_obj_start_line = -1;
     m_road2_num_blocks = 0;
+    m_default_rendering_distance = 0.f;
     
     m_def = std::shared_ptr<TObjFile>(new TObjFile());
 }
@@ -110,6 +111,15 @@ bool TObjParser::ProcessCurrentLine()
     if (strncmp(m_cur_line, "grass", 5) == 0)
     {
         this->ProcessGrassLine();
+        return true;
+    }
+    if (strncmp(m_cur_line, "set_default_rendering_distance", 30) == 0)
+    {
+        const int result = sscanf(m_cur_line, "set_default_rendering_distance %f", &m_default_rendering_distance);
+        if (result != 1)
+        {
+            LOG(fmt::format("too few parameters on line: '{}'", m_cur_line));
+        }
         return true;
     }
     if (strncmp("begin_procedural_roads", m_cur_line, 22) == 0)
@@ -378,6 +388,7 @@ bool TObjParser::ParseObjectLine(TObjEntry& object)
     else if (odef == "roadbridge"        ) { special = TObj::SpecialObject::ROAD_BRIDGE           ; }
 
     object = TObjEntry(pos, rot, odef.ToCStr(), special, type, name);
+    object.rendering_distance = m_default_rendering_distance;
     return true;
 }
 

--- a/source/main/resources/tobj_fileformat/TObjFileFormat.h
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.h
@@ -147,6 +147,7 @@ struct TObjEntry
     char                 type[TObj::STR_LEN]          = {};
     char                 instance_name[TObj::STR_LEN] = {};
     char                 odef_name[TObj::STR_LEN]     = {};
+    float                rendering_distance           = 0.f; // 0 means 'always rendered', see https://ogrecave.github.io/ogre/api/1.11/class_ogre_1_1_movable_object.html#afe1f2a1009e3f14f36e1bcc9b1b9557e
 };
 
 // -----------------------------------------------------------------------------
@@ -196,6 +197,7 @@ private:
     int                        m_line_number;
     const char*                m_cur_line;
     const char*                m_cur_line_trimmed;
+    float                      m_default_rendering_distance;
 
     // Procedural roads
     bool                       m_in_procedural_road;

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -445,7 +445,7 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
         }
 
         const String type = "";
-        App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(objectName, pos, rot, instanceName, type, true, handler_func_id, uniquifyMaterials);
+        App::GetGameContext()->GetTerrain()->getObjectManager()->LoadTerrainObject(objectName, pos, rot, instanceName, type, /*rendering_distance=*/0, true, handler_func_id, uniquifyMaterials);
     }
     catch (std::exception& e)
     {

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -243,7 +243,7 @@ void TerrainObjectManager::LoadTObjFile(Ogre::String tobj_name)
     // Entries
     for (TObjEntry entry : tobj->objects)
     {
-        this->LoadTerrainObject(entry.odef_name, entry.position, entry.rotation, entry.instance_name, entry.type);
+        this->LoadTerrainObject(entry.odef_name, entry.position, entry.rotation, entry.instance_name, entry.type, entry.rendering_distance);
     }
 
     if (App::diag_terrn_log_roads->getBool())
@@ -536,7 +536,7 @@ ODefFile* TerrainObjectManager::FetchODef(std::string const & odef_name)
     }
 }
 
-bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, bool enable_collisions /* = true */, int scripthandler /* = -1 */, bool uniquifyMaterial /* = false */)
+bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, float rendering_distance /* = 0 */, bool enable_collisions /* = true */, int scripthandler /* = -1 */, bool uniquifyMaterial /* = false */)
 {
     if (type == "grid")
     {
@@ -546,7 +546,7 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
             for (int z = 0; z < 500; z += 50)
             {
                 const String notype = "";
-                LoadTerrainObject(name, pos + Vector3(x, 0.0f, z), rot, name, notype, enable_collisions, scripthandler, uniquifyMaterial);
+                LoadTerrainObject(name, pos + Vector3(x, 0.0f, z), rot, name, notype, /*rendering_distance:*/0, enable_collisions, scripthandler, uniquifyMaterial);
             }
         }
         return true;
@@ -575,6 +575,7 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
         if (mo->getEntity())
         {
             mo->getEntity()->setCastShadows(odef->header.cast_shadows);
+            mo->getEntity()->setRenderingDistance(rendering_distance);
             m_mesh_objects.push_back(mo);
         }
         else

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -79,7 +79,7 @@ public:
     std::vector<EditorObject>& GetEditorObjects() { return m_editor_objects; }
     std::vector<MapEntity>& GetMapEntities() { return m_map_entities; }
     void           LoadTObjFile(Ogre::String filename);
-    bool           LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, bool enable_collisions = true, int scripthandler = -1, bool uniquifyMaterial = false);
+    bool           LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, float rendering_distance = 0, bool enable_collisions = true, int scripthandler = -1, bool uniquifyMaterial = false);
     void           MoveObjectVisuals(const Ogre::String& instancename, const Ogre::Vector3& pos);
     void           unloadObject(const Ogre::String& instancename);
     void           LoadTelepoints();


### PR DESCRIPTION
TOBJ fileformat: added `set_default_rendering_distance`

This is a directive - you can place it anywhere and it affects all lines that come after it, much like directives in the truck fileformat do.
The parameter is distance in meters. 0 means infinite distance (object is always rendered). Default value is 0.
Internally, it uses `Ogre::Entity::setRenderingDistance()`, see https://ogrecave.github.io/ogre/api/1.11/class_ogre_1_1_movable_object.html#afe1f2a1009e3f14f36e1bcc9b1b9557e

Examples:
```
; limit distance to 10 meters
set_default_rendering_distance 10.0
; reset to infinite distance
set_default_rendering_distance 0
```

NOTE: I observed there is some glitch in the distance calculation, even with the same distance value, some objects appear faster than others. I debugged my code and concluded it's an OGRE issue.
