### PR TITLE
Node affectors

### DIFF
--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -117,6 +117,8 @@ enum MsgType
     MSG_EDI_ENTER_TERRN_EDITOR_REQUESTED,
     MSG_EDI_LEAVE_TERRN_EDITOR_REQUESTED,
     MSG_EDI_RELOAD_BUNDLE_REQUESTED,       //!< Payload = RoR::CacheEntry* (weak)
+    MSG_EDI_ADD_AFFECTOR_REQUESTED,        //!< Payload = RoR::AddAffectorRequest* (owner)
+    MSG_EDI_REMOVE_AFFECTOR_REQUESTED,     //!< Payload = RoR::RemoveAffectorRequest* (owner)
 };
 
 const char* MsgTypeToString(MsgType type);

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SOURCE_FILES
         gfx/skyx/VClouds/VClouds.{h,cpp}
         gui/DashBoardManager.{h,cpp}
         gui/GUIManager.{h,cpp}
+        gui/GUITheme.h
         gui/GUIUtils.{h,cpp}
         gui/OverlayWrapper.{h,cpp}
         gui/RTTLayer.{h,cpp}
@@ -138,6 +139,7 @@ set(SOURCE_FILES
         gui/panels/GUI_ScriptMonitor.{h,cpp}
         gui/panels/GUI_SimPerfStats.{h,cpp}
         gui/panels/GUI_SurveyMap.{h,cpp}
+        gui/panels/GUI_ThemeEditor.{h,cpp}
         gui/panels/GUI_VehicleDescription.{h,cpp}
         gui/panels/GUI_VehicleButtons.{h,cpp}
         network/DiscordRpc.{h,cpp}

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -37,6 +37,9 @@ namespace RoR
     typedef int ScriptUnitId_t; //!< Unique sequentially generated ID of a loaded and running scriptin session. Use `ScriptEngine::getScriptUnit()`
     static const ScriptUnitId_t SCRIPTUNITID_INVALID = -1;
 
+    typedef int AffectorID_t; //!< Index to `Actor::ar_affectors`, use RoR::AFFECTORID_INVALID as empty value.
+    static const AffectorID_t AFFECTORID_INVALID = -1;
+
     class  Actor;
     class  ActorManager;
     class  ActorSpawner;

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -93,7 +93,7 @@ void SceneMouse::releaseMousePick()
 
     // remove forces
     if (grab_truck)
-        grab_truck->mouseMove(minnode, Vector3::ZERO, 0);
+        grab_truck->clearNodeEffectForceTowardsPoint(minnode);
 
     this->reset();
 }
@@ -198,7 +198,8 @@ void SceneMouse::UpdateSimulation()
         lastgrabpos = mouseRay.getPoint(mindist);
 
         // add forces
-        grab_truck->mouseMove(minnode, lastgrabpos, MOUSE_GRAB_FORCE);
+        grab_truck->clearNodeEffectForceTowardsPoint(minnode);
+        grab_truck->addNodeEffectForceTowardsPoint(minnode, lastgrabpos, MOUSE_GRAB_FORCE);
     }
 }
 

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -2,7 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
-    Copyright 2013-2014 Petr Ohlidal
+    Copyright 2013-2023 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -29,6 +29,8 @@
 #include "Application.h"
 #include "GameContext.h"
 #include "GfxScene.h"
+#include "GUIUtils.h"
+#include "InputEngine.h"
 #include "ScriptEngine.h"
 
 #include <Ogre.h>
@@ -101,14 +103,10 @@ void SceneMouse::releaseMousePick()
 void SceneMouse::reset()
 {
     minnode = NODENUM_INVALID;
-    grab_truck = 0;
-    mindist = 99999;
+    grab_truck = nullptr;
+    mindist = std::numeric_limits<float>::max();
     mouseGrabState = 0;
     lastgrabpos = Vector3::ZERO;
-    lastMouseX = 0;
-    lastMouseY = 0;
-
-    mouseGrabState = 0;
 }
 
 bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
@@ -118,47 +116,12 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
     // experimental mouse hack
     if (ms.buttonDown(OIS::MB_Left) && mouseGrabState == 0)
     {
-        lastMouseY = ms.Y.abs;
-        lastMouseX = ms.X.abs;
 
-        Ray mouseRay = getMouseRay();
-
-        // walk all trucks
-        minnode = NODENUM_INVALID;
-        grab_truck = NULL;
-        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
-        {
-            if (actor->ar_state == ActorState::LOCAL_SIMULATED)
-            {
-                // check if our ray intersects with the bounding box of the truck
-                std::pair<bool, Real> pair = mouseRay.intersects(actor->ar_bounding_box);
-                if (!pair.first)
-                    continue;
-
-                for (int j = 0; j < actor->ar_num_nodes; j++)
-                {
-                    if (actor->ar_nodes[j].nd_no_mouse_grab)
-                        continue;
-
-                    // check if our ray intersects with the node
-                    std::pair<bool, Real> pair = mouseRay.intersects(Sphere(actor->ar_nodes[j].AbsPosition, 0.1f));
-                    if (pair.first)
-                    {
-                        // we hit it, check if its the nearest node
-                        if (pair.second < mindist)
-                        {
-                            mindist = pair.second;
-                            minnode = (NodeNum_t)j;
-                            grab_truck = actor;
-                        }
-                    }
-                }
-            }
-        }
-
+        // mouse selection is updated every frame in `update()`
         // check if we hit a node
-        if (grab_truck && minnode != NODENUM_INVALID)
+        if (mintruck && minnode != NODENUM_INVALID)
         {
+            grab_truck = mintruck;
             mouseGrabState = 1;
             TRIGGER_EVENT(SE_TRUCK_MOUSE_GRAB, grab_truck->ar_instance_id);
 
@@ -174,8 +137,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
     else if (ms.buttonDown(OIS::MB_Left) && mouseGrabState == 1)
     {
         // force applying and so forth happens in update()
-        lastMouseY = ms.Y.abs;
-        lastMouseX = ms.X.abs;
+
         // not fixed
         return false;
     }
@@ -189,18 +151,125 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
     return false;
 }
 
+void SceneMouse::updateMouseHighlights(ActorPtr actor)
+{
+    ROR_ASSERT(actor != nullptr);
+    ROR_ASSERT(actor->ar_state == ActorState::LOCAL_SIMULATED);
+
+    ImGui::Text("DBG updateMouseHighlights()");
+
+    Ray mouseRay = getMouseRay();
+
+    // check if our ray intersects with the bounding box of the truck
+    std::pair<bool, Real> pair = mouseRay.intersects(actor->ar_bounding_box);
+    if (!pair.first)
+    {
+        ImGui::Text("DBG AABB intersection fail!");
+        return;
+    }
+
+    int numGrabHits = 0;
+    int numHighlightHits = 0;
+    for (int j = 0; j < actor->ar_num_nodes; j++)
+    {
+        // skip nodes with grabbing disabled
+        if (actor->ar_nodes[j].nd_no_mouse_grab)
+        {
+            continue;
+        }
+
+        // check if our ray intersects with the node
+        std::pair<bool, Real> pair = mouseRay.intersects(Sphere(actor->ar_nodes[j].AbsPosition, GRAB_SPHERE_SIZE));
+        if (pair.first)
+        {
+            numGrabHits++;
+
+            // we hit it, check if its the nearest node
+            if (pair.second < mindist)
+            {
+                mindist = pair.second;
+                minnode = static_cast<NodeNum_t>(j);
+                mintruck = actor;
+            }
+        }
+
+        // check if the node is close enough to be highlighted
+        std::pair<bool, Real> highlight_result = mouseRay.intersects(Sphere(actor->ar_nodes[j].AbsPosition, this->HIGHLIGHT_SPHERE_SIZE));
+        if (highlight_result.first)
+        {
+            numHighlightHits++;
+            highlightedTruck = actor;
+
+            highlightedNodes.push_back({ highlight_result.second, static_cast<NodeNum_t>(j) });
+            highlightedNodesTopDistance = std::max(highlightedNodesTopDistance, highlight_result.second);
+        }
+    }
+    ImGui::Text("DBG numGrabHits: %4d, numHighlightHits: %4d", numGrabHits, numHighlightHits);
+}
+
 void SceneMouse::UpdateSimulation()
 {
+    Ray mouseRay = getMouseRay();
+    highlightedNodes.clear(); // clear every frame - highlights are not displayed when grabbing
+    highlightedTruck = nullptr;
+
     if (mouseGrabState == 1 && grab_truck)
     {
         // get values
-        Ray mouseRay = getMouseRay();
         lastgrabpos = mouseRay.getPoint(mindist);
 
         // add forces
         grab_truck->clearNodeEffectForceTowardsPoint(minnode);
         grab_truck->addNodeEffectForceTowardsPoint(minnode, lastgrabpos, MOUSE_GRAB_FORCE);
     }
+    else
+    {
+        // refresh mouse highlight
+        mintruck = nullptr;
+        minnode = NODENUM_INVALID;
+        mindist = std::numeric_limits<float>::max();
+        for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
+        {
+            if (actor->ar_state == ActorState::LOCAL_SIMULATED)
+            {
+                this->updateMouseHighlights(actor);
+            }
+        }
+    }
+}
+
+void SceneMouse::drawMouseHighlights()
+{
+    ActorPtr actor = (mintruck != nullptr) ? mintruck : highlightedTruck;
+    if (!actor)
+        return; // Nothing to draw
+
+    ImDrawList* drawlist = GetImDummyFullscreenWindow("Mouse-grab node highlights");
+    const int LAYER_HIGHLIGHTS = 0;
+    const int LAYER_MINNODE = 1;
+    drawlist->ChannelsSplit(2);
+
+    Vector2 screenPos;
+    for (const HighlightedNode& hnode : highlightedNodes)
+    {
+        if (GetScreenPosFromWorldPos(actor->ar_nodes[hnode.nodenum].AbsPosition, /*out:*/screenPos))
+        {
+            if (hnode.nodenum == minnode)
+            {
+                drawlist->ChannelsSetCurrent(LAYER_MINNODE);
+                drawlist->AddCircle(ImVec2(screenPos.x, screenPos.y), MINNODE_RADIUS, ImColor(MINNODE_COLOR));
+            }
+
+            float animRatio = 1.f - (hnode.distance / highlightedNodesTopDistance); // the closer the bigger
+            float radius = (HIGHLIGHTED_NODE_RADIUS_MAX - HIGHLIGHTED_NODE_RADIUS_MIN) * animRatio;
+            ImVec4 color = HIGHLIGHTED_NODE_COLOR * animRatio;
+            color.w = 1.f; // no transparency
+            drawlist->ChannelsSetCurrent(LAYER_HIGHLIGHTS);
+            drawlist->AddCircleFilled(ImVec2(screenPos.x, screenPos.y), radius, ImColor(color));
+        }
+    }
+
+    drawlist->ChannelsMerge();
 }
 
 void SceneMouse::UpdateVisuals()
@@ -208,6 +277,8 @@ void SceneMouse::UpdateVisuals()
     if (grab_truck == nullptr)
     {
         pickLineNode->setVisible(false);   // Hide the line     
+
+        this->drawMouseHighlights();
     }
     else
     {
@@ -228,8 +299,6 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
 
     if (ms.buttonDown(OIS::MB_Middle))
     {
-        lastMouseY = ms.Y.abs;
-        lastMouseX = ms.X.abs;
         Ray mouseRay = getMouseRay();
 
         if (App::sim_state->getEnum<SimState>() == SimState::EDITOR_MODE)
@@ -310,6 +379,9 @@ bool SceneMouse::mouseReleased(const OIS::MouseEvent& _arg, OIS::MouseButtonID _
 
 Ray SceneMouse::getMouseRay()
 {
+    int lastMouseX = App::GetInputEngine()->getMouseState().X.abs;
+    int lastMouseY = App::GetInputEngine()->getMouseState().Y.abs;
+
     Viewport* vp = App::GetCameraManager()->GetCamera()->getViewport();
 
     return App::GetCameraManager()->GetCamera()->getCameraToViewportRay((float)lastMouseX / (float)vp->getActualWidth(), (float)lastMouseY / (float)vp->getActualHeight());

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -239,7 +239,7 @@ void SceneMouse::updateMouseBeamHighlights()
         highlightedBeamsNodeProximity.assign(mintruck->ar_num_nodes, 0);
 
         // Fire up the recursive update
-        const GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+        const GUITheme& theme = App::GetGuiManager()->GetTheme();
         highlightedBeamsNodeProximity[minnode] = 255;
         this->updateMouseBeamHighlightsRecursive(
             minnode, 0.f, theme.mouse_beam_traversal_length);
@@ -346,7 +346,7 @@ void SceneMouse::drawMouseBeamHighlights()
 
     ImDrawList* drawlist = GetImDummyFullscreenWindow("Mouse-grab beam highlights");
 
-    const GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+    const GUITheme& theme = App::GetGuiManager()->GetTheme();
 
     for (int beamID: highlightedBeamIDs)
     {
@@ -381,7 +381,7 @@ void SceneMouse::drawMouseNodeHighlights()
     drawlist->ChannelsSplit(2);
 
     Vector2 screenPos;
-    const GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+    const GUITheme& theme = App::GetGuiManager()->GetTheme();
     for (const HighlightedNode& hnode : highlightedNodes)
     {
         if (GetScreenPosFromWorldPos(actor->ar_nodes[hnode.nodenum].AbsPosition, /*out:*/screenPos))
@@ -409,7 +409,7 @@ void SceneMouse::drawMouseNodeHighlights()
 
 void SceneMouse::drawNodeEffects()
 {
-    const GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+    const GUITheme& theme = App::GetGuiManager()->GetTheme();
     ImDrawList* drawlist = GetImDummyFullscreenWindow("Node effect view");
     const int LAYER_LINES = 0;
     const int LAYER_CIRCLES = 1;

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -52,6 +52,7 @@ public:
     void UpdateSimulation();
     void UpdateVisuals();
     void DiscardVisuals();
+    void UpdateInputEvents();
 
 protected:
 
@@ -59,12 +60,13 @@ protected:
     ActorPtr grab_truck; // grabbed node truck
     Ogre::Vector3 lastgrabpos;
 
-    /// @name Mouse node selection with animated highlights: 1. closest node 2. surrounding nodes (animated by distance)
+    /// @name Mouse node (or pinned force) selection with animated highlights: 1. closest node 2. surrounding nodes (animated by distance)
     /// @{
     
     const float HIGHLIGHT_SPHERE_SIZE = 1.f; //!< in meters
     const float GRAB_SPHERE_SIZE = 0.1f; //!< in meters
     const float FORCE_NEWTONS_TO_LINE_LENGTH_RATIO = 15.5f;
+    const float FORCE_UNPIN_SPHERE_SIZE = 0.2; //!< in meters
     // Colors and scales are defined in GUI Theme, see GUIManager.h
 
     struct HighlightedNode
@@ -78,6 +80,16 @@ protected:
     float mindist;
     ActorPtr mintruck;
 
+    // the node const force effect
+    int cfEffect_minnode = NODENUM_INVALID;
+    float cfEffect_mindist;
+    ActorPtr cfEffect_mintruck;
+
+    // the node force2point effect
+    int f2pEffect_minnode = NODENUM_INVALID;
+    float f2pEffect_mindist;
+    ActorPtr f2pEffect_mintruck;
+
     // surrounding nodes
     std::vector<HighlightedNode> highlightedNodes;
     float highlightedNodesTopDistance;
@@ -88,7 +100,8 @@ protected:
     void releaseMousePick();
     Ogre::Ray getMouseRay();
     void reset();
-    void updateMouseHighlights(ActorPtr actor);
+    void updateMouseNodeHighlights(ActorPtr& actor);
+    void updateMouseEffectHighlights(ActorPtr& actor);
     void drawMouseHighlights();
     void drawNodeEffects();
 };

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -55,10 +55,7 @@ public:
 
 protected:
 
-    Ogre::ManualObject* pickLine;
-    Ogre::SceneNode* pickLineNode;
     int mouseGrabState;
-
     ActorPtr grab_truck; // grabbed node truck
     Ogre::Vector3 lastgrabpos;
 
@@ -67,12 +64,9 @@ protected:
     
     const float HIGHLIGHT_SPHERE_SIZE = 1.f; //!< in meters
     const float GRAB_SPHERE_SIZE = 0.1f; //!< in meters
-    const ImVec4 MINNODE_COLOR = ImVec4(1.f, 0.8f, 0.3f, 1.f);
-    const float MINNODE_RADIUS = 2;
-    const ImVec4 HIGHLIGHTED_NODE_COLOR = ImVec4(0.7f, 1.f, 0.4f, 1.f);
-    const float HIGHLIGHTED_NODE_RADIUS_MAX = 10; //!< in pixels
-    const float HIGHLIGHTED_NODE_RADIUS_MIN = 0.5; //!< in pixels
-    
+    const float FORCE_NEWTONS_TO_LINE_LENGTH_RATIO = 15.5f;
+    // Colors and scales are defined in GUI Theme, see GUIManager.h
+
     struct HighlightedNode
     {
         float distance;
@@ -96,6 +90,7 @@ protected:
     void reset();
     void updateMouseHighlights(ActorPtr actor);
     void drawMouseHighlights();
+    void drawNodeEffects();
 };
 
 /// @}

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -53,10 +53,12 @@ public:
     void UpdateVisuals();
     void DiscardVisuals();
     void UpdateInputEvents();
+    void SetMouseAffector(AffectorID_t id) { grab_affectorid = id; }
 
 protected:
 
     int mouseGrabState;
+    AffectorID_t grab_affectorid = AFFECTORID_INVALID;
     ActorPtr grab_truck; // grabbed node truck
     Ogre::Vector3 lastgrabpos;
 
@@ -80,15 +82,16 @@ protected:
     float mindist;
     ActorPtr mintruck;
 
-    // the node const force effect
-    int cfEffect_minnode = NODENUM_INVALID;
-    float cfEffect_mindist;
-    ActorPtr cfEffect_mintruck;
+    // the affector node
+    NodeNum_t aff_nodes_minnode = NODENUM_INVALID;
+    AffectorID_t aff_nodes_minaffector = AFFECTORID_INVALID;
+    float aff_nodes_mindist;
+    ActorPtr aff_nodes_mintruck;
 
-    // the node force2point effect
-    int f2pEffect_minnode = NODENUM_INVALID;
-    float f2pEffect_mindist;
-    ActorPtr f2pEffect_mintruck;
+    // the PINNED affector's pin position
+    AffectorID_t aff_pins_minaffector = AFFECTORID_INVALID;
+    float aff_pins_mindist;
+    ActorPtr aff_pins_mintruck;
 
     // surrounding nodes
     std::vector<HighlightedNode> highlightedNodes;
@@ -97,6 +100,7 @@ protected:
 
     /// @}
 
+    void activateMousePick();
     void releaseMousePick();
     Ogre::Ray getMouseRay();
     void reset();

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -98,6 +98,10 @@ protected:
     float highlightedNodesTopDistance;
     ActorPtr highlightedTruck;
 
+    // Highlight of neighbour beams
+    std::vector<uint8_t> highlightedBeamsNodeProximity;
+    std::vector<int> highlightedBeamIDs;
+
     /// @}
 
     void activateMousePick();
@@ -106,11 +110,10 @@ protected:
     void reset();
     void updateMouseNodeHighlights(ActorPtr& actor);
     void updateMouseBeamHighlights();
-    void updateMouseBeamHighlightsRecursive(NodeNum_t nodenum, float remTraversalLen, float maxTraversalLen);
+    void updateMouseBeamHighlightsRecursive(NodeNum_t nodenum, float traversalLen, float maxTraversalLen);
     void updateMouseEffectHighlights(ActorPtr& actor);
     void drawMouseNodeHighlights();
     void drawMouseBeamHighlights();
-    void drawBeamHighlightsRecursive(ImDrawList* drawlist, NodeNum_t node);
     void drawNodeEffects();
 };
 

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -2,7 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
-    Copyright 2013-2014 Petr Ohlidal
+    Copyright 2013-2023 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -35,6 +35,9 @@
 
 namespace RoR {
 
+/// @addtogroup Gameplay
+/// @{
+
 class SceneMouse
 {
 public:
@@ -56,15 +59,45 @@ protected:
     Ogre::SceneNode* pickLineNode;
     int mouseGrabState;
 
+    ActorPtr grab_truck; // grabbed node truck
+    Ogre::Vector3 lastgrabpos;
+
+    /// @name Mouse node selection with animated highlights: 1. closest node 2. surrounding nodes (animated by distance)
+    /// @{
+    
+    const float HIGHLIGHT_SPHERE_SIZE = 1.f; //!< in meters
+    const float GRAB_SPHERE_SIZE = 0.1f; //!< in meters
+    const ImVec4 MINNODE_COLOR = ImVec4(1.f, 0.8f, 0.3f, 1.f);
+    const float MINNODE_RADIUS = 2;
+    const ImVec4 HIGHLIGHTED_NODE_COLOR = ImVec4(0.7f, 1.f, 0.4f, 1.f);
+    const float HIGHLIGHTED_NODE_RADIUS_MAX = 10; //!< in pixels
+    const float HIGHLIGHTED_NODE_RADIUS_MIN = 0.5; //!< in pixels
+    
+    struct HighlightedNode
+    {
+        float distance;
+        NodeNum_t nodenum;
+    };
+
+    // the grabbable node
     NodeNum_t minnode = NODENUM_INVALID;
     float mindist;
-    ActorPtr grab_truck;
-    Ogre::Vector3 lastgrabpos;
-    int lastMouseX, lastMouseY;
+    ActorPtr mintruck;
+
+    // surrounding nodes
+    std::vector<HighlightedNode> highlightedNodes;
+    float highlightedNodesTopDistance;
+    ActorPtr highlightedTruck;
+
+    /// @}
 
     void releaseMousePick();
     Ogre::Ray getMouseRay();
     void reset();
+    void updateMouseHighlights(ActorPtr actor);
+    void drawMouseHighlights();
 };
+
+/// @}
 
 } // namespace RoR

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -105,8 +105,12 @@ protected:
     Ogre::Ray getMouseRay();
     void reset();
     void updateMouseNodeHighlights(ActorPtr& actor);
+    void updateMouseBeamHighlights();
+    void updateMouseBeamHighlightsRecursive(NodeNum_t nodenum, float remTraversalLen, float maxTraversalLen);
     void updateMouseEffectHighlights(ActorPtr& actor);
-    void drawMouseHighlights();
+    void drawMouseNodeHighlights();
+    void drawMouseBeamHighlights();
+    void drawBeamHighlightsRecursive(ImDrawList* drawlist, NodeNum_t node);
     void drawNodeEffects();
 };
 

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -455,7 +455,7 @@ void RoR::GfxActor::UpdateParticles(float dt_sec)
 
     for (NodeGfx& nfx: m_gfx_nodes)
     {
-        const node_t& n = m_actor->ar_nodes[nfx.nx_node_idx];
+        const node_t& n = m_actor->ar_nodes[nfx.nx_nodenum];
 
         // 'Wet' effects - water dripping and vapour
         if (nfx.nx_may_get_wet && !nfx.nx_no_particles)
@@ -1667,7 +1667,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
 
     for (NodeGfx& nx: m_gfx_nodes)
     {
-        m_simbuf.simbuf_nodes[nx.nx_node_idx].nd_is_wet = (nx.nx_wet_time_sec != -1.f);
+        m_simbuf.simbuf_nodes[nx.nx_nodenum].nd_is_wet = (nx.nx_wet_time_sec != -1.f);
     }
 
     // Elements: beams
@@ -3188,7 +3188,7 @@ void RoR::GfxActor::SetNodeHot(NodeNum_t nodenum, bool value)
 {
     for (NodeGfx& nfx : m_gfx_nodes)
     {
-        if (nfx.nx_node_idx == nodenum)
+        if (nfx.nx_nodenum == nodenum)
         {
             nfx.nx_is_hot = value;
         }

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -149,7 +149,6 @@ public:
     void                 CalcPropAnimation(const int flag_state, float& cstate, int& div, float timer,
                                               const float lower_limit, const float upper_limit, const float option3);
     std::vector<Prop>&   getProps() { return m_props; }
-    std::vector<NodeGfx>& getNodes() { return m_gfx_nodes; }
     bool                 hasCamera() { return m_videocameras.size() > 0; }
 
 private:

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -149,6 +149,7 @@ public:
     void                 CalcPropAnimation(const int flag_state, float& cstate, int& div, float timer,
                                               const float lower_limit, const float upper_limit, const float option3);
     std::vector<Prop>&   getProps() { return m_props; }
+    std::vector<NodeGfx>& getNodes() { return m_gfx_nodes; }
     bool                 hasCamera() { return m_videocameras.size() > 0; }
 
 private:

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -155,6 +155,15 @@ private:
 
     static Ogre::Quaternion SpecialGetRotationTo(const Ogre::Vector3& src, const Ogre::Vector3& dest);
 
+    // diagnostic and editor visualizations (managed by `UpdateDebugView()`)
+    void                 DrawDebugViewSubmesh();    // DebugViewType::DEBUGVIEW_SUBMESH
+    void                 DrawDebugViewSlidenodes(); // DebugViewType::DEBUGVIEW_SLIDENODES
+    void                 DrawDebugViewRotators();   // DebugViewType::DEBUGVIEW_ROTATORS
+    void                 DrawDebugViewShocks();     // DebugViewType::DEBUGVIEW_SHOCKS
+    void                 DrawDebugViewWheels();     // DebugViewType::DEBUGVIEW_WHEELS
+    void                 DrawDebugViewSkeleton();   // DebugViewType::DEBUGVIEW_{SKELETON/NODES/BEAMS}
+    void                 DrawPhysicsPausedIndicator();
+
     // Static info
     ActorPtr                      m_actor = nullptr;
     std::string                 m_custom_resource_group;

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -223,7 +223,7 @@ struct VideoCamera
 struct NodeGfx
 {
     NodeGfx(NodeNum_t node_idx):
-        nx_node_idx(node_idx),
+        nx_nodenum(node_idx),
         nx_no_particles(false), // Bitfields can't be initialized in-class :(
         nx_may_get_wet(false),
         nx_is_hot(false),
@@ -232,7 +232,8 @@ struct NodeGfx
     {}
 
     float      nx_wet_time_sec = -1; //!< 'Wet' means "already out of water, producing dripping particles". Set to -1 when not 'wet'.
-    NodeNum_t  nx_node_idx = NODENUM_INVALID;
+    float      nx_mouse_traversal_result_perc = -1.f; //!< 1.0 = pointed by mouse, 0.0 = at maximum traversal distance.
+    NodeNum_t  nx_nodenum = NODENUM_INVALID;
 
     // Bit flags
     bool       nx_no_particles:1;     //!< User-defined attr; disable all particles

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -232,7 +232,6 @@ struct NodeGfx
     {}
 
     float      nx_wet_time_sec = -1; //!< 'Wet' means "already out of water, producing dripping particles". Set to -1 when not 'wet'.
-    float      nx_mouse_traversal_result_perc = -1.f; //!< 1.0 = pointed by mouse, 0.0 = at maximum traversal distance.
     NodeNum_t  nx_nodenum = NODENUM_INVALID;
 
     // Bit flags

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -242,7 +242,7 @@ void GfxScene::UpdateScene(float dt_sec)
 
     App::GetGuiManager()->DrawSimGuiBuffered(player_gfx_actor);
 
-    App::GetGameContext()->GetSceneMouse().UpdateVisuals();
+    ImGui::ShowDemoWindow();
 
     // Actors - finalize threaded tasks
     for (GfxActor* gfx_actor: m_live_gfx_actors)
@@ -373,7 +373,7 @@ void GfxScene::DrawNetLabel(Ogre::Vector3 scene_pos, float cam_dist, std::string
         ImVec2 pos((int)pos_xyz.x+0.5, (int)pos_xyz.y+0.5);
 
         ImVec2 text_size = ImGui::CalcTextSize(caption.c_str());
-        GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+        GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
         ImDrawList* drawlist = GetImDummyFullscreenWindow();
         ImGuiContext* g = ImGui::GetCurrentContext();

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -63,7 +63,7 @@
 
 namespace RoR {
 
-inline ImVec4 ImVec4RGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
+inline ImVec4 RGBAv4(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
 {
     return ImVec4(static_cast<float>(r)/255.f, static_cast<float>(g)/255.f, static_cast<float>(b)/255.f, static_cast<float>(b)/255.f);
 }
@@ -96,13 +96,15 @@ public:
 
         // Mouse pick of nodes
         float  node_circle_num_segments           = 10.f;
-        ImVec4 mouse_minnode_color                = ImVec4(0.3f, 0.2f, 1.f, 1.f);
+        ImVec4 mouse_minnode_color                = RGBAv4(25, 59, 255, 255);
         float  mouse_minnode_thickness            = 3.f; //!< in pixels
         ImVec4 mouse_highlighted_node_color       = ImVec4(0.7f, 1.f, 0.4f, 1.f);
-        float  mouse_highlighted_node_radius_max  = 10; //!< in pixels
-        float  mouse_highlighted_node_radius_min  = 0.5; //!< in pixels
-        ImVec4 mouse_beam_close_color             = ImVec4RGBA(7, 109, 112, 255);
-        ImVec4 mouse_beam_far_color               = ImVec4RGBA(66, 56, 63, 64);
+        float  mouse_node_highlight_ref_distance  = 5.f;
+        float  mouse_node_highlight_aabb_padding = 2.f; //!< in meters, for all directions; Inflates actor AABB in test so highlights show earlier
+        float  mouse_highlighted_node_radius_max  = 5; //!< in pixels
+        float  mouse_highlighted_node_radius_min  = 1; //!< in pixels
+        ImVec4 mouse_beam_close_color             = RGBAv4(3, 148, 109, 255);
+        ImVec4 mouse_beam_far_color               = RGBAv4(38, 54, 51, 180);
         float  mouse_beam_thickness               = 2.f; //!< in pixels
         float  mouse_beam_traversal_length        = 0.8f; //!< in meters
 

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -102,6 +102,7 @@ public:
         float  node_effect_force_line_thickness   = 2.f;
         ImVec4 node_effect_force_circle_color     = ImVec4(0.15f, 0.2f, 1.f, 1.f);
         float  node_effect_force_circle_radius    = 4.f;
+        ImVec4 node_effect_highlight_line_color   = ImVec4(1.f, 1.f, 0.f, 1.f);
 
     };
 

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -88,6 +88,21 @@ public:
         ImVec2 semitrans_text_bg_padding = ImVec2(4.f, 2.f);
 
         ImFont* default_font = nullptr;
+
+        // Mouse pick of nodes
+        float  node_circle_num_segments           = 10.f;
+        ImVec4 mouse_minnode_color                = ImVec4(0.3f, 0.2f, 1.f, 1.f);
+        float  mouse_minnode_thickness            = 3.f; //!< in pixels
+        ImVec4 mouse_highlighted_node_color       = ImVec4(0.7f, 1.f, 0.4f, 1.f);
+        float  mouse_highlighted_node_radius_max  = 10; //!< in pixels
+        float  mouse_highlighted_node_radius_min  = 0.5; //!< in pixels
+
+        // Node effects
+        ImVec4 node_effect_force_line_color       = ImVec4(0.3f, 0.2f, 1.f, 1.f);
+        float  node_effect_force_line_thickness   = 2.f;
+        ImVec4 node_effect_force_circle_color     = ImVec4(0.15f, 0.2f, 1.f, 1.f);
+        float  node_effect_force_circle_radius    = 4.f;
+
     };
 
     // NOTE: RoR's mouse cursor management is a mess - cursor is hidden/revealed ad-hoc in the code (originally by calling `MyGUI::PointerManager::setVisible()`); this enum+API cleans it up a bit ~ only_a_ptr, 09/2017

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -63,9 +63,9 @@
 
 namespace RoR {
 
-inline ImVec4 ImVec4RGB(uint8_t r, uint8_t g, uint8_t b)
+inline ImVec4 ImVec4RGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
 {
-    return ImVec4(static_cast<float>(r)/255.f, static_cast<float>(g)/255.f, static_cast<float>(b)/255.f, 1.f);
+    return ImVec4(static_cast<float>(r)/255.f, static_cast<float>(g)/255.f, static_cast<float>(b)/255.f, static_cast<float>(b)/255.f);
 }
 
 class GUIManager
@@ -101,10 +101,10 @@ public:
         ImVec4 mouse_highlighted_node_color       = ImVec4(0.7f, 1.f, 0.4f, 1.f);
         float  mouse_highlighted_node_radius_max  = 10; //!< in pixels
         float  mouse_highlighted_node_radius_min  = 0.5; //!< in pixels
-        ImVec4 mouse_beam_close_color             = ImVec4RGB(171, 109, 3);
-        ImVec4 mouse_beam_far_color               = ImVec4RGB(128, 114, 91);
+        ImVec4 mouse_beam_close_color             = ImVec4RGBA(7, 109, 112, 255);
+        ImVec4 mouse_beam_far_color               = ImVec4RGBA(66, 56, 63, 64);
         float  mouse_beam_thickness               = 2.f; //!< in pixels
-        float  mouse_beam_traversal_length        = 2.f; //!< in meters
+        float  mouse_beam_traversal_length        = 0.8f; //!< in meters
 
         // Node effects
         ImVec4 node_effect_force_line_color       = ImVec4(0.3f, 0.2f, 1.f, 1.f);

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -63,7 +63,12 @@
 
 namespace RoR {
 
-class GUIManager: public ZeroedMemoryAllocator
+inline ImVec4 ImVec4RGB(uint8_t r, uint8_t g, uint8_t b)
+{
+    return ImVec4(static_cast<float>(r)/255.f, static_cast<float>(g)/255.f, static_cast<float>(b)/255.f, 1.f);
+}
+
+class GUIManager
 {
 public:
 
@@ -96,6 +101,10 @@ public:
         ImVec4 mouse_highlighted_node_color       = ImVec4(0.7f, 1.f, 0.4f, 1.f);
         float  mouse_highlighted_node_radius_max  = 10; //!< in pixels
         float  mouse_highlighted_node_radius_min  = 0.5; //!< in pixels
+        ImVec4 mouse_beam_close_color             = ImVec4RGB(171, 109, 3);
+        ImVec4 mouse_beam_far_color               = ImVec4RGB(128, 114, 91);
+        float  mouse_beam_thickness               = 2.f; //!< in pixels
+        float  mouse_beam_traversal_length        = 2.f; //!< in meters
 
         // Node effects
         ImVec4 node_effect_force_line_color       = ImVec4(0.3f, 0.2f, 1.f, 1.f);

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -26,7 +26,7 @@
 
 #include "OgreImGui.h"
 #include "Application.h"
-#include "GUI_MessageBox.h"
+#include "GUITheme.h"
 
 // GUI panels
 #include "GUI_CollisionsDebug.h"
@@ -63,59 +63,9 @@
 
 namespace RoR {
 
-inline ImVec4 RGBAv4(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
-{
-    return ImVec4(static_cast<float>(r)/255.f, static_cast<float>(g)/255.f, static_cast<float>(b)/255.f, static_cast<float>(b)/255.f);
-}
-
 class GUIManager
 {
 public:
-
-    struct GuiTheme
-    {
-        ImVec4 in_progress_text_color    = ImVec4(1.f, 0.832031f, 0.f, 1.f);
-        ImVec4 no_entries_text_color     = ImVec4(0.7f, 0.7f, 0.7f, 1.f);
-        ImVec4 error_text_color          = ImVec4(1.f, 0.175439f, 0.175439f, 1.f);
-        ImVec4 selected_entry_text_color = ImVec4(.9f, 0.7f, 0.05f, 1.f);
-        ImVec4 value_red_text_color      = ImVec4(.9f, .1f, .1f, 1.f);
-        ImVec4 value_blue_text_color     = ImVec4(0.34f, 0.67f, 0.84f, 1.f);
-        ImVec4 highlight_text_color      = ImVec4(0.78f, 0.39f, 0.f, 1.f);
-        ImVec4 success_text_color        = ImVec4(0.f, 0.8f, 0.f, 1.f);
-        ImVec4 warning_text_color        = ImVec4(0.9f, 0.8f, 0.1f, 1.f);
-        ImVec4 help_text_color           = ImVec4(0.5f, 0.7f, 1.f, 1.f);
-
-        ImVec4 semitransparent_window_bg = ImVec4(0.1f, 0.1f, 0.1f, 0.8f);
-        ImVec4 semitrans_text_bg_color   = ImVec4(0.1f, 0.1f, 0.1f, 0.6f);
-        ImVec4 color_mark_max_darkness   = ImVec4(0.2, 0.2, 0.2, 0.0); //!< If all RGB components are darker than this, text is auto-lightened.
-
-        ImVec2 screen_edge_padding       = ImVec2(10.f, 10.f);
-        ImVec2 semitrans_text_bg_padding = ImVec2(4.f, 2.f);
-
-        ImFont* default_font = nullptr;
-
-        // Mouse pick of nodes
-        float  node_circle_num_segments           = 10.f;
-        ImVec4 mouse_minnode_color                = RGBAv4(25, 59, 255, 255);
-        float  mouse_minnode_thickness            = 3.f; //!< in pixels
-        ImVec4 mouse_highlighted_node_color       = ImVec4(0.7f, 1.f, 0.4f, 1.f);
-        float  mouse_node_highlight_ref_distance  = 5.f;
-        float  mouse_node_highlight_aabb_padding = 2.f; //!< in meters, for all directions; Inflates actor AABB in test so highlights show earlier
-        float  mouse_highlighted_node_radius_max  = 5; //!< in pixels
-        float  mouse_highlighted_node_radius_min  = 1; //!< in pixels
-        ImVec4 mouse_beam_close_color             = RGBAv4(3, 148, 109, 255);
-        ImVec4 mouse_beam_far_color               = RGBAv4(38, 54, 51, 180);
-        float  mouse_beam_thickness               = 2.f; //!< in pixels
-        float  mouse_beam_traversal_length        = 0.8f; //!< in meters
-
-        // Node effects
-        ImVec4 node_effect_force_line_color       = ImVec4(0.3f, 0.2f, 1.f, 1.f);
-        float  node_effect_force_line_thickness   = 2.f;
-        ImVec4 node_effect_force_circle_color     = ImVec4(0.15f, 0.2f, 1.f, 1.f);
-        float  node_effect_force_circle_radius    = 4.f;
-        ImVec4 node_effect_highlight_line_color   = ImVec4(1.f, 1.f, 0.f, 1.f);
-
-    };
 
     // NOTE: RoR's mouse cursor management is a mess - cursor is hidden/revealed ad-hoc in the code (originally by calling `MyGUI::PointerManager::setVisible()`); this enum+API cleans it up a bit ~ only_a_ptr, 09/2017
     enum class MouseCursorVisibility
@@ -182,7 +132,7 @@ public:
     void SetUpMenuWallpaper();
 
     inline OgreImGui& GetImGui() { return m_imgui; }
-    inline GuiTheme&  GetTheme() { return m_theme; }
+    inline GUITheme&  GetTheme() { return m_theme; }
 
     void WakeUpGUI();
 
@@ -197,7 +147,7 @@ private:
     MyGUI::OgrePlatform* m_mygui_platform           = nullptr;
     bool                 m_hide_gui                 = false;
     OgreImGui            m_imgui;
-    GuiTheme             m_theme;
+    GUITheme             m_theme;
     bool                 m_gui_kb_capture_queued    = false; //!< Resets and accumulates every frame
     bool                 m_gui_kb_capture_requested = false; //!< Effective value, persistent
     Ogre::Timer          m_last_mousemove_time;

--- a/source/main/gui/GUITheme.h
+++ b/source/main/gui/GUITheme.h
@@ -1,0 +1,76 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2023 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+namespace RoR {
+
+inline ImVec4 RGBAv4(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255)
+{
+    return ImVec4(static_cast<float>(r) / 255.f, static_cast<float>(g) / 255.f, static_cast<float>(b) / 255.f, static_cast<float>(b) / 255.f);
+}
+
+struct GUITheme
+{
+    ImVec4 in_progress_text_color    = ImVec4(1.f, 0.832031f, 0.f, 1.f);
+    ImVec4 no_entries_text_color     = ImVec4(0.7f, 0.7f, 0.7f, 1.f);
+    ImVec4 error_text_color          = ImVec4(1.f, 0.175439f, 0.175439f, 1.f);
+    ImVec4 selected_entry_text_color = ImVec4(.9f, 0.7f, 0.05f, 1.f);
+    ImVec4 value_red_text_color      = ImVec4(.9f, .1f, .1f, 1.f);
+    ImVec4 value_blue_text_color     = ImVec4(0.34f, 0.67f, 0.84f, 1.f);
+    ImVec4 highlight_text_color      = ImVec4(0.78f, 0.39f, 0.f, 1.f);
+    ImVec4 success_text_color        = ImVec4(0.f, 0.8f, 0.f, 1.f);
+    ImVec4 warning_text_color        = ImVec4(0.9f, 0.8f, 0.1f, 1.f);
+    ImVec4 help_text_color           = ImVec4(0.5f, 0.7f, 1.f, 1.f);
+
+    ImVec4 semitransparent_window_bg = ImVec4(0.1f, 0.1f, 0.1f, 0.8f);
+    ImVec4 semitrans_text_bg_color = ImVec4(0.1f, 0.1f, 0.1f, 0.6f);
+    ImVec4 color_mark_max_darkness = ImVec4(0.2, 0.2, 0.2, 0.0); //!< If all RGB components are darker than this, text is auto-lightened.
+
+    ImVec2 screen_edge_padding = ImVec2(10.f, 10.f);
+    ImVec2 semitrans_text_bg_padding = ImVec2(4.f, 2.f);
+
+    ImFont* default_font = nullptr;
+
+    // Mouse pick of nodes
+    float  node_circle_num_segments          = 10.f;
+    ImVec4 mouse_minnode_color               = RGBAv4(25, 59, 255, 255);
+    float  mouse_minnode_thickness           = 3.f; //!< in pixels
+    ImVec4 mouse_highlighted_node_color      = ImVec4(0.7f, 1.f, 0.4f, 1.f);
+    float  mouse_node_highlight_ref_distance = 5.f;
+    float  mouse_node_highlight_aabb_padding = 2.f; //!< in meters, for all directions; Inflates actor AABB in test so highlights show earlier
+    float  mouse_highlighted_node_radius_max = 5; //!< in pixels
+    float  mouse_highlighted_node_radius_min = 1; //!< in pixels
+    ImVec4 mouse_beam_close_color            = RGBAv4(3, 148, 109, 255);
+    ImVec4 mouse_beam_far_color              = RGBAv4(38, 54, 51, 180);
+    float  mouse_beam_thickness              = 2.f; //!< in pixels
+    float  mouse_beam_traversal_length       = 0.8f; //!< in meters
+
+    // Node effects
+    ImVec4 node_effect_force_line_color = ImVec4(0.3f, 0.2f, 1.f, 1.f);
+    float  node_effect_force_line_thickness = 2.f;
+    ImVec4 node_effect_force_circle_color = ImVec4(0.15f, 0.2f, 1.f, 1.f);
+    float  node_effect_force_circle_radius = 4.f;
+    ImVec4 node_effect_highlight_line_color = ImVec4(1.f, 1.f, 0.f, 1.f);
+
+};
+
+} // namespace RoR

--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -421,3 +421,22 @@ void RoR::ImTerminateComboboxString(std::string& target)
     // Make space for 2 trailing with NULs
     target.resize(prev_size + 2, '\0');
 }
+
+void RoR::ImAddLineColorGradient(ImDrawList* drawlist, const ImVec2& p1, const ImVec2& p2, ImU32 c1, ImU32 c2, float thickness)
+{
+    // Let DearIMGUI draw a line and then adjust colors in the draw buffer
+    // Note that DearIMGUI archieves antialiasing by drawing semitransparent tris around the line tris.
+    // ------------------------------------------------------------------------------------------------
+
+    // Draw the line using color c1
+    drawlist->AddLine(p1, p2, c1, thickness);
+
+    // Prepare the c2 AA color ~ see `ImDrawList::AddPolyLine()` in 'imgui_draw.cpp', around line 610
+    const ImU32 c2aa = c2 & ~IM_COL32_A_MASK;
+
+    // Inject the colors to draw list ~ see `ImDrawList::AddPolyLine()` in 'imgui_draw.cpp', around line 770
+    (drawlist->_VtxWritePtr - 1)->col = c2aa; // end right AA
+    (drawlist->_VtxWritePtr - 2)->col = c2; // end right
+    (drawlist->_VtxWritePtr - 3)->col = c2; // end left
+    (drawlist->_VtxWritePtr - 4)->col = c2aa; // end left AA
+}

--- a/source/main/gui/GUIUtils.h
+++ b/source/main/gui/GUIUtils.h
@@ -74,7 +74,9 @@ void DrawGCombo(CVar* cvar, const char* label, const char* values);
 
 Ogre::TexturePtr FetchIcon(const char* name);
 
-ImDrawList* GetImDummyFullscreenWindow();
+ImDrawList* GetImDummyFullscreenWindow(const char* name = nullptr);
+
+bool GetScreenPosFromWorldPos(Ogre::Vector3 const& world_pos, Ogre::Vector2& out_screen);
 
 // Helpers for coposing combobox item strings.
 void ImAddItemToComboboxString(std::string& target, std::string const& item);

--- a/source/main/gui/GUIUtils.h
+++ b/source/main/gui/GUIUtils.h
@@ -76,10 +76,13 @@ Ogre::TexturePtr FetchIcon(const char* name);
 
 ImDrawList* GetImDummyFullscreenWindow(const char* name = nullptr);
 
+/// @returns true if the position is in front of the camera
 bool GetScreenPosFromWorldPos(Ogre::Vector3 const& world_pos, Ogre::Vector2& out_screen);
 
 // Helpers for coposing combobox item strings.
 void ImAddItemToComboboxString(std::string& target, std::string const& item);
 void ImTerminateComboboxString(std::string& target);
+
+void ImAddLineColorGradient(ImDrawList* drawlist, const ImVec2& p1, const ImVec2& p2, ImU32 c1, ImU32 c2, float thickness);
 
 } // namespace RoR

--- a/source/main/gui/imgui/OgreImGui.h
+++ b/source/main/gui/imgui/OgreImGui.h
@@ -45,6 +45,8 @@ static inline ImVec2& operator-=(ImVec2& lhs, const ImVec2& rhs)                
 static inline ImVec2& operator*=(ImVec2& lhs, const float rhs)                  { lhs.x *= rhs; lhs.y *= rhs; return lhs; }
 static inline ImVec2& operator/=(ImVec2& lhs, const float rhs)                  { lhs.x /= rhs; lhs.y /= rhs; return lhs; }
 
+static inline ImVec4 operator*(const ImVec4& lhs, const float rhs)             { return ImVec4(lhs.x*rhs, lhs.y*rhs, lhs.z*rhs, lhs.w*rhs); }
+
 /// DearIMGUI integration.
 /// Input handling is done by injecting OIS events to ImGUI
 /// Rendering is done via port of Ogre::ImGuiOverlay; this is temporary until we migrate to OGRE 1.12.x

--- a/source/main/gui/imgui/OgreImGui.h
+++ b/source/main/gui/imgui/OgreImGui.h
@@ -44,8 +44,13 @@ static inline ImVec2& operator+=(ImVec2& lhs, const ImVec2& rhs)                
 static inline ImVec2& operator-=(ImVec2& lhs, const ImVec2& rhs)                { lhs.x -= rhs.x; lhs.y -= rhs.y; return lhs; }
 static inline ImVec2& operator*=(ImVec2& lhs, const float rhs)                  { lhs.x *= rhs; lhs.y *= rhs; return lhs; }
 static inline ImVec2& operator/=(ImVec2& lhs, const float rhs)                  { lhs.x /= rhs; lhs.y /= rhs; return lhs; }
+//static inline ImVec2 ImLerp(const ImVec2& a, const ImVec2& b, float t)          { return ImVec2(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t); }
+//static inline ImVec4 ImLerp(const ImVec4& a, const ImVec4& b, float t)          { return ImVec4(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t, a.w + (b.w - a.w) * t); }
 
+
+// Extra math functions
 static inline ImVec4 operator*(const ImVec4& lhs, const float rhs)             { return ImVec4(lhs.x*rhs, lhs.y*rhs, lhs.z*rhs, lhs.w*rhs); }
+
 
 /// DearIMGUI integration.
 /// Input handling is done by injecting OIS events to ImGUI

--- a/source/main/gui/panels/GUI_CollisionsDebug.cpp
+++ b/source/main/gui/panels/GUI_CollisionsDebug.cpp
@@ -41,7 +41,7 @@ using namespace Ogre;
 
 void CollisionsDebug::Draw()
 {
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize;
     bool keep_open = true;
@@ -351,7 +351,7 @@ void CollisionsDebug::DrawLabelAtWorldPos(std::string const& caption, Ogre::Vect
         ImVec2 pos((int)pos_xyz.x + 0.5, (int)pos_xyz.y + 0.5);
 
         ImVec2 text_size = ImGui::CalcTextSize(caption.c_str());
-        GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+        GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
         ImDrawList* drawlist = GetImDummyFullscreenWindow();
         ImGuiContext* g = ImGui::GetCurrentContext();

--- a/source/main/gui/panels/GUI_ConsoleView.cpp
+++ b/source/main/gui/panels/GUI_ConsoleView.cpp
@@ -155,7 +155,7 @@ void ConsoleView::DrawConsoleMessages()
 ImVec2 ConsoleView::DrawMessage(ImVec2 cursor, Console::Message const& m)
 {
     Str<LINE_BUF_MAX> line;
-    GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+    GUITheme& theme = App::GetGuiManager()->GetTheme();
 
     const unsigned long curr_timestamp = App::GetConsole()->queryMessageTimer();
     unsigned long overtime = curr_timestamp - (m.cm_timestamp + (cvw_msg_duration_ms - fadeout_interval));

--- a/source/main/gui/panels/GUI_GameAbout.cpp
+++ b/source/main/gui/panels/GUI_GameAbout.cpp
@@ -38,7 +38,7 @@ using namespace GUI;
 
 void GameAbout::Draw()
 {
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGui::SetNextWindowSize(ImVec2(475.f, ImGui::GetIO().DisplaySize.y - 40.f), ImGuiCond_Appearing);
     ImGui::SetNextWindowPosCenter(ImGuiCond_Appearing);

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -47,7 +47,7 @@ GameChatBox::GameChatBox()
 
 void GameChatBox::Draw()
 {
-    GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+    GUITheme& theme = App::GetGuiManager()->GetTheme();
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0,0,0,0)); // Fully transparent background!
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0,0));
 

--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -40,7 +40,7 @@ void GameControls::Draw()
     {
         // Interactive keybind mode - controls window remains 'visible', but box is drawn instead.
 
-        GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+        GUITheme& theme = App::GetGuiManager()->GetTheme();
         Ogre::String keys_pressed;
         int num_nonmodifier_keys = App::GetInputEngine()->getCurrentKeyCombo(&keys_pressed);
 
@@ -107,7 +107,7 @@ void GameControls::Draw()
         bool keep_open = true;
         ImGui::Begin(_LC("GameControls", "Game Controls"), &keep_open);
 
-        GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+        GUITheme& theme = App::GetGuiManager()->GetTheme();
 
         // Toolbar
 
@@ -157,7 +157,7 @@ void GameControls::DrawEvent(RoR::events ev_code)
 {
     // Var
     InputEngine::TriggerVec& triggers = App::GetInputEngine()->getEvents()[ev_code];
-    GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+    GUITheme& theme = App::GetGuiManager()->GetTheme();
     float cursor_x = ImGui::GetCursorPosX();
 
     // Check if we have anything to show

--- a/source/main/gui/panels/GUI_LoadingWindow.cpp
+++ b/source/main/gui/panels/GUI_LoadingWindow.cpp
@@ -79,7 +79,7 @@ void LoadingWindow::SetProgressNetConnect(const std::string& net_status)
 
 void LoadingWindow::Draw()
 {
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     // Height calc
     float text_h = ImGui::CalcTextSize("A").y;

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -76,7 +76,7 @@ void MainSelector::Show(LoaderType type, std::string const& filter_guid, CacheEn
 
 void MainSelector::Draw()
 {
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse;
     ImGui::SetNextWindowPosCenter(ImGuiCond_FirstUseEver);

--- a/source/main/gui/panels/GUI_MultiplayerClientList.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerClientList.cpp
@@ -61,7 +61,7 @@ void MpClientList::Draw()
         this->CacheIcons();
     }
 
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse |
         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar;

--- a/source/main/gui/panels/GUI_MultiplayerSelector.cpp
+++ b/source/main/gui/panels/GUI_MultiplayerSelector.cpp
@@ -227,7 +227,7 @@ void MultiplayerSelector::DrawDirectTab()
 
 void MultiplayerSelector::DrawServerlistTab()
 {
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     const char* draw_label_text = nullptr;
     ImVec4      draw_label_color;

--- a/source/main/gui/panels/GUI_RepositorySelector.cpp
+++ b/source/main/gui/panels/GUI_RepositorySelector.cpp
@@ -347,7 +347,7 @@ RepositorySelector::~RepositorySelector()
 
 void RepositorySelector::Draw()
 {
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGui::SetNextWindowSize(ImVec2((ImGui::GetIO().DisplaySize.x / 1.4), (ImGui::GetIO().DisplaySize.y / 1.2)), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowPosCenter(ImGuiCond_Appearing);
@@ -1201,7 +1201,7 @@ void RepositorySelector::DrawThumbnail(int resource_item_idx)
     // Displays a thumbnail image if available, or shows a spinner and initiates async download.
     // -----------------------------------------------------------------------------------------
 
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImVec2 image_size;
     if (m_view_mode == "List")

--- a/source/main/gui/panels/GUI_SimActorStats.cpp
+++ b/source/main/gui/panels/GUI_SimActorStats.cpp
@@ -35,7 +35,7 @@ using namespace GUI;
 
 void SimActorStats::Draw(RoR::GfxActor* actorx)
 {
-    GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+    GUITheme& theme = App::GetGuiManager()->GetTheme();
     
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoCollapse |
         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar;

--- a/source/main/gui/panels/GUI_SimPerfStats.cpp
+++ b/source/main/gui/panels/GUI_SimPerfStats.cpp
@@ -35,7 +35,7 @@ using namespace GUI;
 
 void SimPerfStats::Draw()
 {
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoCollapse |
         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar;

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -107,7 +107,7 @@ void SurveyMap::Draw()
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, WINDOW_ROUNDING);
     ImGui::SetNextWindowSize(ImVec2((view_size.x + view_padding.x), (view_size.y + view_padding.y)));
 
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
     ImGui::PushStyleColor(ImGuiCol_WindowBg, theme.semitransparent_window_bg);
 
     if (mMapMode == SurveyMapMode::BIG)

--- a/source/main/gui/panels/GUI_ThemeEditor.cpp
+++ b/source/main/gui/panels/GUI_ThemeEditor.cpp
@@ -1,0 +1,109 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2023 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "GUI_ThemeEditor.h"
+
+#include "Application.h"
+#include "Actor.h"
+#include "GameContext.h"
+#include "GUIManager.h"
+#include "GUITheme.h"
+#include "InputEngine.h"
+#include "Language.h"
+
+#include <fmt/format.h>
+#include <imgui.h>
+
+using namespace RoR;
+using namespace GUI;
+
+void ThemeEditor::Draw()
+{
+    ImGui::SetNextWindowPosCenter(ImGuiCond_Appearing);
+    
+    if (!ImGui::Begin("ThemeEditor", &m_is_visible))
+    {
+        ImGui::End(); // The window is collapsed
+        return;
+    }
+
+    GUITheme& theme = App::GetGuiManager()->GetTheme();
+
+    if (ImGui::CollapsingHeader(_LC("ThemeEditor", "Text"), ImGuiTreeNodeFlags_DefaultOpen))
+    {
+        this->EditColor(theme.in_progress_text_color    , _LC("UITheme", "In progress"));
+        this->EditColor(theme.no_entries_text_color     , _LC("UITheme", "No entries"));
+        this->EditColor(theme.error_text_color          , _LC("UITheme", "Error"));
+        this->EditColor(theme.selected_entry_text_color , _LC("UITheme", "Selected entry"));
+        this->EditColor(theme.value_red_text_color      , _LC("UITheme", "Red"));
+        this->EditColor(theme.value_blue_text_color     , _LC("UITheme", "Blue"));
+        this->EditColor(theme.highlight_text_color      , _LC("UITheme", "Highlighted"));
+        this->EditColor(theme.success_text_color        , _LC("UITheme", "Success"));
+        this->EditColor(theme.warning_text_color        , _LC("UITheme", "Warning"));
+        this->EditColor(theme.help_text_color           , _LC("UITheme", "Help"));
+    }
+
+    if (ImGui::CollapsingHeader(_LC("ThemeEditor", "Windows"), ImGuiTreeNodeFlags_DefaultOpen))
+    {
+        this->EditColor(theme.semitransparent_window_bg , _LC("UITheme", "Semitrans BG"));
+        this->EditColor(theme.semitrans_text_bg_color   , _LC("UITheme", "Semitrans text BG"));
+        ImGui::TextDisabled(_LC("ThemeEditor", "If all RGB components are darker than this, text is auto-lightened."));
+        this->EditColor(theme.color_mark_max_darkness   , _LC("UITheme", "Max text darkness"));
+
+    }
+
+    if (ImGui::CollapsingHeader(_LC("ThemeEditor", "Mouse scene interaction")))
+    {
+        // Mouse pick of nodes
+        this->EditFloat(theme.node_circle_num_segments           , _LC("UITheme", "Circle num segments"));   // float  
+        this->EditColor(theme.mouse_minnode_color                , _LC("UITheme", "Hovered node color"));   // ImVec4 
+        this->EditFloat(theme.mouse_minnode_thickness            , _LC("UITheme", "Hovered node thickness"));   // float  
+        this->EditColor(theme.mouse_highlighted_node_color       , _LC("UITheme", "Highlighted node color"));   // ImVec4 
+        this->EditFloat(theme.mouse_node_highlight_ref_distance  , _LC("UITheme", "Node highlight ref distance"));   // float  
+        this->EditFloat(theme.mouse_node_highlight_aabb_padding  , _LC("UITheme", "Node highlight AABB padding"));   // float  
+        this->EditFloat(theme.mouse_highlighted_node_radius_max  , _LC("UITheme", "Highlighted node radius max"));   // float  
+        this->EditFloat(theme.mouse_highlighted_node_radius_min  , _LC("UITheme", "Highlighted node radius min"));   // float  
+        this->EditColor(theme.mouse_beam_close_color             , _LC("UITheme", "Beam color close"));   // ImVec4 
+        this->EditColor(theme.mouse_beam_far_color               , _LC("UITheme", "Beam color far"));   // ImVec4 
+        this->EditFloat(theme.mouse_beam_thickness               , _LC("UITheme", "Beam thickness"));   // float  
+        this->EditFloat(theme.mouse_beam_traversal_length        , _LC("UITheme", "Beam traversal length"));   // float  
+
+        // Node effects
+        this->EditColor(theme.node_effect_force_line_color       , _LC("UITheme", "Force line color"));   // ImVec4 
+        this->EditFloat(theme.node_effect_force_line_thickness   , _LC("UITheme", "Force line thickness"));   // float  
+        this->EditColor(theme.node_effect_force_circle_color     , _LC("UITheme", "Affector circle color"));   // ImVec4 
+        this->EditFloat(theme.node_effect_force_circle_radius    , _LC("UITheme", "Affector circle radius"));   // float  
+        this->EditColor(theme.node_effect_highlight_line_color   , _LC("UITheme", "Affector highlight color"));   // ImVec4 
+    }
+
+    App::GetGuiManager()->RequestGuiCaptureKeyboard(ImGui::IsWindowHovered());
+    ImGui::End();
+}
+
+void ThemeEditor::EditColor(ImVec4& color, const char* desc)
+{
+    ImGui::ColorEdit4(desc, (float*)&color);
+}
+
+void ThemeEditor::EditFloat(float& val, const char* desc)
+{
+    ImGui::InputFloat(desc, &val);
+}

--- a/source/main/gui/panels/GUI_ThemeEditor.h
+++ b/source/main/gui/panels/GUI_ThemeEditor.h
@@ -1,0 +1,50 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2023 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+/// @author Petr Ohlidal
+/// @date   05/2023
+
+#pragma once
+
+#include <imgui.h>
+
+namespace RoR {
+namespace GUI {
+
+class ThemeEditor
+{
+public:
+
+
+    void SetVisible(bool vis) { m_is_visible = vis; }
+    bool IsVisible() const { return m_is_visible; }
+
+    void Draw();
+
+private:
+    void EditColor(ImVec4& color, const char* desc);
+    void EditFloat(float& val, const char* desc);
+    bool m_is_visible = false;
+};
+
+} // namespace GUI
+} // namespace RoR

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -107,7 +107,7 @@ void TopMenubar::Update()
     // ## ImGui's 'menubar' and 'menuitem' features won't quite cut it...
     // ## Let's do our own menus and menuitems using buttons and coloring tricks.
 
-    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    GUITheme const& theme = App::GetGuiManager()->GetTheme();
 
     int num_playable_actors = 0;
     for (ActorPtr& actor: App::GetGameContext()->GetActorManager()->GetActors())
@@ -1564,7 +1564,7 @@ void TopMenubar::DrawSpecialStateBox(float top_offset)
 
         // Calculate distance
         GameContextSB& data = App::GetGfxScene()->GetSimDataBuffer();
-        GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+        GUITheme const& theme = App::GetGuiManager()->GetTheme();
         float distance = 0.0f;
         ActorPtr player_actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
         if (player_actor != nullptr && App::GetGameContext()->GetPlayerActor() &&

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -41,7 +41,7 @@ using namespace GUI;
 
 void VehicleButtons::Draw(RoR::GfxActor* actorx)
 {
-    GUIManager::GuiTheme& theme = App::GetGuiManager()->GetTheme();
+    GUITheme& theme = App::GetGuiManager()->GetTheme();
 
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar;
     ImGui::SetNextWindowPos(ImVec2(theme.screen_edge_padding.x - ImGui::GetStyle().WindowPadding.x, 100.f));

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -882,6 +882,24 @@ int main(int argc, char *argv[])
                     break;
                 }
 
+                case MSG_EDI_ADD_AFFECTOR_REQUESTED:
+                {
+                    AddAffectorRequest* req = static_cast<AddAffectorRequest*>(m.payload);
+                    AffectorID_t affectorid = App::GetGameContext()->GetActorManager()->AddAffector(req);
+                    if (req->aar_set_mouseforce)
+                        App::GetGameContext()->GetSceneMouse().SetMouseAffector(affectorid);
+                    delete req;
+                    break;
+                }
+
+                case MSG_EDI_REMOVE_AFFECTOR_REQUESTED:
+                {
+                    RemoveAffectorRequest* req = static_cast<RemoveAffectorRequest*>(m.payload);
+                    App::GetGameContext()->GetActorManager()->RemoveAffector(req);
+                    delete req;
+                    break;
+                }
+
                 default:;
                 }
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -961,6 +961,7 @@ int main(int argc, char *argv[])
                         App::GetOverlayWrapper()->update(dt);
                         App::GetGameContext()->GetRecoveryMode().UpdateInputEvents(dt);
                         App::GetGameContext()->GetActorManager()->UpdateInputEvents(dt);
+                        App::GetGameContext()->GetSceneMouse().UpdateInputEvents();
                         if (App::sim_state->getEnum<SimState>() == SimState::RUNNING)
                         {
                             if (App::GetCameraManager()->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_FREE)

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1270,11 +1270,24 @@ void Actor::resetPosition(Ogre::Vector3 translation, bool setInitPosition)
     calculateAveragePosition();
 }
 
-void Actor::mouseMove(NodeNum_t node, Vector3 pos, float force)
+void Actor::addNodeEffectConstantForce(NodeNum_t nodenum, Ogre::Vector3 force)
 {
-    m_mouse_grab_node = node;
-    m_mouse_grab_move_force = force * std::pow(m_total_mass / 3000.0f, 0.75f);
-    m_mouse_grab_pos = pos;
+    ar_node_effects_constant_force.push_back({ nodenum, force });
+}
+
+void Actor::clearNodeEffectConstantForce(NodeNum_t nodenum)
+{
+    EraseIf(ar_node_effects_constant_force, [nodenum](const NodeEffectConstantForce& e) {return e.nodenum == nodenum; });
+}
+
+void Actor::addNodeEffectForceTowardsPoint(NodeNum_t nodenum, Ogre::Vector3 pos, float force)
+{
+    ar_node_effects_force_towards_point.push_back({nodenum, pos, force});
+}
+
+void Actor::clearNodeEffectForceTowardsPoint(NodeNum_t nodenum)
+{
+    EraseIf(ar_node_effects_force_towards_point, [nodenum](const NodeEffectForceTowardsPoint& e) {return e.nodenum == nodenum; });
 }
 
 void Actor::toggleWheelDiffMode()
@@ -4404,8 +4417,6 @@ Actor::Actor(
     , m_spawn_rotation(0.0)
     , ar_net_stream_id(0)
     , m_min_camera_radius(0.0f)
-    , m_mouse_grab_move_force(0.0f)
-    , m_mouse_grab_pos(Ogre::Vector3::ZERO)
     , m_net_initialized(false)
     , ar_initial_total_mass(0)
     , ar_parking_brake(false)

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1270,26 +1270,6 @@ void Actor::resetPosition(Ogre::Vector3 translation, bool setInitPosition)
     calculateAveragePosition();
 }
 
-void Actor::addNodeEffectConstantForce(NodeNum_t nodenum, Ogre::Vector3 force)
-{
-    ar_node_effects_constant_force.push_back({ nodenum, force });
-}
-
-void Actor::clearNodeEffectConstantForce(NodeNum_t nodenum)
-{
-    EraseIf(ar_node_effects_constant_force, [nodenum](const NodeEffectConstantForce& e) {return e.nodenum == nodenum; });
-}
-
-void Actor::addNodeEffectForceTowardsPoint(NodeNum_t nodenum, Ogre::Vector3 pos, float force)
-{
-    ar_node_effects_force_towards_point.push_back({nodenum, pos, force});
-}
-
-void Actor::clearNodeEffectForceTowardsPoint(NodeNum_t nodenum)
-{
-    EraseIf(ar_node_effects_force_towards_point, [nodenum](const NodeEffectForceTowardsPoint& e) {return e.nodenum == nodenum; });
-}
-
 void Actor::toggleWheelDiffMode()
 {
     for (int i = 0; i < m_num_wheel_diffs; ++i)

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -126,8 +126,12 @@ public:
     void              antilockbrakeToggle();
     void              toggleCustomParticles();
     bool              getCustomParticleMode();
+    void              addNodeEffectConstantForce(NodeNum_t nodenum, Ogre::Vector3 force);
+    void              clearNodeEffectConstantForce(NodeNum_t nodenum);
+    void              addNodeEffectForceTowardsPoint(NodeNum_t nodenum, Ogre::Vector3 point, float force);
+    void              clearNodeEffectForceTowardsPoint(NodeNum_t nodenum);
+    void              clearNodeEffects(NodeNum_t nodenum);
     // not exported to scripting:
-    void              mouseMove(NodeNum_t node, Ogre::Vector3 pos, float force);
     void              tieToggle(int group=-1);
     bool              isTied();
     void              hookToggle(int group=-1, HookAction mode=HOOK_TOGGLE, NodeNum_t node_number=NODENUM_INVALID);
@@ -415,6 +419,11 @@ public:
     float             ar_collision_range;             //!< Physics attr
     float             ar_top_speed;                   //!< Sim state
     ground_model_t*   ar_last_fuzzy_ground_model;     //!< GUI state
+
+    // Node effects
+    std::vector<NodeEffectConstantForce> ar_node_effects_constant_force;
+    std::vector<NodeEffectForceTowardsPoint> ar_node_effects_force_towards_point;
+
     CollisionBoxPtrVec m_potential_eventboxes;
     std::vector<std::pair<collision_box_t*, NodeNum_t>> m_active_eventboxes;
 
@@ -469,7 +478,7 @@ private:
     void              CalcFuseDrag();                      
     void              CalcHooks();                         
     void              CalcHydros();                        
-    void              CalcMouse();                         
+    void              CalcNodeEffects();                         
     void              CalcNodes();
     void              CalcEventBoxes();
     void              CalcReplay();                        
@@ -525,9 +534,6 @@ private:
     float             m_stabilizer_shock_sleep;     //!< Sim state
     Replay*           m_replay_handler;
     float             m_total_mass;            //!< Physics state; total mass in Kg
-    NodeNum_t         m_mouse_grab_node = NODENUM_INVALID;  //!< Sim state; node currently being dragged by user
-    Ogre::Vector3     m_mouse_grab_pos;
-    float             m_mouse_grab_move_force;
     float             m_spawn_rotation;
     Ogre::Timer       m_reset_timer;
     Ogre::Vector3     m_rotation_request_center;

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -59,7 +59,7 @@ void Actor::CalcForcesEulerCompute(bool doUpdate, int num_steps)
     this->CalcCommands(doUpdate);
     this->CalcTies();
     this->CalcTruckEngine(doUpdate); // must be done after the commands / engine triggers are updated
-    this->CalcMouse();
+    this->CalcNodeEffects();
     this->CalcBeams(doUpdate);
     this->CalcCabCollisions();
     this->updateSlideNodeForces(PHYSICS_DT); // must be done after the contacters are updated
@@ -91,12 +91,17 @@ void Actor::CalcForceFeedback(bool doUpdate)
     }
 }
 
-void Actor::CalcMouse()
+void Actor::CalcNodeEffects()
 {
-    if (m_mouse_grab_node != NODENUM_INVALID)
+    for (const NodeEffectConstantForce& e : ar_node_effects_constant_force)
     {
-        Vector3 dir = m_mouse_grab_pos - ar_nodes[m_mouse_grab_node].AbsPosition;
-        ar_nodes[m_mouse_grab_node].Forces += m_mouse_grab_move_force * dir;
+        ar_nodes[e.nodenum].Forces += e.force;
+    }
+
+    for (const NodeEffectForceTowardsPoint& e : ar_node_effects_force_towards_point)
+    {
+        const Vector3 dir = e.point - ar_nodes[e.nodenum].AbsPosition;
+        ar_nodes[e.nodenum].Forces += e.force * dir;
     }
 }
 

--- a/source/main/physics/ActorManager.h
+++ b/source/main/physics/ActorManager.h
@@ -56,6 +56,12 @@ public:
     void           DeleteActorInternal(ActorPtr actor); //!< Do not call directly; use `GameContext::DeleteActor()`
     /// @}
 
+    /// @name Editing
+    /// @{
+    AffectorID_t   AddAffector(AddAffectorRequest* rq);
+    void           RemoveAffector(RemoveAffectorRequest* rq);
+    /// @}
+
     void           UpdateActors(ActorPtr player_actor);
     void           SyncWithSimThread();
     void           UpdatePhysicsSimulation();

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -89,16 +89,19 @@ using namespace RoR;
 void ActorSpawner::ConfigureSections(Ogre::String const & sectionconfig, RigDef::DocumentPtr def)
 {   
     m_selected_modules.push_back(def->root_module);
-    auto result = def->user_modules.find(sectionconfig);
+    if (sectionconfig != "")
+    {
+        auto result = def->user_modules.find(sectionconfig);
 
-    if (result != def->user_modules.end())
-    {
-        m_selected_modules.push_back(result->second);
-        LOG(" == ActorSpawner: Module added to configuration: " + sectionconfig);
-    }
-    else
-    {
-        this->AddMessage(Message::TYPE_WARNING, "Selected module not found: " + sectionconfig);
+        if (result != def->user_modules.end())
+        {
+            m_selected_modules.push_back(result->second);
+            LOG(" == ActorSpawner: Module added to configuration: " + sectionconfig);
+        }
+        else
+        {
+            this->AddMessage(Message::TYPE_WARNING, "Selected module not found: " + sectionconfig);
+        }
     }
 }
 
@@ -5892,6 +5895,15 @@ void ActorSpawner::ProcessCinecam(RigDef::Cinecam & def)
     // NOTE: Not applying the 'node_mass' value here for backwards compatibility - this node must go through initial `Actor::RecalculateNodeMasses()` pass with default weight.
 
     m_actor->ar_minimass[camera_node.pos] = m_state.global_minimass;
+    
+    // node GFX
+    NodeGfx nfx(camera_node.pos);
+    nfx.nx_no_particles = BITMASK_IS_1(def.node_defaults->options, RigDef::Node::OPTION_p_NO_PARTICLES);
+    nfx.nx_may_get_wet  = BITMASK_IS_0(def.node_defaults->options, RigDef::Node::OPTION_c_NO_GROUND_CONTACT);
+    nfx.nx_no_particles = BITMASK_IS_1(def.node_defaults->options, RigDef::Node::OPTION_p_NO_PARTICLES);
+    nfx.nx_no_sparks    = BITMASK_IS_1(def.node_defaults->options, RigDef::Node::OPTION_f_NO_SPARKS);
+    m_actor->m_gfx_actor->m_gfx_nodes.push_back(nfx);
+
 
     m_actor->ar_cinecam_node[m_actor->ar_num_cinecams] = camera_node.pos;
     m_actor->ar_num_cinecams++;

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -664,6 +664,19 @@ struct PropAnimKeyState
     events event_id = EV_MODE_LAST; // invalid
 };
 
+struct NodeEffectConstantForce
+{
+    NodeNum_t nodenum;
+    Ogre::Vector3 force; //!< Newtons
+};
+
+struct NodeEffectForceTowardsPoint
+{
+    NodeNum_t nodenum;
+    Ogre::Vector3 point;
+    float force; //!< Newtons
+};
+
 /// @}
 
 // --------------------------------

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -1472,6 +1472,37 @@ bool GameScript::pushMessage(MsgType type, AngelScript::CScriptDictionary* dict)
         }
         break;
     }
+
+    // Editing:
+    case MSG_EDI_ADD_AFFECTOR_REQUESTED:        //!< Payload = RoR::AddAffectorRequest* (owner)
+    {
+        AffectorType type = AffectorType::INVALID;
+        // `dictionary` converts all primitives to `double` or `int64`, see 'scriptdictionary.cpp', function `Set()`
+        int64_t instance_id = -1;
+        double force_min = 0.f;
+        double force_max = 0.f;
+        if (this->GetValueFromDict(log_msg, dict, /*required:*/true, "instance_id", "int64", instance_id) &&
+            this->GetValueFromDict(log_msg, dict, /*required:*/true, "type", "AffectorType", type) &&
+            this->GetValueFromDict(log_msg, dict, /*required:*/true, "force_min", "double", force_min) &&
+            this->GetValueFromDict(log_msg, dict, /*required:*/true, "force_max", "double", force_max)
+            )
+        {
+            AddAffectorRequest* req = new AddAffectorRequest();
+            req->aar_actor = static_cast<ActorInstanceID_t>(instance_id);
+            req->aar_affector.af_type = type;
+            req->aar_affector.af_force_max = static_cast<float>(force_max);
+            req->aar_affector.af_force_min = static_cast<float>(force_min);
+
+            this->GetValueFromDict(log_msg, dict, /*required:*/false, "force_vector", "vector3", req->aar_affector.af_force_vector);
+
+            m.payload = req;
+        }
+        break;
+    }
+    case MSG_EDI_REMOVE_AFFECTOR_REQUESTED:     //!< Payload = RoR::RemoveAffectorRequest* (owner)
+    {
+        break;
+    }
     
     default:;
     }

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -77,6 +77,13 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("ActorModifyRequestType", "ACTOR_MODIFY_REQUEST_RESTORE_SAVED", (int)ActorModifyRequest::Type::RESTORE_SAVED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("ActorModifyRequestType", "ACTOR_MODIFY_REQUEST_WAKE_UP", (int)ActorModifyRequest::Type::WAKE_UP); ROR_ASSERT(result >= 0);
 
+    // enum AffectorType
+    result = engine->RegisterEnum("AffectorType"); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("AffectorType", "ACTUATOR_TYPE_INVALID", (int)AffectorType::INVALID); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("AffectorType", "ACTUATOR_TYPE_UNIFORM_FORCE", (int)AffectorType::UNIFORM_FORCE); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("AffectorType", "ACTUATOR_TYPE_PINNED_FORCE", (int)AffectorType::PINNED_FORCE); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("AffectorType", "ACTUATOR_TYPE_THRUSTER", (int)AffectorType::THRUSTER); ROR_ASSERT(result >= 0);
+
     // class Actor (historically Beam)
     Actor::RegisterRefCountingObject(engine, "BeamClass");
     ActorPtr::RegisterRefCountingObjectPtr(engine, "BeamClassPtr", "BeamClass");

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -39,6 +39,7 @@
 #endif
 
 using namespace Ogre;
+using namespace RoR;
 
 String RoR::sha1sum(const char *key, int len)
 {

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -26,6 +26,7 @@
 #include "RoRVersion.h"
 #include "SHA1.h"
 #include "Application.h"
+#include "CameraManager.h"
 
 #include <Ogre.h>
 #include <string>
@@ -202,6 +203,15 @@ std::string RoR::PrintMeshInfo(std::string const& title, MeshPtr mesh)
     }
 
     return text.ToCStr();
+}
+
+World2ScreenConverter World2ScreenConverter::Default()
+{
+    ImVec2 screen_size = ImGui::GetIO().DisplaySize;
+    return World2ScreenConverter(
+        App::GetCameraManager()->GetCamera()->getViewMatrix(true),
+        App::GetCameraManager()->GetCamera()->getProjectionMatrix(),
+        Ogre::Vector2(screen_size.x, screen_size.y));
 }
 
 void RoR::CvarAddFileToList(CVar* cvar, const std::string& filename)

--- a/source/main/utils/Utils.h
+++ b/source/main/utils/Utils.h
@@ -85,6 +85,8 @@ public:
         m_view_matrix(view_mtx), m_projection_matrix(proj_mtx), m_screen_size(screen_size)
     {}
 
+    static World2ScreenConverter Default();
+
     /// @return X,Y=screen pos, Z=view space pos ('Z<0' means 'in front of the camera')
     Ogre::Vector3 Convert(Ogre::Vector3 world_pos)
     {


### PR DESCRIPTION
Affectors are actuators which apply force to nodes. Applying forces from script or GUI is not trivial because physics runs at 2000FPS while Script/GUI are updated once per frame (roughly 100FPS). Until now there was 1 "slot" for a mouse-cursor grab force. Affectors are an extension of this system - you can add multiple forces this way and control them in various ways. The mouse grab system was remade using affectors.
Planned features (**general status: alpha version**):

- **uniform force affector** - applies constant force in constant direction to nodes. Status: stub, no scripting.
- **pinned force affector** - pulls nodes towards a given point. Status: working (used in mouse grab), scripting not tested.
- **thruster affector** - applies force within a frame of reference given by nodes `noderef/nodex/nodey`, like aeroengines/screwprops. Status: stub.
- **live editing** - use `MSG_EDI_ADD/REMOVE_AFFECTOR_REQUESTED` with arguments-struct. This works (used in mouse grab).
- **script editing** - call `game.pushMessage(MSG_EDI_ADD/REMOVE_AFFECTOR_REQUESTED, {})` with a dictionary of params. Status: ADD is coded but not tested, REMOVE isn't coded yet.
- **force pinning with INSERT** - an extension to grab mode. Use right mouse button to unpin again. This works, see GIF below.
- **theme editor UI** - because the debug views get more complex and color definitions are hardcoded all over the place. And while I'm consolidating it, it's a small job to do a theme editor. Status: stub, not usable yet.

![dafMousePinForces](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/79821e76-dc13-450e-876e-688e34f6de1c)
