### PR TITLE
Improved diag. logging on renderer startup.

### DIFF
--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -229,8 +229,11 @@ void AppContext::SetRenderWindowIcon(Ogre::RenderWindow* rw)
 bool AppContext::SetUpRendering()
 {
     // Create 'OGRE root' facade
+    // * leave 'plugins' param empty, we load manually below
+    // * note file 'ogre.cfg' isn't read immediatelly but only after calling 'restoreConfig()' below.
     std::string log_filepath = PathCombine(App::sys_logs_dir->getStr(), "RoR.log");
     std::string cfg_filepath = PathCombine(App::sys_config_dir->getStr(), "ogre.cfg");
+    LOG(fmt::format("[RoR|Startup|Rendering] Creating OGRE renderer Root object, config='{}'", cfg_filepath));
     m_ogre_root = new Ogre::Root("", cfg_filepath, log_filepath);
 
     // load OGRE plugins manually
@@ -239,6 +242,7 @@ bool AppContext::SetUpRendering()
 #else
 	std::string plugins_path = PathCombine(RoR::App::sys_process_dir->getStr(), "plugins.cfg");
 #endif
+    LOG(fmt::format("[RoR|Startup|Rendering] Loading OGRE renderer plugins config '{}'.", plugins_path));
     try
     {
         Ogre::ConfigFile cfg;
@@ -256,23 +260,34 @@ bool AppContext::SetUpRendering()
     }
     catch (Ogre::Exception& e)
     {
-        ErrorUtils::ShowError (_L("Startup error"), e.getFullDescription());
+        ErrorUtils::ShowError (
+            _L("Startup error"), 
+            fmt::format(_L("Could not load file '{}' - make sure the game is installed correctly.\n\nDetailed info: {}"), plugins_path, e.getDescription()));
         return false;
     }
 
     // Load renderer configuration
     if (!m_ogre_root->restoreConfig())
     {
+        LOG(fmt::format("[RoR|Startup|Rendering] WARNING - invalid 'ogre.cfg', selecting render plugin manually..."));
+
         const auto render_systems = App::GetAppContext()->GetOgreRoot()->getAvailableRenderers();
         if (!render_systems.empty())
+        {
+            LOG(fmt::format("[RoR|Startup|Rendering] Auto-selected renderer plugin '{}'", render_systems.front()->getName()));
             m_ogre_root->setRenderSystem(render_systems.front());
+        }
         else
+        {
             ErrorUtils::ShowError (_L("Startup error"), _L("No render system plugin available. Check your plugins.cfg"));
+            return false;
+        }
     }
 
     const auto rs = m_ogre_root->getRenderSystemByName(App::app_rendersys_override->getStr());
     if (rs != nullptr && rs != m_ogre_root->getRenderSystem())
     {
+        LOG(fmt::format("[RoR|Startup|Rendering] Setting renderer '{}' on behalf of 'app_rendersys_override' (user selection via Settings UI)", rs->getName()));
         // The user has selected a different render system during the previous session.
         m_ogre_root->setRenderSystem(rs);
         m_ogre_root->saveConfig();
@@ -280,10 +295,24 @@ bool AppContext::SetUpRendering()
     App::app_rendersys_override->setStr("");
 
     // Start the renderer
+    LOG(fmt::format("[RoR|Startup|Rendering] Starting renderer '{}' (without auto-creating render window)", m_ogre_root->getRenderSystem()->getName()));
     m_ogre_root->initialise(/*createWindow=*/false);
 
-    // Configure the render window
+    // Review configuration options
     Ogre::ConfigOptionMap ropts = m_ogre_root->getRenderSystem()->getConfigOptions();
+    std::stringstream ropts_log;
+    for (auto& pair: ropts)
+    {
+        ropts_log << "  " << pair.first << " = " << pair.second.currentValue << " (";
+        for (auto& val: pair.second.possibleValues)
+        {
+            ropts_log << val << ", ";
+        }
+        ropts_log << ")\n";
+    }
+    LOG(fmt::format("[RoR|Startup|Rendering] Renderer options as reported by OGRE:\n{}", ropts_log.str()));
+
+    // Configure the render window
     Ogre::NameValuePairList miscParams;
     miscParams["FSAA"] = ropts["FSAA"].currentValue;
     miscParams["vsync"] = ropts["VSync"].currentValue;
@@ -307,6 +336,14 @@ bool AppContext::SetUpRendering()
     
     if(width < 800) width = 800;
     if(height < 600) height = 600;
+
+    // Review render window settings
+    std::stringstream miscParams_log;
+    for (auto& pair: miscParams)
+    {
+        miscParams_log << "  " << pair.first << " = " << pair.second << "\n";
+    }
+    LOG(fmt::format("[RoR|Startup|Rendering] Creating render window with settings:\n{}", miscParams_log.str()));
 
     // Create render window
     m_render_window = Ogre::Root::getSingleton().createRenderWindow (

--- a/source/main/utils/ErrorUtils.cpp
+++ b/source/main/utils/ErrorUtils.cpp
@@ -42,6 +42,7 @@ using namespace Ogre;
 
 int ErrorUtils::ShowError(Ogre::UTFString title, Ogre::UTFString err)
 {
+    LOG(fmt::format("[RoR|ErrorPopupDialog] {}: {}", title.asUTF8(), err.asUTF8()));
     Ogre::UTFString infoText = _L("An internal error occured in Rigs of Rods.\n\nTechnical details below: \n\n");
     return ErrorUtils::ShowMsgBox(_L("FATAL ERROR"), infoText + err, 0);
 }


### PR DESCRIPTION
To help diagnose #3141, I added extra logging of renderer config and startup.
* Displaying the fatal error dialog will now be logged to RoR.log - see file ErrorUtils.cpp.
* New entries in RoR.log - see file AppContext.cpp, function `SetUpRendering()`
```
00:56:19: [RoR|Startup|Rendering] Loading OGRE renderer plugins config 'C:\Users\Petr\builds\rigs-of-rods\bin\plugins_d.cfg'.
 (...)
00:56:19: [RoR|Startup|Rendering] WARNING - invalid 'ogre.cfg', selecting render plugin manually...
00:56:19: [RoR|Startup|Rendering] Auto-selected renderer plugin 'Direct3D9 Rendering Subsystem'
00:56:19: [RoR|Startup|Rendering] Starting renderer 'Direct3D9 Rendering Subsystem' (without auto-creating render window)
 (...)
00:56:19: [RoR|Startup|Rendering] Renderer options as reported by OGRE:
  Allow DirectX9Ex = No (Yes, No, )
  Allow NVPerfHUD = No (Yes, No, )
  Backbuffer Count = Auto (Auto, 1, 2, )
  FSAA = 0 (0, 2, 4, 8, 8 [Quality], )
  Fixed Pipeline Enabled = Yes (Yes, No, )
  Floating-point mode = Fastest (Fastest, Consistent, )
  Full Screen = No (No, Yes, )
  Multi device memory hint = Use minimum system memory (Use minimum system memory, Auto hardware buffers management, )
  Rendering Device = Monitor-1-NVIDIA GeForce RTX 4070 Ti (Monitor-1-NVIDIA GeForce RTX 4070 Ti, )
  Resource Creation Policy = Create on all devices (Create on all devices, Create on active device, )
  Use Multihead = Auto (Auto, Yes, No, )
  VSync = Yes (No, Yes, )
  VSync Interval = 1 (1, 2, 3, 4, )
  Video Mode = 1920 x 1440 @ 32-bit colour (640 x 480 @ 32-bit colour, 720 x 480 @ 32-bit colour, 720 x 576 @ 32-bit colour, 800 x 600 @ 32-bit colour, 1024 x 768 @ 32-bit colour, 1152 x 864 @ 32-bit colour, 1176 x 664 @ 32-bit colour, 1280 x 720 @ 32-bit colour, 1280 x 768 @ 32-bit colour, 1280 x 800 @ 32-bit colour, 1280 x 960 @ 32-bit colour, 1280 x 1024 @ 32-bit colour, 1360 x 768 @ 32-bit colour, 1366 x 768 @ 32-bit colour, 1600 x 900 @ 32-bit colour, 1600 x 1024 @ 32-bit colour, 1600 x 1200 @ 32-bit colour, 1680 x 1050 @ 32-bit colour, 1920 x 1080 @ 32-bit colour, 1920 x 1200 @ 32-bit colour, 1920 x 1440 @ 32-bit colour, 2560 x 1440 @ 32-bit colour, 3440 x 1440 @ 32-bit colour, 1440 x 900 @ 32-bit colour, )
  sRGB Gamma Conversion = No (No, Yes, )

00:56:19: [RoR|Startup|Rendering] Creating render window with settings:
  FSAA = 0
  border = fixed
  gamma = No
  monitorIndex = 0
  vsync = Yes
  windowProc = 140722066888731

```