### PR TITLE
Always log CURL error string

### DIFF
--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -85,10 +85,10 @@ enum MsgType
     MSG_NET_USER_DISCONNECT,
     MSG_NET_RECV_ERROR,
     MSG_NET_REFRESH_SERVERLIST_SUCCESS,    //!< Payload = GUI::MpServerInfoVec* (owner)
-    MSG_NET_REFRESH_SERVERLIST_FAILURE,
+    MSG_NET_REFRESH_SERVERLIST_FAILURE,    //!< Payload = RoR::CurlFailInfo* (owner)
     MSG_NET_REFRESH_REPOLIST_SUCCESS,      //!< Payload = GUI::ResourcesCollection* (owner)
     MSG_NET_OPEN_RESOURCE_SUCCESS,         //!< Payload = GUI::ResourcesCollection* (owner)
-    MSG_NET_REFRESH_REPOLIST_FAILURE,
+    MSG_NET_REFRESH_REPOLIST_FAILURE,      //!< Payload = RoR::CurlFailInfo* (owner)
     MSG_NET_REFRESH_AI_PRESETS,
     // Simulation
     MSG_SIM_PAUSE_REQUESTED,

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -54,6 +54,7 @@ namespace RoR
     class  ConfigFile;
     class  Console;
     class  ContentManager;
+    struct CurlFailInfo;
     class  CVar;
     class  DashBoard;
     class  DashBoardManager;

--- a/source/main/gui/panels/GUI_MultiplayerSelector.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerSelector.cpp
@@ -70,16 +70,18 @@ void FetchServerlist(std::string portal_url)
     curl_easy_setopt(curl, CURLOPT_WRITEDATA,     &response_payload);
     curl_easy_setopt(curl, CURLOPT_HEADERDATA,    &response_header);
 
-    curl_easy_perform(curl);
+    CURLcode curl_result = curl_easy_perform(curl);
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
 
     curl_easy_cleanup(curl);
     curl = nullptr;
 
-    if (response_code != 200)
+    if (curl_result != CURLE_OK || response_code != 200)
     {
         Ogre::LogManager::getSingleton().stream() 
-            << "[RoR|Multiplayer] Failed to retrieve serverlist; HTTP status code: " << response_code;
+            << "[RoR|Multiplayer] Failed to retrieve serverlist;"
+            << " Error: '" << curl_easy_strerror(curl_result) << "'; HTTP status code: " << response_code;
+
         App::GetGameContext()->PushMessage(
             Message(MSG_NET_REFRESH_SERVERLIST_FAILURE, _LC("MultiplayerSelector", "Error connecting to server :(")));
         return;

--- a/source/main/gui/panels/GUI_MultiplayerSelector.h
+++ b/source/main/gui/panels/GUI_MultiplayerSelector.h
@@ -63,7 +63,7 @@ public:
     inline bool         IsVisible() const { return m_is_visible; }
     void                StartAsyncRefresh(); //!< Launch refresh from main thread
     void                Draw();
-    void                DisplayRefreshFailed(std::string const& msg);
+    void                DisplayRefreshFailed(CurlFailInfo* failinfo);
     void                UpdateServerlist(MpServerInfoVec* data);
 
 private:
@@ -72,8 +72,6 @@ private:
     void                DrawServerlistTab();
 
     MpServerInfoVec     m_serverlist_data;
-    std::string         m_serverlist_msg;
-    ImVec4              m_serverlist_msg_color;
     int                 m_selected_item = -1;
     char                m_window_title[100];
     bool                m_is_visible = false;
@@ -84,6 +82,12 @@ private:
     Str<1000>           m_server_host_buf;
     Ogre::TexturePtr    m_lock_icon;
     bool                m_show_spinner = false;
+
+    // status or error messages
+    std::string         m_serverlist_msg;
+    ImVec4              m_serverlist_msg_color;
+    std::string         m_serverlist_curlmsg; //!< Displayed as dimmed text
+    std::string         m_serverlist_httpmsg; //!< Displayed as dimmed text
 };
 
 } // namespace GUI

--- a/source/main/gui/panels/GUI_RepositorySelector.h
+++ b/source/main/gui/panels/GUI_RepositorySelector.h
@@ -102,7 +102,7 @@ public:
     void                                Refresh();
     void                                UpdateResources(ResourcesCollection* data);
     void                                UpdateFiles(ResourcesCollection* data);
-    void                                ShowError(std::string const& msg);
+    void                                ShowError(CurlFailInfo* failinfo);
     void                                DrawThumbnail(int resource_item_idx);
 
     /// Ogre::WorkQueue API
@@ -112,9 +112,6 @@ public:
 private:
     bool                                m_is_visible = false;
     bool                                m_draw = false;
-    std::string                         m_repolist_msg;
-    ImVec4                              m_repolist_msg_color;
-    std::string                         m_repofiles_msg;
     ResourcesCollection                 m_data;
     Str<500>                            m_search_input;
     std::string                         m_current_category;
@@ -132,6 +129,13 @@ private:
 #ifdef USE_CURL
     CURL                                *curl_th = curl_easy_init(); // One connection for fetching thumbnails using connection reuse
 #endif
+
+    // status or error messages
+    std::string                         m_repofiles_msg;
+    std::string                         m_repolist_msg;
+    ImVec4                              m_repolist_msg_color;
+    std::string                         m_repolist_curlmsg; //!< Displayed as dimmed text
+    std::string                         m_repolist_httpmsg; //!< Displayed as dimmed text
 };
 
 }// namespace GUI

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -86,13 +86,19 @@ void GetJson()
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWriteFunc);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_payload);
 
-    curl_easy_perform(curl);
+    CURLcode curl_result = curl_easy_perform(curl);
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
 
     curl_easy_cleanup(curl);
     curl = nullptr;
 
-    if (response_code == 200)
+    if (curl_result != CURLE_OK || response_code != 200)
+    {
+        Ogre::LogManager::getSingleton().stream()
+            << "[RoR|Repository] Failed to download AI presets;"
+            << " Error: '" << curl_easy_strerror(curl_result) << "'; HTTP status code: " << response_code;
+    }
+    else
     {
         Message m(MSG_NET_REFRESH_AI_PRESETS);
         m.description = response_payload;

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -32,7 +32,6 @@
 #include "ErrorUtils.h"
 #include "GameContext.h"
 #include "GfxScene.h"
-#include "GUIManager.h"
 #include "GUI_DirectionArrow.h"
 #include "GUI_FrictionSettings.h"
 #include "GUI_GameControls.h"
@@ -44,6 +43,8 @@
 #include "GUI_RepositorySelector.h"
 #include "GUI_SimActorStats.h"
 #include "GUI_SurveyMap.h"
+#include "GUIManager.h"
+#include "GUIUtils.h"
 #include "InputEngine.h"
 #include "Language.h"
 #include "MumbleIntegration.h"
@@ -506,7 +507,9 @@ int main(int argc, char *argv[])
 
                 case MSG_NET_REFRESH_SERVERLIST_FAILURE:
                 {
-                    App::GetGuiManager()->MultiplayerSelector.DisplayRefreshFailed(m.description);
+                    CurlFailInfo* failinfo = static_cast<CurlFailInfo*>(m.payload);
+                    App::GetGuiManager()->MultiplayerSelector.DisplayRefreshFailed(failinfo);
+                    delete failinfo;
                     break;
                 }
 
@@ -527,8 +530,12 @@ int main(int argc, char *argv[])
                 }
 
                 case MSG_NET_REFRESH_REPOLIST_FAILURE:
-                    App::GetGuiManager()->RepositorySelector.ShowError(m.description);
+                {
+                    CurlFailInfo* failinfo = static_cast<CurlFailInfo*>(m.payload);
+                    App::GetGuiManager()->RepositorySelector.ShowError(failinfo);
+                    delete failinfo;
                     break;
+                }
 
                 case MSG_NET_REFRESH_AI_PRESETS:
                     App::GetGuiManager()->TopMenubar.Refresh(m.description);

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -44,6 +44,13 @@ namespace RoR {
 /// @addtogroup Network
 /// @{
 
+struct CurlFailInfo
+{
+    std::string title;
+    CURLcode curl_result = CURLE_OK;
+    long http_response = 0;
+};
+
 // ----------------------- Network messages (packed) -------------------------
 
 #pragma pack(push, 1)


### PR DESCRIPTION
At one moment the server had a certificate expired and I realized the game doesn't log anything useful in that situation. The HTTP response code remains '0' in those cases.

Seeing all the copy-pasted and mostly identical `curl_easy*()` calls, I should probably create a helper for it, but at the moment I just uniformly extended all the occurences with an error logging code.