### PR TITLE
✨ Add option for Keyboard Steering Sensitivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ tools/l10n/languages/
 tools/l10n/ror\.pot
 CMakeUserPresets.json
 tools/l10n/TMP.pot
+.cache

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -196,6 +196,7 @@ CVar* io_ffb_stress_gain;
 CVar* io_input_grab_mode;
 CVar* io_arcade_controls;
 CVar* io_hydro_coupling;
+CVar* io_hydro_sensivity;
 CVar* io_outgauge_mode;
 CVar* io_outgauge_ip;
 CVar* io_outgauge_port;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -408,6 +408,7 @@ extern CVar* io_ffb_stress_gain;
 extern CVar* io_input_grab_mode;
 extern CVar* io_arcade_controls;
 extern CVar* io_hydro_coupling;
+extern CVar* io_hydro_sensivity;
 extern CVar* io_outgauge_mode;
 extern CVar* io_outgauge_ip;
 extern CVar* io_outgauge_port;

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -661,9 +661,11 @@ void TopMenubar::Draw(float dt)
                 ImGui::Separator();
                 ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Vehicle control options:"));
                 DrawGCheckbox(App::io_hydro_coupling, _LC("TopMenubar", "Keyboard steering speed coupling"));
-                ImGui::Separator();
-                ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Keyboard steering:"));
                 DrawGFloatSlider(App::io_hydro_sensivity, _LC("TopMenubar", "Sensitivity"), 0.3, 5);
+                if (ImGui::Button("Reset", ImVec2(80, 0)))
+                {
+                    App::io_hydro_sensivity->setVal(1.f);
+                }
             }
             if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
             {

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -661,6 +661,9 @@ void TopMenubar::Draw(float dt)
                 ImGui::Separator();
                 ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Vehicle control options:"));
                 DrawGCheckbox(App::io_hydro_coupling, _LC("TopMenubar", "Keyboard steering speed coupling"));
+                ImGui::Separator();
+                ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Keyboard steering:"));
+                DrawGFloatSlider(App::io_hydro_sensivity, _LC("TopMenubar", "Sensitivity"), 0.3, 5);
             }
             if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
             {

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -662,7 +662,8 @@ void TopMenubar::Draw(float dt)
                 ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Vehicle control options:"));
                 DrawGCheckbox(App::io_hydro_coupling, _LC("TopMenubar", "Keyboard steering speed coupling"));
                 DrawGFloatSlider(App::io_hydro_sensivity, _LC("TopMenubar", "Sensitivity"), 0.3, 5);
-                if (ImGui::Button("Reset", ImVec2(80, 0)))
+                ImGui::SameLine();
+                if (ImGui::SmallButton("Reset"))
                 {
                     App::io_hydro_sensivity->setVal(1.f);
                 }

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -563,7 +563,7 @@ void Actor::CalcHydros()
             {
                 if (!App::io_hydro_coupling->getBool())
                 {
-                    float rate = std::max(1.2f, 30.0f / (10.0f));
+                    float rate = App::io_hydro_sensivity->getFloat() * std::max(1.2f, 30.0f / (10.0f));
                     if (ar_hydro_dir_state > ar_hydro_dir_command)
                         ar_hydro_dir_state -= PHYSICS_DT * rate;
                     else
@@ -572,14 +572,16 @@ void Actor::CalcHydros()
                 else
                 {
                     // minimum rate: 20% --> enables to steer high velocity vehicles
-                    float rate = std::max(1.2f, 30.0f / (10.0f + std::abs(ar_wheel_speed / 2.0f)));
+                    float rate = App::io_hydro_sensivity->getFloat() *
+                        std::max(1.2f, 30.0f / (10.0f + std::abs(ar_wheel_speed / 2.0f)));
                     if (ar_hydro_dir_state > ar_hydro_dir_command)
                         ar_hydro_dir_state -= PHYSICS_DT * rate;
                     else
                         ar_hydro_dir_state += PHYSICS_DT * rate;
                 }
             }
-            float dirdelta = PHYSICS_DT;
+            // return rate
+            float dirdelta = App::io_hydro_sensivity->getFloat() * PHYSICS_DT;
             if (ar_hydro_dir_state > dirdelta)
                 ar_hydro_dir_state -= dirdelta;
             else if (ar_hydro_dir_state < -dirdelta)

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -21,6 +21,7 @@
 
 #include "Application.h"
 #include "Console.h"
+#include "CVar.h"
 
 #include <Ogre.h>
 
@@ -140,6 +141,7 @@ void Console::cVarSetupBuiltins()
     App::io_input_grab_mode      = this->cVarCreate("io_input_grab_mode",      "Input Grab",                 CVAR_ARCHIVE | CVAR_TYPE_INT,     "1"/*(int)IoInputGrabMode::ALL*/);
     App::io_arcade_controls      = this->cVarCreate("io_arcade_controls",      "ArcadeControls",             CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::io_hydro_coupling       = this->cVarCreate("io_hydro_coupling",  "Keyboard Steering Speed Coupling",CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
+    App::io_hydro_sensivity      = this->cVarCreate("io_hydro_sensivity", "Keyboard Steering Sensitivity",   CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "1.0");
     App::io_outgauge_mode        = this->cVarCreate("io_outgauge_mode",        "OutGauge Mode",              CVAR_ARCHIVE | CVAR_TYPE_INT);    // 0 = disabled, 1 = enabled
     App::io_outgauge_ip          = this->cVarCreate("io_outgauge_ip",          "OutGauge IP",                CVAR_ARCHIVE,                     "192.168.1.100");
     App::io_outgauge_port        = this->cVarCreate("io_outgauge_port",        "OutGauge Port",              CVAR_ARCHIVE | CVAR_TYPE_INT,      "1337");


### PR DESCRIPTION
So I added a new var and a slider on GUI for Keyboard Steering Sensitivity,
which is simply how fast you steer wheels with keyboard left/right. Default 1.0 is like it was before.
Depends on vehicle actually. Some had slow steering so 2.0 is fine for me now, some had okay and it's not needed above 1.2 etc.