### PR TITLE
:video_game: UI Presets (Novice/Regular/Expert/Minimallist)

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -261,6 +261,7 @@ CVar* flexbody_defrag_invert_lookup;
 // GUI
 CVar* ui_show_live_repair_controls;
 CVar* ui_show_vehicle_buttons;
+CVar* ui_preset;
 
 // Instance access
 AppContext*            GetAppContext         () { return &g_app_context; };
@@ -551,6 +552,18 @@ std::string ToLocalizedString(SimResetMode e)
     case SimResetMode::HARD: return _LC("SimResetMode", "Hard");
     case SimResetMode::SOFT: return _LC("SimResetMode", "Soft");
     default:                 return "";
+    }
+}
+
+std::string ToLocalizedString(UiPreset e)
+{
+    switch (e)
+    {
+    case UiPreset::NOVICE:      return _LC("UiPreset", "Novice");
+    case UiPreset::REGULAR:     return _LC("UiPreset", "Regular");
+    case UiPreset::EXPERT:      return _LC("UiPreset", "Expert");
+    case UiPreset::MINIMALLIST: return _LC("UiPreset", "Minimallist");
+    default:                     return "";
     }
 }
 

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -262,6 +262,7 @@ CVar* flexbody_defrag_invert_lookup;
 CVar* ui_show_live_repair_controls;
 CVar* ui_show_vehicle_buttons;
 CVar* ui_preset;
+CVar* ui_hide_gui;
 
 // Instance access
 AppContext*            GetAppContext         () { return &g_app_context; };

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -533,6 +533,7 @@ extern CVar* flexbody_defrag_invert_lookup;
 extern CVar* ui_show_live_repair_controls; //!< bool
 extern CVar* ui_show_vehicle_buttons;
 extern CVar* ui_preset; //!< enum `RoR::UiPreset`
+extern CVar* ui_hide_gui; //!< bool; The 'hide GUI' hotkey state
 
 // ------------------------------------------------------------------------------------------------
 // Global objects

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -279,6 +279,18 @@ enum class SimResetMode
 };
 std::string ToLocalizedString(SimResetMode e);
 
+/// See `UiPresets[]` list in GUIManager.cpp (declared extern in GUIManager.h)
+// Do NOT change numbers - used for indexing `RoR::UiPresetEntry::uip_values`
+enum class UiPreset
+{
+    NOVICE,
+    REGULAR,
+    EXPERT,
+    MINIMALLIST,
+    Count
+};
+std::string ToLocalizedString(UiPreset e);
+
 enum VisibilityMasks
 {
     DEPTHMAP_ENABLED  = BITMASK(1),
@@ -518,8 +530,9 @@ extern CVar* flexbody_defrag_reorder_texcoords;
 extern CVar* flexbody_defrag_invert_lookup;
 
 // GUI
-extern CVar* ui_show_live_repair_controls;
+extern CVar* ui_show_live_repair_controls; //!< bool
 extern CVar* ui_show_vehicle_buttons;
+extern CVar* ui_preset; //!< enum `RoR::UiPreset`
 
 // ------------------------------------------------------------------------------------------------
 // Global objects

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -53,9 +53,9 @@ using namespace RoR;
 UiPresetEntry RoR::UiPresets[] =
 {
     // Cvar name                      | NOVICE, REGULAR, EXPERT, MINIMALLIST
-    { "gfx_declutter_map",            {"false", "true", "false", "true"} },
-    { "ui_show_live_repair_controls", {"true", "false", "false", "false"} },
-    { "sim_quickload_dialog",         {"true", "false", "false", "false"} },
+    { "gfx_surveymap_icons",          {"true",  "true",  "true",  "false"} },
+    { "gfx_declutter_map",            {"false", "true",  "false", "true"} },
+    { "ui_show_live_repair_controls", {"true",  "false", "false", "false"} },
 
     // List closure
     { nullptr, {} }

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -195,7 +195,7 @@ void GUIManager::DrawSimGuiBuffered(GfxActor* player_gfx_actor)
 
     if (!this->ConsoleWindow.IsVisible())
     {
-        if (!m_hide_gui)
+        if (!App::ui_hide_gui->getBool())
         {
             this->ChatBox.Draw(); // Messages must be always visible
         }
@@ -278,7 +278,7 @@ void GUIManager::SetSceneManagerForGuiRendering(Ogre::SceneManager* scene_manage
 
 void GUIManager::SetGuiHidden(bool hidden)
 {
-    m_hide_gui = hidden;
+    App::ui_hide_gui->setVal(hidden);
     App::GetOverlayWrapper()->showDashboardOverlays(!hidden, App::GetGameContext()->GetPlayerActor());
     if (hidden)
     {
@@ -390,7 +390,7 @@ void GUIManager::SetupImGui()
 
 void GUIManager::DrawCommonGui()
 {
-    if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED && !m_hide_gui && !this->SurveyMap.IsVisible())
+    if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED && !App::ui_hide_gui->getBool() && !this->SurveyMap.IsVisible())
     {
         this->MpClientList.Draw();
     }

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -47,7 +47,19 @@
 
 #define RESOURCE_FILENAME "MyGUI_Core.xml"
 
-namespace RoR {
+using namespace RoR;
+
+/// Global list of UI Presets, selectable via Settings menu in TopMenubar
+UiPresetEntry RoR::UiPresets[] =
+{
+    // Cvar name                      | NOVICE, REGULAR, EXPERT, MINIMALLIST
+    { "gfx_declutter_map",            {"false", "true", "false", "true"} },
+    { "ui_show_live_repair_controls", {"true", "false", "false", "false"} },
+    { "sim_quickload_dialog",         {"true", "false", "false", "false"} },
+
+    // List closure
+    { nullptr, {} }
+};
 
 GUIManager::GUIManager()
 {
@@ -124,6 +136,19 @@ bool GUIManager::AreStaticMenusAllowed() //!< i.e. top menubar / vehicle UI butt
             !this->MainSelector.IsHovered() &&
             !this->SurveyMap.IsHovered() &&
             !this->FlexbodyDebug.IsHovered());
+}
+
+void GUIManager::ApplyUiPreset() //!< reads cvar 'ui_preset'
+{
+    const int preset = App::ui_preset->getInt();
+    int i = 0;
+    while (UiPresets[i].uip_cvar != nullptr)
+    {
+        App::GetConsole()->cVarSet(
+            UiPresets[i].uip_cvar,
+            UiPresets[i].uip_values[preset]);
+        i++;
+    }
 }
 
 void GUIManager::DrawSimulationGui(float dt)
@@ -532,5 +557,3 @@ void GUIManager::UpdateInputEvents(float dt)
         }
     }
 }
-
-} // namespace RoR

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -151,7 +151,7 @@ public:
     void DrawCommonGui();
 
     void SetGuiHidden(bool visible);
-    bool IsGuiHidden() const { return m_hide_gui; }
+    bool IsGuiHidden() const { return App::ui_hide_gui->getBool(); }
 
     void SetSceneManagerForGuiRendering(Ogre::SceneManager* scene_manager);
 
@@ -176,7 +176,6 @@ private:
 
     MyGUI::Gui*          m_mygui                    = nullptr;
     MyGUI::OgrePlatform* m_mygui_platform           = nullptr;
-    bool                 m_hide_gui                 = false;
     OgreImGui            m_imgui;
     GuiTheme             m_theme;
     bool                 m_gui_kb_capture_queued    = false; //!< Resets and accumulates every frame

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -26,6 +26,7 @@
 
 #include "OgreImGui.h"
 #include "Application.h"
+#include "CVar.h"
 #include "GUI_MessageBox.h"
 
 // GUI panels
@@ -59,7 +60,17 @@
 #include <MyGUI_UString.h>
 #include <OgreOverlay.h>
 
+#include <string>
+
 namespace RoR {
+
+struct UiPresetEntry
+{
+    const char* uip_cvar;
+    std::string uip_values[(int)UiPreset::Count];
+};
+
+extern UiPresetEntry UiPresets[];
 
 class GUIManager
 {
@@ -131,6 +142,7 @@ public:
     bool IsGuiCaptureKeyboardRequested() const { return m_gui_kb_capture_requested; }
     void ApplyGuiCaptureKeyboard(); //!< Call after rendered frame to apply queued value
     bool AreStaticMenusAllowed(); //!< i.e. top menubar / vehicle UI buttons
+    void ApplyUiPreset(); //!< reads cvar 'ui_preset'
 
     void NewImGuiFrame(float dt);
     void DrawMainMenuGui();

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -74,6 +74,13 @@ void GameSettings::Draw()
         ImGui::EndChild();
         ImGui::EndTabItem();
     }
+    if (ImGui::BeginTabItem(_LC("GameSettings", "UI")))
+    {
+        ImGui::BeginChild("Settings-UI-scroll", ImVec2(0.f, child_height), false);
+        this->DrawUiSettings();
+        ImGui::EndChild();
+        ImGui::EndTabItem();
+    }
     if (ImGui::BeginTabItem(_LC("GameSettings", "Graphics")))
     {
         ImGui::BeginChild("Settings-Graphics-scroll", ImVec2(0.f, child_height), false);
@@ -273,9 +280,6 @@ void GameSettings::DrawGameplaySettings()
     DrawGCombo(App::sim_gearbox_mode, _LC("GameSettings", "Gearbox mode"),
         m_combo_items_gearbox_mode.c_str());
 
-    DrawGCheckbox(App::gfx_speedo_digital, _LC("GameSettings", "Digital speedometer"));
-    DrawGCheckbox(App::gfx_speedo_imperial, _LC("GameSettings", "Imperial speedometer"));
-
     //DrawGCheckbox(App::gfx_flexbody_cache,     "Enable flexbody cache");
 
     DrawGCheckbox(App::sim_spawn_running, _LC("GameSettings", "Engines spawn running"));
@@ -297,10 +301,6 @@ void GameSettings::DrawGameplaySettings()
     DrawGCheckbox(App::io_discord_rpc, _LC("GameSettings", "Discord Rich Presence"));
 
     DrawGCheckbox(App::sim_quickload_dialog, _LC("GameSettings", "Show confirm. UI dialog for quickload"));
-
-    DrawGCheckbox(App::ui_show_live_repair_controls, _LC("GameSettings", "Show controls in live repair box"));
-
-    DrawGCheckbox(App::ui_show_vehicle_buttons, _LC("GameSettings", "Show vehicle buttons menu"));
 
     DrawGCheckbox(App::sim_tuning_enabled, _LC("GameSettings", "Enable vehicle tuning"));
 }
@@ -333,6 +333,30 @@ void GameSettings::DrawAudioSettings()
     DrawGCheckbox(App::audio_menu_music,       _LC("GameSettings", "Main menu music"));
     DrawGFloatSlider(App::audio_master_volume, _LC("GameSettings", "Master volume"), 0, 1);
 #endif // USE_OPENAL
+}
+
+void GameSettings::DrawUiSettings()
+{
+    ImGui::TextDisabled("%s", _LC("GameSettings", "UI settings"));
+
+    this->DrawUiPresetCombo();
+
+    ImGui::Separator();
+
+    DrawGCheckbox(App::gfx_speedo_digital, _LC("GameSettings", "Digital speedometer"));
+    DrawGCheckbox(App::gfx_speedo_imperial, _LC("GameSettings", "Imperial speedometer"));
+
+    DrawGCheckbox(App::ui_show_live_repair_controls, _LC("GameSettings", "Show controls in live repair box"));
+    
+    DrawGCheckbox(App::ui_show_vehicle_buttons, _LC("GameSettings", "Show vehicle buttons menu"));
+
+
+    DrawGCheckbox(App::gfx_surveymap_icons,  _LC("GameSettings", "Overview map icons"));
+    if (App::gfx_surveymap_icons->getBool())
+    {
+        DrawGCheckbox(App::gfx_declutter_map,  _LC("GameSettings", "Declutter overview map"));
+    }
+
 }
 
 void GameSettings::DrawGraphicsSettings()
@@ -578,4 +602,73 @@ void GameSettings::SetVisible(bool v)
         ImAddItemToComboboxString(m_combo_items_input_grab, ToLocalizedString(IoInputGrabMode::DYNAMIC));
         ImTerminateComboboxString(m_combo_items_input_grab);
     }
+
+    if (m_cached_uipreset_combo_string == "")
+    {
+        ImAddItemToComboboxString(m_cached_uipreset_combo_string, ToLocalizedString(UiPreset::NOVICE));
+        ImAddItemToComboboxString(m_cached_uipreset_combo_string, ToLocalizedString(UiPreset::REGULAR));
+        ImAddItemToComboboxString(m_cached_uipreset_combo_string, ToLocalizedString(UiPreset::EXPERT));
+        ImAddItemToComboboxString(m_cached_uipreset_combo_string, ToLocalizedString(UiPreset::MINIMALLIST));
+        ImTerminateComboboxString(m_cached_uipreset_combo_string);
+    }
+}
+
+void GameSettings::DrawUiPresetCombo()
+{
+    ImGui::PushID("uiPreset");
+    
+
+    DrawGCombo(App::ui_preset, _LC("TopMenubar", "UI Preset"), m_cached_uipreset_combo_string.c_str());
+    if (ImGui::IsItemEdited())
+    {
+        App::GetGuiManager()->ApplyUiPreset();
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::BeginTooltip();
+        const float COLLUMNWIDTH_NAME = 175.f;
+        const float COLLUMNWIDTH_VALUE = 60.f;
+        // Hack to make space for the table (doesn't autoresize)
+        ImGui::Dummy(ImVec2(COLLUMNWIDTH_NAME + COLLUMNWIDTH_VALUE*((int)UiPreset::Count), 1.f));
+
+        // UiPresets table
+        ImGui::Columns((int)UiPreset::Count + 1);
+        ImGui::SetColumnWidth(0, COLLUMNWIDTH_NAME);
+        for (int i = 0; i < (int)UiPreset::Count; i++)
+        {
+            ImGui::SetColumnWidth(i+1, COLLUMNWIDTH_VALUE);
+        }
+
+        // table header
+        ImGui::TextDisabled("%s", "Setting");
+        ImGui::NextColumn();
+        for (int i = 0; i < (int)UiPreset::Count; i++)
+        {
+            ImGui::TextDisabled("%s", ToLocalizedString((UiPreset)i).c_str());
+            ImGui::NextColumn();
+        }
+
+        // table body
+        ImGui::Separator();
+
+        int presetId = 0;
+        while (UiPresets[presetId].uip_cvar != nullptr)
+        {
+            ImGui::Text("%s", UiPresets[presetId].uip_cvar);
+            ImGui::NextColumn();
+            for (int i = 0; i < (int)UiPreset::Count; i++)
+            {
+                ImGui::Text("%s", UiPresets[presetId].uip_values[i].c_str());
+                ImGui::NextColumn();
+            }
+
+            presetId++;
+        }
+
+        // end table
+        ImGui::Columns(1);
+        ImGui::EndTooltip();
+    }
+
+    ImGui::PopID(); //"uiPreset"
 }

--- a/source/main/gui/panels/GUI_GameSettings.h
+++ b/source/main/gui/panels/GUI_GameSettings.h
@@ -37,10 +37,14 @@ private:
     void DrawRenderSystemSettings();
     void DrawGeneralSettings();
     void DrawGameplaySettings();
+    void DrawUiSettings();
     void DrawGraphicsSettings();
     void DrawAudioSettings();
     void DrawControlSettings();
     void DrawDiagSettings();
+
+    // Helpers
+    void DrawUiPresetCombo();
 
     // GUI state
     bool m_is_visible = false;
@@ -63,6 +67,7 @@ private:
     std::string m_combo_items_water_mode;
     std::string m_combo_items_extcam_mode;
     std::string m_combo_items_input_grab;
+    std::string m_cached_uipreset_combo_string;
 
     // Render settings
     bool m_render_must_restart = false;

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -569,9 +569,13 @@ void TopMenubar::Draw(float dt)
         ImGui::SetNextWindowPos(menu_pos);
         if (ImGui::Begin(_LC("TopMenubar", "Settings menu"), nullptr, static_cast<ImGuiWindowFlags_>(flags)))
         {
+            // AUDIO SETTINGS
+            ImGui::Separator();
             ImGui::PushItemWidth(125.f); // Width includes [+/-] buttons
             ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Audio:"));
             DrawGFloatSlider(App::audio_master_volume, _LC("TopMenubar", "Volume"), 0, 1);
+
+            // RENDER SETTINGS
             ImGui::Separator();
             ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Frames per second:"));
             if (App::gfx_envmap_enabled->getBool())
@@ -580,6 +584,7 @@ void TopMenubar::Draw(float dt)
             }
             DrawGIntSlider(App::gfx_fps_limit, _LC("TopMenubar", "Game"), 0, 240);
 
+            // SIM SETTINGS
             ImGui::Separator();
             ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Simulation:"));
             float slowmotion = std::min(App::GetGameContext()->GetActorManager()->GetSimulationSpeed(), 1.0f);
@@ -592,6 +597,8 @@ void TopMenubar::Draw(float dt)
             {
                 App::GetGameContext()->GetActorManager()->SetSimulationSpeed(timelapse);
             }
+
+            // CAMERA SETTINGS
             if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_STATIC)
             {
                 ImGui::Separator();
@@ -624,6 +631,8 @@ void TopMenubar::Draw(float dt)
                     DrawGCheckbox(App::gfx_fixed_cam_tracking, _LC("TopMenubar", "Tracking"));
                 }
             }
+
+            // SKY SETTINGS
 #ifdef USE_CAELUM
             if (App::gfx_sky_mode->getEnum<GfxSkyMode>() == GfxSkyMode::CAELUM)
             {
@@ -642,6 +651,8 @@ void TopMenubar::Draw(float dt)
                 }
             }       
 #endif // USE_CAELUM
+
+            // WATER SETTINGS
             if (RoR::App::gfx_water_waves->getBool() && App::mp_state->getEnum<MpState>() != MpState::CONNECTED && App::GetGameContext()->GetTerrain()->getWater())
             {
                 if (App::gfx_water_mode->getEnum<GfxWaterMode>() != GfxWaterMode::HYDRAX && App::gfx_water_mode->getEnum<GfxWaterMode>() != GfxWaterMode::NONE)
@@ -656,12 +667,15 @@ void TopMenubar::Draw(float dt)
                 }
             }    
             
+            // VEHICLE CONTROL SETTINGS
             if (current_actor != nullptr)
             {
                 ImGui::Separator();
                 ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Vehicle control options:"));
                 DrawGCheckbox(App::io_hydro_coupling, _LC("TopMenubar", "Keyboard steering speed coupling"));
             }
+
+            // MULTIPLAYER SETTINGS
             if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
             {
                 ImGui::Separator();

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -202,6 +202,7 @@ void Console::cVarSetupBuiltins()
     App::ui_show_live_repair_controls      = this->cVarCreate("ui_show_live_repair_controls",      "", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "true");
     App::ui_show_vehicle_buttons           = this->cVarCreate("ui_show_vehicle_buttons", "Show vehicle buttons menu", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "true");
     App::ui_preset                         = this->cVarCreate("ui_preset",                         "", CVAR_ARCHIVE | CVAR_TYPE_INT, "0"/*(int)UiPreset::NOVICE*/);
+    App::ui_hide_gui                       = this->cVarCreate("ui_hide_gui",                       "", CVAR_TYPE_BOOL, "false");
 }
 
 CVar* Console::cVarCreate(std::string const& name, std::string const& long_name,

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -201,6 +201,7 @@ void Console::cVarSetupBuiltins()
 
     App::ui_show_live_repair_controls      = this->cVarCreate("ui_show_live_repair_controls",      "", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "true");
     App::ui_show_vehicle_buttons           = this->cVarCreate("ui_show_vehicle_buttons", "Show vehicle buttons menu", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "true");
+    App::ui_preset                         = this->cVarCreate("ui_preset",                         "", CVAR_ARCHIVE | CVAR_TYPE_INT, "0"/*(int)UiPreset::NOVICE*/);
 }
 
 CVar* Console::cVarCreate(std::string const& name, std::string const& long_name,


### PR DESCRIPTION
![obrazek](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/26bbc568-9bbd-4c6b-89cf-dc9ed265fff8)

Since the game is a very loose sandbox, it's impossible to create an UI to satisfy everyone. But to make some space for debate and future enhancements, I've coined these 4 presets. 

**This is a prototype - the preset cvars and values are open for debate.**

Suggested on Discord: https://discord.com/channels/136544456244461568/189904947649708032/1128168306558390383
I added a whole new tab "UI" to the Settings panel: https://discord.com/channels/136544456244461568/189904947649708032/1128419817645424711

I took care to make it data-driven and intuitively readable in code, so that users can read it as reference and UI automatically reflects changes.

![obrazek](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/6d4f6db1-d24c-43b7-a6bf-a397f5ffc157)

