### PR TITLE
New mod type: asset pack (.assetpack)

### DIFF
--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -261,7 +261,7 @@ enum VisibilityMasks
     HIDE_MIRROR       = BITMASK(3),
 };
 
-enum LoaderType //!< Operation mode for GUI::MainSelector
+enum LoaderType //!< Search mode for `ModCache::Query()` & Operation mode for `GUI::MainSelector`
 {
     LT_None,
     LT_Terrain,   // Invocable from GUI; No script alias, used in main menu
@@ -278,6 +278,7 @@ enum LoaderType //!< Operation mode for GUI::MainSelector
     LT_AllBeam,   // Invocable from GUI; Script "all",  ext: truck car boat airplane train load
     LT_AddonPart, // No script alias, invoked manually, ext: addonpart
     LT_Tuneup,    // No script alias, invoked manually, ext: tuneup
+    LT_AssetPack, // No script alias, invoked manually, ext: assetpack
 };
 
 // ------------------------------------------------------------------------------------------------

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -126,7 +126,7 @@ bool GameContext::LoadTerrain(std::string const& filename_part)
     // Init resources
     App::GetCacheSystem()->LoadResource(terrn_entry);
 
-    // Load the terrain
+    // Load the terrain def file
     Terrn2Def terrn2;
     std::string const& filename = terrn_entry->fname;
     try
@@ -143,6 +143,11 @@ bool GameContext::LoadTerrain(std::string const& filename_part)
     {
         App::GetGuiManager()->ShowMessageBox(_L("Terrain loading error"), e.getFullDescription().c_str());
         return false;
+    }
+
+    for (std::string const& assetpack_filename: terrn2.assetpack_files)
+    {
+        App::GetCacheSystem()->LoadAssetPack(terrn_entry, assetpack_filename);
     }
 
     // CAUTION - the global instance must be set during init! Needed by:

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -90,6 +90,7 @@ ActorPtr ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr 
     ActorSpawner spawner;
     spawner.ConfigureSections(actor->m_section_config, def);
     spawner.ConfigureAddonParts(actor->m_working_tuneup_def);
+    spawner.ConfigureAssetPacks(actor, def);
     spawner.ProcessNewActor(actor, rq, def);
 
     if (App::diag_actor_dump->getBool())

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -142,6 +142,17 @@ void ActorSpawner::ConfigureAddonParts(TuneupDefPtr& tuneup_def)
     }
 }
 
+void ActorSpawner::ConfigureAssetPacks(ActorPtr actor, RigDef::DocumentPtr def)
+{
+    for (auto& module: m_selected_modules)
+    {
+        for (RigDef::Assetpack const& assetpack: module->assetpacks)
+        {
+            App::GetCacheSystem()->LoadAssetPack(actor->getUsedActorEntry(), assetpack.filename);
+        }
+    }
+}
+
 void ActorSpawner::CalcMemoryRequirements(ActorMemoryRequirements& req, RigDef::Document::Module* module_def)
 {
     // 'nodes'

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -96,6 +96,7 @@ public:
     /// @{
     void                           ConfigureSections(Ogre::String const & sectionconfig, RigDef::DocumentPtr def);
     void                           ConfigureAddonParts(TuneupDefPtr& tuneup_def);
+    void                           ConfigureAssetPacks(ActorPtr actor, RigDef::DocumentPtr def);
     void                           ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef::DocumentPtr def);
     static void                    SetupDefaultSoundSources(ActorPtr const& actor);
     /// @}

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -46,7 +46,7 @@ namespace RoR {
 
 struct AuthorInfo
 {
-    int id;
+    int id = -1;
     Ogre::String type;
     Ogre::String name;
     Ogre::String email;
@@ -295,6 +295,7 @@ public:
     void                  ReLoadResource(CacheEntryPtr& t); //!< Forces reloading the associated bundle.
     void                  UnLoadResource(CacheEntryPtr& t); //!< Unloads associated bundle, destroying all spawned actors.
     void                  LoadSupplementaryDocuments(CacheEntryPtr& t); //!< Loads the associated .truck*, .skin and .tuneup files.
+    void                  LoadAssetPack(CacheEntryPtr& t_dest, Ogre::String const & assetpack_filename); //!< Adds asset pack to the requesting cache entry's resource group.
     /// @}
 
     /// @name Projects
@@ -350,6 +351,7 @@ private:
     void FillSkinDetailInfo(CacheEntryPtr &entry, std::shared_ptr<SkinDef>& skin_def);
     void FillAddonPartDetailInfo(CacheEntryPtr &entry, Ogre::DataStreamPtr ds);
     void FillTuneupDetailInfo(CacheEntryPtr &entry, TuneupDefPtr& tuneup_def);
+    void FillAssetPackDetailInfo(CacheEntryPtr &entry, Ogre::DataStreamPtr ds);
     /// @}
 
     void GenerateHashFromFilenames();         //!< For quick detection of added/removed content

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -330,7 +330,9 @@ bool ContentManager::resourceCollision(Ogre::Resource* resource, Ogre::ResourceM
 {
     // RoR loads each resource bundle (see CacheSystem.h for info)
     // into dedicated resource group outside the global pool [see CacheSystem::LoadResource()]
-    // This means resource collision is entirely content creator's fault.
+    // This means resource collision is pretty much content creator's fault, with 2 exceptions:
+    // * asset packs (introduced 2024) are mixed into the requesting mod's resource group.
+    // * bundled resources (e.g. beamobjects.zip) are also mixed into the mod's resource group.
     RoR::LogFormat("[RoR|ContentManager] Skipping resource with duplicate name: '%s' (origin: '%s')",
         resource->getName().c_str(), resource->getOrigin().c_str());
     return false; // Instruct OGRE to drop the new resource and keep the original.

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -70,6 +70,7 @@ enum class Keyword
     AIRBRAKES,
     ANIMATORS,
     ANTILOCKBRAKES,
+    ASSETPACKS,
     AUTHOR,
     AXLES,
     BACKMESH,
@@ -397,6 +398,11 @@ struct AeroAnimator // used by Animator
 
     BitMask_t flags      = 0u;
     unsigned int engine_idx = 0u;
+};
+
+struct Assetpack
+{
+    std::string filename;
 };
 
 struct BaseWheel
@@ -1473,6 +1479,7 @@ struct Document
         std::vector<Airbrake>              airbrakes;
         std::vector<Animator>              animators;
         std::vector<AntiLockBrakes>        antilockbrakes;
+        std::vector<Assetpack>             assetpacks;
         std::vector<Author>                author;
         std::vector<Axle>                  axles;
         std::vector<Beam>                  beams;

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -235,6 +235,7 @@ void Parser::ProcessCurrentLine()
     {
         case Keyword::AIRBRAKES:            this->ParseAirbrakes();               return;
         case Keyword::ANIMATORS:            this->ParseAnimator();                return;
+        case Keyword::ASSETPACKS:           this->ParseAssetpacks();              return;
         case Keyword::AXLES:                this->ParseAxles();                   return;
         case Keyword::BEAMS:                this->ParseBeams();                   return;
         case Keyword::BRAKES:               this->ParseBrakes();                  return;
@@ -1631,6 +1632,17 @@ void Parser::ParseAirbrakes()
     airbrake.texcoord_y2           = this->GetArgFloat  (13);
 
     m_current_module->airbrakes.push_back(airbrake);
+}
+
+void Parser::ParseAssetpacks()
+{
+    if (! this->CheckNumArguments(1)) { return; }
+
+    Assetpack assetpack;
+
+    assetpack.filename = this->GetArgStr(0);
+
+    m_current_module->assetpacks.push_back(assetpack);
 }
 
 void Parser::ParseVideoCamera()

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.h
@@ -116,6 +116,7 @@ private:
     void ParseAirbrakes();
     void ParseAnimator();
     void ParseAntiLockBrakes();
+    void ParseAssetpacks();
     void ParseAuthor();
     void ParseAxles();
     void ParseBeams();

--- a/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
@@ -122,6 +122,7 @@ namespace Regexes
     E_KEYWORD_BLOCK("airbrakes")       /* Position 2 */           \
     E_KEYWORD_BLOCK("animators")       /* Position 3 etc... */    \
     E_KEYWORD_INLINE("AntiLockBrakes")                            \
+    E_KEYWORD_BLOCK("assetpacks")                                 \
     E_KEYWORD_INLINE("author")                                    \
     E_KEYWORD_BLOCK("axles")                                      \
     E_KEYWORD_BLOCK("backmesh")                                   \

--- a/source/main/resources/terrn2_fileformat/Terrn2FileFormat.cpp
+++ b/source/main/resources/terrn2_fileformat/Terrn2FileFormat.cpp
@@ -112,6 +112,15 @@ bool Terrn2Parser::LoadTerrn2(Terrn2Def& def, Ogre::DataStreamPtr &ds)
         }
     }
 
+    if (file.HasSection("AssetPacks"))
+    {
+        for (auto& assetpack: file.getSettings("AssetPacks"))
+        {
+            Ogre::String assetpack_filename = SanitizeUtf8String(assetpack.first);
+            def.assetpack_files.push_back(TrimStr(assetpack_filename));
+        }
+    }
+
     this->ProcessTeleport(def, &file);
 
     return true;

--- a/source/main/resources/terrn2_fileformat/Terrn2FileFormat.h
+++ b/source/main/resources/terrn2_fileformat/Terrn2FileFormat.h
@@ -62,6 +62,7 @@ struct Terrn2Def
     std::list<Terrn2Author>  authors;
     std::list<std::string>   tobj_files;
     std::list<std::string>   as_files;
+    std::list<std::string>   assetpack_files;
     std::list<Terrn2Telepoint> telepoints;
     std::string              caelum_config;
     int                      caelum_fog_start;

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -65,11 +65,6 @@ inline float getTerrainHeight(Real x, Real z, void* unused = 0)
 TerrainObjectManager::TerrainObjectManager(Terrain* terrainManager) :
     terrainManager(terrainManager)
 {
-
-    // terrain custom group
-    m_resource_group = terrainManager->GetDef().name + "-TerrnObjects";
-    Ogre::ResourceGroupManager::getSingleton().createResourceGroup(m_resource_group);
-
     m_procedural_manager = new ProceduralManager();
 }
 
@@ -89,8 +84,6 @@ TerrainObjectManager::~TerrainObjectManager()
 #endif //USE_PAGED
 
     App::GetGfxScene()->GetSceneManager()->destroyAllEntities();
-
-    Ogre::ResourceGroupManager::getSingleton().destroyResourceGroup(m_resource_group);
 }
 
 void GenerateGridAndPutToScene(Ogre::Vector3 position)
@@ -573,7 +566,7 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
     if (odef->header.mesh_name != "none")
     {
         Str<100> ebuf; ebuf << m_entity_counter++ << "-" << odef->header.mesh_name;
-        mo = new MeshObject(odef->header.mesh_name, m_resource_group, ebuf.ToCStr(), tenode);
+        mo = new MeshObject(odef->header.mesh_name, terrainManager->getTerrainFileResourceGroup(), ebuf.ToCStr(), tenode);
         if (mo->getEntity())
         {
             mo->getEntity()->setCastShadows(odef->header.cast_shadows);

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -164,7 +164,6 @@ protected:
     Terrain*           terrainManager;
     ProceduralManagerPtr      m_procedural_manager;
     int                       m_entity_counter = 0;
-    std::string               m_resource_group;
 
 #ifdef USE_PAGED
     std::vector<Forests::PagedGeometry*> m_paged_geometry;


### PR DESCRIPTION
Quick 2hr draft - ~BUILDS, NOT TESTED.~ Tested, added example mods.

A new file type "*.assetpack" was added to modcache with all the usual treatment:
- the file is recorded to the cache file (/cache/cache.json),
- it's searchable and selectable via UI (`LT_AssetPack`)
- can have a thumbnail (filename format '{}-mini.*'' where {} is the assetpack file name without extension)
- The file itself can be empty, recognized entries are `assetpack_name` (display name), `assetpack_description` (for display in selector UI) and `assetpack_author` (same syntax as in  .truck file).
- When requested, the game loads the entire containing ZIP/directory (called 'bundle' by jargon).

Assetpacks are referenced by the file name (standard approach) and can be used for both terrains and actors:
- Terrains: in .terrn2 file, add section `[AssetPacks]` followed by list of filenames (with extension, each on separate line) ending with `=` token, same as in `[Objects/Scripts]` sections - this is a quirk of the game.
- Actors: in the .truck file, use section `assetpacks` followed by list of filenames (with extension, each on separate line)

Note that, unlike any other mod, assetpacks aren't loaded to their own resource group but rather to the resoruce group of the mod which requested them. Therefore try to name all resources in an unique way to avoid clashes.

**Test mods** - a wacky mini terrain I created for future tests, and one mesh (with multiple .ODEFs) I extracted from it:
* testpack-crazycones.assetpack: [testpack-crazycones.zip](https://github.com/RigsOfRods/rigs-of-rods/files/14338275/testpack-crazycones.zip)
* terrnbatcher_testmap.terrn2: [terrnbatcher_testmap.zip](https://github.com/RigsOfRods/rigs-of-rods/files/14338281/terrnbatcher_testmap.zip)

