### PR TITLE
Fixed `forset` backwards compatibility

### DIFF
--- a/source/main/gameplay/RecoveryMode.cpp
+++ b/source/main/gameplay/RecoveryMode.cpp
@@ -154,7 +154,7 @@ void RecoveryMode::UpdateInputEvents(float dt)
         }
 
         ActorModifyRequest* rq = new ActorModifyRequest;
-        rq->amr_actor = App::GetGameContext()->GetPlayerActor();
+        rq->amr_actor = App::GetGameContext()->GetPlayerActor()->ar_instance_id;
         rq->amr_type = reset_type;
         App::GetGameContext()->PushMessage(Message(MSG_SIM_MODIFY_ACTOR_REQUESTED, (void*)rq));
     }

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4339,7 +4339,7 @@ void Actor::engineTriggerHelper(int engineNumber, EngineTriggerType type, float 
 }
 
 Actor::Actor(
-    int actor_id,
+    ActorInstanceID_t actor_id,
     unsigned int vector_index,
     RigDef::DocumentPtr def,
     RoR::ActorSpawnRequest rq

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -54,7 +54,7 @@ class Actor : public ZeroedMemoryAllocator, public RefCountingObject<Actor>
 public:
 
     Actor(
-          int actor_id
+          ActorInstanceID_t actor_id
         , unsigned int vector_index
         , RigDef::DocumentPtr def
         , ActorSpawnRequest rq

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -57,7 +57,7 @@
 using namespace Ogre;
 using namespace RoR;
 
-static int m_actor_counter = 0;
+static ActorInstanceID_t m_actor_counter = 0;
 
 ActorManager::ActorManager()
     : m_dt_remainder(0.0f)

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -89,16 +89,19 @@ using namespace RoR;
 void ActorSpawner::ConfigureSections(Ogre::String const & sectionconfig, RigDef::DocumentPtr def)
 {   
     m_selected_modules.push_back(def->root_module);
-    auto result = def->user_modules.find(sectionconfig);
+    if (sectionconfig != "")
+    {
+        auto result = def->user_modules.find(sectionconfig);
 
-    if (result != def->user_modules.end())
-    {
-        m_selected_modules.push_back(result->second);
-        LOG(" == ActorSpawner: Module added to configuration: " + sectionconfig);
-    }
-    else
-    {
-        this->AddMessage(Message::TYPE_WARNING, "Selected module not found: " + sectionconfig);
+        if (result != def->user_modules.end())
+        {
+            m_selected_modules.push_back(result->second);
+            LOG(" == ActorSpawner: Module added to configuration: " + sectionconfig);
+        }
+        else
+        {
+            this->AddMessage(Message::TYPE_WARNING, "Selected module not found: " + sectionconfig);
+        }
     }
 }
 

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -883,7 +883,8 @@ void Parser::ParseDirectiveForset()
     // --------------------------------------------------------------------------------------------
     // BEWARE OF QUIRKS in the following code (they must be preserved for backwards compatibility):
     // - a space between the 'forset' keyword and arguments is optional.
-    // - a separator at the end of line will silently add '0' to the node list.
+    // - garbage characters anywhere on the line will silently add node 0 to the set.
+    // - a separator at the end of line will silently add node 0 to the set.
     // --------------------------------------------------------------------------------------------
 
     //parsing set definition

--- a/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
@@ -101,6 +101,10 @@ namespace Regexes
 #define E_KEYWORD_INLINE(_NAME_) \
     "(^" _NAME_ E_DELIMITER_CLASSIC ".*$)?"
 
+/// Hack for `forset` which doesn't require a separator from args, see also BEWARE OF QUIRKS in `ParseDirectiveForset()`
+#define E_KEYWORD_INLINE_UNSEPARATED(_NAME_) \
+    "(^" _NAME_ ".*$)?"
+
 /// Actual regex definition macro.
 #define DEFINE_REGEX(_NAME_,_REGEXP_) \
     const std::regex _NAME_ = std::regex( _REGEXP_, std::regex::ECMAScript);
@@ -114,7 +118,6 @@ namespace Regexes
 
 // IMPORTANT! If you add a value here, you must also modify File::Keywords enum, it relies on positions in this regex
 #define IDENTIFY_KEYWORD_REGEX_STRING                             \
-    /* E_KEYWORD_BLOCK("advdrag") ~~ Not supported yet */         \
     E_KEYWORD_INLINE("add_animation")  /* Position 1 */           \
     E_KEYWORD_BLOCK("airbrakes")       /* Position 2 */           \
     E_KEYWORD_BLOCK("animators")       /* Position 3 etc... */    \
@@ -158,7 +161,7 @@ namespace Regexes
     E_KEYWORD_BLOCK("flexbodies")                                 \
     E_KEYWORD_INLINE("flexbody_camera_mode")                      \
     E_KEYWORD_BLOCK("flexbodywheels")                             \
-    E_KEYWORD_INLINE("forset")                                    \
+    E_KEYWORD_INLINE_UNSEPARATED("forset")                        \
     E_KEYWORD_BLOCK("forwardcommands")                            \
     E_KEYWORD_BLOCK("fusedrag")                                   \
     E_KEYWORD_BLOCK("globals")                                    \


### PR DESCRIPTION
Fixes #3053

Reprint of code comments about `forset` parsing:
```
    // --------------------------------------------------------------------------------------------
    // BEWARE OF QUIRKS in the following code (they must be preserved for backwards compatibility):
    // - a space between the 'forset' keyword and arguments is optional.
    // - garbage characters anywhere on the line will silently add node 0 to the set. <<<========= THE NEW ONE!
    // - a separator at the end of line will silently add node 0 to the set.
    // --------------------------------------------------------------------------------------------
```