### PR TITLE
:video_game: Improved 'LiveRepair' (formerly 'interactive repair')

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -108,6 +108,7 @@ CVar* sim_no_self_collisions;
 CVar* sim_gearbox_mode;
 CVar* sim_soft_reset_mode;
 CVar* sim_quickload_dialog;
+CVar* sim_live_repair_interval;
 
 // Multiplayer
 CVar* mp_state;
@@ -250,6 +251,9 @@ CVar* flexbody_defrag_prog_down_penalty;
 CVar* flexbody_defrag_reorder_indices;
 CVar* flexbody_defrag_reorder_texcoords;
 CVar* flexbody_defrag_invert_lookup;
+
+// GUI
+CVar* ui_show_live_repair_controls;
 
 // Instance management
 void SetCacheSystem    (CacheSystem* obj)             { g_cache_system = obj; }

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -484,6 +484,16 @@ std::string ToLocalizedString(IoInputGrabMode e)
     }
 }
 
+std::string ToLocalizedString(SimResetMode e)
+{
+    switch (e)
+    {
+    case SimResetMode::HARD: return _LC("SimResetMode", "Hard");
+    case SimResetMode::SOFT: return _LC("SimResetMode", "Soft");
+    default:                 return "";
+    }
+}
+
 const char* MsgTypeToString(MsgType type)
 {
     switch (type)

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -303,6 +303,7 @@ extern CVar* sim_no_self_collisions;
 extern CVar* sim_gearbox_mode;
 extern CVar* sim_soft_reset_mode;
 extern CVar* sim_quickload_dialog;
+extern CVar* sim_live_repair_interval;
 
 // Multiplayer
 extern CVar* mp_state;
@@ -446,6 +447,9 @@ extern CVar* flexbody_defrag_prog_down_penalty;
 extern CVar* flexbody_defrag_reorder_indices;
 extern CVar* flexbody_defrag_reorder_texcoords;
 extern CVar* flexbody_defrag_invert_lookup;
+
+// GUI
+extern CVar* ui_show_live_repair_controls;
 
 // ------------------------------------------------------------------------------------------------
 // Global objects

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -241,6 +241,13 @@ enum class IoInputGrabMode
 };
 std::string ToLocalizedString(IoInputGrabMode e);
 
+enum class SimResetMode
+{
+    HARD = 0, // 'sim_soft_reset=false'
+    SOFT = 1  // 'sim_soft_reset=true'
+};
+std::string ToLocalizedString(SimResetMode e);
+
 enum VisibilityMasks
 {
     DEPTHMAP_ENABLED  = BITMASK(1),
@@ -303,7 +310,7 @@ extern CVar* sim_no_self_collisions;
 extern CVar* sim_gearbox_mode;
 extern CVar* sim_soft_reset_mode;
 extern CVar* sim_quickload_dialog;
-extern CVar* sim_live_repair_interval;
+extern CVar* sim_live_repair_interval; //!< Hold EV_COMMON_REPAIR_TRUCK to enter LiveRepair mode. 0 or negative interval disables.
 
 // Multiplayer
 extern CVar* mp_state;

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SOURCE_FILES
         gameplay/EngineSim.{h,cpp}
         gameplay/Landusemap.{h,cpp}
         gameplay/RaceSystem.{h,cpp}
-        gameplay/RecoveryMode.{h,cpp}
+        gameplay/RepairMode.{h,cpp}
         gameplay/Replay.{h,cpp}
         gameplay/SceneMouse.{h,cpp}
         gameplay/ScriptEvents.h

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -30,7 +30,7 @@
 #include "CacheSystem.h"
 #include "CharacterFactory.h"
 #include "RaceSystem.h"
-#include "RecoveryMode.h"
+#include "RepairMode.h"
 #include "SceneMouse.h"
 #include "SimData.h"
 #include "Terrain.h"
@@ -163,7 +163,7 @@ public:
     /// @{
 
     RaceSystem&         GetRaceSystem() { return m_race_system; }
-    RecoveryMode&       GetRecoveryMode() { return m_recovery_mode; }
+    RepairMode&       GetRepairMode() { return m_recovery_mode; }
     SceneMouse&         GetSceneMouse() { return m_scene_mouse; }
     void                TeleportPlayer(float x, float z);
     void                UpdateGlobalInputEvents();
@@ -202,7 +202,7 @@ private:
 
     // Gameplay feats (misc.)
     RaceSystem          m_race_system;
-    RecoveryMode        m_recovery_mode;                     //!< Aka 'advanced repair' or 'interactive reset'
+    RepairMode        m_recovery_mode;                     //!< Aka 'advanced repair' or 'interactive reset'
     SceneMouse          m_scene_mouse;                       //!< Mouse interaction with scene
     Ogre::Timer         m_timer;
     Ogre::Vector3       prev_pos = Ogre::Vector3::ZERO;

--- a/source/main/gameplay/RepairMode.cpp
+++ b/source/main/gameplay/RepairMode.cpp
@@ -38,30 +38,34 @@ void RepairMode::UpdateInputEvents(float dt)
 
     if (!App::GetGameContext()->GetPlayerActor())
     {
+        m_quick_repair_active = false;
         m_live_repair_active = false;
         m_live_repair_timer = 0.0f;
         return;
     }
 
-    if (!App::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
-    {
-        m_live_repair_timer = 0.0f;
-    }
-
     if (App::GetInputEngine()->getEventBoolValue(EV_COMMON_LIVE_REPAIR_MODE))
     {
         m_live_repair_active = true;
-        // Hack to bypass the timer - because EV_COMMON_REPAIR_TRUCK (default Alt+Backspace) may not be 'EXPL' so the below condition may execute.
-        m_live_repair_timer = App::sim_live_repair_interval->getFloat() + 1.f;
+        // Hack to bypass the timer - because EV_COMMON_REPAIR_TRUCK (default Backspace) may not be 'EXPL' so the below condition may execute.
+        m_live_repair_timer = App::sim_live_repair_interval->getFloat() + 0.1f;
     }
 
-    if (App::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK) || m_live_repair_active)
+    // Update LiveRepair timer
+    m_quick_repair_active = App::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK);
+    if (m_quick_repair_active)
     {
-        if (App::GetInputEngine()->getEventBoolValue(EV_COMMON_REPAIR_TRUCK))
-        {
-            m_live_repair_active = m_live_repair_timer > App::sim_live_repair_interval->getFloat();
-        }
+        if (App::sim_live_repair_interval->getFloat() > 0)
+            m_live_repair_active = m_live_repair_timer > App::sim_live_repair_interval->getFloat();    
+    }
+    else
+    {
+        m_live_repair_timer = 0.f;
+    }
 
+    // Handle repair controls
+    if (m_quick_repair_active || m_live_repair_active)
+    {
         Ogre::Vector3 translation = Ogre::Vector3::ZERO;
         float rotation = 0.0f;
 

--- a/source/main/gameplay/RepairMode.h
+++ b/source/main/gameplay/RepairMode.h
@@ -35,14 +35,15 @@ namespace RoR {
 
 /// Actor feat - interactive recovery and repair mode, operates on player vehicle
 ///              Aka 'advanced repair' or 'interactive reset'
-class RecoveryMode
+class RepairMode
 {
 public:
     void                UpdateInputEvents(float dt);
+    bool                IsLiveRepairActive() const { return m_live_repair_active; }
 
 private:
-    bool                m_advanced_vehicle_repair = false;
-    float               m_advanced_vehicle_repair_timer = 0.f;
+    bool                m_live_repair_active = false;
+    float               m_live_repair_timer = 0.f;
 };
 
 /// @} // addtogroup Gameplay

--- a/source/main/gameplay/RepairMode.h
+++ b/source/main/gameplay/RepairMode.h
@@ -33,16 +33,19 @@ namespace RoR {
 /// @addtogroup Gameplay
 /// @{
 
-/// Actor feat - interactive recovery and repair mode, operates on player vehicle
-///              Aka 'advanced repair' or 'interactive reset'
+/// Interactive recovery and repair mode, operates on player vehicle
+/// Formerly 'advanced repair' or 'interactive reset'
 class RepairMode
 {
 public:
     void                UpdateInputEvents(float dt);
     bool                IsLiveRepairActive() const { return m_live_repair_active; }
+    bool                IsQuickRepairActive() const { return m_quick_repair_active; }
+    float               GetLiveRepairTimer() const { return m_live_repair_timer; }
 
 private:
-    bool                m_live_repair_active = false;
+    bool                m_quick_repair_active = false; // Player is holding EV_COMMON_REPAIR_TRUCK
+    bool                m_live_repair_active = false; // Player pressed EV_COMMON_LIVE_REPAIR_MODE or held QuickRepair for 'sim_live_repair_interval' seconds.
     float               m_live_repair_timer = 0.f;
 };
 

--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -412,7 +412,7 @@ void RoR::ImDrawEventHighlighted(events input_event)
     std::string text = App::GetInputEngine()->getKeyForCommand(input_event);
     const ImVec2 PAD = ImVec2(2.f, 0.f);
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, PAD);
-    ImGui::BeginChildFrame(input_event, ImGui::CalcTextSize(text.c_str()) + PAD*2);
+    ImGui::BeginChildFrame(ImGuiID(input_event), ImGui::CalcTextSize(text.c_str()) + PAD*2);
     ImGui::TextColored(col, "%s", text.c_str());
     ImGui::EndChildFrame();
     ImGui::PopStyleVar(); // FramePadding
@@ -426,5 +426,11 @@ void RoR::ImDrawModifierKeyHighlighted(OIS::KeyCode key)
     {
         col = App::GetGuiManager()->GetTheme().highlight_text_color;
     }
-    ImGui::TextColored(col, "%s", App::GetInputEngine()->getModifierKeyName(key).c_str());
+    std::string text = App::GetInputEngine()->getModifierKeyName(key);
+    const ImVec2 PAD = ImVec2(2.f, 0.f);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, PAD);
+    ImGui::BeginChildFrame(ImGuiID(key), ImGui::CalcTextSize(text.c_str()) + PAD*2);
+    ImGui::TextColored(col, "%s", text.c_str());
+    ImGui::EndChildFrame();
+    ImGui::PopStyleVar(); // FramePadding
 }

--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -401,3 +401,30 @@ void RoR::ImTerminateComboboxString(std::string& target)
     // Make space for 2 trailing with NULs
     target.resize(prev_size + 2, '\0');
 }
+
+void RoR::ImDrawEventHighlighted(events input_event)
+{
+    ImVec4 col = ImGui::GetStyle().Colors[ImGuiCol_Text];
+    if (App::GetInputEngine()->getEventValue(input_event))
+    {
+        col = App::GetGuiManager()->GetTheme().highlight_text_color;
+    }
+    std::string text = App::GetInputEngine()->getKeyForCommand(input_event);
+    const ImVec2 PAD = ImVec2(2.f, 0.f);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, PAD);
+    ImGui::BeginChildFrame(input_event, ImGui::CalcTextSize(text.c_str()) + PAD*2);
+    ImGui::TextColored(col, "%s", text.c_str());
+    ImGui::EndChildFrame();
+    ImGui::PopStyleVar(); // FramePadding
+
+}
+
+void RoR::ImDrawModifierKeyHighlighted(OIS::KeyCode key)
+{
+    ImVec4 col = ImGui::GetStyle().Colors[ImGuiCol_Text];
+    if (App::GetInputEngine()->isKeyDown(key))
+    {
+        col = App::GetGuiManager()->GetTheme().highlight_text_color;
+    }
+    ImGui::TextColored(col, "%s", App::GetInputEngine()->getModifierKeyName(key).c_str());
+}

--- a/source/main/gui/GUIUtils.h
+++ b/source/main/gui/GUIUtils.h
@@ -80,4 +80,8 @@ ImDrawList* GetImDummyFullscreenWindow();
 void ImAddItemToComboboxString(std::string& target, std::string const& item);
 void ImTerminateComboboxString(std::string& target);
 
+// Input engine helpers
+void ImDrawEventHighlighted(events input_event);
+void ImDrawModifierKeyHighlighted(OIS::KeyCode key);
+
 } // namespace RoR

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -266,6 +266,8 @@ void GameSettings::DrawGameplaySettings()
     DrawGCheckbox(App::io_discord_rpc, _LC("GameSettings", "Discord Rich Presence"));
 
     DrawGCheckbox(App::sim_quickload_dialog, _LC("GameSettings", "Show confirm. UI dialog for quickload"));
+
+    DrawGCheckbox(App::ui_show_live_repair_controls, _LC("GameSettings", "Show controls in live repair box"));
 }
 
 void GameSettings::DrawAudioSettings()

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -47,7 +47,7 @@ public:
     const ImVec4  RED_TEXT              = ImVec4(1.00f, 0.00f, 0.00f, 1.f);
 
     enum class TopMenu { TOPMENU_NONE, TOPMENU_SIM, TOPMENU_ACTORS, TOPMENU_SAVEGAMES, TOPMENU_SETTINGS, TOPMENU_TOOLS, TOPMENU_AI };
-    enum class StateBox { STATEBOX_NONE, STATEBOX_REPLAY, STATEBOX_RACE, STATEBOX_LIVE_REPAIR };
+    enum class StateBox { STATEBOX_NONE, STATEBOX_REPLAY, STATEBOX_RACE, STATEBOX_LIVE_REPAIR, STATEBOX_QUICK_REPAIR };
 
     TopMenubar(): m_open_menu(), m_daytime(0), m_quickload(false), m_confirm_remove_all(false) {}
 

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -47,8 +47,9 @@ public:
     const ImVec4  RED_TEXT              = ImVec4(1.00f, 0.00f, 0.00f, 1.f);
 
     enum class TopMenu { TOPMENU_NONE, TOPMENU_SIM, TOPMENU_ACTORS, TOPMENU_SAVEGAMES, TOPMENU_SETTINGS, TOPMENU_TOOLS, TOPMENU_AI };
+    enum class StateBox { STATEBOX_NONE, STATEBOX_REPLAY, STATEBOX_RACE, STATEBOX_LIVE_REPAIR };
 
-    TopMenubar(): m_open_menu(TopMenu::TOPMENU_NONE), m_daytime(0), m_quickload(false), m_confirm_remove_all(false) {}
+    TopMenubar(): m_open_menu(), m_daytime(0), m_quickload(false), m_confirm_remove_all(false) {}
 
     void Update();
     bool ShouldDisplay(ImVec2 window_pos);
@@ -93,7 +94,12 @@ private:
 
     ImVec2  m_open_menu_hoverbox_min;
     ImVec2  m_open_menu_hoverbox_max;
-    TopMenu m_open_menu;
+    TopMenu m_open_menu = TopMenu::TOPMENU_NONE;
+
+    ImVec2  m_state_box_hoverbox_min;
+    ImVec2  m_state_box_hoverbox_max;
+    StateBox m_state_box = StateBox::STATEBOX_NONE;
+
     bool    m_confirm_remove_all;
 
     float   m_daytime;

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -1024,7 +1024,7 @@ int main(int argc, char *argv[])
                         }
                         App::GetCameraManager()->UpdateInputEvents(dt);
                         App::GetOverlayWrapper()->update(dt);
-                        App::GetGameContext()->GetRecoveryMode().UpdateInputEvents(dt);
+                        App::GetGameContext()->GetRepairMode().UpdateInputEvents(dt);
                         App::GetGameContext()->GetActorManager()->UpdateInputEvents(dt);
                         if (App::sim_state->getEnum<SimState>() == SimState::RUNNING)
                         {

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -58,6 +58,7 @@ void Console::cVarSetupBuiltins()
     App::sim_gearbox_mode        = this->cVarCreate("sim_gearbox_mode",        "GearboxMode",                CVAR_ARCHIVE | CVAR_TYPE_INT);
     App::sim_soft_reset_mode     = this->cVarCreate("sim_soft_reset_mode",     "",                                          CVAR_TYPE_BOOL,    "false");
     App::sim_quickload_dialog    = this->cVarCreate("sim_quickload_dialog",    "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
+    App::sim_live_repair_interval = this->cVarCreate("sim_live_repair_interval", "",                           CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "2.f");
 
     App::mp_state                = this->cVarCreate("mp_state",                "",                                          CVAR_TYPE_INT,     "0"/*(int)MpState::DISABLED*/);
     App::mp_join_on_startup      = this->cVarCreate("mp_join_on_startup",      "Auto connect",               CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
@@ -190,6 +191,8 @@ void Console::cVarSetupBuiltins()
     App::flexbody_defrag_reorder_indices   = this->cVarCreate("flexbody_defrag_reorder_indices",   "", CVAR_TYPE_BOOL, "true");
     App::flexbody_defrag_reorder_texcoords = this->cVarCreate("flexbody_defrag_reorder_texcoords", "", CVAR_TYPE_BOOL, "true");
     App::flexbody_defrag_invert_lookup     = this->cVarCreate("flexbody_defrag_invert_lookup",     "", CVAR_TYPE_BOOL, "true");
+
+    App::ui_show_live_repair_controls      = this->cVarCreate("ui_show_live_repair_controls",      "", CVAR_TYPE_BOOL, "true");
 }
 
 CVar* Console::cVarCreate(std::string const& name, std::string const& long_name,

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -68,6 +68,7 @@ InputEvent eventInfo[] = {
     {"COMMON_AUTOLOCK",               EV_COMMON_AUTOLOCK,               "Keyboard EXPL+ALT+L",          _LC("InputEvent", "unlock autolock hook node")},
     {"COMMON_ROPELOCK",               EV_COMMON_ROPELOCK,               "Keyboard EXPL+CTRL+L",         _LC("InputEvent", "connect a rope to a node in close proximity")},
     {"COMMON_REPAIR_TRUCK",           EV_COMMON_REPAIR_TRUCK,           "Keyboard BACK",                _LC("InputEvent", "repair truck")},
+    {"COMMON_LIVE_REPAIR_MODE",       EV_COMMON_LIVE_REPAIR_MODE,       "Keyboard ALT+BACK",            _LC("InputEvent", "toggle truck interactive repair mode")},
     {"COMMON_RESCUE_TRUCK",           EV_COMMON_RESCUE_TRUCK,           "Keyboard EXPL+R",              _LC("InputEvent", "teleport to rescue truck")},
     {"COMMON_RESET_TRUCK",            EV_COMMON_RESET_TRUCK,            "Keyboard I",                   _LC("InputEvent", "reset truck to original starting position")},
     {"COMMON_TOGGLE_RESET_MODE",      EV_COMMON_TOGGLE_RESET_MODE,      "Keyboard EXPL+APOSTROPHE",     _LC("InputEvent", "toggle reset mode")},
@@ -2165,4 +2166,20 @@ String InputEngine::getKeyForCommand(int eventID)
 
     std::vector<event_trigger_t>::iterator it2 = it->second.begin();
     return getKeyNameForKeyCode((OIS::KeyCode)it2->keyCode);
+}
+
+Ogre::String InputEngine::getModifierKeyName(OIS::KeyCode key)
+{
+    switch (key)
+    {
+    case OIS::KC_LMENU: return _LC("ModifierKey", "Left Alt");
+    case OIS::KC_LSHIFT: return _LC("ModifierKey", "Left Shift");
+    case OIS::KC_LCONTROL: return _LC("ModifierKey", "Left Ctrl");
+
+    case OIS::KC_RMENU: return _LC("ModifierKey", "Right Alt");
+    case OIS::KC_RSHIFT: return _LC("ModifierKey", "Right Shift");
+    case OIS::KC_RCONTROL: return _LC("ModifierKey", "Right Ctrl");
+
+    default: return "";
+    }
 }

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -248,6 +248,7 @@ enum events
     EV_COMMON_QUICKSAVE,          //!< quicksave scene to the disk
     EV_COMMON_QUIT_GAME,          //!< exit the game
     EV_COMMON_REPAIR_TRUCK,       //!< repair truck to original condition
+    EV_COMMON_LIVE_REPAIR_MODE,   //!< toggles live repair and recovery mode, controlled by keyboard
     EV_COMMON_REPLAY_BACKWARD,
     EV_COMMON_REPLAY_FAST_BACKWARD,
     EV_COMMON_REPLAY_FAST_FORWARD,
@@ -487,6 +488,7 @@ public:
         // Event info
 
     Ogre::String        getKeyForCommand(int eventID);
+    Ogre::String        getModifierKeyName(OIS::KeyCode key);
     Ogre::String        getDeviceName(event_trigger_t const& evt);
     Ogre::String        getEventCommand(int eventID);
     std::string         getEventCommandTrimmed(int eventID);                //!< Omits 'EXPL' modifier


### PR DESCRIPTION
I renamed the feature because this is shorter and fits better in UIs and variable names. Hopefully it'll also fit better in player's vocabulary. Fixes #3062

**Changes:**
* new UI box "Live repair active" with optional display of hotkeys. It displays right under the top menubar (like existing "physics paused/terrain editor" boxes). See screenshot below.
* new input event EV_COMMON_LIVE_REPAIR_MODE (default Alt+Backspace) - throws you right into the LiveRepair mode, no need to wait.
* new cvar 'sim_live_repair_interval' (float) - default 2 sec - how long you must hold Backspace and be still before the LiveRepair mode kicks in. Used to be 1sec.
* new cvar 'ui_show_live_repair_controls' (bool) - controls the UI checkbox in "Live repair is active" statebox. Also configurable in GameSettings UI.

![obrazek](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/25816b42-d29b-4037-9f7e-e40853f02ad3)

**New (juicy) helper functions:**
* `void ImDrawEventHighlighted(events input_event)` - draws the configured key combo for given input event, with a darker frame around it and color highlight when the keys are pressed.
* `void ImDrawModifierKeyHighlighted(OIS::KeyCode key)` - draws the localized modifier key name (shift/alt/ctrl), with color highlight when the keys are pressed.
* `InputEngine::getModifierKeyName(OIS::KeyCode key)` - gives you localized name for the modifier key (shift/alt/ctrl)