### PR TITLE
:angel: Script: Log meaningful error upon callback mixup.

### DIFF
--- a/doc/angelscript/Game2Script/script_callbacks.h
+++ b/doc/angelscript/Game2Script/script_callbacks.h
@@ -32,7 +32,9 @@ void eventCallback(Script2Game::scriptEvents event, int param);
 */
 void eventCallbackEx(Script2Game::scriptEvents event, int arg1, int arg2ex, int arg3ex, int arg4ex, string arg5ex, string arg6ex, string arg7ex, string arg8ex);
 
-/** Optional; Invoked when a vehicle touches an eventbox which has no custom handler function.
+/** OBSOLETE, ONLY WORKS WITH TERRAIN SCRIPTS - Use `eventCallbackEx()` with event `SE_EVENTBOX_ENTER` instead, it does the same job and works with any script.
+*    Optional; Invoked when a vehicle touches an eventbox which has no custom handler function.
+*    This is a legacy feature which pre-dates generic events `SE_EVENTBOX_ENTER` and `SE_EVENTBOX_EXIT` and bundled objects like truckshop/spawners still rely on it.
 *   @param trigger_type Unused, always 0.
 *   @param inst Unique ID of the terrain object instance which created the eventbox.
 *   @param box Name of the eventbox as defined by the terrain object's ODEF file.

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -444,15 +444,19 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
         int handler_func_id = -1; // no function
         if (!eventhandler.empty())
         {
-            AngelScript::asIScriptFunction* handler_func = module->GetFunctionByName(eventhandler.c_str());
+            // Let script author know (via Angelscript.log) there's a better alternative.
+            App::GetScriptEngine()->SLOG(
+                "spawnObject(): Specifying event handler function in `game.spawnObject()` (or .TOBJ file) is obsolete and only works with terrain scripts;"
+                " Use `eventCallbackEx()` with event `SE_EVENTBOX_ENTER` instead, it does the same job and works with any script."
+                " Just pass an empty string to the `game.spawnObject()` parameter.");
+
+            // Look up the function and log if not found or found with bad arguments (probably a typo).
+            AngelScript::asIScriptFunction* handler_func = App::GetScriptEngine()->getFunctionByDeclAndLogCandidates(
+                App::GetScriptEngine()->getTerrainScriptUnit(), GETFUNCFLAG_REQUIRED,
+                eventhandler, GETFUNC_DEFAULTEVENTCALLBACK_SIGFMT);
             if (handler_func != nullptr)
             {
                 handler_func_id = handler_func->GetId();
-            }
-            else
-            {
-                this->logFormat("spawnObject(): Warning; Failed to find handler function '%s' in script module '%s'",
-                    eventhandler.c_str(), module->GetName());
             }
         }
 

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -445,10 +445,12 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
         if (!eventhandler.empty())
         {
             // Let script author know (via Angelscript.log) there's a better alternative.
+            App::GetScriptEngine()->setForwardScriptLogToConsole(false);
             App::GetScriptEngine()->SLOG(
                 "spawnObject(): Specifying event handler function in `game.spawnObject()` (or .TOBJ file) is obsolete and only works with terrain scripts;"
                 " Use `eventCallbackEx()` with event `SE_EVENTBOX_ENTER` instead, it does the same job and works with any script."
                 " Just pass an empty string to the `game.spawnObject()` parameter.");
+            App::GetScriptEngine()->setForwardScriptLogToConsole(true);
 
             // Look up the function and log if not found or found with bad arguments (probably a typo).
             AngelScript::asIScriptFunction* handler_func = App::GetScriptEngine()->getFunctionByDeclAndLogCandidates(

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -988,9 +988,16 @@ void ScriptEngine::unloadScript(ScriptUnitId_t id)
     }
 }
 
-void ScriptEngine::activateLogging()
+void ScriptEngine::setForwardScriptLogToConsole(bool doForward)
 {
-    scriptLog->addListener(this);
+    // Always remove right away, to avoid attaching twice
+    scriptLog->removeListener(this);
+
+    // Re-attach if requested
+    if (doForward)
+    {
+        scriptLog->addListener(this);
+    }
 }
 
 bool ScriptEngine::scriptUnitExists(ScriptUnitId_t unique_id)

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -145,7 +145,7 @@ public:
      */
     void framestep(Ogre::Real dt);
 
-    void activateLogging();
+    void setForwardScriptLogToConsole(bool doForward);
 
     /**
      * triggers an event; Not to be used by the end-user.

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -100,6 +100,15 @@ struct ScriptCallbackArgs
     NodeNum_t node = NODENUM_INVALID;
 };
 
+typedef BitMask_t GetFuncFlags_t; //!< Flags for `RoR::ScriptEngine::getFunctionByDeclAndLogCandidates()`
+const GetFuncFlags_t GETFUNCFLAG_OPTIONAL = 0; //!< Only logs warning if candidate is found, to help modder find a typo.
+const GetFuncFlags_t GETFUNCFLAG_REQUIRED = BITMASK(1); //!< Always logs warning that function was not found.
+const GetFuncFlags_t GETFUNCFLAG_SILENT = BITMASK(2); //!< Never logs
+
+// Params to `RoR::ScriptEngine::getFunctionByDeclAndLogCandidates()`
+const std::string GETFUNC_DEFAULTEVENTCALLBACK_SIGFMT = "void {}(int, string, string, int)";
+const std::string GETFUNC_DEFAULTEVENTCALLBACK_NAME = "defaultEventCallback";
+
 /**
  *  @brief This class represents the angelscript scripting interface. It can load and execute scripts.
  *  @authors Thomas Fischer (thomas{AT}rigsofrods{DOT}com)
@@ -189,6 +198,12 @@ public:
      * @param arg A declaration for the variable.
     */
     int deleteVariable(const Ogre::String& arg);
+
+    /**
+    * Finds a function by full declaration, and if not found, finds candidates by name and logs them to Angelscript.log
+    * @return Angelscript function on success, null on error.
+    */
+    AngelScript::asIScriptFunction* getFunctionByDeclAndLogCandidates(ScriptUnitId_t nid, GetFuncFlags_t flags, const std::string& funcName, const std::string& fmtFuncDecl);
 
     int fireEvent(std::string instanceName, float intensity);
 

--- a/source/main/terrain/Terrain.cpp
+++ b/source/main/terrain/Terrain.cpp
@@ -444,6 +444,9 @@ void RoR::Terrain::initTerrainCollisions()
 void RoR::Terrain::initScripting()
 {
 #ifdef USE_ANGELSCRIPT
+    // suspend AS logging, so we dont spam the users screen with initialization messages
+    App::GetScriptEngine()->setForwardScriptLogToConsole(false);
+
     bool loaded = false;
 
     for (std::string as_filename : m_def.as_files)
@@ -457,8 +460,9 @@ void RoR::Terrain::initScripting()
         // load a default script that does the most basic things
         App::GetScriptEngine()->loadScript(DEFAULT_TERRAIN_SCRIPT);
     }
-    // finally activate AS logging, so we dont spam the users screen with initialization messages
-    App::GetScriptEngine()->activateLogging();
+
+    // finally resume AS logging
+    App::GetScriptEngine()->setForwardScriptLogToConsole(true);
 #endif //USE_ANGELSCRIPT
 }
 


### PR DESCRIPTION
One point for @Xploder98 in a friendly Devs vs. Users match :)

Long story short, Xploder mixed up callbacks and the game obligued which resulted in script failure with error asCONTEXT_NOT_PREPARED. This hapenned because our callback system is very confusing:
* we have a legacy "script handler" mechanic in .TOBJ file and classic `game.spawnObject()`, where you pass a function name and it gets invoked on eventbox collision.
* we also have recently introduced `SE_EVENTBOX_ENTER` and `SE_EVENTBOX_EXIT` which work with the classic event callback mechanism `eventCallback()` (and the extended `eventCallbackEx()` version) - it does the same job and even provides some extra data. This works independently of the "script handler" mecahnic described above - you just do `game.registerForEvent(SE_EVENTBOX_ENTER)` and you're covered, for all objects.

**Changes made:**
* clarified the legacy eventbox callback in docs on 'developer.rigsofrods.org' (will update when this commit/PR is merged).
* Added a "this is obsolete" notice to AngelScript.log, see below.
* Added a sensible "did you make a typo in arguments?" notice to AngelScript.log, see below.

**Example AngelScript.log if you mix up the callbacks:**
```
13:03:15: spawnObject(): Specifying event handler function in `game.spawnObject()` is obsolete and only works with terrain scripts; Use `eventCallbackEx()` with event `SE_EVENTBOX_ENTER` instead, it provides the same data and works with any script. Just pass an empty string to the `game.spawnObject()` parameter.
13:03:15: Warning: a callback function with signature 'void eventCallback(int, string, string, int)' was not found but a function with given name exists: 'void eventCallback(int, int)' - did you make a typo in arguments?
```

**What needs to be tested:** 
* Terrain scripts should work normally: check races, spawners and truckshops. 
* Custom scripts like 'demo_script.as' or 'road_editor.as' should work normally.