### PR TITLE
Enabled direct shifting in "manual shift, auto clutch" mode

### DIFF
--- a/source/main/gameplay/EngineSim.cpp
+++ b/source/main/gameplay/EngineSim.cpp
@@ -1422,9 +1422,26 @@ void EngineSim::UpdateInputEvents(float dt)
                 this->shift(-1);
             }
         }
-        else if (shiftmode != SimGearboxMode::AUTO && App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL))
+        else if (shiftmode != SimGearboxMode::AUTO)
         {
-            this->shiftTo(0);
+            if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_NEUTRAL))
+            {
+                this->shiftTo(0);
+            }
+            else if (App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR_REVERSE))
+            {
+                this->shiftTo(-1);
+            }
+            else
+            {
+                for (int i = 1; i < 19; i++)
+                {
+                    if (App::GetInputEngine()->getEventBoolValue(EV_TRUCK_SHIFT_GEAR01 + i - 1))
+                    {
+                        this->shiftTo(i);
+                    }
+                }
+            }
         }
     }
     else //if (shiftmode > SimGearboxMode::MANUAL) // h-shift or h-shift with ranges shifting

--- a/source/main/gameplay/EngineSim.cpp
+++ b/source/main/gameplay/EngineSim.cpp
@@ -435,7 +435,7 @@ void EngineSim::UpdateEngineSim(float dt, int doUpdate)
         totaltorque += m_braking_torque;
     }
 
-    // braking by m_hydropump_state
+    // braking by hydropump
     if (m_cur_engine_rpm > 100.0f)
     {
         totaltorque -= 8.0f * m_hydropump_state / (m_cur_engine_rpm * 0.105f * dt);


### PR DESCRIPTION
These input events now work in "Manual Shift - Auto Clutch" mode:
```
    TRUCK_SHIFT_GEAR_REVERSE  - shift directly to reverse gear
    TRUCK_SHIFT_GEAR01        - shift directly to first gear
    TRUCK_SHIFT_GEAR02        - shift directly to second gear
    TRUCK_SHIFT_GEAR03        - shift directly to third gear
    TRUCK_SHIFT_GEAR04        - shift directly to fourth gear
    TRUCK_SHIFT_GEAR05        - shift directly to 5th gear
    TRUCK_SHIFT_GEAR06        - shift directly to 6th gear
    TRUCK_SHIFT_GEAR07        - shift directly to 7th gear
    TRUCK_SHIFT_GEAR08        - shift directly to 8th gear
    TRUCK_SHIFT_GEAR09        - shift directly to 9th gear
    TRUCK_SHIFT_GEAR10        - shift directly to 10th gear
    TRUCK_SHIFT_GEAR11        - shift directly to 11th gear
    TRUCK_SHIFT_GEAR12        - shift directly to 12th gear
    TRUCK_SHIFT_GEAR13        - shift directly to 13th gear
    TRUCK_SHIFT_GEAR14        - shift directly to 14th gear
    TRUCK_SHIFT_GEAR15        - shift directly to 15th gear
    TRUCK_SHIFT_GEAR16        - shift directly to 16th gear
    TRUCK_SHIFT_GEAR17        - shift directly to 17th gear
    TRUCK_SHIFT_GEAR18        - shift directly to 18th gear
```

Fixes #2995

[Download dev builds here](https://github.com/RigsOfRods/rigs-of-rods/actions/runs/4478965394?pr=3028)