### PR TITLE
PROOF OF CONCEPT: reinit rendering after conf change

### DIFF
--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -473,6 +473,7 @@ void AppContext::ReinitRendering()
     m_overlay_system = nullptr;
 
     LOG("[RoR|Rendering] Reinitializing rendering system: destroying scene manager");
+    App::GetGfxScene()->GetEnvMap().ShutdownEnvMap();
     App::GetGfxScene()->Shutdown();
 
     LOG("[RoR|Rendering] Reinitializing rendering system: destroying camera manager");
@@ -498,7 +499,6 @@ void AppContext::ReinitRendering()
     this->SetUpOverlaySystem();
 
     LOG("[RoR|Rendering] Reinitializing rendering system: create manual resources");
-    // BEGIN copypasta
     Ogre::ConfigOptionMap ropts = App::GetAppContext()->GetOgreRoot()->getRenderSystem()->getConfigOptions();
     int resolution = Ogre::StringConverter::parseInt(Ogre::StringUtil::split(ropts["Video Mode"].currentValue, " x ")[0], 1024);
     int fsaa = 2 * (Ogre::StringConverter::parseInt(ropts["FSAA"].currentValue, 0) / 4);
@@ -558,6 +558,8 @@ void AppContext::ReinitRendering()
 
     LOG("[RoR|Rendering] Reinitializing rendering system: setting up menu wallpaper");
     App::GetGuiManager()->SetUpMenuWallpaper();
+
+    App::GetGameContext()->PushMessage(Message(MSG_APP_MODCACHE_LOAD_REQUESTED));
 }
 
 // --------------------------

--- a/source/main/AppContext.h
+++ b/source/main/AppContext.h
@@ -31,6 +31,7 @@
 
 #include <Bites/OgreWindowEventUtilities.h>
 #include <Ogre.h>
+#include <OgreOverlaySystem.h>
 #include <OIS.h>
 
 namespace RoR {
@@ -52,6 +53,7 @@ public:
     void                 SetUpLogging();
     bool                 SetUpResourcesDir();
     bool                 SetUpRendering();
+    void                 SetUpOverlaySystem();
     bool                 SetUpConfigSkeleton();
     bool                 SetUpInput();
     void                 SetUpObsoleteConfMarker();
@@ -60,11 +62,13 @@ public:
     Ogre::RenderWindow*  CreateCustomRenderWindow(std::string const& name, int width, int height);
     void                 CaptureScreenshot();
     void                 ActivateFullscreen(bool val);
+    void                 ReinitRendering();
 
     // Getters
     Ogre::Root*          GetOgreRoot() { return m_ogre_root; }
     Ogre::Viewport*      GetViewport() { return m_viewport; }
     Ogre::RenderWindow*  GetRenderWindow() { return m_render_window; }
+    Ogre::OverlaySystem* GetOverlaySystem() { return m_overlay_system; }
     RoR::ForceFeedback&  GetForceFeedback() { return m_force_feedback; }
     std::thread::id      GetMainThreadID() { return m_mainthread_id; }
 
@@ -97,6 +101,7 @@ private:
     Ogre::Root*          m_ogre_root     = nullptr;
     Ogre::RenderWindow*  m_render_window = nullptr;
     Ogre::Viewport*      m_viewport      = nullptr;
+    Ogre::OverlaySystem* m_overlay_system = nullptr;
     bool                 m_windowed_fix = false; //!< Workaround OGRE glitch when switching from fullscreen.
 
     std::time_t          m_prev_screenshot_time;

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -325,12 +325,6 @@ void CreateCameraManager()
     g_camera_manager = new CameraManager();
 }
 
-void CreateGfxScene()
-{
-    ROR_ASSERT(!g_gfx_scene.GetSceneManager());
-    g_gfx_scene.Init();
-}
-
 void CreateSoundScriptManager()
 {
 #if USE_OPENAL
@@ -352,6 +346,30 @@ void DestroyOverlayWrapper()
 {
     delete g_overlay_wrapper;
     g_overlay_wrapper = nullptr;
+}
+
+void DestroyCameraManager()
+{
+    delete g_camera_manager;
+    g_camera_manager = nullptr;
+}
+
+void DestroySoundScriptManager()
+{
+    delete g_sound_script_manager;
+    g_sound_script_manager = nullptr;
+}
+
+void DestroyGuiManager()
+{
+    delete g_gui_manager;
+    g_gui_manager = nullptr;
+}
+
+void DestroyInputEngine()
+{
+    delete g_input_engine;
+    g_input_engine = nullptr;
 }
 
 } // namespace App

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -85,6 +85,7 @@ enum MsgType
     MSG_APP_LOAD_SCRIPT_REQUESTED,         //!< Payload = RoR::LoadScriptRequest* (owner)
     MSG_APP_UNLOAD_SCRIPT_REQUESTED,       //!< Payload = RoR::ScriptUnitId_t* (owner)
     MSG_APP_SCRIPT_THREAD_STATUS,          //!< Payload = RoR::ScriptEventArgs* (owner)
+    MSG_APP_REINIT_RENDERER_REQUESTED,
     // Networking
     MSG_NET_CONNECT_REQUESTED,
     MSG_NET_CONNECT_STARTED,
@@ -518,7 +519,6 @@ void CreateInputEngine();
 void CreateMumble();
 void CreateThreadPool();
 void CreateCameraManager();
-void CreateGfxScene();
 void CreateSoundScriptManager();
 void CreateScriptEngine();
 
@@ -527,6 +527,10 @@ void SetCacheSystem          (CacheSystem*       obj);
 
 // Cleanups
 void DestroyOverlayWrapper();
+void DestroyCameraManager();
+void DestroySoundScriptManager();
+void DestroyGuiManager();
+void DestroyInputEngine();
 
 } // namespace App
 

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -191,7 +191,7 @@ void RoR::GfxEnvmap::SetupEnvMap()
     }
 }
 
-RoR::GfxEnvmap::~GfxEnvmap()
+void RoR::GfxEnvmap::ShutdownEnvMap()
 {
     for (int face = 0; face < NUM_FACES; face++)
     {

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -35,10 +35,10 @@ class GfxEnvmap
 public:
 
     GfxEnvmap();
-    ~GfxEnvmap();
 
     void SetupEnvMap();
     void UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, bool full = false);
+    void ShutdownEnvMap();
 
 private:
 

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -87,6 +87,15 @@ void GfxScene::Init()
     m_skidmark_conf.LoadDefaultSkidmarkDefs();
 }
 
+void GfxScene::Shutdown()
+{
+    if (m_scene_manager)
+    {
+        App::GetAppContext()->GetOgreRoot()->destroySceneManager(m_scene_manager);
+        m_scene_manager = nullptr;
+    }
+}
+
 void GfxScene::UpdateScene(float dt_sec)
 {
     // Actors - start threaded tasks

--- a/source/main/gfx/GfxScene.h
+++ b/source/main/gfx/GfxScene.h
@@ -46,7 +46,12 @@ class GfxScene
 {
 public:
 
+    /// @name Lifetime
+    /// @{
     void           Init();
+    void           Shutdown();
+    /// @}
+
     void           CreateDustPools();
     DustPool*      GetDustPool(const char* name);
     void           SetParticlesVisible(bool visible);

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -107,6 +107,12 @@ void GUIManager::ShutdownMyGUI()
     }
 }
 
+void GUIManager::ShutdownImGui()
+{
+    App::GetGfxScene()->GetSceneManager()->removeRenderQueueListener(&m_imgui);
+    m_imgui.Shutdown();
+}
+
 void GUIManager::ApplyGuiCaptureKeyboard()
 {
     m_gui_kb_capture_requested = m_gui_kb_capture_queued;

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -148,6 +148,7 @@ public:
     void SetSceneManagerForGuiRendering(Ogre::SceneManager* scene_manager);
 
     void ShutdownMyGUI();
+    void ShutdownImGui();
     void SetMouseCursorVisibility(MouseCursorVisibility visi);
     void UpdateMouseCursorVisibility();
     void SupressCursor(bool do_supress);

--- a/source/main/gui/imgui/OgreImGui.cpp
+++ b/source/main/gui/imgui/OgreImGui.cpp
@@ -86,6 +86,12 @@ void OgreImGui::Init()
     m_imgui_overlay->show();
 }
 
+void OgreImGui::Shutdown()
+{
+    m_imgui_overlay->hide();
+    m_imgui_overlay = nullptr;
+}
+
 void OgreImGui::InjectMouseMoved( const OIS::MouseEvent &arg )
 {
 

--- a/source/main/gui/imgui/OgreImGui.h
+++ b/source/main/gui/imgui/OgreImGui.h
@@ -55,6 +55,7 @@ class OgreImGui: public Ogre::RenderQueueListener
 {
 public:
     void Init();
+    void Shutdown();
 
     // Input-injecting functions
     void InjectMouseMoved( const OIS::MouseEvent &arg );

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -156,6 +156,7 @@ void GameSettings::DrawRenderSystemSettings()
             if (rs->validateConfigOptions().empty())
             {
                 ogre_root->saveConfig();
+                App::GetGameContext()->PushMessage(Message(MSG_APP_REINIT_RENDERER_REQUESTED));
             }
         }
     }

--- a/source/main/gui/panels/GUI_GameSettings.h
+++ b/source/main/gui/panels/GUI_GameSettings.h
@@ -62,6 +62,9 @@ private:
     std::string m_combo_items_water_mode;
     std::string m_combo_items_extcam_mode;
     std::string m_combo_items_input_grab;
+
+    // Renderer settings
+    bool m_render_settings_changed = false;
 };
 
 } // namespace GUI

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -412,11 +412,8 @@ int main(int argc, char *argv[])
                 {
                     try
                     {
-                        if (!App::GetCacheSystem()->IsModCacheLoaded()) // If not already loaded...
-                        {
-                            App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
-                            App::GetContentManager()->InitModCache(CacheValidity::UNKNOWN);
-                        }
+                        App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
+                        App::GetContentManager()->InitModCache(CacheValidity::UNKNOWN);
                     }
                     catch (...)
                     {
@@ -887,6 +884,9 @@ int main(int argc, char *argv[])
                     catch (...)
                     {
                         HandleMsgQueueException(m.type);
+                        App::GetGuiManager()->LoadingWindow.SetVisible(false);
+                        App::GetGuiManager()->GameMainMenu.SetVisible(true);
+                        App::GetGuiManager()->ShowMessageBox(_L("Internal error"), _L("Internal error while loading terrain, see RoR.log"));
                     }
                     break;
                 }


### PR DESCRIPTION
When you go to {Main Menu / Game Settings / Render System} and change resolution, the game will immediatelly reopen the rendering window, load all resources (they become invalid) and start rendering again with the new settings.

Only works smoothly if you start game, do the change and then exit game. Entering simulation before/after causes crashes, hangs and other weird stuff.

I had to duplicate most of our startup code to get this to work, RoR wasn't written with renderer reinit in mind.