### PR TITLE
Fixed ties failing to appear if invisible hooks are present

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -3338,6 +3338,24 @@ void RoR::GfxActor::RemoveBeam(int beam_index)
     {
         if (itor->rod_beam_index == beam_index)
         {
+            // Destroy OGRE objects
+            if (itor->rod_scenenode)
+            {
+                if (itor->rod_scenenode->getAttachedObject(0))
+                {
+                    Ogre::Entity* ent = static_cast<Ogre::Entity*>(itor->rod_scenenode->getAttachedObject(0));
+                    if (ent)
+                    {
+                        ent->detachFromParent();
+                        App::GetGfxScene()->GetSceneManager()->destroyEntity(ent);
+                    }
+                }
+
+                App::GetGfxScene()->GetSceneManager()->destroySceneNode(itor->rod_scenenode);
+                itor->rod_scenenode = nullptr;
+            }
+
+            // Destroy the beam visuals
             m_gfx_beams.erase(itor);
             return;
         }

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -5703,7 +5703,7 @@ void ActorSpawner::CreateBeamVisuals(beam_t const & beam, int beam_index, bool v
         beamx.rod_target_actor = m_actor;
         beamx.rod_is_visible = false;
 
-        beamx.rod_scenenode = m_actor->m_gfx_actor->m_gfx_beams_parent_scenenode->createChildSceneNode(this->ComposeName("beam", (int)m_actor->m_gfx_actor->m_gfx_beams.size()));
+        beamx.rod_scenenode = m_actor->m_gfx_actor->m_gfx_beams_parent_scenenode->createChildSceneNode(this->ComposeName("beam", beam_index));
         beamx.rod_scenenode->attachObject(entity);
         beamx.rod_scenenode->setVisible(visible, /*cascade:*/ false);
         beamx.rod_scenenode->setScale(beam_defaults->visual_beam_diameter, -1, beam_defaults->visual_beam_diameter);


### PR DESCRIPTION
Fixes #3162

Problem introduced by myself in 965d250ff983f0b184698c2ac869f2df6381bb83 - I named beam scene nodes explicitly, but the scheme I used allowed for repetition in case beam visuals were created and then destroyed again during spawn. Unfortunately, for 'hooks' we don't know the visibility flags beforehand so we must always create visuals and then delete them if not desirable.

Changes:
- ActorSpawner.cpp - function `CreateBeamVisuals()` - generate name based on unique beam number instead of the visual count.
- GfxActor.cpp - function `RemoveBeam()` - properly dispose all OGRE objects when deleting beam visuals.