### PR TITLE
:rocket: Use prebuild dependencies by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ set(PROJECT_NAME_SHORT "RoR")
 set(PROJECT_NAME_UNDERSCORE "Rigs_of_Rods")
 set(PROJECT_NAME_LONG "Rigs of Rods")
 
-set(REQUIRED_DEPS_VERSION 30)
-
 project(${PROJECT_NAME_UNDERSCORE})
 
 ################################################################################
@@ -25,16 +23,23 @@ option(BUILD_DEV_VERSION "Disable this for official releases" ON)
 option(BUILD_DOC_DOXYGEN "Build documentation from sources with Doxygen" OFF)
 option(USE_PCH "Use a Precompiled header for speeding up the build" ON)
 option(CREATE_CONTENT_FOLDER "Create the base content folder" ON)
-set(ROR_DEPENDENCY_DIR "${CMAKE_SOURCE_DIR}/dependencies" CACHE PATH "Path to the dependencies")
+if(NOT DEFINED DOWNLOAD_DEPS)
+    option(DOWNLOAD_DEPS "Download prebuild dependencies" ON)
+endif ()
 set(ROR_FEAT_TIMING OFF)
 
 # global cmake options
+set(FETCHCONTENT_QUIET OFF)
 SET(BUILD_SHARED_LIBS ON)
 SET(CMAKE_USE_RELATIVE_PATHS OFF)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+if(DOWNLOAD_DEPS)
+    include(cmake/DownloadDeps.cmake)
+endif ()
+
 # setup paths
-SET(CMAKE_PREFIX_PATH ${ROR_DEPENDENCY_DIR} ${CMAKE_PREFIX_PATH})
+SET(CMAKE_PREFIX_PATH ${dependencies_SOURCE_DIR} ${CMAKE_PREFIX_PATH})
 SET(RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")
 SET(LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/")
 SET(ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/")
@@ -48,14 +53,6 @@ if (NOT USE_PCH)
     if (SCCACHE_PROGRAM)
         set(CMAKE_CXX_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}")
         message("Using ${SCCACHE_PROGRAM} for speeding up build")
-    endif ()
-endif ()
-
-# Check deps version
-if (EXISTS "${ROR_DEPENDENCY_DIR}/version.cmake")
-    include("${ROR_DEPENDENCY_DIR}/version.cmake")
-    if (NOT ${REQUIRED_DEPS_VERSION} EQUAL ${DEPENDENCIES_VERSION})
-        message(FATAL_ERROR "\n The ror-dependencies version is ${DEPENDENCIES_VERSION}, while RoR requires ${REQUIRED_DEPS_VERSION} \n Please update the dependencies")
     endif ()
 endif ()
 

--- a/cmake/DownloadDeps.cmake
+++ b/cmake/DownloadDeps.cmake
@@ -1,0 +1,50 @@
+include(FetchContent)
+include(CheckCXXSourceRuns)
+
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+
+if (WIN32)
+    FetchContent_Declare(
+        dependencies
+        URL      http://prdownloads.sourceforge.net/rigs-of-rods/dependencies_win_31.tar.gz
+        URL_HASH SHA1=83f843d21868d6a5731630cd1c3bf81859778ab0
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+elseif (UNIX)
+    FetchContent_Declare(
+        dependencies
+        URL      http://prdownloads.sourceforge.net/rigs-of-rods/dependencies_linux_31.tar.gz
+        URL_HASH SHA1=75f56cb4e181864bfe7dd464f368c5b5c9361b6d
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+endif ()
+
+FetchContent_MakeAvailable(dependencies)
+
+function(run_deps_test)
+    # Run a simple test to see if the prebuild dependencies are compatible with the used compiler 
+    include("${dependencies_SOURCE_DIR}/ZLIB-release-x86_64-data.cmake")
+
+    set(CMAKE_REQUIRED_INCLUDES ${zlib_INCLUDE_DIRS_RELEASE})
+    if (WIN32)
+        set(CMAKE_REQUIRED_LIBRARIES "${zlib_LIB_DIRS_RELEASE}/zlib.lib")
+    elseif (UNIX)
+        set(CMAKE_REQUIRED_LIBRARIES "${zlib_LIB_DIRS_RELEASE}/libz.a")
+    endif ()
+
+    check_cxx_source_runs([==[
+    #include <stdio.h>
+    #include <zlib.h>
+
+    int main(void) {
+        printf("ZLIB VERSION: %s", zlibVersion());
+        return 0;
+    }
+    ]==] DEPS_CHECK)
+
+    if(NOT DEPS_CHECK)
+        message(FATAL_ERROR "Failed to build test program with prebuild deps, please use conan")
+    endif()    
+endfunction(run_deps_test)
+
+run_deps_test()

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,6 +2,7 @@ import os
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMakeDeps
 from conan.tools.files import copy
+from conan.tools.cmake import CMakeToolchain, CMakeDeps
 
 class RoR(ConanFile):
     name = "Rigs of Rods"
@@ -31,6 +32,7 @@ class RoR(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["DOWNLOAD_DEPS"] = "OFF"
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -511,6 +511,9 @@ endif ()
 fast_copy("${CMAKE_SOURCE_DIR}/resources/managed_materials" "${RUNTIME_OUTPUT_DIRECTORY}/resources/managed_materials")
 fast_copy("${CMAKE_SOURCE_DIR}/resources/fonts" "${RUNTIME_OUTPUT_DIRECTORY}/languages")
 fast_copy("${CMAKE_SOURCE_DIR}/languages" "${RUNTIME_OUTPUT_DIRECTORY}/languages")
+if(DOWNLOAD_DEPS)
+    fast_copy("${dependencies_SOURCE_DIR}/deploy" "${RUNTIME_OUTPUT_DIRECTORY}")
+endif ()
 
 
 #  Install targets

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -340,12 +340,23 @@ int ScriptEngine::executeContextAndHandleErrors(ScriptUnitId_t nid)
             if (context->GetFunction())
             {
                 SLOG(fmt::format("The script ended with error code asCONTEXT_NOT_PREPARED; Function to execute: {},currently triggered event: {}, NID: {}",
-                    context->GetFunction()->GetName(), fmt::underlying(m_currently_executing_event_trigger), nid));
+                    context->GetFunction()->GetName(), 
+#if FMT_VERSION >= 100000
+                    fmt::underlying(m_currently_executing_event_trigger)
+#else
+                    m_currently_executing_event_trigger
+#endif         
+                    , nid));
             }
             else
             {
-                SLOG(fmt::format("The script ended with error code asCONTEXT_NOT_PREPARED; Function to execute NOT SET,currently triggered event: {}, NID: {}",
-                    fmt::underlying(m_currently_executing_event_trigger), nid));
+                SLOG(fmt::format("The script ended with error code asCONTEXT_NOT_PREPARED; Function to execute NOT SET,currently triggered event: {}, NID: {}",        
+#if FMT_VERSION >= 100000
+                    fmt::underlying(m_currently_executing_event_trigger)
+#else
+                    m_currently_executing_event_trigger
+#endif   
+                    , nid));
             }
         }
         else


### PR DESCRIPTION
This removes the requirement for installing conan to build RoR
Now cmake will download a prebuild dependencies tarball, extract it and run a small test to see if it is able to build with the dependencies 
Limitations of this system:
* Only the Release build config is supported, for a debug build running Conan is still required
* The Linux tarball might not work on every distro, if it fails using Conan is still recommended

**To build on Linux**:
Create a build dir: `mkdir build && cd build` 
Generate ninja files: `cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. `
Build the game: `ninja`

**To build on Windows**:
Create a build dir: `mkdir build && cd build` 
Generate VS studio files: `cmake -G"Visual Studio 16 2019" .. `
Open the `Rigs_of_Rods.sln` file and switch the config to Release 
Build the game as usual