### PR TITLE
Fixed paused actor physics resuming after switching to another actor

### DIFF
--- a/doc/angelscript/Script2Game/globals.h
+++ b/doc/angelscript/Script2Game/globals.h
@@ -75,7 +75,9 @@ void print(const string message);
 
  	SE_GENERIC_MESSAGEBOX_CLICK        //!< triggered when the user clicks on a message box button, the argument refers to the button pressed
     SE_GENERIC_EXCEPTION_CAUGHT        //!< Triggered when C++ exception (usually Ogre::Exception) is thrown; #1 ScriptUnitID, #5 originFuncName, #6 type, #7 message.
-    SE_GENERIC_MODCACHE_ACTIVITY       //!< Triggered when status of modcache changes, args: #1 type, #2 entry number, for other args see `RoR::modCacheActivityType`    
+    SE_GENERIC_MODCACHE_ACTIVITY       //!< Triggered when status of modcache changes, args: #1 type, #2 entry number, for other args see `RoR::modCacheActivityType`  
+
+    SE_GENERIC_TRUCK_LINKING_CHANGED   //!< Triggered when 2 actors become linked or unlinked via ties/hooks/ropes/slidenodes; args: #1 state (1=linked, 0=unlinked), #2 action `ActorLinkingRequestType` #3 master ActorInstanceID_t, #4 slave ActorInstanceID_t
 
  	SE_ALL_EVENTS                      = 0xffffffff,
     SE_NO_EVENTS                       = 0

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1367,21 +1367,20 @@ void GameContext::UpdateCommonInputEvents(float dt)
     {
         //m_player_actor->hookToggle(-1, HOOK_TOGGLE, -1);
         ActorLinkingRequest* hook_rq = new ActorLinkingRequest();
-        hook_rq->alr_type = ActorLinkingRequestType::HOOK_ACTION;
+        hook_rq->alr_type = ActorLinkingRequestType::HOOK_TOGGLE;
         hook_rq->alr_actor_instance_id = m_player_actor->ar_instance_id;
-        hook_rq->alr_hook_action = HOOK_TOGGLE;
         App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, hook_rq));
 
         //m_player_actor->toggleSlideNodeLock();
         ActorLinkingRequest* slidenode_rq = new ActorLinkingRequest();
-        slidenode_rq->alr_type = ActorLinkingRequestType::SLIDENODE_ACTION;
+        slidenode_rq->alr_type = ActorLinkingRequestType::SLIDENODE_TOGGLE;
         hook_rq->alr_actor_instance_id = m_player_actor->ar_instance_id;
         App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, slidenode_rq));
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_AUTOLOCK))
     {
-        m_player_actor->hookToggle(-2, HOOK_UNLOCK, -1); //unlock all autolocks
+        m_player_actor->hookToggle(-2, ActorLinkingRequestType::HOOK_UNLOCK, -1); //unlock all autolocks
     }
 
     //strap

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1398,13 +1398,19 @@ void GameContext::UpdateCommonInputEvents(float dt)
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_TOGGLE_DEBUG_VIEW))
     {
         m_player_actor->GetGfxActor()->ToggleDebugView();
-        // NOTE: Syncing with linked actors is done in `SyncLinkedActors()`
+        for (ActorPtr& actor : m_player_actor->ar_linked_actors)
+        {
+            actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());
+        }
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_CYCLE_DEBUG_VIEWS))
     {
         m_player_actor->GetGfxActor()->CycleDebugViews();
-        // NOTE: Syncing with linked actors is done in `SyncLinkedActors()`
+        for (ActorPtr& actor : m_player_actor->ar_linked_actors)
+        {
+            actor->GetGfxActor()->SetDebugView(m_player_actor->GetGfxActor()->GetDebugView());
+        }
     }
 
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESCUE_TRUCK, 0.5f) &&
@@ -1463,7 +1469,10 @@ void GameContext::UpdateCommonInputEvents(float dt)
     // toggle physics
     if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_TOGGLE_PHYSICS))
     {
-        // NOTE: Syncing with linked actors is done in `SyncLinkedActors()`
+        for (ActorPtr& actor : App::GetGameContext()->GetPlayerActor()->ar_linked_actors)
+        {
+            actor->ar_physics_paused = !App::GetGameContext()->GetPlayerActor()->ar_physics_paused;
+        }
         App::GetGameContext()->GetPlayerActor()->ar_physics_paused = !App::GetGameContext()->GetPlayerActor()->ar_physics_paused;
     }
 

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1374,7 +1374,7 @@ void GameContext::UpdateCommonInputEvents(float dt)
         //m_player_actor->toggleSlideNodeLock();
         ActorLinkingRequest* slidenode_rq = new ActorLinkingRequest();
         slidenode_rq->alr_type = ActorLinkingRequestType::SLIDENODE_TOGGLE;
-        hook_rq->alr_actor_instance_id = m_player_actor->ar_instance_id;
+        slidenode_rq->alr_actor_instance_id = m_player_actor->ar_instance_id;
         App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, slidenode_rq));
     }
 

--- a/source/main/gameplay/RepairMode.cpp
+++ b/source/main/gameplay/RepairMode.cpp
@@ -124,14 +124,28 @@ void RepairMode::UpdateInputEvents(float dt)
 
             App::GetGameContext()->GetPlayerActor()->requestRotation(rotation, rotation_center);
             App::GetGameContext()->GetPlayerActor()->requestTranslation(translation);
-            // NOTE: Syncing with linked actors is done in `SyncLinkedActors()`
+
+            if (App::sim_soft_reset_mode->getBool())
+            {
+                for (ActorPtr& actor : App::GetGameContext()->GetPlayerActor()->ar_linked_actors)
+                {
+                    actor->requestRotation(rotation, rotation_center);
+                    actor->requestTranslation(translation);
+                }
+            }
 
             m_live_repair_timer = 0.0f;
         }
         else if (App::GetInputEngine()->isKeyDownValueBounce(OIS::KC_SPACE))
         {
             App::GetGameContext()->GetPlayerActor()->requestAngleSnap(45);
-            // NOTE: Syncing with linked actors is done in `SyncLinkedActors()`
+            if (App::sim_soft_reset_mode->getBool())
+            {
+                for (ActorPtr& actor : App::GetGameContext()->GetPlayerActor()->ar_linked_actors)
+                {
+                    actor->requestAngleSnap(45);
+                }
+            }
         }
         else
         {

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -165,11 +165,10 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
             {
                 if (it->hk_hook_node->pos == minnode)
                 {
-                    //grab_truck->hookToggle(it->hk_group, MOUSE_HOOK_TOGGLE, minnode);
+                    //grab_truck->hookToggle(it->hk_group, HOOK_MOUSE_TOGGLE, minnode);
                     ActorLinkingRequest* rq = new ActorLinkingRequest();
-                    rq->alr_type = ActorLinkingRequestType::HOOK_ACTION;
+                    rq->alr_type = ActorLinkingRequestType::HOOK_MOUSE_TOGGLE;
                     rq->alr_actor_instance_id = grab_truck->ar_instance_id;
-                    rq->alr_hook_action = MOUSE_HOOK_TOGGLE;
                     rq->alr_hook_group = it->hk_group;
                     rq->alr_hook_mousenode = minnode;
                     App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, rq));

--- a/source/main/gameplay/ScriptEvents.h
+++ b/source/main/gameplay/ScriptEvents.h
@@ -61,6 +61,8 @@ enum scriptEvents
     SE_GENERIC_EXCEPTION_CAUGHT        = BITMASK(24), //!< Triggered when C++ exception (usually Ogre::Exception) is thrown; #1 ScriptUnitID, #5 originFuncName, #6 type, #7 message.
     SE_GENERIC_MODCACHE_ACTIVITY       = BITMASK(25), //!< Triggered when status of modcache changes, args: #1 type, #2 entry number, for other args see `RoR::modCacheActivityType`
 
+    SE_GENERIC_TRUCK_LINKING_CHANGED   = BITMASK(26), //!< Triggered when 2 actors become linked or unlinked via ties/hooks/ropes/slidenodes; args: #1 state (1=linked, 0=unlinked), #2 action `ActorLinkingRequestType` #3 master ActorInstanceID_t, #4 slave ActorInstanceID_t
+
     SE_ALL_EVENTS                      = 0xffffffff,
     SE_NO_EVENTS                       = 0
 

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -627,7 +627,10 @@ void VehicleButtons::DrawActorPhysicsButton(RoR::GfxActor* actorx)
 
     if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(m_actor_physics_icon->getHandle()), ImVec2(24, 24)))
     {
-        // NOTE: Syncing with linked actors is done in `SyncLinkedActors()`
+        for (ActorPtr& actor : actorx->GetActor()->ar_linked_actors)
+        {
+            actor->ar_physics_paused = !actorx->GetActor()->ar_physics_paused;
+        }
         actorx->GetActor()->ar_physics_paused = !actorx->GetActor()->ar_physics_paused;
     }
 

--- a/source/main/gui/panels/GUI_VehicleButtons.cpp
+++ b/source/main/gui/panels/GUI_VehicleButtons.cpp
@@ -1183,14 +1183,13 @@ void VehicleButtons::DrawLockButton(RoR::GfxActor* actorx)
     {
         //actorx->GetActor()->hookToggle(-1, HOOK_TOGGLE, -1);
         ActorLinkingRequest* hook_rq = new ActorLinkingRequest();
-        hook_rq->alr_type = ActorLinkingRequestType::HOOK_ACTION;
+        hook_rq->alr_type = ActorLinkingRequestType::HOOK_TOGGLE;
         hook_rq->alr_actor_instance_id = actorx->GetActor()->ar_instance_id;
-        hook_rq->alr_hook_action = HOOK_TOGGLE;
         App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, hook_rq));
 
         //actorx->GetActor()->toggleSlideNodeLock();
         ActorLinkingRequest* slidenode_rq = new ActorLinkingRequest();
-        slidenode_rq->alr_type = ActorLinkingRequestType::SLIDENODE_ACTION;
+        slidenode_rq->alr_type = ActorLinkingRequestType::SLIDENODE_TOGGLE;
         hook_rq->alr_actor_instance_id = actorx->GetActor()->ar_instance_id;
         App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, slidenode_rq));
     }

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -1142,23 +1142,26 @@ int main(int argc, char *argv[])
                         {
                             switch (request->alr_type)
                             {
-                            case ActorLinkingRequestType::HOOK_ACTION:
-                                actor->hookToggle(request->alr_hook_group, request->alr_hook_action, request->alr_hook_mousenode);
-                                if (request->alr_hook_action == MOUSE_HOOK_TOGGLE)
-                                {
-                                    TRIGGER_EVENT_ASYNC(SE_TRUCK_MOUSE_GRAB, request->alr_actor_instance_id);
-                                }
+                            case ActorLinkingRequestType::HOOK_LOCK:
+                            case ActorLinkingRequestType::HOOK_UNLOCK:
+                            case ActorLinkingRequestType::HOOK_TOGGLE:
+                                actor->hookToggle(request->alr_hook_group, request->alr_type);
                                 break;
 
-                            case ActorLinkingRequestType::TIE_ACTION:
+                            case ActorLinkingRequestType::HOOK_MOUSE_TOGGLE:
+                                actor->hookToggle(request->alr_hook_group, request->alr_type, request->alr_hook_mousenode);
+                                    TRIGGER_EVENT_ASYNC(SE_TRUCK_MOUSE_GRAB, request->alr_actor_instance_id);
+                                break;
+
+                            case ActorLinkingRequestType::TIE_TOGGLE:
                                 actor->tieToggle(request->alr_tie_group);
                                 break;
 
-                            case ActorLinkingRequestType::ROPE_ACTION:
+                            case ActorLinkingRequestType::ROPE_TOGGLE:
                                 actor->ropeToggle(request->alr_rope_group);
                                 break;
 
-                            case ActorLinkingRequestType::SLIDENODE_ACTION:
+                            case ActorLinkingRequestType::SLIDENODE_TOGGLE:
                                 actor->toggleSlideNodeLock();
                                 break;
                             }

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -1651,9 +1651,6 @@ int main(int argc, char *argv[])
             App::GetSoundScriptManager()->update(dt); // update 3d audio listener position
 #endif // USE_OPENAL
 
-            // Sync shared state (lights, brakes, debugviews, pause/reset) between linked actors.
-            App::GetGameContext()->GetActorManager()->SyncLinkedActors();
-
 #ifdef USE_ANGELSCRIPT
             App::GetScriptEngine()->framestep(dt);
 #endif // USE_ANGELSCRIPT

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3436,7 +3436,27 @@ void Actor::tieToggle(int group)
             if (it->ti_locked_actor != this)
             {
                 this->RemoveInterActorBeam(it->ti_beam);
-                // NOTE: updating skeletonview on the tied actors is now done in `SyncLinkedActors()`
+                // update skeletonview on the untied actors
+                auto linked_actors = it->ti_locked_actor->ar_linked_actors;
+                if (!(std::find(linked_actors.begin(), linked_actors.end(), this) != linked_actors.end()))
+                {
+                    if (this == player_actor.GetRef())
+                    {
+                        it->ti_locked_actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
+                        for (ActorPtr& actor : it->ti_locked_actor->ar_linked_actors)
+                        {
+                            actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
+                        }
+                    }
+                    else if (it->ti_locked_actor == player_actor)
+                    {
+                        m_gfx_actor->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
+                        for (ActorPtr& actor : this->ar_linked_actors)
+                        {
+                            actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
+                        }
+                    }
+                }
             }
             it->ti_locked_actor = nullptr;
         }
@@ -3507,7 +3527,23 @@ void Actor::tieToggle(int group)
                     if (it->ti_beam->bm_inter_actor)
                     {
                         AddInterActorBeam(it->ti_beam, this, nearest_actor);
-                        // NOTE: updating skeletonview on the tied actors is now done in `SyncLinkedActors()`
+                        // update skeletonview on the tied actors
+                        if (this == player_actor.GetRef())
+                        {
+                            nearest_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
+                            for (ActorPtr& actor : nearest_actor->ar_linked_actors)
+                            {
+                                actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
+                            }
+                        }
+                        else if (nearest_actor == player_actor)
+                        {
+                            m_gfx_actor->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
+                            for (ActorPtr& actor : this->ar_linked_actors)
+                            {
+                                actor->GetGfxActor()->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
+                            }
+                        }
                     }
                 }
             }
@@ -3539,7 +3575,27 @@ void Actor::ropeToggle(int group)
             if (it->rp_locked_actor != this)
             {
                 this->RemoveInterActorBeam(it->rp_beam);
-                // NOTE: updating skeletonview on the unroped actors is now done in `SyncLinkedActors()`
+                // update skeletonview on the unroped actors
+                auto linked_actors = it->rp_locked_actor->ar_linked_actors;
+                if (!(std::find(linked_actors.begin(), linked_actors.end(), this) != linked_actors.end()))
+                {
+                    if (this == player_actor.GetRef())
+                    {
+                        it->rp_locked_actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
+                        for (ActorPtr& actor : it->rp_locked_actor->ar_linked_actors)
+                        {
+                            actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
+                        }
+                    }
+                    else if (it->rp_locked_actor == player_actor)
+                    {
+                        m_gfx_actor->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
+                        for (ActorPtr& actor : this->ar_linked_actors)
+                        {
+                            actor->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
+                        }
+                    }
+                }
             }
             it->rp_locked_actor = nullptr;
             it->rp_locked_ropable = nullptr;
@@ -3584,7 +3640,23 @@ void Actor::ropeToggle(int group)
                 if (nearest_actor != this)
                 {
                     AddInterActorBeam(it->rp_beam, this, nearest_actor);
-                    // NOTE: updating skeletonview on the roped up actor is now done in `SyncLinkedActors()`
+                    // update skeletonview on the roped up actors
+                    if (this == player_actor.GetRef())
+                    {
+                        nearest_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
+                        for (ActorPtr& actor : nearest_actor->ar_linked_actors)
+                        {
+                            actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
+                        }
+                    }
+                    else if (nearest_actor == player_actor)
+                    {
+                        m_gfx_actor->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
+                        for (ActorPtr& actor : this->ar_linked_actors)
+                        {
+                            actor->GetGfxActor()->SetDebugView(player_actor->GetGfxActor()->GetDebugView());
+                        }
+                    }
                 }
             }
         }
@@ -3716,7 +3788,26 @@ void Actor::hookToggle(int group, HookAction mode, NodeNum_t mousenode /*=NODENU
             it->hk_beam->bm_disabled = true;
         }
 
-        // NOTE: updating skeletonview on the (un)hooked actor is now done in `SyncLinkedActors()`
+        // update skeletonview on the (un)hooked actor
+        if (it->hk_locked_actor != prev_locked_actor)
+        {
+            if (it->hk_locked_actor)
+            {
+                it->hk_locked_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
+                for (ActorPtr& actor : it->hk_locked_actor->ar_linked_actors)
+                {
+                    actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
+                }
+            }
+            else if (prev_locked_actor != this)
+            {
+                prev_locked_actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
+                for (ActorPtr& actor : prev_locked_actor->ar_linked_actors)
+                {
+                    actor->GetGfxActor()->SetDebugView(m_gfx_actor->GetDebugView());
+                }
+            }
+        }
     }
 }
 

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -43,7 +43,9 @@ namespace RoR {
 /// @{
 
 /// Softbody object; can be anything from soda can to a space shuttle
-/// Former name: `Beam` (that's why scripting uses `BeamClass`)
+/// Constructed from a truck definition file, see https://docs.rigsofrods.org/vehicle-creation/fileformat-truck/
+/// To spawn in-game, use `MSG_SIM_SPAWN_ACTOR_REQUESTED`, see `GameContext::PushMessage()`, in AngelScript use `game.pushMessage();`
+/// Gameplay states are described by `enum ActorState`. For additional state vars see "Gameplay state" section below.
 class Actor : public RefCountingObject<Actor>
 {
     friend class ActorSpawner;
@@ -132,11 +134,11 @@ public:
     bool              getCustomParticleMode();
     // not exported to scripting:
     void              mouseMove(NodeNum_t node, Ogre::Vector3 pos, float force);
-    void              tieToggle(int group=-1);
+    void              tieToggle(int group=-1, ActorLinkingRequestType mode=ActorLinkingRequestType::TIE_TOGGLE, ActorInstanceID_t forceunlock_filter=ACTORINSTANCEID_INVALID);
     bool              isTied();
-    void              hookToggle(int group=-1, HookAction mode=HOOK_TOGGLE, NodeNum_t mousenode=NODENUM_INVALID);
+    void              hookToggle(int group=-1, ActorLinkingRequestType mode=ActorLinkingRequestType::HOOK_TOGGLE,NodeNum_t mousenode=NODENUM_INVALID, ActorInstanceID_t forceunlock_filter=ACTORINSTANCEID_INVALID);
     bool              isLocked();                          //!< Are hooks locked?
-    void              ropeToggle(int group=-1);
+    void              ropeToggle(int group=-1, ActorLinkingRequestType mode=ActorLinkingRequestType::ROPE_TOGGLE, ActorInstanceID_t forceunlock_filter=ACTORINSTANCEID_INVALID);
     void              engineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              toggleSlideNodeLock();
     bool              getParkingBrake() { return ar_parking_brake; }
@@ -303,7 +305,6 @@ public:
     std::vector<Ogre::Vector3>     ar_initial_node_positions;
     std::vector<std::pair<float, float>> ar_initial_beam_defaults;
     std::vector<wheeldetacher_t>   ar_wheeldetachers;
-    ActorPtrVec                    ar_linked_actors;              //!< Sim state; other actors linked using 'hooks'
     std::vector<std::vector<int>>  ar_node_to_node_connections;
     std::vector<std::vector<int>>  ar_node_to_beam_connections;
     std::vector<Ogre::AxisAlignedBox>  ar_collision_bounding_boxes; //!< smart bounding boxes, used for determining the state of an actor (every box surrounds only a subset of nodes)
@@ -435,6 +436,7 @@ public:
 
     // Gameplay state
     ActorState        ar_state = ActorState::LOCAL_SIMULATED;
+    ActorPtrVec       ar_linked_actors;            //!< BEWARE: Includes indirect links, see `DetermineLinkedActors()`; Other actors linked using 'hooks/ties/ropes/slidenodes'; use `MSG_SIM_ACTOR_LINKING_REQUESTED`
 
     // Repair state
     Ogre::Vector3     m_rotation_request_center = Ogre::Vector3::ZERO;
@@ -505,9 +507,9 @@ private:
     void              DetermineLinkedActors();
     void              RecalculateNodeMasses(Ogre::Real total); //!< Previously 'calc_masses2()'
     void              calcNodeConnectivityGraph();
-    void              AddInterActorBeam(beam_t* beam, ActorPtr a, ActorPtr b);
-    void              RemoveInterActorBeam(beam_t* beam);
-    void              DisjoinInterActorBeams();            //!< Destroys all inter-actor beams which are connected with this actor
+    void              AddInterActorBeam(beam_t* beam, ActorPtr other, ActorLinkingRequestType type);  //!< Do not call directly - use `MSG_SIM_ACTOR_LINKING_REQUESTED`
+    void              RemoveInterActorBeam(beam_t* beam, ActorLinkingRequestType type);  //!< Do not call directly - use `MSG_SIM_ACTOR_LINKING_REQUESTED`
+    void              DisjoinInterActorBeams();            //!< Helper for `MSG_` handlers, do not invoke by hand.
     void              autoBlinkReset();                    //!< Resets the turn signal when the steering wheel is turned back.
     void              ResetAngle(float rot);
     void              calculateLocalGForces();             //!< Derive the truck local g-forces from the global ones

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -1109,9 +1109,8 @@ bool Actor::CalcForcesEulerPrepare(bool doUpdate)
     {
         //this->hookToggle(-2, HOOK_LOCK, -1);
         ActorLinkingRequest* rq = new ActorLinkingRequest();
-        rq->alr_type = ActorLinkingRequestType::HOOK_ACTION;
+        rq->alr_type = ActorLinkingRequestType::HOOK_LOCK;
         rq->alr_actor_instance_id = ar_instance_id;
-        rq->alr_hook_action = HOOK_LOCK;
         rq->alr_hook_group = -2;
         App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, rq));
     }
@@ -1748,8 +1747,7 @@ void Actor::CalcHooks()
                             //force exceeded, reset the hook node
                             ActorLinkingRequest* rq = new ActorLinkingRequest();
                             rq->alr_actor_instance_id = ar_instance_id;
-                            rq->alr_type = ActorLinkingRequestType::HOOK_ACTION;
-                            rq->alr_hook_action = HOOK_UNLOCK;
+                            rq->alr_type = ActorLinkingRequestType::HOOK_UNLOCK;
                             App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, rq));
                         }
                     }

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -685,7 +685,7 @@ void ActorManager::ForwardCommands(ActorPtr source_actor)
                 {
                     //actor->tieToggle();
                     ActorLinkingRequest* rq = new ActorLinkingRequest();
-                    rq->alr_type = ActorLinkingRequestType::TIE_ACTION;
+                    rq->alr_type = ActorLinkingRequestType::TIE_TOGGLE;
                     rq->alr_actor_instance_id = actor->ar_instance_id;
                     rq->alr_tie_group = -1;
                     App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, rq));
@@ -695,7 +695,7 @@ void ActorManager::ForwardCommands(ActorPtr source_actor)
                 {
                     //actor->ropeToggle(-1);
                     ActorLinkingRequest* rq = new ActorLinkingRequest();
-                    rq->alr_type = ActorLinkingRequestType::ROPE_ACTION;
+                    rq->alr_type = ActorLinkingRequestType::ROPE_TOGGLE;
                     rq->alr_actor_instance_id = actor->ar_instance_id;
                     rq->alr_rope_group = -1;
                     App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, rq));
@@ -719,6 +719,20 @@ void ActorManager::ForwardCommands(ActorPtr source_actor)
             hook.hk_locked_actor->setLightStateMask(source_actor->getLightStateMask());
         }
     }
+}
+
+bool ActorManager::AreActorsDirectlyLinked(const ActorPtr& a1, const ActorPtr& a2)
+{
+    for (auto& entry: inter_actor_links)
+    {
+        auto& actor_pair = entry.second;
+        if ((actor_pair.first == a1 && actor_pair.second == a2) ||
+            (actor_pair.first == a2 && actor_pair.second == a1))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 void ActorManager::UpdateSleepingState(ActorPtr player_actor, float dt)
@@ -1070,7 +1084,7 @@ void ActorManager::UpdateActors(ActorPtr player_actor)
         {
             //player_actor->tieToggle();
             ActorLinkingRequest* rq = new ActorLinkingRequest();
-            rq->alr_type = ActorLinkingRequestType::TIE_ACTION;
+            rq->alr_type = ActorLinkingRequestType::TIE_TOGGLE;
             rq->alr_actor_instance_id = player_actor->ar_instance_id;
             rq->alr_tie_group = -1;
             App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, rq));
@@ -1081,7 +1095,7 @@ void ActorManager::UpdateActors(ActorPtr player_actor)
         {
             //player_actor->ropeToggle(-1);
             ActorLinkingRequest* rq = new ActorLinkingRequest();
-            rq->alr_type = ActorLinkingRequestType::ROPE_ACTION;
+            rq->alr_type = ActorLinkingRequestType::ROPE_TOGGLE;
             rq->alr_actor_instance_id = player_actor->ar_instance_id;
             rq->alr_rope_group = -1;
             App::GetGameContext()->PushMessage(Message(MSG_SIM_ACTOR_LINKING_REQUESTED, rq));

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -721,61 +721,6 @@ void ActorManager::ForwardCommands(ActorPtr source_actor)
     }
 }
 
-// Internal helper for future extensions
-void SyncSlaveActorWithMasterActor(const ActorPtr& slave, const ActorPtr& master)
-{
-    // Always sync the paused state
-    slave->ar_physics_paused = master->ar_physics_paused;
-
-    // Always sync skeletonview
-    slave->GetGfxActor()->SetDebugView(master->GetGfxActor()->GetDebugView());
-
-    // Sync live repair movement if requested
-    if (App::sim_soft_reset_mode->getBool())
-    {
-        slave->requestRotation(master->m_rotation_request, master->m_rotation_request_center);
-        slave->requestTranslation(master->m_translation_request);
-        slave->requestAngleSnap(master->m_anglesnap_request);
-    }
-}
-
-// internal helper for future extensions
-void ResetUnlinkedActor(const ActorPtr& loner)
-{
-    // Always unpause
-    loner->ar_physics_paused = false;
-
-    // Always disable skeletonview
-    loner->GetGfxActor()->SetDebugView(DebugViewType::DEBUGVIEW_NONE);
-}
-
-void ActorManager::SyncLinkedActors()
-{
-    // Sync shared state (debugviews, pause, repair) between linked actors
-    // Reset state of non-linked actors
-    // -------------------------------------------------------------------
-
-    // For now, we only sync state of player-driven actor with all it's linked actors
-    // TBD: Maintain a graph of master->slave relations so AI vehicles sync too.
-    if (App::GetGameContext()->GetPlayerActor())
-    {
-        for (const ActorPtr& actor : App::GetGameContext()->GetPlayerActor()->ar_linked_actors)
-        {
-            SyncSlaveActorWithMasterActor(actor, App::GetGameContext()->GetPlayerActor());
-        }
-    }
-
-    // Reset unlinked actors, except the player actor
-    for (const ActorPtr& actor: m_actors)
-    {
-        if (actor->ar_linked_actors.size() == 0
-            && actor != App::GetGameContext()->GetPlayerActor())
-        {
-            ResetUnlinkedActor(actor);
-        }
-    }
-}
-
 void ActorManager::UpdateSleepingState(ActorPtr player_actor, float dt)
 {
     if (!m_forced_awake)

--- a/source/main/physics/ActorManager.h
+++ b/source/main/physics/ActorManager.h
@@ -109,8 +109,8 @@ public:
 
     std::pair<ActorPtr, float> GetNearestActor(Ogre::Vector3 position);
 
-    // A list of all beams interconnecting two actors
     std::map<beam_t*, std::pair<ActorPtr, ActorPtr>> inter_actor_links;
+    bool AreActorsDirectlyLinked(const ActorPtr& a1, const ActorPtr& a2);
 
     static const ActorPtr ACTORPTR_NULL; // Dummy value to be returned as const reference.
 

--- a/source/main/physics/ActorManager.h
+++ b/source/main/physics/ActorManager.h
@@ -109,12 +109,8 @@ public:
 
     std::pair<ActorPtr, float> GetNearestActor(Ogre::Vector3 position);
 
-    /// @name Actor grouping
-    /// @{
     // A list of all beams interconnecting two actors
     std::map<beam_t*, std::pair<ActorPtr, ActorPtr>> inter_actor_links;
-    void SyncLinkedActors();
-    /// @}
 
     static const ActorPtr ACTORPTR_NULL; // Dummy value to be returned as const reference.
 

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -959,7 +959,7 @@ void ActorManager::RestoreSavedState(ActorPtr actor, rapidjson::Value const& j_e
             locked_actor < (int)actors.size() &&
             actors[locked_actor] != nullptr)
         {
-            actor->AddInterActorBeam(&actor->ar_beams[i], actor, actors[locked_actor]);
+            actor->AddInterActorBeam(&actor->ar_beams[i], actors[locked_actor], ActorLinkingRequestType::LOAD_SAVEGAME); // OK to be invoked here - RestoreSavedState() - processing MSG_SIM_MODIFY_ACTOR_REQUESTED
         }
     }
 

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -61,18 +61,6 @@ enum class ExtCameraMode
     NODE    = 2,
 };
 
-/// @addtogroup Gameplay
-/// @{
-
-enum HookAction
-{
-    HOOK_LOCK=0,
-    HOOK_UNLOCK,
-    HOOK_TOGGLE,
-    MOUSE_HOOK_TOGGLE,
-};
-
-/// @}
 
 /// @addtogroup Physics
 /// @{
@@ -852,10 +840,21 @@ struct ActorModifyRequest
 enum class ActorLinkingRequestType
 {
     INVALID,
-    HOOK_ACTION,
-    TIE_ACTION,
-    ROPE_ACTION,
-    SLIDENODE_ACTION
+    LOAD_SAVEGAME,
+    // hookToggle()
+    HOOK_LOCK,
+    HOOK_UNLOCK,
+    HOOK_TOGGLE,
+    HOOK_MOUSE_TOGGLE,
+    HOOK_RESET,
+    // tieToggle()
+    TIE_TOGGLE,
+    TIE_RESET,
+    // ropeToggle()
+    ROPE_TOGGLE,
+    ROPE_RESET,
+    // toggleSlideNodeLock()
+    SLIDENODE_TOGGLE
 };
 
 /// Estabilishing a physics linkage between 2 actors modifies a global linkage table
@@ -867,7 +866,6 @@ struct ActorLinkingRequest
     ActorLinkingRequestType alr_type = ActorLinkingRequestType::INVALID;
     // hookToggle()
     int alr_hook_group = -1;
-    HookAction alr_hook_action;
     NodeNum_t alr_hook_mousenode = NODENUM_INVALID;
     // tieToggle()
     int alr_tie_group = -1;

--- a/source/main/scripting/bindings/ScriptEventsAngelscript.cpp
+++ b/source/main/scripting/bindings/ScriptEventsAngelscript.cpp
@@ -65,6 +65,8 @@ void RoR::RegisterScriptEvents(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("scriptEvents", "SE_GENERIC_EXCEPTION_CAUGHT", SE_GENERIC_EXCEPTION_CAUGHT); ROR_ASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_GENERIC_MODCACHE_ACTIVITY", SE_GENERIC_MODCACHE_ACTIVITY); ROR_ASSERT(result>=0);
 
+    result = engine->RegisterEnumValue("scriptEvents", "SE_GENERIC_TRUCK_LINKING_CHANGED", SE_GENERIC_TRUCK_LINKING_CHANGED); ROR_ASSERT(result>=0);
+
     result = engine->RegisterEnumValue("scriptEvents", "SE_ALL_EVENTS", SE_ALL_EVENTS); ROR_ASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_NO_EVENTS", SE_NO_EVENTS); ROR_ASSERT(result>=0);
 

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -550,6 +550,13 @@ void TerrainGeometryManager::SetupBlendMaps(OTCPage& page, Ogre::Terrain* terrai
 {
     const int layerCount = terrain->getLayerCount();
     auto layer_def_itor = page.layers.begin();
+
+    if (page.layers.size() < 2)
+    {
+        LOG(fmt::format("[RoR|Terrain] Page {}-{} has no blend layers defined, blendmap will not be set up.", page.pos_x, page.pos_z));
+        return;
+    }
+
     ++layer_def_itor;
     for (int i = 1; i < layerCount; i++)
     {


### PR DESCRIPTION
Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/3105.

This was quite an endeavor - it turned out there's no single spot to correctly reset the physics pausd state (or skeletonview state - related). While researching how to add it, I realized scripts may want to know when (un)linking of actors happens, so I added a script event `SE_GENERIC_TRUCK_LINKING_CHANGED` for it.

**What changed:** code changed signifficantly; all data remained the same - code handling hooks/ties/ropes/slidenodes got only cosmetic edits. There are many new sanity/integrity checks in the (un)linking logic which will trigger Asserts on Debug and just prevent damage on Release.

**What to test:** Operation of ties/hooks/ropes/slidenodes, including savegame and abrupt deleting of one of the actors.

