### PR TITLE
Added option to invert orbit camera controls

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -200,6 +200,7 @@ CVar* io_outgauge_port;
 CVar* io_outgauge_delay;
 CVar* io_outgauge_id;
 CVar* io_discord_rpc;
+CVar* io_invert_orbitcam;
               
 // Audio
 CVar* audio_master_volume;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -404,6 +404,7 @@ extern CVar* io_outgauge_port;
 extern CVar* io_outgauge_delay;
 extern CVar* io_outgauge_id;
 extern CVar* io_discord_rpc;
+extern CVar* io_invert_orbitcam;
 
 // Audio
 extern CVar* audio_master_volume;

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -827,9 +827,16 @@ void CameraManager::CameraBehaviorOrbitUpdate()
         }
     }
 
-    m_cam_rot_x += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_RIGHT) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_LEFT)) * m_cct_rot_scale;
-    m_cam_rot_y += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_UP) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_DOWN)) * m_cct_rot_scale;
-
+    if (App::io_invert_orbitcam->getBool() && this->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM)
+    {
+        m_cam_rot_x += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_LEFT) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_RIGHT)) * m_cct_rot_scale;
+        m_cam_rot_y += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_DOWN) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_UP)) * m_cct_rot_scale;
+    }
+    else
+    {
+        m_cam_rot_x += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_RIGHT) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_LEFT)) * m_cct_rot_scale;
+        m_cam_rot_y += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_UP) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_DOWN)) * m_cct_rot_scale;
+    }
     m_cam_rot_y = std::max((Radian)Degree(-80), m_cam_rot_y);
     m_cam_rot_y = std::min(m_cam_rot_y, (Radian)Degree(88));
 
@@ -938,8 +945,16 @@ bool CameraManager::CameraBehaviorOrbitMouseMoved(const OIS::MouseEvent& _arg)
     if (ms.buttonDown(OIS::MB_Right))
     {
         float scale = RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LMENU) ? 0.002f : 0.02f;
-        m_cam_rot_x += Degree(ms.X.rel * 0.13f);
-        m_cam_rot_y += Degree(-ms.Y.rel * 0.13f);
+        if (App::io_invert_orbitcam->getBool() && this->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM)
+        {
+            m_cam_rot_x += Degree(ms.X.rel * -0.13f);
+            m_cam_rot_y += Degree(-ms.Y.rel * -0.13f);
+        }
+        else
+        {
+            m_cam_rot_x += Degree(ms.X.rel * 0.13f);
+            m_cam_rot_y += Degree(-ms.Y.rel * 0.13f);
+        }
         m_cam_dist += -ms.Z.rel * scale;
         return true;
     }

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -944,6 +944,7 @@ bool CameraManager::CameraBehaviorOrbitMouseMoved(const OIS::MouseEvent& _arg)
 
     if (ms.buttonDown(OIS::MB_Right))
     {
+        App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
         float scale = RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LMENU) ? 0.002f : 0.02f;
         if (App::io_invert_orbitcam->getBool() && this->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM)
         {

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -423,6 +423,7 @@ void GameSettings::DrawControlSettings()
     DrawGFloatSlider(App::io_blink_lock_range,   _LC("GameSettings", "Blinker Lock Range"),       0.1f, 1.0f);
 
     DrawGCheckbox(App::io_arcade_controls, _LC("GameSettings", "Use arcade controls"));
+    DrawGCheckbox(App::io_invert_orbitcam, _LC("GameSettings", "Invert orbit camera"));
 
     DrawGCheckbox(App::io_ffb_enabled, _LC("GameSettings", "Enable ForceFeedback"));
     if (App::io_ffb_enabled->getBool())

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -144,6 +144,7 @@ void Console::cVarSetupBuiltins()
     App::io_outgauge_delay       = this->cVarCreate("io_outgauge_delay",       "OutGauge Delay",             CVAR_ARCHIVE | CVAR_TYPE_FLOAT,    "10.0");
     App::io_outgauge_id          = this->cVarCreate("io_outgauge_id",          "OutGauge ID",                CVAR_ARCHIVE | CVAR_TYPE_INT);
     App::io_discord_rpc          = this->cVarCreate("io_discord_rpc",          "Discord Rich Presence",      CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
+    App::io_invert_orbitcam      = this->cVarCreate("io_invert_orbitcam",      "Invert orbit camera",        CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
 
     App::audio_master_volume     = this->cVarCreate("audio_master_volume",     "Sound Volume",               CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "1.0");
     App::audio_enable_creak      = this->cVarCreate("audio_enable_creak",      "Creak Sound",                CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");


### PR DESCRIPTION
This adds an "Invert orbit camera" (CVar `io_invert_orbitcam`)  option to Controls settings, inverting mouse and numpad controls. 
![image](https://github.com/RigsOfRods/rigs-of-rods/assets/46073351/206b5c36-611c-4d7d-8756-cec009237cdb)

In addition, mouse cursor now hides when moving the camera. Also wanted to make the cursor auto hide after a few seconds of inactivity like in previous RoR versions, which apparently broke with the switch to the DearIMGUI-based cursor. Code for this seems to exist but doesn't appear to work correctly: https://github.com/RigsOfRods/rigs-of-rods/blob/26411c1a86ae807a3c6eef504259276baee26f22/source/main/gui/GUIManager.cpp#L294-L300
Moving this code to `CameraManager` causes the mouse to become permanently hidden. 

Old code:
https://github.com/ohlidalp/ror-legacy-svn-trunk/blob/0a55a993899d6a06cdc58fd98b5b675b371eb89a/source/main/gui/GUIManager.cpp#L142C1-L147C3