### PR TITLE
Added setting to hide vehicle buttons menu

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -256,6 +256,7 @@ CVar* flexbody_defrag_invert_lookup;
 
 // GUI
 CVar* ui_show_live_repair_controls;
+CVar* ui_show_vehicle_buttons;
 
 // Instance management
 void SetCacheSystem    (CacheSystem* obj)             { g_cache_system = obj; }

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -460,6 +460,7 @@ extern CVar* flexbody_defrag_invert_lookup;
 
 // GUI
 extern CVar* ui_show_live_repair_controls;
+extern CVar* ui_show_vehicle_buttons;
 
 // ------------------------------------------------------------------------------------------------
 // Global objects

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -268,6 +268,8 @@ void GameSettings::DrawGameplaySettings()
     DrawGCheckbox(App::sim_quickload_dialog, _LC("GameSettings", "Show confirm. UI dialog for quickload"));
 
     DrawGCheckbox(App::ui_show_live_repair_controls, _LC("GameSettings", "Show controls in live repair box"));
+
+    DrawGCheckbox(App::ui_show_vehicle_buttons, _LC("GameSettings", "Show vehicle buttons menu"));
 }
 
 void GameSettings::DrawAudioSettings()

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -57,20 +57,20 @@ void VehicleButtons::Draw(RoR::GfxActor* actorx)
     bool is_visible = false;
 
     // Show only once for 5 sec, with a notice
-    if (actorx && !m_init)
+    if (App::ui_show_vehicle_buttons->getBool() && actorx && !m_init)
     {
         m_timer.reset();
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
                                       fmt::format(_LC("VehicleButtons", "Hover the mouse on the left to see controls")), "lightbulb.png");
         m_init = true;
     }
-    if (m_timer.getMilliseconds() < 5000)
+    if (App::ui_show_vehicle_buttons->getBool() && m_timer.getMilliseconds() < 5000)
     {
         is_visible = true;
     }
 
     // Show when mouse is on the left of screen
-    if (App::GetGuiManager()->AreStaticMenusAllowed() &&
+    if (App::ui_show_vehicle_buttons->getBool() && App::GetGuiManager()->AreStaticMenusAllowed() &&
         (ImGui::GetIO().MousePos.x <= window_pos.x + ImGui::GetStyle().WindowPadding.x) && ImGui::GetIO().MousePos.y <= ImGui::GetIO().DisplaySize.y && !ImGui::IsMouseDown(1))
     {
         is_visible = true;

--- a/source/main/system/AppConfig.cpp
+++ b/source/main/system/AppConfig.cpp
@@ -416,6 +416,7 @@ void Console::saveConfig()
     WriteVarsHelper(f, "Simulation",    "sim_");
     WriteVarsHelper(f, "Input/Output",  "io_");
     WriteVarsHelper(f, "Graphics",      "gfx_");
+    WriteVarsHelper(f, "GUI",           "ui_");
     WriteVarsHelper(f, "Audio",         "audio_");
     WriteVarsHelper(f, "Diagnostics",   "diag_");
 

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -196,6 +196,7 @@ void Console::cVarSetupBuiltins()
     App::flexbody_defrag_invert_lookup     = this->cVarCreate("flexbody_defrag_invert_lookup",     "", CVAR_TYPE_BOOL, "true");
 
     App::ui_show_live_repair_controls      = this->cVarCreate("ui_show_live_repair_controls",      "", CVAR_TYPE_BOOL, "true");
+    App::ui_show_vehicle_buttons           = this->cVarCreate("ui_show_vehicle_buttons", "Show vehicle buttons menu", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "true");
 }
 
 CVar* Console::cVarCreate(std::string const& name, std::string const& long_name,


### PR DESCRIPTION
For those who find the vehicle buttons menu not useful and/or intrusive, this adds "Show vehicle buttons menu" (CVar `ui_show_vehicle_buttons`) to Settings -> Gameplay:

![image](https://github.com/RigsOfRods/rigs-of-rods/assets/46073351/4f87d27f-f661-41cd-a05f-967dd49ee399)
![image](https://github.com/RigsOfRods/rigs-of-rods/assets/46073351/7ea66225-4e4e-4df9-ade1-9bf6b8c71ed0)

Note: I had to add `WriteVarsHelper(f, "GUI", "ui_");` to `AppConfig.cpp`, otherwise any `ui_` CVar wouldn't get saved to `RoR.cfg`.
![image](https://github.com/RigsOfRods/rigs-of-rods/assets/46073351/b0f1c654-0d37-40e4-8223-2a8f46334d33)
