### PR TITLE
🎮 Enabled character/actor collision in multiplayer. 

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -108,6 +108,7 @@ CVar* sim_no_self_collisions;
 CVar* sim_gearbox_mode;
 CVar* sim_soft_reset_mode;
 CVar* sim_quickload_dialog;
+CVar* sim_character_collisions;
 
 // Multiplayer
 CVar* mp_state;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -301,6 +301,7 @@ extern CVar* sim_no_self_collisions;
 extern CVar* sim_gearbox_mode;
 extern CVar* sim_soft_reset_mode;
 extern CVar* sim_quickload_dialog;
+extern CVar* sim_character_collisions;
 
 // Multiplayer
 extern CVar* mp_state;

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -488,7 +488,7 @@ void GameContext::ChangePlayerActor(ActorPtr actor)
             Character* player_character = this->GetPlayerCharacter();
             if (player_character)
             {
-                player_character->SetActorCoupling(false, nullptr);
+                player_character->SetActorCoupling(nullptr);
                 player_character->setRotation(Ogre::Radian(rotation));
                 player_character->setPosition(position);
             }
@@ -518,7 +518,7 @@ void GameContext::ChangePlayerActor(ActorPtr actor)
         Character* player_character = this->GetPlayerCharacter();
         if (player_character)
         {
-            player_character->SetActorCoupling(true, m_player_actor);
+            player_character->SetActorCoupling(m_player_actor);
         }
 
         App::GetGuiManager()->FlexbodyDebug.AnalyzeFlexbodies();

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -197,7 +197,7 @@ void Character::update(float dt)
                         position.y += std::min(depth, 0.05f);
                     }
 
-                    if (m_contacting_actor != nullptr && App::sim_character_collisions->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED)
+                    if (m_contacting_actor != nullptr)
                     {
                         int motion_cab = -1;
                         if (m_contacting_cab == m_last_contacting_cab) // we're on the same cab - just get it's current pos.
@@ -212,26 +212,31 @@ void Character::update(float dt)
                         m_vehicle_position = cab_position;
                         m_vehicle_rotation = Ogre::Radian(m_contacting_actor->getRotation());
 
-                        position += (m_vehicle_position - m_last_vehicle_position);
-                        this->setRotation(m_character_rotation + (m_vehicle_rotation - m_last_vehicle_rotation));
+                        if (App::sim_character_collisions->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED)
+                        {
+                            position += (m_vehicle_position - m_last_vehicle_position);
+                            this->setRotation(m_character_rotation + (m_vehicle_rotation - m_last_vehicle_rotation));
+                        }
 
                         m_inertia = true;
                         m_inertia_position = (m_vehicle_position - m_last_vehicle_position);
                         m_inertia_rotation = (m_vehicle_rotation - m_last_vehicle_rotation);
                     }
-                    else if (m_inertia && App::sim_character_collisions->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED)
+                    else if (m_inertia)
                     {
-                        position += m_inertia_position;
-                        this->setRotation(m_character_rotation + m_inertia_rotation);
+                        if (App::sim_character_collisions->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED)
+                        {
+                            position += m_inertia_position;
+                            this->setRotation(m_character_rotation + m_inertia_rotation);
+                        }
                     }
                 }
-                else if (m_contacting_actor != nullptr && !m_contacting_actor->ar_bounding_box.contains(position) && App::sim_character_collisions->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED) // we lost contact, reset contacting actor
+                else if (m_contacting_actor != nullptr && !m_contacting_actor->ar_bounding_box.contains(position)) // we lost contact, reset contacting actor
                 {
                     m_contacting_actor = nullptr;
                 }
             }
-            if (App::sim_character_collisions->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED)
-            {
+
                 if (m_contacting_cab == m_last_contacting_cab)
                 {
                     m_last_vehicle_position = m_vehicle_position;
@@ -243,7 +248,6 @@ void Character::update(float dt)
                 }
                 m_last_contacting_cab = m_contacting_cab;
                 m_last_vehicle_rotation = m_vehicle_rotation;
-            }
         }
 
         // Obstacle detection

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -205,11 +205,13 @@ void Character::update(float dt)
                         const Affine3 old_matrix = m_prev_contacting_cab_matrix;
                         const Affine3 cur_matrix = CalcCabTransformMatrix(actor, m_prev_contacting_cab);
 
+                        const int tmpv = actor->ar_collcabs[m_contacting_cab] * 3;
+                        const Vector3 a = actor->ar_nodes[actor->ar_cabs[tmpv + 0]].AbsPosition;
 
                         Vector3 old_pos = old_matrix * m_prev_contacting_cab_localpos;
                         Vector3 projected_pos = cur_matrix * m_prev_contacting_cab_localpos;
-                        position.x = projected_pos.x;
-                        position.z = projected_pos.z;
+                        position.x = projected_pos.x + a.x;
+                        position.z = projected_pos.z + a.z;
 
                         // Delta rot
                     //    Ogre::Radian delta_rotation = -(cur_matrix.extractQuaternion() - old_matrix.extractQuaternion()).getYaw();
@@ -496,7 +498,7 @@ Ogre::Affine3 Character::CalcCabTransformMatrix(ActorPtr& actor, int cab_index)
     const Vector3 y_axis = x_axis.crossProduct(z_axis);
     Quaternion rot = Quaternion(x_axis, y_axis, z_axis);
 
-    return Affine3(a, rot);
+    return Affine3(Vector3::ZERO, rot);
 }
 
 void Character::move(Vector3 offset)

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -549,10 +549,11 @@ void Character::SendStreamData()
     NetCharacterMsgPos msg;
     if (m_contacting_actor)
     {
+        const Ogre::Vector3 cab_coords = CalcCabAveragePos(m_contacting_actor, m_contacting_cab);
         msg.command = CHARACTER_CMD_POSITION_CAB;
-        msg.pos_x = m_character_position.x - m_vehicle_position.x;
-        msg.pos_y = m_character_position.y - m_vehicle_position.y;
-        msg.pos_z = m_character_position.z - m_vehicle_position.z;
+        msg.pos_x = m_character_position.x - cab_coords.x;
+        msg.pos_y = m_character_position.y - cab_coords.y;
+        msg.pos_z = m_character_position.z - cab_coords.z;
         msg.cab_index = m_contacting_cab;
     }
     else

--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -64,6 +64,7 @@ public:
     void           SetActorCoupling(ActorPtr actor); //!< Seating
     void           SetContactingActor(ActorPtr); //!< Standing - collision
     GfxCharacter*  SetupGfx();
+    void           drawCabWalkingDbg();
 
 private:
 
@@ -96,18 +97,17 @@ private:
     float            m_driving_anim_length;
 
     // Collision with actor (standing):
-    Ogre::Vector3    m_vehicle_position;
-    Ogre::Radian     m_vehicle_rotation;
-    Ogre::Vector3    m_last_vehicle_position;
-    Ogre::Radian     m_last_vehicle_rotation;
     bool             m_inertia = false;
     Ogre::Vector3    m_inertia_position;
     Ogre::Radian     m_inertia_rotation;
     ActorPtr         m_contacting_actor;
     int              m_contacting_cab = 0;
-    int              m_last_contacting_cab = 0;
-    Ogre::Vector3    m_net_cab_offset = Ogre::Vector3::ZERO;
-    Ogre::Vector3    CalcCabAveragePos(ActorPtr actor, int cab_index);
+    Ogre::Affine3    m_contacting_cab_matrix;
+    Ogre::Vector3    m_contacting_cab_localpos;
+    int              m_prev_contacting_cab = 0;
+    Ogre::Affine3    m_prev_contacting_cab_matrix;
+    Ogre::Vector3    m_prev_contacting_cab_localpos;
+    Ogre::Affine3    CalcCabTransformMatrix(ActorPtr& actor, int cab_index);
 };
 
 /// @} // addtogroup Character

--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -61,7 +61,8 @@ public:
     void           update(float dt);
     void           updateCharacterRotation();
     void           receiveStreamData(unsigned int& type, int& source, unsigned int& streamid, char* buffer);
-    void           SetActorCoupling(bool enabled, ActorPtr actor);
+    void           SetActorCoupling(ActorPtr actor); //!< Seating
+    void           SetContactingActor(ActorPtr); //!< Standing - collision
     GfxCharacter*  SetupGfx();
 
 private:
@@ -71,7 +72,6 @@ private:
     void           SendStreamSetup();
     void           SetAnimState(std::string mode, float time = 0);
 
-    ActorPtr         m_actor_coupling; //!< The vehicle or machine which the character occupies
     Ogre::Radian     m_character_rotation;
     float            m_character_h_speed;
     float            m_character_v_speed;
@@ -84,25 +84,29 @@ private:
     bool             m_is_remote;
     std::string      m_anim_name;
     float            m_anim_time;
-    float            m_net_last_anim_time;
-    float            m_driving_anim_length;
+    float            m_net_last_anim_time;    
     std::string      m_instance_name;
     Ogre::UTFString  m_net_username;
     Ogre::Timer      m_net_timer;
     unsigned long    m_net_last_update_time;
     GfxCharacter*    m_gfx_character;
 
-    // Collision with actor:
+    // Occupying an actor (seating):
+    ActorPtr         m_actor_coupling; //!< The vehicle or machine which the character occupies
+    float            m_driving_anim_length;
+
+    // Collision with actor (standing):
     Ogre::Vector3    m_vehicle_position;
     Ogre::Radian     m_vehicle_rotation;
     Ogre::Vector3    m_last_vehicle_position;
     Ogre::Radian     m_last_vehicle_rotation;
-    bool m_inertia   = false;
+    bool             m_inertia = false;
     Ogre::Vector3    m_inertia_position;
     Ogre::Radian     m_inertia_rotation;
     ActorPtr         m_contacting_actor;
-    int              m_contacting_cab;
-    int              m_last_contacting_cab;
+    int              m_contacting_cab = 0;
+    int              m_last_contacting_cab = 0;
+    Ogre::Vector3    m_net_cab_offset = Ogre::Vector3::ZERO;
     Ogre::Vector3    CalcCabAveragePos(ActorPtr actor, int cab_index);
 };
 

--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -91,6 +91,19 @@ private:
     Ogre::Timer      m_net_timer;
     unsigned long    m_net_last_update_time;
     GfxCharacter*    m_gfx_character;
+
+    // Collision with actor:
+    Ogre::Vector3    m_vehicle_position;
+    Ogre::Radian     m_vehicle_rotation;
+    Ogre::Vector3    m_last_vehicle_position;
+    Ogre::Radian     m_last_vehicle_rotation;
+    bool m_inertia   = false;
+    Ogre::Vector3    m_inertia_position;
+    Ogre::Radian     m_inertia_rotation;
+    ActorPtr         m_contacting_actor;
+    int              m_contacting_cab;
+    int              m_last_contacting_cab;
+    Ogre::Vector3    CalcCabAveragePos(ActorPtr actor, int cab_index);
 };
 
 /// @} // addtogroup Character
@@ -105,7 +118,7 @@ struct GfxCharacter
         Ogre::UTFString    simbuf_net_username;
         bool               simbuf_is_remote;
         int                simbuf_color_number;
-        ActorPtr             simbuf_actor_coupling;
+        ActorPtr           simbuf_actor_coupling;
         std::string        simbuf_anim_name;
         float              simbuf_anim_time; // Intentionally left empty = forces initial update.
     };

--- a/source/main/gameplay/CharacterFactory.cpp
+++ b/source/main/gameplay/CharacterFactory.cpp
@@ -86,6 +86,16 @@ void CharacterFactory::Update(float dt)
     }
 }
 
+void CharacterFactory::DrawDebug()
+{
+    m_local_character->drawCabWalkingDbg();
+
+    for (auto& c : m_remote_characters)
+    {
+        c->drawCabWalkingDbg();
+    }
+}
+
 void CharacterFactory::UndoRemoteActorCoupling(ActorPtr actor)
 {
     for (auto& c : m_remote_characters)

--- a/source/main/gameplay/CharacterFactory.cpp
+++ b/source/main/gameplay/CharacterFactory.cpp
@@ -92,7 +92,7 @@ void CharacterFactory::UndoRemoteActorCoupling(ActorPtr actor)
     {
         if (c->GetActorCoupling() == actor)
         {
-            c->SetActorCoupling(false, nullptr);
+            c->SetActorCoupling(nullptr);
         }
     }
 }

--- a/source/main/gameplay/CharacterFactory.h
+++ b/source/main/gameplay/CharacterFactory.h
@@ -45,6 +45,7 @@ public:
     void DeleteAllCharacters();
     void UndoRemoteActorCoupling(ActorPtr actor);
     void Update(float dt);
+    void DrawDebug();
 #ifdef USE_SOCKETW
     void handleStreamData(std::vector<RoR::NetRecvPacket> packet);
 #endif // USE_SOCKETW

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -603,6 +603,12 @@ void TopMenubar::Update()
                 DrawGCheckbox(App::mp_pseudo_collisions, _LC("TopMenubar", "Collisions"));
                 DrawGCheckbox(App::mp_hide_net_labels,   _LC("TopMenubar", "Hide labels"));
             }
+            if (App::mp_state->getEnum<MpState>() != MpState::CONNECTED)
+            {
+                ImGui::Separator();
+                ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Miscellaneous:"));
+                DrawGCheckbox(App::sim_character_collisions, _LC("TopMenubar", "Character collisions"));
+            }
             ImGui::PopItemWidth();
             m_open_menu_hoverbox_min = menu_pos;
             m_open_menu_hoverbox_max.x = menu_pos.x + ImGui::GetWindowWidth();

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -1020,6 +1020,7 @@ int main(int argc, char *argv[])
                         App::GetGuiManager()->FrictionSettings.setActiveCol(App::GetGameContext()->GetPlayerActor()->ar_last_fuzzy_ground_model);
                     }
                 }
+                App::GetGameContext()->GetCharacterFactory()->DrawDebug();
             }
 
 #ifdef USE_MUMBLE

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -51,9 +51,11 @@ namespace RoR {
 enum NetCharacterCmd
 {
     CHARACTER_CMD_INVALID,
-    CHARACTER_CMD_POSITION,
-    CHARACTER_CMD_ATTACH,
-    CHARACTER_CMD_DETACH
+    CHARACTER_CMD_POSITION_GROUND,
+    CHARACTER_CMD_POSITION_CAB,
+    CHARACTER_CMD_ATTACH_SEAT,  //!< Sets 'actor coupling' for seated (+driving) animation.
+    CHARACTER_CMD_ATTACH_CAB,   //!< Sets 'contacting actor' for walking on cab triangles.
+    CHARACTER_CMD_DETACH        //!< Detaches from actor
 };
 
 struct NetCharacterMsgGeneric
@@ -64,10 +66,13 @@ struct NetCharacterMsgGeneric
 struct NetCharacterMsgPos
 {
     int32_t command;
-    float   pos_x, pos_y, pos_z;
-    float   rot_angle;
+    // Both on ground and cab:
+    float   pos_x, pos_y, pos_z; //!< Global when on ground, local when on cab.
+    float   rot_angle;           //!< Always global.
     float   anim_time;
     char    anim_name[CHARACTER_ANIM_NAME_LEN];
+    // Only on cab:
+    int32_t cab_index;
 };
 
 struct NetCharacterMsgAttach

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -58,6 +58,7 @@ void Console::cVarSetupBuiltins()
     App::sim_gearbox_mode        = this->cVarCreate("sim_gearbox_mode",        "GearboxMode",                CVAR_ARCHIVE | CVAR_TYPE_INT);
     App::sim_soft_reset_mode     = this->cVarCreate("sim_soft_reset_mode",     "",                                          CVAR_TYPE_BOOL,    "false");
     App::sim_quickload_dialog    = this->cVarCreate("sim_quickload_dialog",    "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
+    App::sim_character_collisions = this->cVarCreate("sim_character_collisions", "CharacterCollisions",      CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
 
     App::mp_state                = this->cVarCreate("mp_state",                "",                                          CVAR_TYPE_INT,     "0"/*(int)MpState::DISABLED*/);
     App::mp_join_on_startup      = this->cVarCreate("mp_join_on_startup",      "Auto connect",               CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");


### PR DESCRIPTION
This is an experimental spinoff from https://github.com/RigsOfRods/rigs-of-rods/pull/3049. I felt inspired.
![characterCollNetworkedDaf](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/a43f3872-bb53-48a5-a239-444822efc36b)

Since the collision works by "sticking" the character to the actor while in contact, I realized I could extend our existing driver-attachment logic to also handle this attachment.

It's glitchy right now, partly because the networked cab offset is always in world coordinates, so it causes sliding when the vehicle turns.
