### PR TITLE
Fix #3079 - Minimap teleport doesn't work if in vehicle

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -845,8 +845,8 @@ void GameContext::TeleportPlayer(float x, float z)
     Ogre::Vector3 translation = Ogre::Vector3(x, y, z) - this->GetPlayerActor()->ar_nodes[0].AbsPosition;
 
     std::vector<ActorPtr> actorsToBeamUp;
-    actorsToBeamUp.push_back(this->GetPlayerActor());
     actorsToBeamUp.assign(this->GetPlayerActor()->ar_linked_actors.begin(), this->GetPlayerActor()->ar_linked_actors.end());
+    actorsToBeamUp.push_back(this->GetPlayerActor());
 
     float src_agl = std::numeric_limits<float>::max(); 
     float dst_agl = std::numeric_limits<float>::max(); 


### PR DESCRIPTION
Broken in https://github.com/RigsOfRods/rigs-of-rods/commit/3111ec97917d6c7eea461d6873687701f6cdb8b2 - adding linked actors to the worklist accidentally overwrites the player actor.