### PR TITLE
:bug: Fixed build failing when building RelWithDebInfo && 🔧 Move conan generated files to a subfolder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,6 @@ mark_as_advanced(
 if (WIN32)
     add_definitions("/D_CRT_SECURE_NO_WARNINGS /wd4005 /wd4996 /wd4251 /wd4275 /wd4099 /nologo")
 
-    set(CMAKE_CONFIGURATION_TYPES "Debug" "Release" CACHE STRING "Configuration types")
-
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}        /MP /GL /Ox /Ob2 /Oi /Ot /Oy /fp:fast /GS- /MP /Zi")
     set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL}     /MP /Zi")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MP /Od /Zi /Gy /fp:except /GF- /GS /Ob0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,12 +1,12 @@
 import os
 from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMakeDeps
 from conan.tools.files import copy
-
 
 class RoR(ConanFile):
     name = "Rigs of Rods"
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain", "CMakeDeps"
+
 
     def requirements(self):
         self.requires("angelscript/2.35.1")
@@ -28,6 +28,14 @@ class RoR(ConanFile):
         self.requires("zlib/1.2.13", override=True)
 
     def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+        if self.settings.os == "Windows" and self.settings.build_type == "Release":
+            deps.configuration = "RelWithDebInfo"
+            deps.generate()
+
         for dep in self.dependencies.values():
             for f in dep.cpp_info.bindirs:
                 self.cp_data(f)

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,6 +7,8 @@ class RoR(ConanFile):
     name = "Rigs of Rods"
     settings = "os", "compiler", "build_type", "arch"
 
+    def layout(self):
+        self.folders.generators = os.path.join(self.folders.build, "generators")
 
     def requirements(self):
         self.requires("angelscript/2.35.1")


### PR DESCRIPTION
Now RoR is buildable on Windows in the RelWithDebInfo config without needing to build the deps in RelWithDebInfo
Also moved the files generated by Conan to the `generators` folder so it no longer clutters up the build folder