### PR TITLE
Autodetect highest resolution on first run

### DIFF
--- a/doc/angelscript/Script2Game/globals.h
+++ b/doc/angelscript/Script2Game/globals.h
@@ -614,6 +614,7 @@ enum MsgType
     MSG_APP_MODCACHE_PURGE_REQUESTED,          //!< Request cleanup and full rebuild of mod cache.
     MSG_APP_LOAD_SCRIPT_REQUESTED,             //!< Request loading a script from resource(file) or memory; Params 'filename' (string)/'buffer'(string - has precedence over filename), 'category' (ScriptCategory), 'associated_actor' (int - only for SCRIPT_CATEGORY_ACTOR)
     MSG_APP_UNLOAD_SCRIPT_REQUESTED,           //!< Request unloading a script; Param 'id' (int - the ID of the script unit, see 'Script Monitor' tab in console UI.)   
+    MSG_APP_REINIT_INPUT_REQUESTED,            //!< Request restarting the entire input subsystem (mouse, keyboard, controllers) including reloading input mappings. Use with caution.
     // Networking
     MSG_NET_CONNECT_REQUESTED,                 //!< Request connection to multiplayer server specified by cvars 'mp_server_host, mp_server_port, mp_server_password'. No params.
     MSG_NET_CONNECT_STARTED,                   //!< Networking notification, DO NOT PUSH MANUALLY.

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -354,6 +354,12 @@ void DestroyOverlayWrapper()
     g_overlay_wrapper = nullptr;
 }
 
+void DestroyInputEngine()
+{
+    delete g_input_engine;
+    g_input_engine = nullptr;
+}
+
 } // namespace App
 
 // ------------------------------------------------------------------------------------------------
@@ -562,6 +568,7 @@ const char* MsgTypeToString(MsgType type)
     case MSG_APP_LOAD_SCRIPT_REQUESTED        : return "MSG_APP_LOAD_SCRIPT_REQUESTED";  
     case MSG_APP_UNLOAD_SCRIPT_REQUESTED      : return "MSG_APP_UNLOAD_SCRIPT_REQUESTED";
     case MSG_APP_SCRIPT_THREAD_STATUS         : return "MSG_APP_SCRIPT_THREAD_STATUS";   
+    case MSG_APP_REINIT_INPUT_REQUESTED       : return "MSG_APP_REINIT_INPUT_REQUESTED";
 
     case MSG_NET_CONNECT_REQUESTED            : return "MSG_NET_CONNECT_REQUESTED";
     case MSG_NET_CONNECT_STARTED              : return "MSG_NET_CONNECT_STARTED";

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -85,6 +85,7 @@ enum MsgType
     MSG_APP_LOAD_SCRIPT_REQUESTED,         //!< Payload = RoR::LoadScriptRequest* (owner)
     MSG_APP_UNLOAD_SCRIPT_REQUESTED,       //!< Payload = RoR::ScriptUnitId_t* (owner)
     MSG_APP_SCRIPT_THREAD_STATUS,          //!< Payload = RoR::ScriptEventArgs* (owner)
+    MSG_APP_REINIT_INPUT_REQUESTED,
     // Networking
     MSG_NET_CONNECT_REQUESTED,
     MSG_NET_CONNECT_STARTED,
@@ -525,11 +526,9 @@ void CreateGfxScene();
 void CreateSoundScriptManager();
 void CreateScriptEngine();
 
-// Setters
-void SetCacheSystem          (CacheSystem*       obj);
-
 // Cleanups
 void DestroyOverlayWrapper();
+void DestroyInputEngine();
 
 } // namespace App
 

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -449,8 +449,16 @@ void GameSettings::DrawControlSettings()
 {
     ImGui::TextDisabled("%s", _LC("GameSettings", "Controller options"));
 
-    DrawGCombo(App::io_input_grab_mode, _LC("GameSettings", "Input grab mode"),
-        m_combo_items_input_grab.c_str());
+    IoInputGrabMode io_input_grab_mode_old = App::io_input_grab_mode->getEnum<IoInputGrabMode>();
+    DrawGCombo(App::io_input_grab_mode, _LC("GameSettings", "Input grab mode"), m_combo_items_input_grab.c_str());
+    if (io_input_grab_mode_old != App::io_input_grab_mode->getEnum<IoInputGrabMode>())
+    {
+        App::GetGameContext()->PushMessage(Message(MSG_APP_REINIT_INPUT_REQUESTED));
+        // This may take a second - display a 'please wait' box
+        App::GetGuiManager()->LoadingWindow.SetProgress(
+            App::GetGuiManager()->LoadingWindow.PERC_HIDE_PROGRESSBAR, 
+            _LC("GameSettings", "Restarting input subsystem, please wait..."), /*render_frame:*/false);
+    }
 
     DrawGFloatSlider(App::io_analog_smoothing,   _LC("GameSettings", "Analog Input Smoothing"),   0.5f, 2.0f);
     DrawGFloatSlider(App::io_analog_sensitivity, _LC("GameSettings", "Analog Input Sensitivity"), 0.5f, 2.0f);

--- a/source/main/gui/panels/GUI_GameSettings.h
+++ b/source/main/gui/panels/GUI_GameSettings.h
@@ -44,6 +44,7 @@ private:
 
     // GUI state
     bool m_is_visible = false;
+    ImVec2 m_window_size = ImVec2(0, 0);
 
     // Buffers for text input boxes
     Str<1000> m_buf_diag_preset_terrain;
@@ -62,6 +63,10 @@ private:
     std::string m_combo_items_water_mode;
     std::string m_combo_items_extcam_mode;
     std::string m_combo_items_input_grab;
+
+    // Render settings
+    bool m_render_must_restart = false;
+    float m_bump_height = 0.0f;
 };
 
 } // namespace GUI

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -514,6 +514,23 @@ int main(int argc, char *argv[])
                     break;
                 }
 
+                case MSG_APP_REINIT_INPUT_REQUESTED:
+                {
+                    try
+                    {
+                        LOG(fmt::format("[RoR] !! Reinitializing input engine !!"));
+                        App::DestroyInputEngine();
+                        App::GetAppContext()->SetUpInput();
+                        LOG(fmt::format("[RoR] DONE Reinitializing input engine."));
+                        App::GetGuiManager()->LoadingWindow.SetVisible(false); // Shown by `GUI::GameSettings` when changing 'grab mode'
+                    }
+                    catch (...)
+                    {
+                        HandleMsgQueueException(m.type);
+                    }
+                    break;
+                }
+
                 // -- Network events --
 
                 case MSG_NET_CONNECT_REQUESTED:

--- a/source/main/scripting/bindings/MsgQueueAngelscript.cpp
+++ b/source/main/scripting/bindings/MsgQueueAngelscript.cpp
@@ -47,6 +47,7 @@ void RoR::RegisterMessageQueue(asIScriptEngine* engine)
     result = engine->RegisterEnumValue("MsgType", "MSG_APP_LOAD_SCRIPT_REQUESTED", MSG_APP_LOAD_SCRIPT_REQUESTED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("MsgType", "MSG_APP_UNLOAD_SCRIPT_REQUESTED", MSG_APP_UNLOAD_SCRIPT_REQUESTED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("MsgType", "MSG_APP_SCRIPT_THREAD_STATUS", MSG_APP_SCRIPT_THREAD_STATUS); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("MsgType", "MSG_APP_REINIT_INPUT_REQUESTED", MSG_APP_REINIT_INPUT_REQUESTED); ROR_ASSERT(result >= 0);
     // Networking
     result = engine->RegisterEnumValue("MsgType", "MSG_NET_CONNECT_REQUESTED", MSG_NET_CONNECT_REQUESTED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("MsgType", "MSG_NET_CONNECT_STARTED", MSG_NET_CONNECT_STARTED); ROR_ASSERT(result >= 0);

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -499,6 +499,10 @@ void InputEngine::setup()
     {
         ShowCursor(FALSE);
     }
+    else
+    {
+        ShowCursor(TRUE); // To make `MSG_APP_REINIT_INPUT_REQUESTED` work correctly
+    }
 #endif
 
     mInputManager = OIS::InputManager::createInputSystem(pl);


### PR DESCRIPTION
Looks up highest res in OGRE's available modes list, then applies.

RoR.log:
```
01:37:17: D3D9 : RenderSystem Option: Video Mode = 800 x 600 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 1024 x 768 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 1152 x 864 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 1280 x 960 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 1280 x 1024 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 1600 x 1024 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 1600 x 1200 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 1920 x 1200 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 1920 x 1440 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 2560 x 1440 @ 32-bit colour
01:37:17: D3D9 : RenderSystem Option: Video Mode = 3440 x 1440 @ 32-bit colour
01:37:17: [RoR|Startup|Rendering] WARNING - invalid 'ogre.cfg', auto-detected resolution 3440x1440
```

Also added a big pop-up banner to the Render Settings UI when a value is changed:
![obrazek](https://github.com/user-attachments/assets/05c66e14-f041-4845-9916-7019bca411fb)

