### PR TITLE
Added `[AI Presets]` section to terrn2 file format

### DIFF
--- a/source/main/gui/panels/GUI_TopMenubar.h
+++ b/source/main/gui/panels/GUI_TopMenubar.h
@@ -95,12 +95,17 @@ public:
     int ai_times_prev = 1;
     int ai_mode_prev = 0;
 
+    // AI waypoint presets
+    void DownloadAiPresets(); //!< Initiate threaded download of 'extern' waypoints from GitHub repo.
+    void RefreshAiPresets();  //!< Refresh the list of presets, used for display. Needs to be called when terrain is loaded.
+    rapidjson::Document ai_presets_all; //!< The full list of presets, used for display. Needs to be refreshed when terrain is loaded.
+    rapidjson::Document ai_presets_extern; //!< Externally provided presets (GitHub repo or local 'savegames/waypoints.json' file).
+    rapidjson::Document ai_presets_bundled; //!< Presets bundled with the terrain, see `[AI Presets]` section in .terrn2 file format.
+
     // Sky
     float sun_size = 1.0;
     float cloud_density = 0.0;
     float sky_light = 0.7;
-
-    void Refresh(std::string payload);
 
     // Tuning menu
     ActorPtr tuning_actor;          //!< Detecting actor change to update cached values.
@@ -140,9 +145,6 @@ private:
     bool    m_quickload = false;
     std::string m_quicksave_name;
     std::vector<std::string> m_savegame_names;
-
-    void GetPresets();
-    rapidjson::Document j_doc;
 };
 
 } // namespace GUI

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -561,7 +561,8 @@ int main(int argc, char *argv[])
                 }
 
                 case MSG_NET_REFRESH_AI_PRESETS:
-                    App::GetGuiManager()->TopMenubar.Refresh(m.description);
+                    App::GetGuiManager()->TopMenubar.ai_presets_extern.Parse(m.description.c_str());
+                    App::GetGuiManager()->TopMenubar.RefreshAiPresets();
                     break;
 
                 // -- Gameplay events --

--- a/source/main/resources/terrn2_fileformat/Terrn2FileFormat.cpp
+++ b/source/main/resources/terrn2_fileformat/Terrn2FileFormat.cpp
@@ -121,6 +121,15 @@ bool Terrn2Parser::LoadTerrn2(Terrn2Def& def, Ogre::DataStreamPtr &ds)
         }
     }
 
+    if (file.HasSection("AI Presets"))
+    {
+        for (auto& presets: file.getSettings("AI Presets"))
+        {
+            Ogre::String presets_filename = SanitizeUtf8String(presets.first);
+            def.ai_presets_files.push_back(TrimStr(presets_filename));
+        }
+    }
+
     this->ProcessTeleport(def, &file);
 
     return true;

--- a/source/main/resources/terrn2_fileformat/Terrn2FileFormat.h
+++ b/source/main/resources/terrn2_fileformat/Terrn2FileFormat.h
@@ -63,6 +63,7 @@ struct Terrn2Def
     std::list<std::string>   tobj_files;
     std::list<std::string>   as_files;
     std::list<std::string>   assetpack_files;
+    std::list<std::string>   ai_presets_files;
     std::list<Terrn2Telepoint> telepoints;
     std::string              caelum_config;
     int                      caelum_fog_start;

--- a/source/main/terrain/Terrain.cpp
+++ b/source/main/terrain/Terrain.cpp
@@ -25,6 +25,7 @@
 #include "ActorManager.h"
 #include "CacheSystem.h"
 #include "Collisions.h"
+#include "ContentManager.h"
 #include "Renderdash.h"
 #include "GfxScene.h"
 #include "GUIManager.h"
@@ -189,6 +190,7 @@ bool RoR::Terrain::initialize()
 
     loading_window->SetProgress(75, _L("Initializing Script Subsystem"));
     this->initScripting();
+    this->initAiPresets();
 
     loading_window->SetProgress(77, _L("Initializing Water Subsystem"));
     this->initWater();
@@ -477,6 +479,36 @@ void RoR::Terrain::initScripting()
     // finally resume AS logging
     App::GetScriptEngine()->setForwardScriptLogToConsole(true);
 #endif //USE_ANGELSCRIPT
+}
+
+void RoR::Terrain::initAiPresets()
+{
+    // Load 'bundled' AI presets - see section `[AI Presets]` in terrn2 file format
+    // ----------------------------------------------------------------------------
+
+    for (const std::string& filename: m_def.ai_presets_files)
+    {
+        // assume there's just one file - load directly into the `ai_presets_bundled` variable
+        if (Ogre::ResourceGroupManager::getSingleton().resourceExists(this->getTerrainFileResourceGroup(), filename))
+        {
+            App::GetContentManager()->LoadAndParseJson(filename, this->getTerrainFileResourceGroup(), App::GetGuiManager()->TopMenubar.ai_presets_bundled);
+        }
+        else
+        {
+            LOG(fmt::format("[RoR|Terrain] AI presets file '{}' declared in '{}' not found!", filename, this->getTerrainFileName()));
+        }
+
+        // Ensure the format is about right
+        if (!App::GetGuiManager()->TopMenubar.ai_presets_bundled.IsArray())
+        {
+            LOG(fmt::format("[RoR|Terrain] AI presets file '{}' declared in '{}' has wrong format - the root element is not an array!",
+                    filename, this->getTerrainFileName()));
+            App::GetGuiManager()->TopMenubar.ai_presets_bundled.Clear();
+        }
+    }
+
+    // Force refresh - this is needed because the 'extern' AI presets are loaded later.
+    App::GetGuiManager()->TopMenubar.ai_presets_all.Clear();
 }
 
 void RoR::Terrain::setGravity(float value)

--- a/source/main/terrain/Terrain.h
+++ b/source/main/terrain/Terrain.h
@@ -117,6 +117,7 @@ private:
     void initLight();
     void initObjects();
     void initScripting();
+    void initAiPresets();
     void initShadows();
     void initSkySubSystem();
     void initVegetation();


### PR DESCRIPTION
This makes it possible to include a waypoints (JSON) file with a terrain. The file can have any name and must be listed in the .terrn2 file under [AI Presets] section, for example:

```
[AI Presets]
f1track_09wip_waypoints.json=
```

The format of the JSON file is the same as 'waypoints.json' downloaded from github repo https://github.com/RigsOfRods-Community/ai-waypoints. The game will check if the format is about right.

Tutorial on creating the presets: https://docs.rigsofrods.org/gameplay/vehicle-ai/#creating-waypoint-presets