### PR TITLE
Fixed huge FPS drop when nodes move far away from vehicle

### DIFF
--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -290,6 +290,7 @@ public:
     std::vector<Airbrake*>    ar_airbrakes;
     CmdKeyArray               ar_command_key; //!< BEWARE: commandkeys are indexed 1-MAX_COMMANDS!
     Ogre::AxisAlignedBox      ar_bounding_box;     //!< standard bounding box (surrounds all nodes of an actor)
+    Ogre::AxisAlignedBox      ar_cabnodes_bounding_box; //!< bounding box around cab-triangle nodes only
     Ogre::AxisAlignedBox      ar_predicted_bounding_box;
     float                     ar_initial_total_mass = 0.f;
     std::vector<float>        ar_initial_node_masses;

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -1088,8 +1088,11 @@ bool Collisions::nodeCollision(node_t *node, float dt)
 
 void Collisions::findPotentialEventBoxes(Actor* actor, CollisionBoxPtrVec& out_boxes)
 {
+    // NOTE: Only collision-cab nodes are considered for eventbox triggering!
+    // ----------------------------------------------------------------------
+
     // Find collision cells occupied by the actor (remember 'Y' is 'up').
-    const AxisAlignedBox aabb = actor->ar_bounding_box;
+    const AxisAlignedBox aabb = actor->ar_cabnodes_bounding_box;
     const int cell_lo_x = (int)(aabb.getMinimum().x / (float)CELL_SIZE);
     const int cell_lo_z = (int)(aabb.getMinimum().z / (float)CELL_SIZE);
     const int cell_hi_x = (int)(aabb.getMaximum().x / (float)CELL_SIZE);


### PR DESCRIPTION
Fixed #3058 - caused by 539a1b24f50bad880611f245c76b634dbde1ad84

Solution: instead of considering the whole bounding box when evaluating eventboxes, only consider a bounding box around collision cab nodes. It makes more sense physically and also eliminates surprises, as loose cab nodes would be easily visible.