### PR TITLE
Fixed survey map on tall terrains

### DIFF
--- a/source/main/gfx/SurveyMapTextureCreator.cpp
+++ b/source/main/gfx/SurveyMapTextureCreator.cpp
@@ -35,7 +35,7 @@ static int counter = 0;
 SurveyMapTextureCreator::SurveyMapTextureCreator(Ogre::Real terrain_height) :
     mCamera(nullptr),
     mRttTex(nullptr),
-    mTerrainHeight(Math::Clamp(terrain_height + 100.0f, 150.0f, 420.0f))
+    mTerrainHeight(Math::Clamp(terrain_height + 100.0f, 150.0f, 2500.0f))
 {
     counter++;
     mTextureName = "MapRttTex-" + TOSTRING(counter);


### PR DESCRIPTION
Fixes survey map on tall terrains such as [Tuanga Challenge](https://forum.rigsofrods.org/resources/tuanga-challenge.296/) and [Eagles Peak](https://forum.rigsofrods.org/resources/eagles-peak.1053/).
Before:
![RoR_2023-12-11_14-38-02](https://github.com/RigsOfRods/rigs-of-rods/assets/46073351/a2708696-4d21-4315-8ee0-3328ef4987a6)
![RoR_2023-12-11_14-46-55](https://github.com/RigsOfRods/rigs-of-rods/assets/46073351/01be153e-ee0d-4ecf-bdb0-5f87487c4489)
After:
![RoR_2023-12-11_14-32-54](https://github.com/RigsOfRods/rigs-of-rods/assets/46073351/74bd87ee-0cdf-485d-b33e-b65fe300bbc5)
![RoR_2023-12-11_14-47-05](https://github.com/RigsOfRods/rigs-of-rods/assets/46073351/5a3ac080-dbcd-49e5-8cdf-878df88318e7)
Doesn't appear to introduce issues with other maps. 