### PR TITLE
Fixed memory leaks in message loop processing (main.cpp). 

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -53,24 +53,27 @@ namespace App {
 // ------------------------------------------------------------------------------------------------
 
 // Object instances
-static AppContext       g_app_context;
-static Console          g_console;
-static ContentManager   g_content_manager;
-static OverlayWrapper*  g_overlay_wrapper;
-static GUIManager*      g_gui_manager;
-static InputEngine*     g_input_engine;
-static CacheSystem*     g_cache_system;
-static MumbleIntegration* g_mumble;
-static ThreadPool*      g_thread_pool;
-static CameraManager*   g_camera_manager;
-static GfxScene         g_gfx_scene;
-static SoundScriptManager* g_sound_script_manager;
-static LanguageEngine   g_language_engine;
-static ScriptEngine*    g_script_engine;
-static Network          g_network;
-static GameContext      g_game_context;
-static OutGauge         g_out_gauge;
-static DiscordRpc       g_discord_rpc;
+static AppContext           g_app_context;
+static CacheSystem*         g_cache_system;
+static CameraManager*       g_camera_manager;
+static Console              g_console;
+static ContentManager       g_content_manager;
+static DiscordRpc           g_discord_rpc;
+static GameContext          g_game_context;
+static GfxScene             g_gfx_scene;
+static GUIManager*          g_gui_manager;
+static InputEngine*         g_input_engine;
+static LanguageEngine       g_language_engine;
+static MumbleIntegration*   g_mumble;
+static OverlayWrapper*      g_overlay_wrapper;
+static OutGauge             g_out_gauge;
+static ScriptEngine*        g_script_engine;
+static SoundScriptManager*  g_sound_script_manager;
+static Terrain*             g_sim_terrain;
+static ThreadPool*          g_thread_pool;
+#if USE_SOCKETW
+    static Network          g_network;
+#endif
 
 // App
 CVar* app_state;
@@ -265,10 +268,14 @@ GfxScene*              GetGfxScene           () { return &g_gfx_scene; }
 SoundScriptManager*    GetSoundScriptManager () { return g_sound_script_manager; }
 LanguageEngine*        GetLanguageEngine     () { return &g_language_engine; }
 ScriptEngine*          GetScriptEngine       () { return g_script_engine; }
-Network*               GetNetwork            () { return &g_network; }
 GameContext*           GetGameContext        () { return &g_game_context; }
 OutGauge*              GetOutGauge           () { return &g_out_gauge; }
 DiscordRpc*            GetDiscordRpc         () { return &g_discord_rpc; }
+#if USE_SOCKETW
+    Network*           GetNetwork            () { return &g_network; }
+#else
+    Network*           GetNetwork            () { return nullptr; }
+#endif
 
 // Factories
 void CreateOverlayWrapper()
@@ -317,14 +324,18 @@ void CreateGfxScene()
 
 void CreateSoundScriptManager()
 {
+#if USE_OPENAL
     ROR_ASSERT(!g_sound_script_manager);
     g_sound_script_manager = new SoundScriptManager();
+#endif
 }
 
 void CreateScriptEngine()
 {
+#if USE_ANGELSCRIPT
     ROR_ASSERT(!g_script_engine);
     g_script_engine = new ScriptEngine();
+#endif
 }
 
 // Cleanup

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -84,8 +84,8 @@ enum MsgType
     MSG_NET_RECV_ERROR,
     MSG_NET_REFRESH_SERVERLIST_SUCCESS,    //!< Payload = GUI::MpServerInfoVec* (owner)
     MSG_NET_REFRESH_SERVERLIST_FAILURE,
-    MSG_NET_REFRESH_REPOLIST_SUCCESS,    //!< Payload = GUI::ResourcesCollection* (owner)
-    MSG_NET_OPEN_RESOURCE_SUCCESS,    //!< Payload = GUI::ResourcesCollection* (owner)
+    MSG_NET_REFRESH_REPOLIST_SUCCESS,      //!< Payload = GUI::ResourcesCollection* (owner)
+    MSG_NET_OPEN_RESOURCE_SUCCESS,         //!< Payload = GUI::ResourcesCollection* (owner)
     MSG_NET_REFRESH_REPOLIST_FAILURE,
     MSG_NET_REFRESH_AI_PRESETS,
     // Simulation

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -332,6 +332,8 @@ void GfxScene::RemoveGfxCharacter(RoR::GfxCharacter* remove_me)
 
 void GfxScene::DrawNetLabel(Ogre::Vector3 scene_pos, float cam_dist, std::string const& nick, int colornum)
 {
+#if USE_SOCKETW
+
         // this ensures that the nickname is always in a readable size
         float font_size = std::max(0.6, cam_dist / 40.0);
         std::string caption;
@@ -385,5 +387,7 @@ void GfxScene::DrawNetLabel(Ogre::Vector3 scene_pos, float cam_dist, std::string
         ImVec4 text_color(color.r, color.g, color.b, 1.f);
         drawlist->AddText(g->Font, g->FontSize, text_pos, ImColor(text_color), caption.c_str());
     }
+
+#endif // USE_SOCKETW
 }
 

--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -203,6 +203,7 @@ ImVec2 ConsoleView::DrawMessage(ImVec2 cursor, Console::Message const& m)
         }
     }
 
+#if USE_SOCKETW
     // Add colored multiplayer username
     if (m.cm_net_userid)
     {
@@ -224,6 +225,9 @@ ImVec2 ConsoleView::DrawMessage(ImVec2 cursor, Console::Message const& m)
     {
         line = m.cm_text;
     }
+#else // USE_SOCKETW
+    line = m.cm_text;
+#endif // USE_SOCKETW
 
     // Colorize text by type
     ImVec4 base_color = ImGui::GetStyle().Colors[ImGuiCol_Text];

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -27,7 +27,9 @@
 #include "Language.h"
 #include "SoundManager.h"
 
-#include <alc.h>
+#ifdef USE_OPENAL
+#   include <alc.h>
+#endif
 
 using namespace RoR;
 using namespace GUI;

--- a/source/main/gui/panels/GUI_MultiplayerClientList.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerClientList.cpp
@@ -44,12 +44,15 @@ using namespace Ogre;
 
 void MpClientList::UpdateClients()
 {
+#if USE_SOCKETW
     m_users = App::GetNetwork()->GetUserInfos();
     m_users.insert(m_users.begin(), App::GetNetwork()->GetLocalUserData());
+#endif // USE_SOCKETW
 }
 
 void MpClientList::Draw()
 {
+#if USE_SOCKETW
     if (m_users.empty())
         return; // UpdateClients() wasn't called yet.
 
@@ -228,6 +231,7 @@ void MpClientList::Draw()
 
     ImGui::End();
     ImGui::PopStyleColor(1); // WindowBg
+#endif // USE_SOCKETW
 }
 
 bool MpClientList::DrawIcon(Ogre::TexturePtr tex, ImVec2 reference_box)

--- a/source/main/gui/panels/GUI_RepositorySelector.h
+++ b/source/main/gui/panels/GUI_RepositorySelector.h
@@ -33,7 +33,9 @@
 #include <memory>
 #include <thread>
 #include <vector>
-#include <curl/curl.h>
+#ifdef USE_CURL
+#   include <curl/curl.h>
+#endif //USE_CURL
 
 namespace RoR {
 namespace GUI {
@@ -127,7 +129,9 @@ private:
     ResourceItem                        m_selected_item;
     Ogre::uint16                        m_ogre_workqueue_channel = 0;
     Ogre::TexturePtr                    m_fallback_thumbnail;
+#ifdef USE_CURL
     CURL                                *curl_th = curl_easy_init(); // One connection for fetching thumbnails using connection reuse
+#endif
 };
 
 }// namespace GUI

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -1406,10 +1406,8 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
     }
 
     // Display user in list
-    Ogre::ColourValue player_color;
 #ifdef USE_SOCKETW
-    player_color = App::GetNetwork()->GetPlayerColor(user.colournum);
-#endif
+    const Ogre::ColourValue player_color = App::GetNetwork()->GetPlayerColor(user.colournum);
     ImVec4 player_gui_color(player_color.r, player_color.g, player_color.b, 1.f);
     ImGui::PushStyleColor(ImGuiCol_Text, player_gui_color);
     ImGui::Text("%s: %u (%s, Ver: %s, Lang: %s)",
@@ -1417,6 +1415,7 @@ void TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
                 App::GetNetwork()->UserAuthToStringShort(user).c_str(),
                 user.clientversion, user.language);
     ImGui::PopStyleColor();
+#endif // USE_SOCKETW
 
     // Display actor list
     Ogre::TexturePtr tex1 = FetchIcon("control_pause.png");

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -393,10 +393,13 @@ int main(int argc, char *argv[])
                 // -- Network events --
 
                 case MSG_NET_CONNECT_REQUESTED:
+#if USE_SOCKETW
                     App::GetNetwork()->StartConnecting();
+#endif
                     break;
 
                 case MSG_NET_DISCONNECT_REQUESTED:
+#if USE_SOCKETW
                     if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
                     {
                         App::GetNetwork()->Disconnect();
@@ -406,6 +409,7 @@ int main(int argc, char *argv[])
                             App::GetGameContext()->PushMessage(Message(MSG_GUI_OPEN_MENU_REQUESTED));
                         }
                     }
+#endif // USE_SOCKETW
                     break;
 
                 case MSG_NET_SERVER_KICK:
@@ -435,6 +439,7 @@ int main(int argc, char *argv[])
                     break;
 
                 case MSG_NET_CONNECT_SUCCESS:
+#if USE_SOCKETW
                     App::GetGuiManager()->LoadingWindow.SetVisible(false);
                     App::GetNetwork()->StopConnecting();
                     App::mp_state->setVal((int)RoR::MpState::CONNECTED);
@@ -461,15 +466,18 @@ int main(int argc, char *argv[])
                             App::GetGameContext()->PushMessage(Message(MSG_SIM_LOAD_TERRN_REQUESTED, App::diag_preset_terrain->getStr()));
                         }
                     }
+#endif // USE_SOCKETW
                     break;
 
                 case MSG_NET_CONNECT_FAILURE:
+#if USE_SOCKETW
                     App::GetGuiManager()->LoadingWindow.SetVisible(false);
                     App::GetNetwork()->StopConnecting();
                     App::GetGameContext()->PushMessage(Message(MSG_NET_DISCONNECT_REQUESTED));
                     App::GetGameContext()->PushMessage(Message(MSG_GUI_OPEN_MENU_REQUESTED));
                     App::GetGuiManager()->ShowMessageBox(
                         _LC("Network", "Multiplayer: connection failed"), m.description.c_str());
+#endif // USE_SOCKETW
                     break;
 
                 case MSG_NET_REFRESH_SERVERLIST_SUCCESS:

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -364,6 +364,7 @@ Vector3 Actor::getPosition()
 
 void Actor::pushNetwork(char* data, int size)
 {
+#if USE_SOCKETW
     NetUpdate update;
 
     update.veh_state.resize(sizeof(RoRnet::VehicleState));
@@ -446,6 +447,7 @@ void Actor::pushNetwork(char* data, int size)
     }
 
     m_net_updates.push_back(update);
+#endif // USE_SOCKETW
 }
 
 void Actor::calcNetwork()

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -825,6 +825,7 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
     j_doc.Accept(writer);
     std::string json = buffer.GetString();
 
+#if USE_CURL
     RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
             _L("using Online API..."), "information.png");
 
@@ -849,6 +850,10 @@ int GameScript::useOnlineAPI(const String& apiquery, const AngelScript::CScriptD
             curl_slist_free_all(slist);
             slist = NULL;
         }).detach();
+#else // USE_CURL
+    RoR::App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+                                       _L("Cannot use Online API in this build (CURL not available)"));
+#endif // USE_CURL
 
     return 0;
 }


### PR DESCRIPTION
Most of them were edge cases, such as ACTOR_SPAWN request outside of simulation, but nonetheless it's a good practice to always `delete` allocated memory.

Also the coding style was unified - all the `case` blocks now use `static_cast<WhateverDataType*>(m.payload)` for type conversion and are formatted `case ABC: { /*profit*/ break; }`.

Also, I cherry picked some build-fixing commits from other branches; building without scripting, audio or networking will not fail anymore.