### PR TITLE
Fixed #193 faulty/incomplete command keys on T-screen UI

### DIFF
--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -67,6 +67,9 @@ namespace RoR
     typedef int ExhaustID_t; //!< Index into `Actor::exhausts`, use `RoR::EXHAUSTID_INVALID` as empty value
     static const ExhaustID_t EXHAUSTID_INVALID = -1;
 
+    typedef int CommandkeyID_t; //!< Index into `Actor::ar_commandkeys` (BEWARE: indexed 1-MAX_COMMANDKEYS, 0 is invalid value, negative subscript of any size is acceptable, see `class CmdKeyArray` ).
+    static const CommandkeyID_t COMMANDKEYID_INVALID = 0;
+
     class  Actor;
     class  ActorManager;
     class  ActorSpawner;

--- a/source/main/gui/panels/GUI_VehicleDescription.cpp
+++ b/source/main/gui/panels/GUI_VehicleDescription.cpp
@@ -74,30 +74,19 @@ void VehicleDescription::Draw()
     if (ImGui::CollapsingHeader(_LC("VehicleDescription", "Commands"), ImGuiTreeNodeFlags_DefaultOpen))
     {
         ImGui::Columns(2, /*id=*/nullptr, /*border=*/true);
-        for (int i = 1; i <= MAX_COMMANDS; i += 2) // BEWARE: commandkeys are indexed 1-MAX_COMMANDS!
+        for (const UniqueCommandKeyPair& qpair: actor->ar_unique_commandkey_pairs)
         {
-            if (actor->ar_command_key[i].description == "hide")
-                continue;
-            if (actor->ar_command_key[i].beams.empty() && actor->ar_command_key[i].rotators.empty())
-                continue;
-
-            int eventID = RoR::InputEngine::resolveEventName(fmt::format("COMMANDS_{:02d}", i));
-            Ogre::String keya = RoR::App::GetInputEngine()->getEventCommand(eventID);
-            eventID = RoR::InputEngine::resolveEventName(fmt::format("COMMANDS_{:02d}", i + 1));
-            Ogre::String keyb = RoR::App::GetInputEngine()->getEventCommand(eventID);
-
-            // cut off expl
-            if (keya.size() > 6 && keya.substr(0, 5) == "EXPL+")
-                keya = keya.substr(5);
-            if (keyb.size() > 6 && keyb.substr(0, 5) == "EXPL+")
-                keyb = keyb.substr(5);
+            int eventID = RoR::InputEngine::resolveEventName(fmt::format("COMMANDS_{:02d}", qpair.uckp_key1));
+            Ogre::String keya = RoR::App::GetInputEngine()->getEventCommandTrimmed(eventID);
+            eventID = RoR::InputEngine::resolveEventName(fmt::format("COMMANDS_{:02d}", qpair.uckp_key2));
+            Ogre::String keyb = RoR::App::GetInputEngine()->getEventCommandTrimmed(eventID);
 
             ImGui::Text("%s/%s", keya.c_str(), keyb.c_str());
             ImGui::NextColumn();
 
-            if (!actor->ar_command_key[i].description.empty())
+            if (qpair.uckp_description != "")
             {
-                ImGui::Text("%s", actor->ar_command_key[i].description.c_str());
+                ImGui::Text("%s", qpair.uckp_description.c_str());
             }
             else
             {

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -309,6 +309,8 @@ public:
     std::vector<Ogre::AxisAlignedBox>  ar_collision_bounding_boxes; //!< smart bounding boxes, used for determining the state of an actor (every box surrounds only a subset of nodes)
     std::vector<Ogre::AxisAlignedBox>  ar_predicted_coll_bounding_boxes;
     std::map<std::string, Ogre::MaterialPtr>  ar_managed_materials;
+    std::vector<UniqueCommandKeyPair> ar_unique_commandkey_pairs; //!< UI helper for displaying command control keys to user (must be built at spawn).
+
     int               ar_num_contactable_nodes = 0; //!< Total number of nodes which can contact ground or cabs
     int               ar_num_contacters = 0; //!< Total number of nodes which can selfcontact cabs
     wheel_t           ar_wheels[MAX_WHEELS] = {};

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -3665,6 +3665,31 @@ void ActorSpawner::ProcessCommand(RigDef::Command2 & def)
 
     m_actor->m_num_command_beams++;
     m_actor->m_has_command_beams = true;
+
+    // Update the unique pair list
+    bool must_insert_qpair = true;
+    for (UniqueCommandKeyPair& qpair: m_actor->ar_unique_commandkey_pairs)
+    {
+        // seek match on both keys (in any order)
+        if ((def.contract_key == qpair.uckp_key1 && def.extend_key == qpair.uckp_key2)
+            || (def.contract_key == qpair.uckp_key2 && def.extend_key == qpair.uckp_key1))
+        {
+            must_insert_qpair = false;
+            if (def.description != "")
+            {
+                qpair.uckp_description = def.description; // Last description always wins
+            }
+            break;
+        }
+    }
+    if (must_insert_qpair)
+    {
+        UniqueCommandKeyPair qpair;
+        qpair.uckp_key1 = def.contract_key;
+        qpair.uckp_key2 = def.extend_key;
+        qpair.uckp_description = def.description;
+        m_actor->ar_unique_commandkey_pairs.push_back(qpair);
+    }
 }
 
 void ActorSpawner::ProcessAnimator(RigDef::Animator & def)

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -701,6 +701,15 @@ private:
     command_t m_dummykey;
 };
 
+/// UI helper for displaying command control keys to user.
+/// Reconstructing such list on runtime isn't possible, we must build it on spawn.
+struct UniqueCommandKeyPair
+{
+    std::string uckp_description;
+    CommandkeyID_t uckp_key1 = COMMANDKEYID_INVALID;
+    CommandkeyID_t uckp_key2 = COMMANDKEYID_INVALID;
+};
+
 /// @}
 
 // --------------------------------


### PR DESCRIPTION
Fixes #193

Test mod: [Hughes 500D helicopter](https://forum.rigsofrods.org/resources/hughes-500d.196/)

The result - the controls are actually this weird by design, see my analysis below:
![obrazek](https://github.com/RigsOfRods/rigs-of-rods/assets/491088/44c86775-7aa3-4ae9-ad23-d59404c344f6)

My analysis of the rig-def file:
```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<---------------------- TRUCK DEF ----------------------------->  //// F keys (/84) --- Description, if any        <=== comparation with UI
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

commands
set_beam_defaults 12500000, 750, 18000000, 35000000
;fuel consumption engine kill
  54,  46, 5.00, 1.000, 1.400, 39, 29, i                           //// 39 = ALT+F3 | 29 = SHIFT+F5                 <=== not shown, the closest is nonexistent "Alt+F3/Alt+F4"
  56,  48, 5.00, 1.000, 1.400, 39, 29, i                           //// 39 = ALT+F3 | 29 = SHIFT+F5                 <=== ditto
                                                                   
set_beam_defaults 2500000, 250, 18000000, 35000000                 
;dashboard trim guages                                             
 145, 148, 0.009, 0.800, 1.200, 7, 8, i                            //// F7|F8                                       <=== OK
 145, 149, 0.009, 0.800, 1.200, 3, 4, i, TRIM_Cruise_Forth/Back    //// F3|F4 --- TRIM_Cruise_Forth/Back            <=== OK
 145, 150, 0.0035, 0.800, 1.200, 6, 5, i, TRIM_Strafe_Left/Right   //// F5|F6 --- !! conflict with 'TRIM_Pivot_Left/Right' *reversed* <=== OK
                                                                   
set_beam_defaults 17500000, 750, 18000000, 35000000                
;rotorhead trims                                                   
 164, 165, 0.0026, 0.952, 1.048, 3, 4, i                           //// F3|F4 --- TRIM_Cruise_Forth/Back            <=== OK
 164, 166, 0.0026, 0.952, 1.048, 4, 3, i                           //// F4|F3 --- TRIM_Cruise_Forth/Back *reversed* <=== OK, maps to the reversed
 164, 167, 0.0026, 0.952, 1.048, 8, 7, i                           //// F8|F7                                       <=== OK, maps to the reversed           
 164, 168, 0.0026, 0.952, 1.048, 7, 8, i                           //// F7|F8                                       <=== OK
                                                                   
;rotorblade animation                                              
set_beam_defaults 15000000, 250, 18000000, 35000000                
  60,  63, 0.003, 0.982,  1.011,  1,  2, i, TRIM_Lift_Up/Down      //// F1|F2 --- TRIM_Lift_Up/Down                 <=== OK              
  60,  64, 0.003, 0.982,  1.011,  1,  2, i                         //// F1|F2 --- TRIM_Lift_Up/Down                 <=== OK
  60,  65, 0.003, 0.982,  1.011,  1,  2, i                         //// F1|F2 --- TRIM_Lift_Up/Down                 <=== OK
  60,  66, 0.003, 0.982,  1.011,  1,  2, i                         //// F1|F2 --- TRIM_Lift_Up/Down                 <=== OK
;collective stick + gauge animation                                
set_beam_defaults 2000000, 250, 18000000, 35000000                 
  19, 159, 0.00370, 0.950,  1.075,  2,  1, i                       //// F2|F1 --- TRIM_Lift_Up/Down *reversed*      <=== OK, maps to the reversed  
 145, 160, 0.00296, 0.880,  1.200,  2,  1, i                       //// F2|F1 --- TRIM_Lift_Up/Down *reversed*      <=== OK, maps to the reversed  
                                                                   
set_beam_defaults 7500000, 250, 18000000, 35000000                 
  94,  93, 0.001, 0.900,  1.100,  5,  6, i, TRIM_Pivot_Left/Right  //// F6|F5 --- !! conflict with 'TRIM_Strafe_Left/Right' *reversed* <=== OK, shown as 'TRIM_Strafe_Left/Right'
                                                                   
set_inertia_defaults 0.55, 0.55, linear linear                     
  61, 128, 0.075, 1.000, 45.000,  9, 10, r, Hook_Up/Down           //// F9|F10 --- Hook_Up/Down                     <=== OK
 128, 129, 0.075, 1.000, 45.000,  9, 10, r                         //// F9|F10 --- Hook_Up/Down                     <=== OK
 129, 130, 0.075, 1.000, 45.000,  9, 10, r                         //// F9|F10 --- Hook_Up/Down                     <=== OK
 130, 131, 0.075, 1.000, 45.000,  9, 10, r                         //// F9|F10 --- Hook_Up/Down                     <=== OK
set_inertia_defaults -1                                            
                                                                   
set_beam_defaults 3000000, 250, 18000000, 35000000                 
commands2                                                          
set_inertia_defaults 1.0, 1.0, linear linear                       
;fast rotor texture swap                                           
  41, 110, 15.000, 15.000, 0.150, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== not shown, instead there's 2 nonexistent entries, "Shift+F7/Shift+F8" and "Shift+F9/Shift+F10"
  42, 111, 15.000, 15.000, 0.150, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
  43, 112, 15.000, 15.000, 0.150, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
  44, 113, 15.000, 15.000, 0.150, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 114,  40, 15.000, 15.000, 0.025, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 115,  40, 15.000, 15.000, 0.025, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 116,  40, 15.000, 15.000, 0.025, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 117,  40, 15.000, 15.000, 0.025, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
;hook fixation                                                                
 133,  40,  0.050,  0.050, 0.900, 1.000, 10,  9, ip                           //// F10|F9 --- Hook_Up/Down *reversed*     <=== OK, maps to the reversed
                                                                              
;fast tail rotor texture swap                                                 
 118,  78,  2.500,  2.500, 0.050, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 119,  78,  2.500,  2.500, 0.050, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 126,  78,  2.500,  2.500, 0.050, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 127,  78,  2.500,  2.500, 0.050, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 120, 122,  2.500,  2.500, 0.200, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
 121, 123,  2.500,  2.500, 0.200, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
  80, 124,  2.500,  2.500, 0.200, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
  81, 125,  2.500,  2.500, 0.200, 1.000, 32, 33, ip                           //// SHIFT+F8|SHIFT+F9                      <=== ditto
set_inertia_defaults -1                                                       
set_beam_defaults 7500000, 250, 18000000, 35000000                            
;startup tail rotor trim                                                      
  94,  78,  0.100,  0.100, 0.989, 1.000, 30, 31, ci                           //// SHIFT+F6|SHIFT+F7                      <=== NOT SHOWN, instead there's nonexistent "Shift+F5/Shift+F6" and  "Shift+F7/Shift+F8"                     

set_beam_defaults 1500000, 250, 18000000, 35000000
set_inertia_defaults 0.01, 0.01, smooth smooth
;screen tilt + slide
 134, 138, 0.025, 0.025, 0.500,  1.000, 11, 12, ip, Camera-Screen_IN/OUT      //// F11|F12 --- Camera-Screen_IN/OUT       <=== OK
 135, 139, 0.025, 0.025, 0.500,  1.000, 11, 12, ip                            //// F11|F12 --- Camera-Screen_IN/OUT       <=== ditto
 136, 140, 0.025, 0.025, 0.500,  1.000, 11, 12, ip                            //// F11|F12 --- Camera-Screen_IN/OUT       <=== ditto
set_inertia_defaults 1.00, 1.00, smooth smooth                                                                            
 136, 137, 0.100, 0.200, 0.450,  1.000, 36, 37, i                             //// SHIFT+F12|ALT+F1                       <=== NOT SHOWN, the closest is nonexistent "Alt+F1/Alt+F2"
set_inertia_defaults -1

set_beam_defaults 1000000, 750, 18000000, 35000000
;fuel consumption
;speed2:  0.00025 = 40 mins burntime 
   2, 161, 0.050, 0.00025, 0.010, 400.0, 25, 26, i, Emergency_Refuel          //// SHIFT+F1|SHIFT+F2 --- Emergency_Refuel <=== OK
 161, 162, 0.050, 0.00025, 0.010, 400.0, 25, 27, i                            //// SHIFT+F1|SHIFT+F3                      <=== NOT shown, closest is nonexistent "Shift+F3/Shift+F4"
 162, 163, 0.050, 0.00025, 0.010, 400.0, 25, 28, i                            //// SHIFT+F1|SHIFT+F4                      <=== NOT shown, closest is nonexistent "Shift+F3/Shift+F4"

;fuel warn
 173,  16, 0.100, 0.100, 0.825, 1.00, 24, 25, i                               //// CTRL+F12|SHIFT+F1                      <=== Not shown, closest is nonexistent "Ctrl+F11/Ctrl+F12"
 174,  16, 0.100, 0.100, 0.825, 1.00, 23, 25, i                               //// CTRL+F11|SHIFT+F1

;overload warn
 175,  16, 0.500, 0.500, 0.700, 1.00, 22, 21, ip                              //// CTRL+F10|CTRL+F9                       <=== Shown reversed

;overspeed warn
 176,  16, 0.500, 0.500, 0.700, 1.00, 20, 19, ip                              //// CTRL+F8|CTRL+F7                        <=== Shown reversed

```