### PR TITLE
Fixed cars without coll. cabs not activating eventboxes (i.e. race checkpoints)

### DIFF
--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1117,7 +1117,7 @@ void Actor::UpdateBoundingBoxes()
     // Reset
     ar_bounding_box = AxisAlignedBox::BOX_NULL;
     ar_predicted_bounding_box = AxisAlignedBox::BOX_NULL;
-    ar_cabnodes_bounding_box = AxisAlignedBox::BOX_NULL;
+    ar_evboxes_bounding_box = AxisAlignedBox::BOX_NULL;
     for (size_t i = 0; i < ar_collision_bounding_boxes.size(); ++i)
     {
         ar_collision_bounding_boxes[i] = AxisAlignedBox::BOX_NULL;
@@ -1137,10 +1137,9 @@ void Actor::UpdateBoundingBoxes()
         int16_t cid = ar_nodes[i].nd_coll_bbox_id;
 
         ar_bounding_box.merge(pos);                                  // Current box
-        if (ar_nodes[i].nd_cab_node                                 // Current cab-nodes box (for eventbox collisions)
-            && (mainCamPos.squaredDistance(ar_nodes[i].RelPosition)) < (CABNODE_MAX_CAMDIST*CABNODE_MAX_CAMDIST)) // ... we compare squared distance for performance
+        if (mainCamPos.squaredDistance(ar_nodes[i].RelPosition) < (CABNODE_MAX_CAMDIST*CABNODE_MAX_CAMDIST))
         {
-            ar_cabnodes_bounding_box.merge(pos);
+            ar_evboxes_bounding_box.merge(pos);
         }
         ar_predicted_bounding_box.merge(pos);                        // Predicted box (current position)
         ar_predicted_bounding_box.merge(pos + vel);                  // Predicted box (future position)

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -294,7 +294,7 @@ public:
     std::vector<Airbrake*>    ar_airbrakes;
     CmdKeyArray               ar_command_key; //!< BEWARE: commandkeys are indexed 1-MAX_COMMANDS!
     Ogre::AxisAlignedBox      ar_bounding_box;     //!< standard bounding box (surrounds all nodes of an actor)
-    Ogre::AxisAlignedBox      ar_cabnodes_bounding_box; //!< bounding box around cab-triangle nodes only
+    Ogre::AxisAlignedBox      ar_evboxes_bounding_box; //!< bounding box around nodes eligible for eventbox triggering
     Ogre::AxisAlignedBox      ar_predicted_bounding_box;
     float                     ar_initial_total_mass = 0.f;
     std::vector<float>        ar_initial_node_masses;

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -1088,11 +1088,11 @@ bool Collisions::nodeCollision(node_t *node, float dt)
 
 void Collisions::findPotentialEventBoxes(Actor* actor, CollisionBoxPtrVec& out_boxes)
 {
-    // NOTE: Only collision-cab nodes are considered for eventbox triggering!
+    // Find collision cells occupied by the actor (remember 'Y' is 'up').
+    // Remember there's a dedicated bounding box `ar_evboxes_bounding_box`.
     // ----------------------------------------------------------------------
 
-    // Find collision cells occupied by the actor (remember 'Y' is 'up').
-    const AxisAlignedBox aabb = actor->ar_cabnodes_bounding_box;
+    const AxisAlignedBox aabb = actor->ar_evboxes_bounding_box;
     const int cell_lo_x = (int)(aabb.getMinimum().x / (float)CELL_SIZE);
     const int cell_lo_z = (int)(aabb.getMinimum().z / (float)CELL_SIZE);
     const int cell_hi_x = (int)(aabb.getMaximum().x / (float)CELL_SIZE);


### PR DESCRIPTION
Fixes #3121
Fixes #3097

This partially reverts d4ec0a0a1db975574938b176d0f16b9b067ce4d7
* the "is a cabnode" node filter condition was dropped, see `Actor::UpdateBoundingBoxes()`.
* The `ar_cabnodes_bounding_box` got renamed to `ar_evboxes_bounding_box`.