### PR TITLE
:truck: new 'guisettings' entry 'shifterAnimTime' (seconds)

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1791,9 +1791,9 @@ void RoR::GfxActor::UpdateSimDataBuffer()
         m_simbuf.simbuf_ap_vs_value      = m_actor->ar_autopilot->GetVsValue();
     }
 
-    m_simbuf.simbuf_speedo_highest_kph = m_actor->ar_speedo_max_kph;
-    m_simbuf.simbuf_speedo_use_engine_max_rpm = m_actor->ar_gui_use_engine_max_rpm;
-
+    m_simbuf.simbuf_speedo_highest_kph = m_actor->ar_guisettings_speedo_max_kph;
+    m_simbuf.simbuf_speedo_use_engine_max_rpm = m_actor->ar_guisettings_use_engine_max_rpm;
+    m_simbuf.simbuf_shifter_anim_time = m_actor->ar_guisettings_shifter_anim_time;
 
 }
 
@@ -2315,24 +2315,22 @@ void RoR::GfxActor::SetBeaconsEnabled(bool beacon_light_is_active)
 }
 
 // Returns a smoothened `cstate`
-float UpdateSmoothShift(PropAnim& anim, float dt, float new_target_cstate)
+float GfxActor::UpdateSmoothShift(PropAnim& anim, float dt, float new_target_cstate)
 {
-    const float SPEED = 5.f;
-
     const float delta_cstate = new_target_cstate - anim.shifterTarget;
     if (delta_cstate != 0)
     {
         anim.shifterStep = delta_cstate;
         anim.shifterTarget = new_target_cstate;
     }
-        
+    
     if (anim.shifterSmooth != anim.shifterTarget)
     {
-        const float cstate_step = anim.shifterStep * (dt * SPEED);
+        const float cstate_step = (dt / m_simbuf.simbuf_shifter_anim_time) * anim.shifterStep;
         anim.shifterSmooth += cstate_step;
         // boundary check
-        if ((cstate_step < 0.f && anim.shifterSmooth < anim.shifterTarget) // undershot
-            || (cstate_step > 0.f) && anim.shifterSmooth > anim.shifterTarget) // overshot
+        if ((anim.shifterStep < 0.f && anim.shifterSmooth < anim.shifterTarget) // undershot
+            || (anim.shifterStep > 0.f) && anim.shifterSmooth > anim.shifterTarget) // overshot
         {
             anim.shifterSmooth = anim.shifterTarget;
         }

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -153,6 +153,7 @@ public:
 private:
 
     static Ogre::Quaternion SpecialGetRotationTo(const Ogre::Vector3& src, const Ogre::Vector3& dest);
+    float UpdateSmoothShift(PropAnim& anim, float dt, float new_target_cstate); // Helper for `CalcPropAnimation()`
 
     // Static info
     ActorPtr                      m_actor = nullptr;

--- a/source/main/gfx/SimBuffers.h
+++ b/source/main/gfx/SimBuffers.h
@@ -187,9 +187,10 @@ struct ActorSB
     float             simbuf_ap_ils_hdev              = 0;
     int               simbuf_ap_vs_value              = 0;
 
-    // GUI
+    // GUI ('guisettings')
     float             simbuf_speedo_highest_kph       = 0;
     bool              simbuf_speedo_use_engine_max_rpm = false;
+    float             simbuf_shifter_anim_time        = 0.f;
 };
 
 struct GameContextSB

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2234,7 +2234,7 @@ void Actor::CalcAnimators(hydrobeam_t const& hydrobeam, float &cstate, int &div)
     // speedo ( scales with speedomax )
     if (hydrobeam.hb_anim_flags & ANIM_FLAG_SPEEDO)
     {
-        float speedo = ar_wheel_speed / ar_speedo_max_kph;
+        float speedo = ar_wheel_speed / ar_guisettings_speedo_max_kph;
         cstate -= speedo * 3.0f;
         div++;
     }
@@ -4333,7 +4333,7 @@ Actor::Actor(
     , ar_update_physics(false)
     , ar_disable_aerodyn_turbulent_drag(false)
     , ar_engine_hydraulics_ready(true) // !!
-    , ar_gui_use_engine_max_rpm(false)
+    , ar_guisettings_use_engine_max_rpm(false)
     , ar_hydro_speed_coupling(false)
     , ar_collision_relevant(false)
     , ar_is_police(false)

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -365,7 +365,7 @@ ActorPtrVec                        ar_linked_actors;              //!< Sim state
     int               ar_num_cinecams = 0;             //!< Sim attr;
     Autopilot*        ar_autopilot = nullptr;
     float             ar_brake_force = 0.f;              //!< Physics attr; filled at spawn
-    float             ar_speedo_max_kph = 0.f;           //!< GUI attr
+    
     Ogre::Vector3     ar_origin = Ogre::Vector3::ZERO;                   //!< Physics state; base position for softbody nodes
     int               ar_num_cameras = 0;
     Ogre::Quaternion  ar_main_camera_dir_corr = Ogre::Quaternion::IDENTITY;              //!< Sim attr;
@@ -421,6 +421,11 @@ ActorPtrVec                        ar_linked_actors;              //!< Sim state
     CollisionBoxPtrVec m_potential_eventboxes;
     std::vector<std::pair<collision_box_t*, NodeNum_t>> m_active_eventboxes;
 
+    // Guisettings
+    bool              ar_guisettings_use_engine_max_rpm = false;
+    float             ar_guisettings_speedo_max_kph = 0.f;
+    float             ar_guisettings_shifter_anim_time = 0.4f;
+
     // Gameplay state
     ActorState        ar_state = ActorState::LOCAL_SIMULATED;
 
@@ -451,7 +456,6 @@ ActorPtrVec                        ar_linked_actors;              //!< Sim state
     bool ar_update_physics:1; //!< Physics state; Should this actor be updated (locally) in the next physics step?
     bool ar_disable_aerodyn_turbulent_drag:1; //!< Physics state
     bool ar_engine_hydraulics_ready:1; //!< Sim state; does engine have enough RPM to power hydraulics?
-    bool ar_gui_use_engine_max_rpm:1;  //!< Gfx attr
     bool ar_hydro_speed_coupling:1;
     bool ar_collision_relevant:1;      //!< Physics state;
     bool ar_is_police:1;        //!< Gfx/sfx attr

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -271,7 +271,7 @@ void ActorSpawner::InitializeRig()
 
     m_actor->m_num_proped_wheels=0;
 
-    m_actor->ar_speedo_max_kph=140;
+    m_actor->ar_guisettings_speedo_max_kph=140;
     m_actor->ar_num_cameras=0;
     for (int i = 0; i < MAX_CAMERAS; ++i)
     {
@@ -1193,18 +1193,22 @@ void ActorSpawner::ProcessGuiSettings(RigDef::GuiSettings & def)
         float maxKph = PARSEREAL(def.value);
         if (maxKph > 10 && maxKph < 32000)
         {
-            m_actor->ar_speedo_max_kph = maxKph;
+            m_actor->ar_guisettings_speedo_max_kph = maxKph;
         }
         else
         {
             this->AddMessage(Message::TYPE_ERROR,
                 fmt::format("Invalid 'speedoMax' ({}), allowed range is <10 -32000>, using default ({})", maxKph, DEFAULT_SPEEDO_MAX_KPH));
-            m_actor->ar_speedo_max_kph = DEFAULT_SPEEDO_MAX_KPH;
+            m_actor->ar_guisettings_speedo_max_kph = DEFAULT_SPEEDO_MAX_KPH;
         }
     }
     else if (def.key == "useMaxRPM")
     {
-        m_actor->ar_gui_use_engine_max_rpm = true;
+        m_actor->ar_guisettings_use_engine_max_rpm = true;
+    }
+    else if (def.key == "shifterAnimTime")
+    {
+        m_actor->ar_guisettings_shifter_anim_time = PARSEREAL(def.value);
     }
 
     // NOTE: Dashboard layouts are processed later


### PR DESCRIPTION
This allows modder to specify how much (if at all) the shifter anims should be smoothed. Default is 0.4sec. Use 0.0sec to disable.

Useful for the ThomasHDX bus which uses the shifter anim for dashboard digits.
![obrazek](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/c6d06bf9-1b00-49a9-aa4b-899d138407d5)
