### PR TITLE
Collision perf: brute force per-actor lookup

### DIFF
--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -40,11 +40,8 @@ namespace RoR
     typedef int ScriptUnitId_t; //!< Unique sequentially generated ID of a loaded and running scriptin session. Use `ScriptEngine::getScriptUnit()`
     static const ScriptUnitId_t SCRIPTUNITID_INVALID = -1;
 
-    typedef int PointidID_t; //!< index to `PointColDetector::hit_pointid_list`, use `RoR::POINTIDID_INVALID` as empty value.
-    static const PointidID_t POINTIDID_INVALID = -1;
-
-    typedef int RefelemID_t; //!< index to `PointColDetector::m_ref_list`, use `RoR::REFELEMID_INVALID` as empty value.
-    static const RefelemID_t REFELEMID_INVALID = -1;
+    typedef int ColPointID_t; //!< index to `PointColDetector::contactable_point_pool`, use `RoR::COLPOINTID_INVALID` as empty value.
+    static const ColPointID_t COLPOINTID_INVALID = -1;
 
     typedef int CacheEntryID_t; //!< index to `CacheSystem::m_cache_entries`, use `RoR::CACHEENTRYNUM_INVALID` as empty value.
     static const CacheEntryID_t CACHEENTRYID_INVALID = -1;

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -101,6 +101,8 @@ namespace RoR
     struct GuiManagerImpl;
     class  HydraxWater;
     class  InputEngine;
+    class  InterPointColDetector;
+    class  IntraPointColDetector;
     class  IWater;
     class  Landusemap;
     class  LanguageEngine;

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -40,9 +40,6 @@ namespace RoR
     typedef int ScriptUnitId_t; //!< Unique sequentially generated ID of a loaded and running scriptin session. Use `ScriptEngine::getScriptUnit()`
     static const ScriptUnitId_t SCRIPTUNITID_INVALID = -1;
 
-    typedef int ColPointID_t; //!< index to `PointColDetector::contactable_point_pool`, use `RoR::COLPOINTID_INVALID` as empty value.
-    static const ColPointID_t COLPOINTID_INVALID = -1;
-
     typedef int CacheEntryID_t; //!< index to `CacheSystem::m_cache_entries`, use `RoR::CACHEENTRYNUM_INVALID` as empty value.
     static const CacheEntryID_t CACHEENTRYID_INVALID = -1;
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -938,12 +938,13 @@ Vector3 Actor::calculateCollisionOffset(Vector3 direction)
                     node_t* na = &actor->ar_nodes[actor->ar_cabs[tmpv + 1]];
                     node_t* nb = &actor->ar_nodes[actor->ar_cabs[tmpv + 2]];
 
-                    m_intra_point_col_detector->query(no->AbsPosition - collision_offset,
+                    collision = m_intra_point_col_detector->QueryCollisionsWithAllPartners(
+                        no->AbsPosition - collision_offset,
                         na->AbsPosition - collision_offset,
                         nb->AbsPosition - collision_offset,
                         actor->ar_collision_range * 3.0f);
 
-                    if (collision = !m_intra_point_col_detector->hit_list.empty())
+                    if (collision)
                         break;
                 }
 
@@ -988,12 +989,13 @@ Vector3 Actor::calculateCollisionOffset(Vector3 direction)
                 node_t* na = &ar_nodes[ar_cabs[tmpv + 1]];
                 node_t* nb = &ar_nodes[ar_cabs[tmpv + 2]];
 
-                m_inter_point_col_detector->query(no->AbsPosition + collision_offset,
+                collision = m_inter_point_col_detector->QueryCollisionsWithAllPartners(
+                    no->AbsPosition + collision_offset,
                     na->AbsPosition + collision_offset,
                     nb->AbsPosition + collision_offset,
                     ar_collision_range * 3.0f);
 
-                if (collision = !m_inter_point_col_detector->hit_list.empty())
+                if (collision)
                     break;
             }
         }

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -533,8 +533,8 @@ private:
     int               m_num_proped_wheels = 0;          //!< Physics attr, filled at spawn - Number of propelled wheels.
     float             m_avg_proped_wheel_radius = 0.f;    //!< Physics attr, filled at spawn - Average proped wheel radius.
     float             m_avionic_chatter_timer = 11.f;      //!< Sound fx state (some pseudo random number,  doesn't matter)
-    PointColDetector* m_inter_point_col_detector = nullptr;   //!< Physics
-    PointColDetector* m_intra_point_col_detector = nullptr;   //!< Physics
+    InterPointColDetector* m_inter_point_col_detector = nullptr;   //!< Physics
+    IntraPointColDetector* m_intra_point_col_detector = nullptr;   //!< Physics
     
     Ogre::Vector3     m_avg_node_position = Ogre::Vector3::ZERO;          //!< average node position
     Ogre::Real        m_min_camera_radius = 0.f;

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -370,12 +370,12 @@ void ActorSpawner::InitializeRig()
 
     if (!App::sim_no_collisions->getBool())
     {
-        m_actor->m_inter_point_col_detector = new PointColDetector(m_actor);
+        m_actor->m_inter_point_col_detector = new InterPointColDetector(m_actor);
     }
 
     if (!App::sim_no_self_collisions->getBool())
     {
-        m_actor->m_intra_point_col_detector = new PointColDetector(m_actor);
+        m_actor->m_intra_point_col_detector = new IntraPointColDetector(m_actor);
     }
 
     m_actor->ar_submesh_ground_model = App::GetGameContext()->GetTerrain()->GetCollisions()->defaultgm;

--- a/source/main/physics/collision/DynamicCollisions.cpp
+++ b/source/main/physics/collision/DynamicCollisions.cpp
@@ -147,9 +147,9 @@ void RoR::ResolveInterActorCollisions(const float dt, PointColDetector &interPoi
             const Triangle triangle(na->AbsPosition, nb->AbsPosition, no->AbsPosition);
             const CartesianToTriangleTransform transform(triangle);
 
-            for (PointidID_t i_hit : interPointCD.hit_list)
+            for (ColPointID_t i_hit : interPointCD.hit_list)
             {
-                const PointColDetector::pointid_t& h = interPointCD.hit_pointid_list[i_hit];
+                const PointColDetector::ColPoint& h = interPointCD.contactable_point_pool[i_hit];
                 const ActorPtr& hit_actor = App::GetGameContext()->GetActorManager()->GetActorById(h.actorid);
                 node_t& hitnode = hit_actor->ar_nodes[h.nodenum];
 
@@ -236,9 +236,9 @@ void RoR::ResolveIntraActorCollisions(const float dt, PointColDetector &intraPoi
             const Triangle triangle(na->AbsPosition, nb->AbsPosition, no->AbsPosition);
             const CartesianToTriangleTransform transform(triangle);
 
-            for (PointidID_t i_hit : intraPointCD.hit_list)
+            for (ColPointID_t i_hit : intraPointCD.hit_list)
             {
-                const PointColDetector::pointid_t& h = intraPointCD.hit_pointid_list[i_hit];
+                const PointColDetector::ColPoint& h = intraPointCD.contactable_point_pool[i_hit];
                 const ActorPtr& hit_actor = App::GetGameContext()->GetActorManager()->GetActorById(h.actorid);
                 node_t& hitnode = hit_actor->ar_nodes[h.nodenum];
 

--- a/source/main/physics/collision/DynamicCollisions.h
+++ b/source/main/physics/collision/DynamicCollisions.h
@@ -32,13 +32,13 @@ namespace RoR {
 /// @addtogroup Collisions
 /// @{
 
-void ResolveInterActorCollisions(const float dt, PointColDetector &interPointCD,
+void ResolveInterActorCollisions(const float dt, InterPointColDetector &interPointCD,
         const int free_collcab, int collcabs[], int cabs[],
         collcab_rate_t inter_collcabrate[], node_t nodes[],
         const float collrange,
         ground_model_t &submesh_ground_model);
 
-void ResolveIntraActorCollisions(const float dt, PointColDetector &intraPointCD,
+void ResolveIntraActorCollisions(const float dt, IntraPointColDetector &intraPointCD,
         const int free_collcab, int collcabs[], int cabs[],
         collcab_rate_t intra_collcabrate[], node_t nodes[],
         const float collrange,

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -152,7 +152,6 @@ void PointColDetector::query(const Vector3 &vec1, const Vector3 &vec2, const Vec
     m_bbmax += enlargeBB;
 
     hit_list.clear();
-    hit_list_actorset.clear();
     queryrec(0, 0);
 }
 
@@ -173,7 +172,6 @@ void PointColDetector::queryrec(int kdindex, int axis)
                 point[2] >= m_bbmin.z && point[2] <= m_bbmax.z)
             {
                 hit_list.push_back(m_ref_list[m_kdtree[kdindex].refid].pidrefid);
-                hit_list_actorset.insert(hit_pointid_list[m_ref_list[m_kdtree[kdindex].refid].pidrefid].actorid);
             }
             return;
         }

--- a/source/main/physics/collision/PointColDetector.cpp
+++ b/source/main/physics/collision/PointColDetector.cpp
@@ -42,10 +42,6 @@ void PointColDetector::UpdateIntraPoint(bool contactables)
     {
         refresh_node_positions();
     }
-
-    m_kdtree[0].refid = REFELEMID_INVALID;
-    m_kdtree[0].begin = 0;
-    m_kdtree[0].end = -m_object_list_size;
 }
 
 void PointColDetector::UpdateInterPoint(bool ignorestate)
@@ -88,19 +84,16 @@ void PointColDetector::UpdateInterPoint(bool ignorestate)
     {
         refresh_node_positions();
     }
-
-    m_kdtree[0].refid = REFELEMID_INVALID;
-    m_kdtree[0].begin = 0;
-    m_kdtree[0].end = -m_object_list_size;
 }
 
 void PointColDetector::update_structures_for_contacters(bool ignoreinternal)
 {
-    m_ref_list.resize(m_object_list_size);
-    hit_pointid_list.resize(m_object_list_size);
+    // Insert all contacters into the list of points to consider for collision.
+    // ------------------------------------------------------------------------
 
-    // Insert all contacters into the list of points to consider when building the kdtree
-    int refi = 0;
+    contactable_point_pool.resize(m_object_list_size);
+
+    ColPointID_t refi = 0;
     for (ActorInstanceID_t actorid : m_collision_partners)
     {
         const ActorPtr& actor = App::GetGameContext()->GetActorManager()->GetActorById(actorid);
@@ -111,246 +104,52 @@ void PointColDetector::update_structures_for_contacters(bool ignoreinternal)
         {
             if (actor->ar_nodes[i].nd_contacter || (!internal_collision && actor->ar_nodes[i].nd_contactable))
             {
-                hit_pointid_list[refi].actorid = actor->ar_instance_id;
-                hit_pointid_list[refi].nodenum = static_cast<NodeNum_t>(i);
-                m_ref_list[refi].pidrefid = refi;
-                m_ref_list[refi].setPoint(actor->ar_nodes[i].AbsPosition);
+                contactable_point_pool[refi].actorid = actor->ar_instance_id;
+                contactable_point_pool[refi].nodenum = static_cast<NodeNum_t>(i);
+                contactable_point_pool[refi].nodepos = actor->ar_nodes[i].AbsPosition;
                 refi++;
             }
         }
     }
-
-    m_kdtree.resize(std::max(1.0, std::pow(2, std::ceil(std::log2(m_object_list_size)) + 1)));
 }
 
 void PointColDetector::query(const Vector3 &vec1, const Vector3 &vec2, const Vector3 &vec3, float enlargeBB)
 {
-    m_bbmin = vec1;
-
-    m_bbmin.x = std::min(vec2.x, m_bbmin.x);
-    m_bbmin.x = std::min(vec3.x, m_bbmin.x);
-
-    m_bbmin.y = std::min(vec2.y, m_bbmin.y);
-    m_bbmin.y = std::min(vec3.y, m_bbmin.y);
-
-    m_bbmin.z = std::min(vec2.z, m_bbmin.z);
-    m_bbmin.z = std::min(vec3.z, m_bbmin.z);
-
-    m_bbmin -= enlargeBB;
-
-    m_bbmax = vec1;
-
-    m_bbmax.x = std::max(m_bbmax.x, vec2.x);
-    m_bbmax.x = std::max(m_bbmax.x, vec3.x);
-
-    m_bbmax.y = std::max(m_bbmax.y, vec2.y);
-    m_bbmax.y = std::max(m_bbmax.y, vec3.y);
-
-    m_bbmax.z = std::max(m_bbmax.z, vec2.z);
-    m_bbmax.z = std::max(m_bbmax.z, vec3.z);
-
-    m_bbmax += enlargeBB;
+    // Create a bounding box of the collcab and do a brute force search
+    // ----------------------------------------------------------------
+    
+    Ogre::AxisAlignedBox collcab_box;
+    collcab_box.merge(vec1);
+    collcab_box.merge(vec2);
+    collcab_box.merge(vec3);
+    collcab_box.setMinimum(collcab_box.getMinimum() - enlargeBB);
+    collcab_box.setMaximum(collcab_box.getMaximum() + enlargeBB);
 
     hit_list.clear();
-    queryrec(0, 0);
-}
-
-void PointColDetector::queryrec(int kdindex, int axis)
-{
-    for (;;)
+    for (ColPointID_t i = 0; i < m_object_list_size; i++)
     {
-        if (m_kdtree[kdindex].end < 0)
+        if (collcab_box.intersects(contactable_point_pool[i].nodepos))
         {
-            build_kdtree_incr(axis, kdindex);
+            hit_list.push_back(i);
         }
-
-        if (m_kdtree[kdindex].refid != REFELEMID_INVALID)
-        {
-            const std::array<float, 3> point = m_ref_list[m_kdtree[kdindex].refid].point;
-            if (point[0] >= m_bbmin.x && point[0] <= m_bbmax.x &&
-                point[1] >= m_bbmin.y && point[1] <= m_bbmax.y &&
-                point[2] >= m_bbmin.z && point[2] <= m_bbmax.z)
-            {
-                hit_list.push_back(m_ref_list[m_kdtree[kdindex].refid].pidrefid);
-            }
-            return;
-        }
-
-        if (m_bbmax[axis] >= m_kdtree[kdindex].middle)
-        {
-            if (m_bbmin[axis] > m_kdtree[kdindex].max)
-            {
-                return;
-            }
-
-            int newaxis = axis + 1;
-
-            if (newaxis >= 3)
-            {
-                newaxis = 0;
-            }
-
-            int newindex = kdindex + kdindex + 1;
-
-            if (m_bbmin[axis] <= m_kdtree[kdindex].middle)
-            {
-                queryrec(newindex, newaxis);
-            }
-
-            kdindex = newindex + 1;
-            axis = newaxis;
-        }
-        else
-        {
-            if (m_bbmax[axis] < m_kdtree[kdindex].min)
-            {
-                return;
-            }
-
-            kdindex = 2 * kdindex + 1;
-            axis++;
-
-            if (axis >= 3)
-            {
-                axis = 0;
-            }
-        }
-    }
-}
-
-void PointColDetector::build_kdtree_incr(int axis, int index)
-{
-    int end = -m_kdtree[index].end;
-    m_kdtree[index].end = end;
-    RefelemID_t begin = m_kdtree[index].begin;
-    RefelemID_t median;
-    int slice_size = end - begin;
-    if (slice_size != 1)
-    {
-        int newindex=index+index+1;
-        if (slice_size == 2)
-        {
-            median = begin+1;
-            if (m_ref_list[begin].point[axis] > m_ref_list[median].point[axis])
-            {
-                std::swap(m_ref_list[begin], m_ref_list[median]);
-            }
-
-            m_kdtree[index].min = m_ref_list[begin].point[axis];
-            m_kdtree[index].max = m_ref_list[median].point[axis];
-            m_kdtree[index].middle = m_kdtree[index].max;
-            m_kdtree[index].refid = REFELEMID_INVALID;
-
-            axis++;
-            if (axis >= 3)
-            {
-                axis = 0;
-            }
-
-            m_kdtree[newindex].refid = begin;
-            m_kdtree[newindex].middle = m_ref_list[m_kdtree[newindex].refid].point[axis];
-            m_kdtree[newindex].min = m_kdtree[newindex].middle;
-            m_kdtree[newindex].max = m_kdtree[newindex].middle;
-            m_kdtree[newindex].end = median;
-            newindex++;
-
-            m_kdtree[newindex].refid = median;
-            m_kdtree[newindex].middle = m_ref_list[m_kdtree[newindex].refid].point[axis];
-            m_kdtree[newindex].min = m_kdtree[newindex].middle;
-            m_kdtree[newindex].max = m_kdtree[newindex].middle;
-            m_kdtree[newindex].end = end;
-            return;
-        }
-        else
-        {
-            median = begin + (slice_size / 2);
-            partintwo(begin, median, end, axis, m_kdtree[index].min, m_kdtree[index].max);
-        }
-
-        m_kdtree[index].middle = m_ref_list[median].point[axis];
-        m_kdtree[index].refid = REFELEMID_INVALID;
-
-        m_kdtree[newindex].begin = begin;
-        m_kdtree[newindex].end = -median;
-
-        newindex++;
-        m_kdtree[newindex].begin = median;
-        m_kdtree[newindex].end = -end;
-
-    }
-    else
-    {
-        m_kdtree[index].refid = begin;
-        m_kdtree[index].middle = m_ref_list[m_kdtree[index].refid].point[axis];
-        m_kdtree[index].min = m_kdtree[index].middle;
-        m_kdtree[index].max = m_kdtree[index].middle;
-    }
-}
-
-void PointColDetector::partintwo(const int start, const int median, const int end, const int axis, float &minex, float &maxex)
-{
-    int i, j, l, m;
-    int k = median;
-    l = start;
-    m = end - 1;
-
-    float x = m_ref_list[k].point[axis];
-    while (l < m)
-    {
-        i = l;
-        j = m;
-        while (!(j < k || k < i))
-        {
-            while (m_ref_list[i].point[axis] < x)
-            {
-                i++;
-            }
-            while (x < m_ref_list[j].point[axis])
-            {
-                j--;
-            }
-
-            std::swap(m_ref_list[i], m_ref_list[j]);
-            i++;
-            j--;
-        }
-        if (j < k)
-        {
-            l = i;
-        }
-        if (k < i)
-        {
-            m = j;
-        }
-        x = m_ref_list[k].point[axis];
-    }
-
-    minex = x;
-    maxex = x;
-    for (int i = start; i < median; ++i)
-    {
-        minex = std::min(m_ref_list[i].point[axis], minex);
-    }
-    for (int i = median+1; i < end; ++i)
-    {
-        maxex = std::max(maxex, m_ref_list[i].point[axis]);
     }
 }
 
 void PointColDetector::refresh_node_positions()
 {
-    // Because the reflist contains cached node positions, we must update it on each tick.
-    // To avoid repeated lookup in actormanager, we loop actors first.
+    // Because the `contactable_point_pool` contains cached node positions, we must update it on each tick.
     // ----------------------------------------------------------------------------------
 
-    for (ActorPtr& actor: App::GetGameContext()->GetActorManager()->GetActors())
+    ActorInstanceID_t cur_actorid = ACTORINSTANCEID_INVALID;
+    ActorPtr cur_actor = nullptr;
+
+    for (ColPoint& pointid: contactable_point_pool)
     {
-        for (refelem_t& refelem: m_ref_list)
+        if (pointid.actorid != cur_actorid)
         {
-            if (hit_pointid_list[refelem.pidrefid].actorid == actor->ar_instance_id)
-            {
-                refelem.setPoint(actor->ar_nodes[hit_pointid_list[refelem.pidrefid].nodenum].AbsPosition);
-            }
+            cur_actorid = pointid.actorid;
+            cur_actor = App::GetGameContext()->GetActorManager()->GetActorById(cur_actorid);
         }
+        pointid.nodepos = cur_actor->ar_nodes[pointid.nodenum].AbsPosition;
     }
 }

--- a/source/main/physics/collision/PointColDetector.h
+++ b/source/main/physics/collision/PointColDetector.h
@@ -40,7 +40,6 @@ public:
     };
 
     std::vector<PointidID_t> hit_list;
-    std::unordered_set<ActorInstanceID_t> hit_list_actorset;
     std::vector<pointid_t> hit_pointid_list;
 
     PointColDetector(ActorPtr actor): m_actor(actor), m_object_list_size(-1) {};


### PR DESCRIPTION
To benchmark, download the attached ZIP, unpack the script to 'Documents\My Games\Rigs of Rods\scripts' and in game, type `loadscript example_game_gridSpawn.as` to console.
[example_game_gridSpawn.as.zip](https://github.com/RigsOfRods/rigs-of-rods/files/15443983/example_game_gridSpawn.as.zip)

![obrazek](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/74a964f9-abe8-45e0-9189-699392cff12e)

On my desktop with Ryzen 5 5600X (6 cores), with Release build, spawning 4X * 3Y * 10Z (total 120) busses gives me these results:
* master branch: average 3.5 FPS
* this branch: average 10 FPS

Note the biggest FPS eaters are, in order:
1. `calcFlexbody()` - depending on how many/how dense flexbodies are used
2. `CalcBeams()` - always
3. `CalcNodes()`
Collisions easily jump CalcNodes() and if it's a bigger crash, it jumps even CalcBeams(). Flexbodies are always the hungriest tho.

Suggested (with a tongue in cheek) on Discord#dev: https://discord.com/channels/136544456244461568/189904947649708032/1242063388624949339