### PR TITLE
Fixed skeletonview hotkeys in TopMenubar/Tools

### DIFF
--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -743,8 +743,8 @@ void TopMenubar::Update()
                 ImGui::Separator();
 
                 ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Live diagnostic views:"));
-                ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "(Toggle with %s)"), App::GetInputEngine()->getEventCommandTrimmed(EV_COMMON_TOGGLE_DEBUG_VIEW).c_str());
-                ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "(Cycle with %s)"), App::GetInputEngine()->getEventCommandTrimmed(EV_COMMON_CYCLE_DEBUG_VIEWS).c_str());
+                ImGui::TextColored(GRAY_HINT_TEXT, "%s", fmt::format(_LC("TopMenubar", "(Toggle with {})"), App::GetInputEngine()->getEventCommandTrimmed(EV_COMMON_TOGGLE_DEBUG_VIEW)).c_str());
+                ImGui::TextColored(GRAY_HINT_TEXT, "%s", fmt::format(_LC("TopMenubar", "(Cycle with {})"), App::GetInputEngine()->getEventCommandTrimmed(EV_COMMON_CYCLE_DEBUG_VIEWS)).c_str());
 
                 int debug_view_type = static_cast<int>(DebugViewType::DEBUGVIEW_NONE);
                 if (current_actor != nullptr)


### PR DESCRIPTION
The hotkeys in orange rectangle now display correctly.
![image](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/2e7c1069-c40d-47d6-83e5-1747962eade6)
