### PR TITLE
Danmackey fov rework

### DIFF
--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -1365,3 +1365,20 @@ void CameraManager::CameraBehaviorVehicleSplineUpdateSplineDisplay()
     }
     m_splinecam_mo->end();
 }
+
+std::string ToLocalizedString(CameraManager::CameraBehaviors behavior)
+{
+    switch (behavior)
+    {
+    case CameraManager::CAMERA_BEHAVIOR_CHARACTER:       return _LC("CameraBehavior", "Character");
+    case CameraManager::CAMERA_BEHAVIOR_STATIC:          return _LC("CameraBehavior", "Static");
+    case CameraManager::CAMERA_BEHAVIOR_VEHICLE:         return _LC("CameraBehavior", "Vehicle");
+    case CameraManager::CAMERA_BEHAVIOR_VEHICLE_SPLINE:  return _LC("CameraBehavior", "Vehicle Spline");
+    case CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM: return _LC("CameraBehavior", "Vehicle CineCam");
+    case CameraManager::CAMERA_BEHAVIOR_FREE:            return _LC("CameraBehavior", "Free");
+    case CameraManager::CAMERA_BEHAVIOR_FIXED:           return _LC("CameraBehavior", "Fixed");
+    case CameraManager::CAMERA_BEHAVIOR_ISOMETRIC:       return _LC("CameraBehavior", "Isometric");
+    case CameraManager::CAMERA_BEHAVIOR_INVALID:         return _LC("CameraBehavior", "Invalid");
+    default:                                             return "";
+    }
+}

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -145,7 +145,7 @@ void CameraManager::ReCreateCameraNode()
     this->CreateCameraNode();
 }
 
-bool CameraManager::EvaluateSwitchBehavior()
+bool CameraManager::evaluateSwitchBehavior()
 {
     switch(m_current_behavior)
     {
@@ -255,7 +255,7 @@ void CameraManager::UpdateInputEvents(float dt) // Called every frame
 
     if ( m_current_behavior < CAMERA_BEHAVIOR_END && App::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_CHANGE) )
     {
-        if ( (m_current_behavior == CAMERA_BEHAVIOR_INVALID) || this->EvaluateSwitchBehavior() )
+        if ( (m_current_behavior == CAMERA_BEHAVIOR_INVALID) || this->evaluateSwitchBehavior() )
         {
             this->switchToNextBehavior();
         }
@@ -1366,7 +1366,31 @@ void CameraManager::CameraBehaviorVehicleSplineUpdateSplineDisplay()
     m_splinecam_mo->end();
 }
 
-std::string ToLocalizedString(CameraManager::CameraBehaviors behavior)
+void CameraManager::switchDirectlyToBehavior(CameraBehaviors new_behavior, int index)
+{
+    // Not all behaviors are the same; some are 'toggled' and some 'cycled'.
+    // * Cycled (see `EV_COMMON_CAMERA_BEHAVIOR_CYCLE`): Character, Static, Vehicle, Vehicle Spline ~ can be changed freely via `switchBehavior()`
+    // * Toggled (see `EV_COMMON_CAMERA_BEHAVIOR_TOGGLE`): Free, Fixed ~ must be changed via `ToggleCameraBehavior()` to keep history for hotkeys.
+    // --------------------------------------------------------------------------------------------------
+
+    switch (new_behavior)
+    {
+    case CameraManager::CAMERA_BEHAVIOR_FREE:
+    case CameraManager::CAMERA_BEHAVIOR_FIXED:
+        this->ToggleCameraBehavior(new_behavior);
+        break;
+
+    case CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM:
+        this->switchBehavior(new_behavior);
+        break;
+
+    default:
+        this->switchBehavior(new_behavior);
+        break;
+    }
+}
+
+std::string RoR::ToLocalizedString(CameraManager::CameraBehaviors behavior)
 {
     switch (behavior)
     {

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -77,7 +77,8 @@ public:
     void ReCreateCameraNode(); //!< Needed since we call `Ogre::SceneManager::ClearScene()` after end of sim. session
 
     void switchToNextBehavior();
-    bool EvaluateSwitchBehavior();
+    bool evaluateSwitchBehavior();
+    void switchDirectlyToBehavior(CameraBehaviors new_behavior, int index = -1);
 
 protected:
 

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -152,4 +152,6 @@ protected:
 /// @} // addtogroup Camera
 /// @} // addtogroup Gfx
 
+std::string ToLocalizedString(CameraManager::CameraBehaviors behavior);
+
 } // namespace RoR

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -560,38 +560,10 @@ void TopMenubar::Draw(float dt)
             {
                 App::GetGameContext()->GetActorManager()->SetSimulationSpeed(timelapse);
             }
-            if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_STATIC)
-            {
-                ImGui::Separator();
-                ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Camera:"));
-                DrawGFloatSlider(App::gfx_static_cam_fov_exp, _LC("TopMenubar", "FOV"), 0.8f, 1.5f);
-                DrawGIntSlider(App::gfx_camera_height, _LC("TopMenubar", "Height"), 1, 50);
-            }
-            else
-            {
-                ImGui::Separator();
-                ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Camera:"));
-                if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM)
-                {
-                    int fov = App::gfx_fov_internal->getInt();
-                    if (ImGui::SliderInt(_LC("TopMenubar", "FOV"), &fov, 10, 120))
-                    {
-                        App::gfx_fov_internal->setVal(fov);
-                    }
-                }
-                else
-                {
-                    int fov = App::gfx_fov_external->getInt();
-                    if (ImGui::SliderInt(_LC("TopMenubar", "FOV"), &fov, 10, 120))
-                    {
-                        App::gfx_fov_external->setVal(fov);
-                    }
-                }
-                if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_FIXED)
-                {
-                    DrawGCheckbox(App::gfx_fixed_cam_tracking, _LC("TopMenubar", "Tracking"));
-                }
-            }
+
+            ImGui::Separator();
+            ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Camera:"));
+            this->DrawCameraControlsBox();
 #ifdef USE_CAELUM
             if (App::gfx_sky_mode->getEnum<GfxSkyMode>() == GfxSkyMode::CAELUM)
             {
@@ -2418,4 +2390,42 @@ void TopMenubar::DrawTuningForceRemoveControls(const int subject_id, const std::
         App::GetGameContext()->PushMessage(Message(MSG_EDI_MODIFY_PROJECT_REQUESTED, req));
     }
 
+}
+
+void TopMenubar::DrawCameraControlsBox()
+{
+    // We have multiple presets:
+    // * `gfx_static_cam_fov_exp` (float) ~ A "zoom factor" of static camera; Adjust by 'Ctrl+mouse wheel' or TopMenubar/Settings.
+    // * `gfx_fov_internal` (int) ~ FOV of cinecam; Adjust by hotkeys EV_COMMON_FOV_{LESS/MORE/RESET}.
+    // * `gfx_fov_external` (int) ~ FOV of exterior cameras (3rd person, free cam, freefixed cam), adjustable by hotkeys EV_COMMON_FOV_{LESS/MORE/RESET}.
+    // -------------------------------------------------------------------------------------------------
+
+    switch (App::GetCameraManager()->GetCurrentBehavior())
+    {
+        case CameraManager::CAMERA_BEHAVIOR_STATIC:
+        {
+            DrawGFloatSlider(App::gfx_static_cam_fov_exp, _LC("TopMenubar", "FOV"), 0.8f, 1.5f);
+            DrawGIntSlider(App::gfx_camera_height, _LC("TopMenubar", "Height"), 1, 50);
+            break;
+        }
+
+        case CameraManager::CAMERA_BEHAVIOR_FIXED:
+        {
+            DrawGIntSlider(App::gfx_fov_external, _LC("TopMenubar", "FOV"), 10, 120);
+            DrawGCheckbox(App::gfx_fixed_cam_tracking, _LC("TopMenubar", "Tracking"));
+            break;
+        }
+
+        case CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM:
+        {
+            DrawGIntSlider(App::gfx_fov_internal, _LC("TopMenubar", "FOV"), 10, 120);
+            break;
+        }
+
+        default:
+        {
+            DrawGIntSlider(App::gfx_fov_external, _LC("TopMenubar", "FOV"), 10, 120);
+            break;
+        }
+    }
 }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -537,7 +537,7 @@ void TopMenubar::Draw(float dt)
         ImGui::SetNextWindowPos(menu_pos);
         if (ImGui::Begin(_LC("TopMenubar", "Settings menu"), nullptr, static_cast<ImGuiWindowFlags_>(flags)))
         {
-            ImGui::PushItemWidth(125.f); // Width includes [+/-] buttons
+            ImGui::PushItemWidth(SETTINGS_ITEMWIDTH); // Width includes [+/-] buttons
             ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar",  "Audio:"));
             DrawGFloatSlider(App::audio_master_volume, _LC("TopMenubar", "Volume"), 0, 1);
             ImGui::Separator();
@@ -563,7 +563,8 @@ void TopMenubar::Draw(float dt)
 
             ImGui::Separator();
             ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Camera:"));
-            this->DrawCameraControlsBox();
+            this->DrawCameraBehaviorSelectionBox();
+            this->DrawCameraContextSensitiveBox();
 #ifdef USE_CAELUM
             if (App::gfx_sky_mode->getEnum<GfxSkyMode>() == GfxSkyMode::CAELUM)
             {
@@ -2392,10 +2393,73 @@ void TopMenubar::DrawTuningForceRemoveControls(const int subject_id, const std::
 
 }
 
-void TopMenubar::DrawCameraControlsBox()
+// Internal helper for `DrawCameraBehaviorSelectionBox()`
+std::string CamBehaviorComboLabel(CameraManager::CameraBehaviors behavior, int index)
+{
+    std::string caption = ToLocalizedString(behavior);
+    if (index != -1)
+    {
+        caption = fmt::format("{} #{}", caption, index+1);
+    }
+    return caption;
+}
+
+// Internal helper for `DrawCameraBehaviorSelectionBox()`
+bool CamBehaviorComboItem(CameraManager::CameraBehaviors active_behavior, int active_index, CameraManager::CameraBehaviors selectable_behavior, int index = -1)
+{
+    const bool is_selected = (selectable_behavior == active_behavior) && (index == active_index);
+    if (ImGui::Selectable(CamBehaviorComboLabel(selectable_behavior, index).c_str(), is_selected))
+    {
+        App::GetCameraManager()->switchDirectlyToBehavior(selectable_behavior);
+        return true;
+    }
+    return false;
+}
+
+void TopMenubar::DrawCameraBehaviorSelectionBox()
+{
+    // Note we have 'cycled' vs 'toggled' camera behaviors - see comments in `CameraManager::switchDirectlyToBehavior()`
+    // Note the cycle-hotkey also traverses sub-elements (i.e. cinecams), see `CameraManager::evaluateSwitchBehavior()`
+    // -------------------------------------------------------------------------------------------------
+
+    CameraManager::CameraBehaviors behavior = App::GetCameraManager()->GetCurrentBehavior();
+    if (App::GetGameContext()->GetPlayerActor())
+    {
+        int index = (behavior == CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM) ? App::GetGameContext()->GetPlayerActor()->ar_current_cinecam : -1;
+        if (ImGui::BeginCombo(_LC("TopMenubar", "Behavior"), CamBehaviorComboLabel(behavior, index).c_str()))
+        {
+            CamBehaviorComboItem(behavior, index, CameraManager::CAMERA_BEHAVIOR_STATIC);
+            CamBehaviorComboItem(behavior, index, CameraManager::CAMERA_BEHAVIOR_VEHICLE);
+            for (int i = 0; i < App::GetGameContext()->GetPlayerActor()->ar_num_cinecams; i++)
+            {
+                if (CamBehaviorComboItem(behavior, index, CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM, i))
+                {
+                    App::GetGameContext()->GetPlayerActor()->ar_current_cinecam = i;
+                    App::GetGameContext()->GetPlayerActor()->NotifyActorCameraChanged();   
+                }
+            }
+            CamBehaviorComboItem(behavior, index, CameraManager::CAMERA_BEHAVIOR_FREE);
+            CamBehaviorComboItem(behavior, index, CameraManager::CAMERA_BEHAVIOR_FIXED);
+            ImGui::EndCombo();
+        }
+    }
+    else
+    {
+        if (ImGui::BeginCombo(_LC("TopMenubar", "Behavior"), ToLocalizedString(behavior).c_str()))
+        {
+            CamBehaviorComboItem(behavior, -1, CameraManager::CAMERA_BEHAVIOR_CHARACTER);
+            CamBehaviorComboItem(behavior, -1, CameraManager::CAMERA_BEHAVIOR_STATIC);
+            CamBehaviorComboItem(behavior, -1, CameraManager::CAMERA_BEHAVIOR_FREE);
+            CamBehaviorComboItem(behavior, -1, CameraManager::CAMERA_BEHAVIOR_FIXED);
+            ImGui::EndCombo();
+        }
+    }
+}
+
+void TopMenubar::DrawCameraContextSensitiveBox()
 {
     // We have multiple presets:
-    // * `gfx_static_cam_fov_exp` (float) ~ A "zoom factor" of static camera; Adjust by 'Ctrl+mouse wheel' or TopMenubar/Settings.
+    // * `gfx_static_cam_fov_exp` (float) ~ A "zoom factor" of static camera (the actual FOV is dynamic based on distance); Adjust by 'Ctrl+mouse wheel' or TopMenubar/Settings.
     // * `gfx_fov_internal` (int) ~ FOV of cinecam; Adjust by hotkeys EV_COMMON_FOV_{LESS/MORE/RESET}.
     // * `gfx_fov_external` (int) ~ FOV of exterior cameras (3rd person, free cam, freefixed cam), adjustable by hotkeys EV_COMMON_FOV_{LESS/MORE/RESET}.
     // -------------------------------------------------------------------------------------------------
@@ -2404,7 +2468,7 @@ void TopMenubar::DrawCameraControlsBox()
     {
         case CameraManager::CAMERA_BEHAVIOR_STATIC:
         {
-            DrawGFloatSlider(App::gfx_static_cam_fov_exp, _LC("TopMenubar", "FOV"), 0.8f, 1.5f);
+            DrawGFloatSlider(App::gfx_static_cam_fov_exp, _LC("TopMenubar", "FOV (exponent)"), 0.8f, 1.5f);
             DrawGIntSlider(App::gfx_camera_height, _LC("TopMenubar", "Height"), 1, 50);
             break;
         }

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -53,6 +53,7 @@ public:
     const ImVec4  ORANGE_TEXT           = ImVec4(0.9f, 0.6f, 0.0f, 1.f);
     const ImVec4  RED_TEXT              = ImVec4(1.00f, 0.00f, 0.00f, 1.f);
     const ImVec2  MENU_HOVERBOX_PADDING = ImVec2(25.f, 10.f);
+    const float   SETTINGS_ITEMWIDTH    = 150.f;
 
     enum class TopMenu { TOPMENU_NONE, TOPMENU_SIM, TOPMENU_ACTORS, TOPMENU_SAVEGAMES, TOPMENU_SETTINGS, TOPMENU_TOOLS, TOPMENU_AI, TOPMENU_TUNING };
     enum class StateBox { STATEBOX_NONE, STATEBOX_REPLAY, STATEBOX_RACE, STATEBOX_LIVE_REPAIR, STATEBOX_QUICK_REPAIR };
@@ -119,7 +120,10 @@ private:
     void DrawActorListSinglePlayer();
     void DrawMpUserToActorList(RoRnet::UserInfo &user); // Multiplayer
     void DrawSpecialStateBox(float top_offset);
-    void DrawCameraControlsBox();
+
+    // Settings menu helpers
+    void DrawCameraBehaviorSelectionBox();
+    void DrawCameraContextSensitiveBox();
 
     // Tuning menu helpers
     void DrawTuningBoxedSubjectIdInline(int subject_id);

--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -119,6 +119,7 @@ private:
     void DrawActorListSinglePlayer();
     void DrawMpUserToActorList(RoRnet::UserInfo &user); // Multiplayer
     void DrawSpecialStateBox(float top_offset);
+    void DrawCameraControlsBox();
 
     // Tuning menu helpers
     void DrawTuningBoxedSubjectIdInline(int subject_id);

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -1147,7 +1147,7 @@ void VehicleButtons::DrawCameraButton()
 {
     if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(m_camera_icon->getHandle()), ImVec2(24, 24)))
     {
-        if (App::GetCameraManager()->EvaluateSwitchBehavior())
+        if (App::GetCameraManager()->evaluateSwitchBehavior())
         {
             App::GetCameraManager()->switchToNextBehavior();
         }


### PR DESCRIPTION
With this ticket I try to clear some confusion about adjusting FOV and the meaning of the slider(s) in Top Menubar UI.

The slider is actually context sensitive; We have multiple presets:
 * `gfx_static_cam_fov_exp` ~`SliderFloat()` ~ A "zoom factor" of static camera (the actual FOV is dynamic based on distance); Adjust by 'Ctrl+mouse wheel' or TopMenubar/Settings.
 * `gfx_fov_internal` ~ `SliderInt()` ~ FOV of cinecam; Adjust by hotkeys EV_COMMON_FOV_{LESS/MORE/RESET}.
 * `gfx_fov_external` ~ `SliderInt()` ~ FOV of exterior cameras (3rd person, free cam, freefixed cam), adjustable by hotkeys. EV_COMMON_FOV_{LESS/MORE/RESET}. 

To start this off, I clarified and commented the code in Top Menubar (as well as related CameraManager code), and I added a combobox to select camera mode:
![obrazek](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/e9dd4753-496d-423c-a8bd-5ff2d74667f3)

Note: having FOV stepped in whole numbers is sort of a convention; thing is, angle degrees aren't typical (base 10) numbers but base 60 numbers, meaning 1 Degree = 60 Angular Minutes. Using a `float` to represent FOV in degrees would be kind of bastardized, but I think I'll do it anyway.
