### PR TITLE
Added option to enable window resizing

### DIFF
--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -288,7 +288,10 @@ bool AppContext::SetUpRendering()
     miscParams["FSAA"] = ropts["FSAA"].currentValue;
     miscParams["vsync"] = ropts["VSync"].currentValue;
     miscParams["gamma"] = ropts["sRGB Gamma Conversion"].currentValue;
+    if (!App::diag_allow_window_resize->getBool())
+    {
     miscParams["border"] = "fixed";
+    }
 #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
     const auto rd = ropts["Rendering Device"];
     const auto it = std::find(rd.possibleValues.begin(), rd.possibleValues.end(), rd.currentValue);

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -156,6 +156,7 @@ CVar* diag_hide_wheels;
 CVar* diag_hide_nodes;
 CVar* diag_terrn_log_roads;
 CVar* diag_actor_dump;
+CVar* diag_allow_window_resize;
 
 // System
 CVar* sys_process_dir;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -367,6 +367,7 @@ extern CVar* diag_hide_wheels;
 extern CVar* diag_hide_nodes;
 extern CVar* diag_terrn_log_roads;
 extern CVar* diag_actor_dump;
+extern CVar* diag_allow_window_resize;
 
 // System
 extern CVar* sys_process_dir;

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -405,6 +405,7 @@ void GameSettings::DrawDiagSettings()
     DrawGCheckbox(App::diag_log_beam_break,      _LC("GameSettings", "Log beam breaking"));
     DrawGCheckbox(App::diag_log_beam_deform,     _LC("GameSettings", "Log beam deforming"));
     DrawGCheckbox(App::diag_log_beam_trigger,    _LC("GameSettings", "Log beam triggers"));
+    DrawGCheckbox(App::diag_allow_window_resize, _LC("GameSettings", "Allow game window resizing"));
     if (ImGui::Button(_LC("GameSettings", "Rebuild cache")))
     {
         App::GetGuiManager()->GameSettings.SetVisible(false);

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -103,6 +103,7 @@ void Console::cVarSetupBuiltins()
     App::diag_hide_nodes         = this->cVarCreate("diag_hide_nodes",         "Hide nodes",                 CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::diag_terrn_log_roads    = this->cVarCreate("diag_terrn_log_roads",    "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::diag_actor_dump         = this->cVarCreate("diag_actor_dump",         "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
+    App::diag_allow_window_resize= this->cVarCreate("diag_allow_window_resize","",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
 
     App::sys_process_dir         = this->cVarCreate("sys_process_dir",         "",                           0);
     App::sys_user_dir            = this->cVarCreate("sys_user_dir",            "",                           0);


### PR DESCRIPTION
Adds `Allow game window resizing` to diagnostic settings. Useful for taking ultrawide or 4:3 screenshots. 