### PR TITLE
Fixed light toggle behavior

### DIFF
--- a/resources/skeleton/config/Bluetooth_LE_XINPUT_compatible_input_device.map
+++ b/resources/skeleton/config/Bluetooth_LE_XINPUT_compatible_input_device.map
@@ -70,7 +70,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 4 LOWER

--- a/resources/skeleton/config/Bluetooth_XINPUT_compatible_input_device.map
+++ b/resources/skeleton/config/Bluetooth_XINPUT_compatible_input_device.map
@@ -70,7 +70,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 4 LOWER

--- a/resources/skeleton/config/Controller__Afterglow_Gamepad_for_Xbox_360_.map
+++ b/resources/skeleton/config/Controller__Afterglow_Gamepad_for_Xbox_360_.map
@@ -70,7 +70,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 4 LOWER

--- a/resources/skeleton/config/Controller__XBOX_360_For_Windows_.map
+++ b/resources/skeleton/config/Controller__XBOX_360_For_Windows_.map
@@ -70,7 +70,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 4 LOWER

--- a/resources/skeleton/config/Controller__Xbox_360_Wireless_Receiver_for_Windows_.map
+++ b/resources/skeleton/config/Controller__Xbox_360_Wireless_Receiver_for_Windows_.map
@@ -70,7 +70,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 4 LOWER

--- a/resources/skeleton/config/Controller__Xbox_One_For_Windows_.map
+++ b/resources/skeleton/config/Controller__Xbox_One_For_Windows_.map
@@ -70,7 +70,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 4 LOWER

--- a/resources/skeleton/config/Logitech_G27_Racing_Wheel_USB.map
+++ b/resources/skeleton/config/Logitech_G27_Racing_Wheel_USB.map
@@ -25,7 +25,7 @@ CHARACTER_RUN                  JoystickButton       0 16
 ; COMMON
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 15 
 COMMON_LOCK                    JoystickButton       0 1 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickButton       0 18 
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickButton       0 18 
 
 
 ; TRUCK

--- a/resources/skeleton/config/Logitech_G29_Driving_Force_Racing_Wheel_USB.map
+++ b/resources/skeleton/config/Logitech_G29_Driving_Force_Racing_Wheel_USB.map
@@ -18,7 +18,7 @@ CHARACTER_RUN                  JoystickButton       0 3
 
 ; COMMON
 COMMON_QUIT_GAME               JoystickButton       0 24 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickButton       0 10 
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickButton       0 10 
 COMMON_TRUCK_INFO              JoystickButton       0 9 
 
 ; MAP

--- a/resources/skeleton/config/Microsoft_X_Box_360_pad.map
+++ b/resources/skeleton/config/Microsoft_X_Box_360_pad.map
@@ -74,7 +74,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 5 UPPER

--- a/resources/skeleton/config/Microsoft_X_Box_360_pad_0.map
+++ b/resources/skeleton/config/Microsoft_X_Box_360_pad_0.map
@@ -71,7 +71,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 East
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 East
 COMMON_REPAIR_TRUCK 					JoystickPov          0 0 West
 
 ; TRUCK

--- a/resources/skeleton/config/Saitek_ST290_Pro.map
+++ b/resources/skeleton/config/Saitek_ST290_Pro.map
@@ -65,7 +65,7 @@ CHARACTER_RIGHT                JoystickAxis         0 3 UPPER
 CHARACTER_RUN                  JoystickButton       0 1 
 
 ; COMMON
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickButton       0 4
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickButton       0 4
 
 ; TRUCK
 TRUCK_BLINK_LEFT               JoystickAxis         0 3 LOWER+DEADZONE=0.15

--- a/resources/skeleton/config/Sony_PLAYSTATION_R_3_Controller.map
+++ b/resources/skeleton/config/Sony_PLAYSTATION_R_3_Controller.map
@@ -75,7 +75,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 ;COMMON_LOCK                    JoystickPov          0 0 East
 ;COMMON_QUIT_GAME               JoystickButton       0 7 
-;COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+;COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 5 UPPER

--- a/resources/skeleton/config/Xbox_360_Wireless_Receiver.linux.map
+++ b/resources/skeleton/config/Xbox_360_Wireless_Receiver.linux.map
@@ -71,7 +71,7 @@ CHARACTER_RUN                  JoystickButton       0 0
 COMMON_ENTER_OR_EXIT_TRUCK     JoystickButton       0 3 
 COMMON_LOCK                    JoystickPov          0 0 East
 COMMON_QUIT_GAME               JoystickButton       0 7 
-COMMON_CYCLE_TRUCK_LIGHTS     JoystickPov          0 0 West
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     JoystickPov          0 0 West
 
 ; TRUCK
 TRUCK_ACCELERATE               JoystickAxis         0 5 UPPER

--- a/resources/skeleton/config/input.map
+++ b/resources/skeleton/config/input.map
@@ -201,7 +201,7 @@ COMMON_TOGGLE_REPLAY_MODE      Keyboard             CTRL+J
 COMMON_TOGGLE_PHYSICS          Keyboard             EXPL+J 
 COMMON_TOGGLE_STATS            Keyboard             EXPL+F 
 COMMON_TOGGLE_TRUCK_BEACONS    Keyboard             M 
-COMMON_CYCLE_TRUCK_LIGHTS     Keyboard             N 
+COMMON_TOGGLE_TRUCK_LOW_BEAMS     Keyboard             EXPL+N 
 COMMON_TRUCK_INFO              Keyboard             EXPL+T 
 COMMON_TRUCK_DESCRIPTION       Keyboard             EXPL+CTRL+T 
 COMMON_FOV_LESS                Keyboard             EXPL+NUMPAD7 


### PR DESCRIPTION
Introduced by me in https://github.com/RigsOfRods/rigs-of-rods/commit/d7474e5cf4f6982e305143a333a782d090fcdb0b

`COMMON_TOGGLE_TRUCK_LIGHTS` was replaced with `COMMON_CYCLE_TRUCK_LIGHTS`, the correct event name is actually `COMMON_TOGGLE_TRUCK_LOW_BEAMS`. This caused lights to toggle in unexpected ways. 

Thanks @MarkROR for bringing this to my attention. 