### PR TITLE
Add rot_yxz for SR road rotations Y then X, Z

### DIFF
--- a/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
@@ -62,8 +62,9 @@ void TObjParser::Prepare()
     m_in_procedural_road = false;
     m_cur_procedural_obj = new ProceduralObject();
     m_cur_procedural_obj_start_line = -1;
-    m_road2_num_blocks = 0;
+    m_road2_num_blocks   = 0;
     m_default_rendering_distance = 0.f;
+    m_rot_yxz            = false;
     
     m_def = std::shared_ptr<TObjFile>(new TObjFile());
 }
@@ -120,6 +121,11 @@ bool TObjParser::ProcessCurrentLine()
         {
             LOG(fmt::format("too few parameters on line: '{}'", m_cur_line));
         }
+        return true;
+    }
+    if (strncmp(m_cur_line, "rot_yxz", 7) == 0)
+    {
+        m_rot_yxz = true;
         return true;
     }
     if (strncmp("begin_procedural_roads", m_cur_line, 22) == 0)
@@ -354,9 +360,18 @@ void TObjParser::ImportProceduralPoint(Ogre::Vector3 const& pos, Ogre::Vector3 c
 
 Ogre::Quaternion TObjParser::CalcRotation(Ogre::Vector3 const& rot) const
 {
-    return Quaternion(Degree(rot.y), Vector3::UNIT_Y) *  // y global
-           Quaternion(Degree(rot.x), Vector3::UNIT_X) *  // x local
-           Quaternion(Degree(rot.z), Vector3::UNIT_Z);   // z local
+    if (m_rot_yxz)
+    {
+        return Quaternion(Degree(rot.y), Vector3::UNIT_Y) *  // y global
+               Quaternion(Degree(rot.x), Vector3::UNIT_X) *  // x local
+               Quaternion(Degree(rot.z), Vector3::UNIT_Z);   // z local
+    }
+    else
+    {
+        return Quaternion(Degree(rot.x), Vector3::UNIT_X) *
+               Quaternion(Degree(rot.y), Vector3::UNIT_Y) *
+               Quaternion(Degree(rot.z), Vector3::UNIT_Z);
+    }
 }
 
 bool TObjParser::ParseObjectLine(TObjEntry& object)

--- a/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
@@ -354,9 +354,9 @@ void TObjParser::ImportProceduralPoint(Ogre::Vector3 const& pos, Ogre::Vector3 c
 
 Ogre::Quaternion TObjParser::CalcRotation(Ogre::Vector3 const& rot) const
 {
-    return Quaternion(Degree(rot.x), Vector3::UNIT_X) *
-           Quaternion(Degree(rot.y), Vector3::UNIT_Y) *
-           Quaternion(Degree(rot.z), Vector3::UNIT_Z);
+    return Quaternion(Degree(rot.y), Vector3::UNIT_Y) *  // y global
+           Quaternion(Degree(rot.x), Vector3::UNIT_X) *  // x local
+           Quaternion(Degree(rot.z), Vector3::UNIT_Z);   // z local
 }
 
 bool TObjParser::ParseObjectLine(TObjEntry& object)

--- a/source/main/resources/tobj_fileformat/TObjFileFormat.h
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.h
@@ -208,6 +208,8 @@ private:
     Ogre::Vector3              m_road2_last_pos;
     Ogre::Vector3              m_road2_last_rot;
     int                        m_road2_num_blocks;
+    
+    bool                       m_rot_yxz;
 };
 
 } // namespace RoR


### PR DESCRIPTION
This fixes for me road roll angles.
Like you said, they were bad. Yaw was only working ok.
Before:
![0237``](https://github.com/RigsOfRods/rigs-of-rods/assets/720641/b5cca106-3eb5-4f71-a273-afa972167297)
After:
![22_18-08-09](https://github.com/RigsOfRods/rigs-of-rods/assets/720641/9f966a2c-32d9-4a8d-8a82-32991399c442)
Track has this road TestC1-Circle-road.tobj, it has a circle with all points: -16, yaw, 0
[TestC1-Circle-road.txt](https://github.com/RigsOfRods/rigs-of-rods/files/14377134/TestC1-Circle-road.txt)
This would be important for SR tracks roads, mainly for better bridge entries.