### PR TITLE
New top menu 'Styling' - change colors and other parameters

### DIFF
--- a/resources/managed_materials/nicemetal_mm.cg
+++ b/resources/managed_materials/nicemetal_mm.cg
@@ -240,6 +240,7 @@ void main_simplemetal_fp(
             uniform float4 lightSpecular,
             uniform float exponent,
             uniform float4 ambient,
+            uniform float3 color,
             
             uniform sampler2D Diffuse_Map: register(s0),
             uniform sampler2D Specular_Map: register(s1),
@@ -257,7 +258,7 @@ void main_simplemetal_fp(
     float4 textColour = tex2D(Diffuse_Map, uv);
     float4 specColour = tex2D(Specular_Map, uv);
 //    oColor = lightDiffuse * textColour * Lit.y + lightSpecular * specColour * Lit.z + textColour*ambient;
-    oColor = lerp(lightDiffuse * textColour * Lit.y + textColour*ambient, lightSpecular * Lit.z, specColour);
+    oColor = lerp(lightDiffuse * textColour * Lit.y + textColour*ambient, lightSpecular * Lit.z, specColour) * float4(color.x, color.y, color.z, 1.0);
     oColor.a=1;
 }
 

--- a/resources/managed_materials/nicemetal_mm.program
+++ b/resources/managed_materials/nicemetal_mm.program
@@ -114,6 +114,7 @@ fragment_program SimpleMetal_PS_mm cg
         param_named_auto lightSpecular light_specular_colour 0
         param_named exponent float 127
         param_named_auto ambient ambient_light_colour
+        param_named color float3 0 0 0
     }
 }
 

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -110,6 +110,7 @@ CVar* sim_soft_reset_mode;
 CVar* sim_quickload_dialog;
 CVar* sim_live_repair_interval;
 CVar* sim_tuning_enabled;
+CVar* sim_styling_enabled;
 
 // Multiplayer
 CVar* mp_state;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -320,6 +320,7 @@ extern CVar* sim_soft_reset_mode;
 extern CVar* sim_quickload_dialog;
 extern CVar* sim_live_repair_interval; //!< Hold EV_COMMON_REPAIR_TRUCK to enter LiveRepair mode. 0 or negative interval disables.
 extern CVar* sim_tuning_enabled;
+extern CVar* sim_styling_enabled;
 
 // Multiplayer
 extern CVar* mp_state;

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -629,6 +629,15 @@ void TopMenubar::Draw(float dt)
                 ImGui::Separator();
                 ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Vehicle control options:"));
                 DrawGCheckbox(App::io_hydro_coupling, _LC("TopMenubar", "Keyboard steering speed coupling"));
+
+                if (ImGui::ColorPicker3("Color", m_color))
+                {
+                    Ogre::MaterialPtr cg_material = Ogre::MaterialManager::getSingleton().getByName("managed/mesh_standard/specular_nicemetal", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+                    Ogre::GpuProgramParametersSharedPtr cg_params = cg_material->getTechnique("BaseTechnique")->getPass("BaseRender")->getFragmentProgramParameters();
+
+                    cg_params->setNamedConstant("color", Ogre::Vector3(m_color[0], m_color[1], m_color[2]));
+                    cg_material->getTechnique("BaseTechnique")->getPass("BaseRender")->setFragmentProgramParameters(cg_params);
+                }
             }
             if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
             {

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -138,6 +138,8 @@ private:
 
     void GetPresets();
     rapidjson::Document j_doc;
+
+    float m_color[3] = { 0.0, 0.0, 0.0 };
 };
 
 } // namespace GUI

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -54,7 +54,7 @@ public:
     const ImVec4  RED_TEXT              = ImVec4(1.00f, 0.00f, 0.00f, 1.f);
     const ImVec2  MENU_HOVERBOX_PADDING = ImVec2(25.f, 10.f);
 
-    enum class TopMenu { TOPMENU_NONE, TOPMENU_SIM, TOPMENU_ACTORS, TOPMENU_SAVEGAMES, TOPMENU_SETTINGS, TOPMENU_TOOLS, TOPMENU_AI, TOPMENU_TUNING };
+    enum class TopMenu { TOPMENU_NONE, TOPMENU_SIM, TOPMENU_ACTORS, TOPMENU_SAVEGAMES, TOPMENU_SETTINGS, TOPMENU_TOOLS, TOPMENU_AI, TOPMENU_TUNING, TOPMENU_STYLING };
     enum class StateBox { STATEBOX_NONE, STATEBOX_REPLAY, STATEBOX_RACE, STATEBOX_LIVE_REPAIR, STATEBOX_QUICK_REPAIR };
 
     TopMenubar();
@@ -65,7 +65,8 @@ public:
 
     bool IsVisible() { return m_open_menu != TopMenu::TOPMENU_NONE; };
 
-    // Vehicle AI
+    /// @name [Vehicle AI] menu
+    /// @{
     std::vector<ai_events> ai_waypoints;
     int ai_num = 1;
     int ai_speed = 50;
@@ -95,9 +96,11 @@ public:
     int ai_times_prev = 1;
     int ai_mode_prev = 0;
 
-    void Refresh(std::string payload);
+    void RefreshAiPresets(std::string payload);
+    /// @}
 
-    // Tuning menu
+    /// @name [Tuning] menu
+    /// @{
     ActorPtr tuning_actor;          //!< Detecting actor change to update cached values.
     std::vector<CacheEntryPtr> tuning_addonparts;   //!< Addonparts of current actor, both matched by GUID and force-installed by user via [browse all] button.
     CacheQuery tuning_saves;        //!< Tuneups saved by user, with category ID `RoR::CID_AddonpartUser`
@@ -109,6 +112,14 @@ public:
     bool tuning_force_refresh = false;
     float tuning_rwidget_cursorx_min = 0.f; //!< Avoid drawing right-side widgets ('Delete' button or 'Protected' chk) over saved tuneup names.
     void RefreshTuningMenu();
+    /// @}
+
+    /// @name [Styling] menu
+    /// @{
+    // Managed material constants; key: "{managedmat index}:{managedmat name}"
+    std::map<std::string, float> styling_mm_constants_float;
+    std::map<std::string, Ogre::Vector3> styling_mm_constants_vector3;
+    /// @}
 
 private:
     void DrawActorListSinglePlayer();
@@ -136,12 +147,8 @@ private:
     std::string m_quicksave_name;
     std::vector<std::string> m_savegame_names;
 
-    void GetPresets();
     rapidjson::Document j_doc;
-
-    // [Settings] Shader params; Key = fmt("{}:{}", iMat, managedMatNames[iMat])
-    std::map<std::string, float> m_known_constants_float;
-    std::map<std::string, Ogre::Vector3> m_known_constants_color;
+    void GetAiPresets();
 };
 
 } // namespace GUI

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -139,7 +139,9 @@ private:
     void GetPresets();
     rapidjson::Document j_doc;
 
-    float m_color[3] = { 0.0, 0.0, 0.0 };
+    // [Settings] Shader params; Key = fmt("{}:{}", iMat, managedMatNames[iMat])
+    std::map<std::string, float> m_known_constants_float;
+    std::map<std::string, Ogre::Vector3> m_known_constants_color;
 };
 
 } // namespace GUI

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -561,7 +561,7 @@ int main(int argc, char *argv[])
                 }
 
                 case MSG_NET_REFRESH_AI_PRESETS:
-                    App::GetGuiManager()->TopMenubar.Refresh(m.description);
+                    App::GetGuiManager()->TopMenubar.RefreshAiPresets(m.description);
                     break;
 
                 // -- Gameplay events --

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4479,6 +4479,25 @@ Replay* Actor::getReplay()
         return nullptr;
 }
 
+Ogre::MaterialPtr Actor::getManagedMaterialInstance(const std::string& orig_name)
+{
+    auto it = ar_managed_materials.find(orig_name);
+    if (it != ar_managed_materials.end())
+        return it->second;
+    else
+        return Ogre::MaterialPtr(); // null
+}
+
+std::vector<std::string> Actor::getManagedMaterialNames()
+{
+    std::vector<std::string> names;
+    for (auto it = ar_managed_materials.begin(); it != ar_managed_materials.end(); ++it)
+    {
+        names.push_back(it->first);
+    }
+    return names;
+}
+
 Vector3 Actor::getNodePosition(int nodeNumber)
 {
     if (nodeNumber >= 0 && nodeNumber < ar_num_nodes)

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -202,9 +202,12 @@ public:
 
     /// @name Subsystems
     /// @{
+    VehicleAIPtr      getVehicleAI() { return ar_vehicle_ai; }
+    Ogre::MaterialPtr        getManagedMaterialInstance(const std::string& orig_name);
+    std::vector<std::string> getManagedMaterialNames();
+    // not exported to scripting:
     Replay*           getReplay();
     TyrePressure&     getTyrePressure() { return m_tyre_pressure; }
-    VehicleAIPtr      getVehicleAI() { return ar_vehicle_ai; }
     //! @}
 
     /// @name Organizational
@@ -303,6 +306,7 @@ public:
     std::vector<std::vector<int>>  ar_node_to_beam_connections;
     std::vector<Ogre::AxisAlignedBox>  ar_collision_bounding_boxes; //!< smart bounding boxes, used for determining the state of an actor (every box surrounds only a subset of nodes)
     std::vector<Ogre::AxisAlignedBox>  ar_predicted_coll_bounding_boxes;
+    std::map<std::string, Ogre::MaterialPtr>  ar_managed_materials;
     int               ar_num_contactable_nodes = 0; //!< Total number of nodes which can contact ground or cabs
     int               ar_num_contacters = 0; //!< Total number of nodes which can selfcontact cabs
     wheel_t           ar_wheels[MAX_WHEELS] = {};

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -6809,6 +6809,8 @@ void ActorSpawner::FinalizeGfxSetup()
                 "Failed to load `help` material '" + m_help_material_name + "', message:" + e.getFullDescription());
         }
     }
+
+    m_actor->ar_managed_materials = m_managed_materials;
 }
 
 void ActorSpawner::ValidateRotator(int id, int axis1, int axis2, NodeNum_t *nodes1, NodeNum_t *nodes2)

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -60,6 +60,7 @@ void Console::cVarSetupBuiltins()
     App::sim_quickload_dialog    = this->cVarCreate("sim_quickload_dialog",    "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
     App::sim_live_repair_interval = this->cVarCreate("sim_live_repair_interval", "",                         CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "2.f");
     App::sim_tuning_enabled      = this->cVarCreate("sim_tuning_enabled",      "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
+    App::sim_styling_enabled     = this->cVarCreate("sim_styling_enabled",     "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
 
     App::mp_state                = this->cVarCreate("mp_state",                "",                                          CVAR_TYPE_INT,     "0"/*(int)MpState::DISABLED*/);
     App::mp_join_on_startup      = this->cVarCreate("mp_join_on_startup",      "Auto connect",               CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");


### PR DESCRIPTION
An experiment: a new menu for adjusting fragment shader params from 'nicemetal.cg' in ManagedMaterials.

**Thoughts:**
* min/max values for all params are hardcoded to <-1.0  1.0>.
* param 'color' is recognized as special, all others are considered `float`.
* only managed materials are listed.
* only shader params are supported, although OGRE material seetings are also interesting.
* This menu could become a '.skin' editor, similarly how the Tuning menu is a '.tuneup' editor.

![obrazek](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/cf483036-f6aa-4dfb-9761-e83e88e174a2)

