### PR TITLE
AI: Per waypoint speed

### DIFF
--- a/resources/scripts/AI.as
+++ b/resources/scripts/AI.as
@@ -1,5 +1,7 @@
 #include "base.as"
 
+array<int> waypoints_speed = game.getWaypointsSpeed();
+
 void main()
 {
     int offset = 0;
@@ -50,7 +52,18 @@ void main()
         }
 
         CurrentTruckai.setActive(true);
-        CurrentTruckai.setValueAtWaypoint("way0",AI_SPEED, game.getAIVehicleSpeed());
+
+        for (uint i = 0; i < waypoints_speed.length(); i++)
+        {
+            if (waypoints_speed[i] >= 5)
+            {
+                CurrentTruckai.setValueAtWaypoint("way"+i, AI_SPEED, waypoints_speed[i]);
+            }
+            else
+            {
+                CurrentTruckai.setValueAtWaypoint("way"+i, AI_SPEED, -1);
+            }
+        }
 
         offset -= game.getAIVehicleDistance();
         translation_x = CurrentTruckai.getTranslation(offset, 0).x;

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -34,7 +34,6 @@
 #include "GUI_FrictionSettings.h"
 #include "GUI_MainSelector.h"
 #include "GUI_TopMenubar.h"
-#include "GUI_SurveyMap.h"
 #include "InputEngine.h"
 #include "OverlayWrapper.h"
 #include "Replay.h"
@@ -1112,7 +1111,14 @@ void GameContext::UpdateSimInputEvents(float dt)
             {
                 if (App::GetGameContext()->GetPlayerActor()->getPosition().distance(prev_pos) >= 5) // Skip very close positions
                 {
-                    App::GetGuiManager()->SurveyMap.ai_waypoints.push_back(App::GetGameContext()->GetPlayerActor()->getPosition());
+                    ai_events waypoint;
+                    waypoint.position = App::GetGameContext()->GetPlayerActor()->getPosition();
+                    waypoint.speed = App::GetGameContext()->GetPlayerActor()->getWheelSpeed() * 3.6;
+                    if (waypoint.speed < 5)
+                    {
+                        waypoint.speed = -1;
+                    }
+                    App::GetGuiManager()->TopMenubar.ai_waypoints.push_back(waypoint);
                 }
                 prev_pos = App::GetGameContext()->GetPlayerActor()->getPosition();
             }
@@ -1120,7 +1126,9 @@ void GameContext::UpdateSimInputEvents(float dt)
             {
                 if (App::GetGameContext()->GetPlayerCharacter()->getPosition() != prev_pos) // Skip same positions
                 {
-                    App::GetGuiManager()->SurveyMap.ai_waypoints.push_back(App::GetGameContext()->GetPlayerCharacter()->getPosition());
+                    ai_events waypoint;
+                    waypoint.position = App::GetGameContext()->GetPlayerCharacter()->getPosition();
+                    App::GetGuiManager()->TopMenubar.ai_waypoints.push_back(waypoint);
                 }
                 prev_pos = App::GetGameContext()->GetPlayerCharacter()->getPosition();
             }

--- a/source/main/gameplay/VehicleAI.h
+++ b/source/main/gameplay/VehicleAI.h
@@ -148,7 +148,7 @@ private:
     std::map<std::string, int> waypoint_ids;//!< Map with all waypoint IDs.
     std::map<int, std::string> waypoint_names;//!< Map with all waypoint names.
     std::map<int, int> waypoint_events;//!< Map with all waypoint events.
-    std::map<int, float> waypoint_speed;//!< Map with all waypoint speeds.
+    std::map<Ogre::String, float> waypoint_speed;//!< Map with all waypoint speeds.
     std::map<int, float> waypoint_power;//!< Map with all waypoint engine power.
     std::map<int, float> waypoint_wait_time;//!< Map with all waypoint wait times.
     int free_waypoints = 0;//!< The amount of waypoints.

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -164,9 +164,9 @@ void SurveyMap::Draw()
     }
 
     bool w_adj = false;
-    if (!ai_waypoints.empty())
+    if (!App::GetGuiManager()->TopMenubar.ai_waypoints.empty())
     {
-        for (int i = 0; i < ai_waypoints.size(); i++)
+        for (int i = 0; i < App::GetGuiManager()->TopMenubar.ai_waypoints.size(); i++)
         {
             ImVec2 cw_dist = this->CalcWaypointMapPos(tl_screen_pos, view_size, view_origin, i);
             if (abs(cw_dist.x) <= 5 && abs(cw_dist.y) <= 5)
@@ -195,7 +195,9 @@ void SurveyMap::Draw()
         if (ImGui::IsItemClicked(1)) // Set AI waypoint
         {
             float y = App::GetGameContext()->GetTerrain()->GetCollisions()->getSurfaceHeight(mouse_map_pos.x, mouse_map_pos.y);
-            ai_waypoints.push_back(Ogre::Vector3(mouse_map_pos.x, y, mouse_map_pos.y));
+            ai_events waypoint;
+            waypoint.position = Ogre::Vector3(mouse_map_pos.x, y, mouse_map_pos.y);
+            App::GetGuiManager()->TopMenubar.ai_waypoints.push_back(waypoint);
         }
         else if (!w_adj) // Teleport
         {
@@ -205,7 +207,7 @@ void SurveyMap::Draw()
     }
     else if (ImGui::IsItemClicked(2) && !w_adj) // 2 = middle click, clear AI waypoints
     {
-        ai_waypoints.clear();
+        App::GetGuiManager()->TopMenubar.ai_waypoints.clear();
     }
     else if (ImGui::IsItemHovered())
     {
@@ -222,9 +224,9 @@ void SurveyMap::Draw()
     }
 
     // Draw AI waypoints
-    if (!ai_waypoints.empty())
+    if (!App::GetGuiManager()->TopMenubar.ai_waypoints.empty())
     {
-        for (int i = 0; i < ai_waypoints.size(); i++)
+        for (int i = 0; i < App::GetGuiManager()->TopMenubar.ai_waypoints.size(); i++)
         {
             ImVec2 cw_dist = this->DrawWaypoint(tl_screen_pos, view_size, view_origin, std::to_string(i), i);
 
@@ -255,11 +257,11 @@ void SurveyMap::Draw()
                 }
 
                 float y = App::GetGameContext()->GetTerrain()->GetCollisions()->getSurfaceHeight(mouse_map_pos.x, mouse_map_pos.y);
-                ai_waypoints[mWaypointNum] = Ogre::Vector3(mouse_map_pos.x, y, mouse_map_pos.y);
+                App::GetGuiManager()->TopMenubar.ai_waypoints[mWaypointNum].position = Ogre::Vector3(mouse_map_pos.x, y, mouse_map_pos.y);
             }
             else if (abs(cw_dist.x) <= 5 && abs(cw_dist.y) <= 5 && ImGui::IsItemClicked(2))
             {
-                ai_waypoints.erase(ai_waypoints.begin() + i);
+                App::GetGuiManager()->TopMenubar.ai_waypoints.erase(App::GetGuiManager()->TopMenubar.ai_waypoints.begin() + i);
             }
         }
     }
@@ -532,8 +534,8 @@ ImVec2 SurveyMap::DrawWaypoint(ImVec2 view_pos, ImVec2 view_size, Ogre::Vector2 
     }
 
     ImVec2 pos1;
-    pos1.x = view_pos.x + ((ai_waypoints[idx].x - view_origin.x) / terrn_size_adj.x) * view_size.x;
-    pos1.y = view_pos.y + ((ai_waypoints[idx].z - view_origin.y) / terrn_size_adj.y) * view_size.y;
+    pos1.x = view_pos.x + ((App::GetGuiManager()->TopMenubar.ai_waypoints[idx].position.x - view_origin.x) / terrn_size_adj.x) * view_size.x;
+    pos1.y = view_pos.y + ((App::GetGuiManager()->TopMenubar.ai_waypoints[idx].position.z - view_origin.y) / terrn_size_adj.y) * view_size.y;
 
     ImDrawList* drawlist = ImGui::GetWindowDrawList();
     ImVec4 col = ImVec4(1,0,0,1);
@@ -546,11 +548,11 @@ ImVec2 SurveyMap::DrawWaypoint(ImVec2 view_pos, ImVec2 view_size, Ogre::Vector2 
     ImVec2 text_pos(pos1.x - (ImGui::CalcTextSize(caption.c_str()).x/2), pos1.y + 5);
     drawlist->AddText(text_pos, ImGui::GetColorU32(ImGui::GetStyle().Colors[ImGuiCol_Text]), caption.c_str());
 
-    if (ai_waypoints.size() >= 2 && idx != ai_waypoints.size() - 1)
+    if (App::GetGuiManager()->TopMenubar.ai_waypoints.size() >= 2 && idx != App::GetGuiManager()->TopMenubar.ai_waypoints.size() - 1)
     {
         ImVec2 pos2;
-        pos2.x = view_pos.x + ((ai_waypoints[idx+1].x - view_origin.x) / terrn_size_adj.x) * view_size.x;
-        pos2.y = view_pos.y + ((ai_waypoints[idx+1].z - view_origin.y) / terrn_size_adj.y) * view_size.y;
+        pos2.x = view_pos.x + ((App::GetGuiManager()->TopMenubar.ai_waypoints[idx+1].position.x - view_origin.x) / terrn_size_adj.x) * view_size.x;
+        pos2.y = view_pos.y + ((App::GetGuiManager()->TopMenubar.ai_waypoints[idx+1].position.z - view_origin.y) / terrn_size_adj.y) * view_size.y;
         drawlist->AddLine(pos1, pos2, ImGui::GetColorU32(ImVec4(1,0,0,1)));
     }
 
@@ -566,8 +568,8 @@ ImVec2 SurveyMap::CalcWaypointMapPos(ImVec2 view_pos, ImVec2 view_size, Ogre::Ve
     }
 
     ImVec2 pos;
-    pos.x = view_pos.x + ((ai_waypoints[idx].x - view_origin.x) / terrn_size_adj.x) * view_size.x;
-    pos.y = view_pos.y + ((ai_waypoints[idx].z - view_origin.y) / terrn_size_adj.y) * view_size.y;
+    pos.x = view_pos.x + ((App::GetGuiManager()->TopMenubar.ai_waypoints[idx].position.x - view_origin.x) / terrn_size_adj.x) * view_size.x;
+    pos.y = view_pos.y + ((App::GetGuiManager()->TopMenubar.ai_waypoints[idx].position.z - view_origin.y) / terrn_size_adj.y) * view_size.y;
 
     return ImGui::GetMousePos() - pos;
 }

--- a/source/main/gui/panels/GUI_SurveyMap.h
+++ b/source/main/gui/panels/GUI_SurveyMap.h
@@ -59,8 +59,6 @@ public:
 
     const char* getTypeByDriveable(int driveable);
 
-    std::vector<Ogre::Vector3> ai_waypoints;
-
 protected:
 
     enum class SurveyMapMode

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -32,6 +32,12 @@
 #include <vector>
 #include <rapidjson/document.h>
 
+struct ai_events
+{
+    Ogre::Vector3 position;
+    int speed = -1;
+};
+
 namespace RoR {
 namespace GUI {
 
@@ -57,6 +63,7 @@ public:
     bool IsVisible() { return m_open_menu != TopMenu::TOPMENU_NONE; };
 
     // Vehicle AI
+    std::vector<ai_events> ai_waypoints;
     int ai_num = 1;
     int ai_speed = 50;
     int ai_times = 1;

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -42,7 +42,6 @@
 #include "GUI_MultiplayerClientList.h"
 #include "GUI_RepositorySelector.h"
 #include "GUI_SimActorStats.h"
-#include "GUI_SurveyMap.h"
 #include "GUIManager.h"
 #include "GUIUtils.h"
 #include "InputEngine.h"
@@ -637,7 +636,7 @@ int main(int argc, char *argv[])
                     App::GetGuiManager()->MainSelector.Close();
                     App::GetGuiManager()->LoadingWindow.SetVisible(false);
                     App::GetGuiManager()->MenuWallpaper->show();
-                    App::GetGuiManager()->SurveyMap.ai_waypoints.clear();
+                    App::GetGuiManager()->TopMenubar.ai_waypoints.clear();
                     App::sim_state->setVal((int)SimState::OFF);
                     App::app_state->setVal((int)AppState::MAIN_MENU);
                     App::GetGameContext()->UnloadTerrain();

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -46,7 +46,6 @@
 #include "GameContext.h"
 #include "GfxScene.h"
 #include "GUIManager.h"
-#include "GUI_SurveyMap.h"
 #include "GUI_TopMenubar.h"
 #include "Language.h"
 #include "Network.h"
@@ -953,7 +952,11 @@ ActorPtr GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, O
         rq.asr_position = pos;
 
         // Set rotation based on first two waypoints
-        std::vector<Ogre::Vector3> waypoints = App::GetGuiManager()->SurveyMap.ai_waypoints;
+        std::vector<Ogre::Vector3> waypoints;
+        for (int i = 0; i < App::GetGuiManager()->TopMenubar.ai_waypoints.size(); i++)
+        {
+            waypoints.push_back(App::GetGuiManager()->TopMenubar.ai_waypoints[i].position);
+        }
         if (App::GetGuiManager()->TopMenubar.ai_mode == 3 && x == 1) // Crash driving mode
         {
             std::reverse(waypoints.begin(), waypoints.end());
@@ -983,7 +986,11 @@ ActorPtr GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, O
 
 AngelScript::CScriptArray* GameScript::getWaypoints(int x)
 {
-    std::vector<Ogre::Vector3> vec = App::GetGuiManager()->SurveyMap.ai_waypoints;
+    std::vector<Ogre::Vector3> vec;
+    for (int i = 0; i < App::GetGuiManager()->TopMenubar.ai_waypoints.size(); i++)
+    {
+        vec.push_back(App::GetGuiManager()->TopMenubar.ai_waypoints[i].position);
+    }
     if (App::GetGuiManager()->TopMenubar.ai_mode == 3 && x == 1) // Crash driving mode
     {
         std::reverse(vec.begin(), vec.end());
@@ -1016,7 +1023,30 @@ AngelScript::CScriptArray* GameScript::getAllTrucks()
 
 void GameScript::addWaypoint(const Ogre::Vector3& pos)
 {
-    App::GetGuiManager()->SurveyMap.ai_waypoints.push_back(pos);
+    std::vector<Ogre::Vector3> waypoints;
+    for (int i = 0; i < App::GetGuiManager()->TopMenubar.ai_waypoints.size(); i++)
+    {
+        waypoints.push_back(App::GetGuiManager()->TopMenubar.ai_waypoints[i].position);
+    }
+}
+
+AngelScript::CScriptArray* GameScript::getWaypointsSpeed()
+{
+    std::vector<int> vec;
+    for (int i = 0; i < App::GetGuiManager()->TopMenubar.ai_waypoints.size(); i++)
+    {
+        vec.push_back(App::GetGuiManager()->TopMenubar.ai_waypoints[i].speed);
+    }
+
+    AngelScript::CScriptArray* arr = AngelScript::CScriptArray::Create(AngelScript::asGetActiveContext()->GetEngine()->GetTypeInfoByDecl("array<int>"), vec.size());
+
+    for(AngelScript::asUINT i = 0; i < arr->GetSize(); i++)
+    {
+        // Set the value of each element
+        arr->SetValue(i, &vec[i]);
+    }
+
+    return arr;
 }
 
 int GameScript::getAIVehicleCount()

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -391,6 +391,7 @@ public:
 
     ActorPtr spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x);
     AngelScript::CScriptArray* getWaypoints(int x);
+    AngelScript::CScriptArray* getWaypointsSpeed();
     void addWaypoint(const Ogre::Vector3& pos);
     int getAIVehicleCount();
     int getAIVehicleDistance();

--- a/source/main/scripting/bindings/GameScriptAngelscript.cpp
+++ b/source/main/scripting/bindings/GameScriptAngelscript.cpp
@@ -123,6 +123,7 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     // > Waypoint AI for actors
     result = engine->RegisterObjectMethod("GameScriptClass", "BeamClassPtr @spawnTruckAI(string &in, vector3 &in, string &in, string &in, int x)", AngelScript::asMETHOD(GameScript, spawnTruckAI), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "array<vector3> @getWaypoints(int x)", AngelScript::asMETHOD(GameScript, getWaypoints), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "array<int> @getWaypointsSpeed()", AngelScript::asMETHOD(GameScript, getWaypointsSpeed), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void addWaypoint(vector3 &in)", asMETHOD(GameScript, addWaypoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleCount()", AngelScript::asMETHOD(GameScript, getAIVehicleCount), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleDistance()", AngelScript::asMETHOD(GameScript, getAIVehicleDistance), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);


### PR DESCRIPTION
- Custom per waypoint speed can be now defined in UI or the json file. Values >= 5 km/h are respected, -1 system default, can be skipped in json.
- Recorder records the speed
- Exporter exports the speed

![kk](https://github.com/RigsOfRods/rigs-of-rods/assets/2660424/1055e593-a46f-46c8-91c2-e39d2ab7a065)

Code changes:
- Moved vector `ai_waypoints` to `GUI_TopMenubar` so now all `ai_*` vars are in one place and made it a struct
- `std::map<int, float> waypoint_speed` changed type from `int` to `Ogre::String` (way0, way1 ...) so custom speeds are correctly aligned in all repeat times



