### PR TITLE
Fixed GFX running on wall time instead of sim. time

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -25,6 +25,7 @@ class RoR(ConanFile):
         self.requires("rapidjson/cci.20211112", force=True)
         self.requires("socketw/3.11.0@anotherfoxguy/stable")
 
+        self.requires("jasper/4.2.4", override=True)
         self.requires("libpng/1.6.39", override=True)
         self.requires("libwebp/1.3.2", override=True)
         self.requires("zlib/1.2.13", override=True)

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -69,8 +69,11 @@ namespace RoR
     typedef int FlareID_t; //!< Index into `Actor::ar_flares`, use `RoR::FLAREID_INVALID` as empty value
     static const FlareID_t FLAREID_INVALID = -1;
 
-    typedef int ExhaustID_t; //!< Index into `Actor::exhausts`, use `RoR::EXHAUSTID_INVALID` as empty value
+    typedef int ExhaustID_t; //!< Index into `GfxActor::m_exhausts`, use `RoR::EXHAUSTID_INVALID` as empty value
     static const ExhaustID_t EXHAUSTID_INVALID = -1;
+
+    typedef int CParticleID_t; //!< Index into `GfxActor::m_cparticles`, use `RoR::CPARTICLEID_INVALID` as empty value
+    static const CParticleID_t CPARTICLEID_INVALID = -1;
 
     typedef int CommandkeyID_t; //!< Index into `Actor::ar_commandkeys` (BEWARE: indexed 1-MAX_COMMANDKEYS, 0 is invalid value, negative subscript of any size is acceptable, see `class CmdKeyArray` ).
     static const CommandkeyID_t COMMANDKEYID_INVALID = 0;
@@ -187,8 +190,8 @@ namespace RoR
     struct rotator_t;
     struct flare_t;
     struct rope_t;
-    struct exhaust_t;
-    struct cparticle_t;
+    struct Exhaust;
+    struct CParticle;
     struct collision_box_t;
     struct tie_t;
     struct hook_t;

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -305,14 +305,14 @@ void SoundScriptManager::modulate(int actor_id, int mod, float value, int linkTy
     }
 }
 
-void SoundScriptManager::update(float dt_sec)
+void SoundScriptManager::update(float dt)
 {
     if (App::sim_state->getEnum<SimState>() == SimState::RUNNING ||
         App::sim_state->getEnum<SimState>() == SimState::EDITOR_MODE)
     {
         Ogre::SceneNode* cam_node = App::GetCameraManager()->GetCameraNode();
         static Vector3 lastCameraPosition;
-        Vector3 cameraSpeed = (cam_node->getPosition() - lastCameraPosition) / dt_sec;
+        Vector3 cameraSpeed = (cam_node->getPosition() - lastCameraPosition) / dt;
         lastCameraPosition = cam_node->getPosition();
         Ogre::Vector3 upVector = App::GetCameraManager()->GetCameraNode()->getOrientation() * Ogre::Vector3::UNIT_Y;
         // Direction points down -Z by default (adapted from Ogre::Camera)

--- a/source/main/audio/SoundScriptManager.h
+++ b/source/main/audio/SoundScriptManager.h
@@ -331,7 +331,7 @@ public:
 
     bool isDisabled() { return disabled; }
 
-    void update(float dt_sec);
+    void update(float dt);
 
     SoundManager* getSoundManager() { return sound_manager; }
 

--- a/source/main/gfx/DustPool.cpp
+++ b/source/main/gfx/DustPool.cpp
@@ -24,6 +24,7 @@
 
 #include "Application.h"
 #include "GameContext.h"
+#include "GfxScene.h"
 #include "Terrain.h"
 #include "Water.h"
 
@@ -193,8 +194,15 @@ void DustPool::allocRipple(Vector3 pos, Vector3 vel)
 
 void DustPool::update()
 {
+    float speed_factor = 0.f;
+    if (App::sim_state->getEnum<SimState>() == SimState::RUNNING && !App::GetGameContext()->GetActorManager()->IsSimulationPaused())
+    {
+        speed_factor = App::GetGfxScene()->GetSimDataBuffer().simbuf_sim_speed;
+    }
+
     for (int i = 0; i < allocated; i++)
     {
+        pss[i]->setSpeedFactor(speed_factor);
         ParticleEmitter* emit = pss[i]->getEmitter(0);
         Vector3 ndir = velocities[i];
         Real vel = ndir.length();

--- a/source/main/gfx/DustPool.cpp
+++ b/source/main/gfx/DustPool.cpp
@@ -194,15 +194,9 @@ void DustPool::allocRipple(Vector3 pos, Vector3 vel)
 
 void DustPool::update()
 {
-    float speed_factor = 0.f;
-    if (App::sim_state->getEnum<SimState>() == SimState::RUNNING && !App::GetGameContext()->GetActorManager()->IsSimulationPaused())
-    {
-        speed_factor = App::GetGfxScene()->GetSimDataBuffer().simbuf_sim_speed;
-    }
-
     for (int i = 0; i < allocated; i++)
     {
-        pss[i]->setSpeedFactor(speed_factor);
+        App::GetGfxScene()->AdjustParticleSystemTimeFactor(pss[i]);
         ParticleEmitter* emit = pss[i]->getEmitter(0);
         Vector3 ndir = velocities[i];
         Real vel = ndir.length();

--- a/source/main/gfx/DustPool.h
+++ b/source/main/gfx/DustPool.h
@@ -80,7 +80,7 @@ protected:
     Ogre::SceneNode* sns[MAX_DUSTS];
     Ogre::SceneNode* parent_snode;
     Ogre::Vector3 positions[MAX_DUSTS];
-    Ogre::Vector3 velocities[MAX_DUSTS];
+    Ogre::Vector3 velocities[MAX_DUSTS]; //!< Velocity in wall time, ignoring the time scale.
     float rates[MAX_DUSTS];
     int allocated;
     int size;

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -419,7 +419,7 @@ void RoR::GfxActor::SetVideoCamState(VideoCamState state)
     m_vidcam_state = state;
 }
 
-void RoR::GfxActor::UpdateVideoCameras(float dt_sec)
+void RoR::GfxActor::UpdateVideoCameras(float dt)
 {
     if (m_vidcam_state != VideoCamState::VCSTATE_ENABLED_ONLINE)
         return;
@@ -539,7 +539,7 @@ void RoR::GfxActor::UpdateVideoCameras(float dt_sec)
     }
 }
 
-void RoR::GfxActor::UpdateParticles(float dt_sec)
+void RoR::GfxActor::UpdateParticles(float dt)
 {
     float water_height = 0.f; // Unused if terrain has no water
     if (App::GetGameContext()->GetTerrain()->getWater() != nullptr)
@@ -563,7 +563,7 @@ void RoR::GfxActor::UpdateParticles(float dt_sec)
             // Dripping water?
             if (nfx.nx_wet_time_sec != -1)
             {
-                nfx.nx_wet_time_sec += dt_sec;
+                nfx.nx_wet_time_sec += dt;
                 if (nfx.nx_wet_time_sec > 5.f) // Dries off in 5 sec
                 {
                     nfx.nx_wet_time_sec = -1.f;
@@ -3182,7 +3182,7 @@ bool ShouldEnableLightSource(FlareType type, bool is_player)
     }
 }
 
-void RoR::GfxActor::UpdateFlares(float dt_sec, bool is_player)
+void RoR::GfxActor::UpdateFlares(float dt, bool is_player)
 {
     // Flare states are determined in simulation, this function only applies them to OGRE objects
     // ------------------------------------------------------------------------------------------

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -95,8 +95,8 @@ public:
 
     // Visual updates
 
-    void                 UpdateVideoCameras(float dt_sec);
-    void                 UpdateParticles(float dt_sec);
+    void                 UpdateVideoCameras(float dt);
+    void                 UpdateParticles(float dt);
     void                 UpdateRods();
     void                 UpdateWheelVisuals();
     void                 UpdateFlexbodies();
@@ -110,7 +110,7 @@ public:
     void                 UpdateCParticles();
     void                 UpdateAeroEngines();
     void                 UpdateNetLabels(float dt);
-    void                 UpdateFlares(float dt_sec, bool is_player);
+    void                 UpdateFlares(float dt, bool is_player);
     void                 UpdateRenderdashRTT ();
 
     // SimBuffers

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -66,6 +66,13 @@ public:
     void                 RegisterCabMesh(Ogre::Entity* ent, Ogre::SceneNode* snode, FlexObj* flexobj);
     void                 SortFlexbodies();
 
+    // Retrieving elements
+
+    std::vector<FlexBody*>& GetFlexbodies() { return m_flexbodies; };
+    std::vector<Prop>&      getProps() { return m_props; }
+    std::vector<CParticle>& getCParticles() { return m_cparticles; }
+    std::vector<Exhaust>&   getExhausts() { return m_exhausts; }
+
     // Visual changes
 
     void                 SetMaterialFlareOn(int flare_index, bool state_on);
@@ -108,6 +115,7 @@ public:
     void                 UpdatePropAnimations(float dt);
     void                 UpdateAirbrakes();
     void                 UpdateCParticles();
+    void                 UpdateExhausts();
     void                 UpdateAeroEngines();
     void                 UpdateNetLabels(float dt);
     void                 UpdateFlares(float dt, bool is_player);
@@ -132,17 +140,15 @@ public:
     void                 CalculateDriverPos(Ogre::Vector3& out_pos, Ogre::Quaternion& out_rot);
     int                  GetActorId() const;
     int                  GetActorState() const;
-    std::vector<FlexBody*>& GetFlexbodies() { return m_flexbodies; };
-    Ogre::MaterialPtr&   GetCabTransMaterial() { return m_cab_mat_visual_trans; }
     VideoCamState        GetVideoCamState() const { return m_vidcam_state; }
     DebugViewType        GetDebugView() const { return m_debug_view; }
     Ogre::String         GetResourceGroup() { return m_custom_resource_group; }
     ActorPtr             GetActor(); // Watch out for multithreading with this!
+    Ogre::MaterialPtr&   GetCabTransMaterial() { return m_cab_mat_visual_trans; }
     Ogre::TexturePtr     GetHelpTex() { return m_help_tex; }
     Ogre::MaterialPtr    GetHelpMat() { return m_help_mat; }
     bool                 HasDriverSeatProp() const { return m_driverseat_prop_index != -1; }
     void                 CalcPropAnimation(PropAnim& anim, float& cstate, int& div, float dt);
-    std::vector<Prop>&   getProps() { return m_props; }
     size_t               getNumVideoCameras() const { return m_videocameras.size(); }
     SurveyMapEntity&     getSurveyMapEntity() { return m_surveymap_entity; }
     WheelSide            getWheelSide(WheelID_t wheel_id) { return (wheel_id >= 0 && (size_t)wheel_id < m_wheels.size()) ? m_wheels[wheel_id].wx_side : WheelSide::INVALID; }
@@ -193,6 +199,8 @@ private:
     DustPool*                   m_particles_ripple = nullptr;
     DustPool*                   m_particles_sparks = nullptr;
     DustPool*                   m_particles_clump = nullptr;
+    std::vector<CParticle>    m_cparticles;
+    std::vector<Exhaust>      m_exhausts;
 
     // Cab mesh ('submesh' in truck fileformat)
     FlexObj*                    m_cab_mesh = nullptr;

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -316,6 +316,23 @@ struct FlareMaterial // materialflares
     Ogre::ColourValue emissive_color;
 };
 
+struct Exhaust
+{
+    NodeNum_t emitterNode   = NODENUM_INVALID;
+    NodeNum_t directionNode = NODENUM_INVALID;
+    Ogre::SceneNode *smokeNode = nullptr;
+    Ogre::ParticleSystem* smoker = nullptr; //!< This remains `nullptr` if removed via `addonpart_unwanted_exhaust` or Tuning UI.
+    std::string particleSystemName; //!< Name in .particle file ~ for display in Tuning UI.
+};
+
+struct CParticle
+{
+    NodeNum_t emitterNode   = NODENUM_INVALID;
+    NodeNum_t directionNode = NODENUM_INVALID;
+    Ogre::SceneNode *snode = nullptr;
+    Ogre::ParticleSystem* psys = nullptr;
+};
+
 /// @} // addtogroup Gfx
 
 } // namespace RoR

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -87,7 +87,7 @@ void GfxScene::Init()
     m_skidmark_conf.LoadDefaultSkidmarkDefs();
 }
 
-void GfxScene::UpdateScene(float dt_sec)
+void GfxScene::UpdateScene(float dt)
 {
     // Actors - start threaded tasks
     for (GfxActor* gfx_actor: m_live_gfx_actors)
@@ -118,7 +118,7 @@ void GfxScene::UpdateScene(float dt_sec)
         {
             if (!m_simbuf.simbuf_sim_paused && !gfx_actor->GetSimDataBuffer().simbuf_physics_paused)
             {
-                gfx_actor->UpdateParticles(m_simbuf.simbuf_sim_speed * dt_sec);
+                gfx_actor->UpdateParticles(m_simbuf.simbuf_sim_speed * dt);
             }
         }
         for (auto itor : m_dustpools)
@@ -136,7 +136,7 @@ void GfxScene::UpdateScene(float dt_sec)
     }
 
     // Terrain - animated meshes and paged geometry
-    App::GetGameContext()->GetTerrain()->getObjectManager()->UpdateTerrainObjects(dt_sec);
+    App::GetGameContext()->GetTerrain()->getObjectManager()->UpdateTerrainObjects(dt);
 
     // Terrain - lightmap; TODO: ported as-is from Terrain::update(), is it needed? ~ only_a_ptr, 05/2018
     App::GetGameContext()->GetTerrain()->getGeometryManager()->UpdateMainLightPosition(); // TODO: Is this necessary? I'm leaving it here just in case ~ only_a_ptr, 04/2017
@@ -153,7 +153,7 @@ void GfxScene::UpdateScene(float dt_sec)
         {
             water->SetReflectionPlaneHeight(water->GetStaticWaterHeight());
         }
-        water->FrameStepWater(dt_sec);
+        water->FrameStepWater(dt);
     }
 
     // Terrain - sky
@@ -168,7 +168,7 @@ void GfxScene::UpdateScene(float dt_sec)
     SkyXManager* skyx_man = App::GetGameContext()->GetTerrain()->getSkyXManager();
     if (skyx_man != nullptr)
     {
-       skyx_man->update(dt_sec); // Light update
+       skyx_man->update(dt); // Light update
     }
 
     // GUI - race
@@ -197,7 +197,7 @@ void GfxScene::UpdateScene(float dt_sec)
     // HUD - network labels (always update)
     for (GfxActor* gfx_actor: m_all_gfx_actors)
     {
-        gfx_actor->UpdateNetLabels(m_simbuf.simbuf_sim_speed * dt_sec);
+        gfx_actor->UpdateNetLabels(m_simbuf.simbuf_sim_speed * dt);
     }
 
     // Player avatars
@@ -217,17 +217,17 @@ void GfxScene::UpdateScene(float dt_sec)
             gfx_actor->UpdateAirbrakes();
             gfx_actor->UpdateCParticles();
             gfx_actor->UpdateAeroEngines();
-            gfx_actor->UpdatePropAnimations(dt_sec);
+            gfx_actor->UpdatePropAnimations(dt);
             gfx_actor->UpdateRenderdashRTT();
         }
         // Beacon flares must always be updated
-        gfx_actor->UpdateProps(dt_sec, (gfx_actor == player_gfx_actor));
+        gfx_actor->UpdateProps(dt, (gfx_actor == player_gfx_actor));
         // Blinkers (turn signals) must always be updated
-        gfx_actor->UpdateFlares(dt_sec, (gfx_actor == player_gfx_actor));
+        gfx_actor->UpdateFlares(dt, (gfx_actor == player_gfx_actor));
     }
     if (player_gfx_actor != nullptr)
     {
-        player_gfx_actor->UpdateVideoCameras(dt_sec);
+        player_gfx_actor->UpdateVideoCameras(dt);
 
         // The old-style render-to-texture dashboard (based on OGRE overlays)
         if (m_simbuf.simbuf_player_actor->ar_driveable == TRUCK && m_simbuf.simbuf_player_actor->ar_engine != nullptr)

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -221,6 +221,7 @@ void GfxScene::UpdateScene(float dt)
             gfx_actor->UpdateWingMeshes();
             gfx_actor->UpdateAirbrakes();
             gfx_actor->UpdateCParticles();
+            gfx_actor->UpdateExhausts();
             gfx_actor->UpdateAeroEngines();
             gfx_actor->UpdatePropAnimations(dt_actor);
             gfx_actor->UpdateRenderdashRTT();
@@ -403,3 +404,13 @@ void GfxScene::DrawNetLabel(Ogre::Vector3 scene_pos, float cam_dist, std::string
 #endif // USE_SOCKETW
 }
 
+void GfxScene::AdjustParticleSystemTimeFactor(Ogre::ParticleSystem* psys)
+{
+    float speed_factor = 0.f;
+    if (App::sim_state->getEnum<SimState>() == SimState::RUNNING && !App::GetGameContext()->GetActorManager()->IsSimulationPaused())
+    {
+        speed_factor = m_simbuf.simbuf_sim_speed;
+    }
+
+    psys->setSpeedFactor(speed_factor);
+}

--- a/source/main/gfx/GfxScene.h
+++ b/source/main/gfx/GfxScene.h
@@ -47,8 +47,12 @@ class GfxScene
 public:
 
     void           Init();
+
+    // Particles:
     void           CreateDustPools();
     DustPool*      GetDustPool(const char* name);
+    void           AdjustParticleSystemTimeFactor(Ogre::ParticleSystem* psys);
+
     void           SetParticlesVisible(bool visible);
     void           DrawNetLabel(Ogre::Vector3 pos, float cam_dist, std::string const& nick, int colornum);
     void           UpdateScene(float dt);

--- a/source/main/gfx/GfxScene.h
+++ b/source/main/gfx/GfxScene.h
@@ -51,7 +51,7 @@ public:
     DustPool*      GetDustPool(const char* name);
     void           SetParticlesVisible(bool visible);
     void           DrawNetLabel(Ogre::Vector3 pos, float cam_dist, std::string const& nick, int colornum);
-    void           UpdateScene(float dt_sec);
+    void           UpdateScene(float dt);
     void           ClearScene();
     void           RegisterGfxActor(RoR::GfxActor* gfx_actor);
     void           RemoveGfxActor(RoR::GfxActor* gfx_actor);

--- a/source/main/gfx/SimBuffers.h
+++ b/source/main/gfx/SimBuffers.h
@@ -155,6 +155,7 @@ struct ActorSB
     float             simbuf_clutch                   = 0;
     int               simbuf_num_gears                = 0; //!< Gearbox
     float             simbuf_engine_max_rpm           = 0;
+    float             simbuf_engine_smoke             = 0;
 
     // Tyre pressure
     float             simbuf_tyre_pressure            = 0;
@@ -164,6 +165,7 @@ struct ActorSB
     BitMask_t         simbuf_lightmask                = 0;
     bool              simbuf_smoke_enabled            = false;
     bool              simbuf_parking_brake            = false;
+    bool              simbuf_cparticles_active        = false;
 
     // Aerial
     float             simbuf_hydro_aileron_state      = 0;

--- a/source/main/gfx/hydrax/Hydrax.cpp
+++ b/source/main/gfx/hydrax/Hydrax.cpp
@@ -292,6 +292,7 @@ namespace Hydrax
 	{
 		if (mCreated && mModule && mVisible)
 		{
+            mMaterialManager->updateAnimatedTextures(timeSinceLastFrame);
             mModule->update(timeSinceLastFrame);
 		    mDecalsManager->update();
 			_checkUnderwater(timeSinceLastFrame);

--- a/source/main/gfx/hydrax/MaterialManager.cpp
+++ b/source/main/gfx/hydrax/MaterialManager.cpp
@@ -1528,9 +1528,11 @@ namespace Hydrax
             {
                 FP_Parameters->setNamedConstant("uCaustics", 0);
             }
-			Ogre::TextureUnitState *TUS_Caustics = DM_Technique0_Pass0->createTextureUnitState("Caustics.bmp");
-			TUS_Caustics->setTextureAddressingMode(Ogre::TextureUnitState::TAM_WRAP);
-			TUS_Caustics->setAnimatedTextureName("Caustics.bmp", 32, 1.5);
+            Ogre::TextureUnitState* TUS_Caustics = DM_Technique0_Pass0->createTextureUnitState("Caustics.bmp");
+            TUS_Caustics->setTextureAddressingMode(Ogre::TextureUnitState::TAM_WRAP);
+            // To account for variable sim. time, we must update animation manually.
+            TUS_Caustics->setAnimatedTextureName("Caustics.bmp", 32);
+            mCausticsAnimTexVec.push_back(TUS_Caustics);
 		}
 
 		DepthMaterial->setReceiveShadows(false);
@@ -1538,6 +1540,31 @@ namespace Hydrax
 
 		return true;
 	}
+
+    const float CAUSTICS_FRAME_DURATION = 1.5f / 32.f; // 1.5sec is the original hardcoded total duration.
+    const unsigned int CAUSTICS_NUM_FRAMES = 32;
+
+    void MaterialManager::updateAnimatedTextures(float dt)
+    {
+        mCausticsAnimCurrentFrameElapsedTime += dt;
+        while (mCausticsAnimCurrentFrameElapsedTime > CAUSTICS_FRAME_DURATION)
+        {
+            // advance anim frame
+            mCausticsAnimCurrentFrame++;
+            if (mCausticsAnimCurrentFrame >= CAUSTICS_NUM_FRAMES)
+            {
+                mCausticsAnimCurrentFrame = 0;
+            }
+            // update time
+            mCausticsAnimCurrentFrameElapsedTime -= CAUSTICS_FRAME_DURATION;
+        }
+
+        // Update frame on registered anims
+        for (Ogre::TextureUnitState* tus : mCausticsAnimTexVec)
+        {
+            tus->setCurrentFrame(mCausticsAnimCurrentFrame);
+        }
+    }
 
 	bool MaterialManager::_createDepthTextureGPUPrograms(const HydraxComponent &Components, const Options &Options, const Ogre::String& AlphaChannel)
 	{
@@ -3409,10 +3436,12 @@ namespace Hydrax
             {
                 FP_Parameters->setNamedConstant("uCaustics", 0);
             }
-			Ogre::TextureUnitState *TUS_Caustics = DM_Technique_Pass0->createTextureUnitState("Caustics.bmp");
-			TUS_Caustics->setName("Caustics");
-			TUS_Caustics->setTextureAddressingMode(Ogre::TextureUnitState::TAM_WRAP);
-			TUS_Caustics->setAnimatedTextureName("Caustics.bmp", 32, 1.5);
+            Ogre::TextureUnitState* TUS_Caustics = DM_Technique_Pass0->createTextureUnitState("Caustics.bmp");
+            TUS_Caustics->setName("Caustics");
+            TUS_Caustics->setTextureAddressingMode(Ogre::TextureUnitState::TAM_WRAP);
+            // To account for variable sim. time, we must update animation manually.
+            TUS_Caustics->setAnimatedTextureName("Caustics.bmp", 32);
+            mCausticsAnimTexVec.push_back(TUS_Caustics);
 		}
 
 		if (AutoUpdate)
@@ -3472,7 +3501,9 @@ namespace Hydrax
 			Ogre::TextureUnitState *TUS_Caustics = DM_Technique_Pass0->createTextureUnitState("Caustics.bmp");
 			TUS_Caustics->setName("Caustics");
 			TUS_Caustics->setTextureAddressingMode(Ogre::TextureUnitState::TAM_WRAP);
-			TUS_Caustics->setAnimatedTextureName("Caustics.bmp", 32, 1.5);
+            // To account for variable sim. time, we must update animation manually.
+			TUS_Caustics->setAnimatedTextureName("Caustics.bmp", 32);
+            mCausticsAnimTexVec.push_back(TUS_Caustics);
 		}
 
         if(mOptions.SM == SM_GLSL)

--- a/source/main/gfx/hydrax/MaterialManager.h
+++ b/source/main/gfx/hydrax/MaterialManager.h
@@ -311,6 +311,10 @@ namespace Hydrax
 		 */
 		void setGpuProgramParameter(const GpuProgram &GpuP, const MaterialType &MType, const Ogre::String &Name, const Ogre::Vector3 &Value);
 
+        /** Animated textures must be updated manually to account for variable simulation time.
+        */
+        void updateAnimatedTextures(float dt);
+
 	private:
 		/** Is component in the given list?
 		    @param List Components list
@@ -373,6 +377,11 @@ namespace Hydrax
 		UnderwaterCompositorListener mUnderwaterCompositorListener;
 		/// Hydrax main pointer
 		Hydrax *mHydrax;
+        /// Caustics animated texture, for manual updating.
+        std::vector<Ogre::TextureUnitState*> mCausticsAnimTexVec;
+        unsigned int mCausticsAnimCurrentFrame = 0;
+        /// Time spent on current animation frame, cumulative.
+        float mCausticsAnimCurrentFrameElapsedTime = 0.f;
 	};
 };
 

--- a/source/main/gui/panels/GUI_SurveyMap.h
+++ b/source/main/gui/panels/GUI_SurveyMap.h
@@ -69,7 +69,7 @@ protected:
     };
 
     void setMapZoom(float zoom);
-    void setMapZoomRelative(float dt_sec);
+    void setMapZoomRelative(float dt);
     const char* getTypeByDriveable(const ActorPtr& actor);
     const char* getAIType(const ActorPtr& actor);
 

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -1858,12 +1858,12 @@ void TopMenubar::Draw(float dt)
                 }
 
                 // Draw exhausts
-                size_t total_exhausts = tuning_actor->exhausts.size();
+                size_t total_exhausts = tuning_actor->GetGfxActor()->getExhausts().size();
                 std::string exhausts_title = fmt::format(_LC("Tuning", "Exhausts ({})"), total_exhausts);
                 if (ImGui::CollapsingHeader(exhausts_title.c_str()))
                 {
                     // Draw all exhausts (those removed by addonparts are also present as placeholders)
-                    for (ExhaustID_t exhaustid = 0; exhaustid < (int)tuning_actor->exhausts.size(); exhaustid++)
+                    for (ExhaustID_t exhaustid = 0; exhaustid < (int)total_exhausts; exhaustid++)
                     {
                         ImGui::PushID(exhaustid);
                         ImGui::AlignTextToFramePadding();
@@ -1872,7 +1872,7 @@ void TopMenubar::Draw(float dt)
 
                         this->DrawTuningForceRemoveControls(
                             exhaustid,
-                            tuning_actor->exhausts[exhaustid].particleSystemName,
+                            tuning_actor->GetGfxActor()->getExhausts()[exhaustid].particleSystemName,
                             tuneup_def && tuneup_def->isExhaustUnwanted(exhaustid),
                             tuneup_def && tuneup_def->isExhaustForceRemoved(exhaustid),
                             ModifyProjectRequestType::TUNEUP_FORCEREMOVE_EXHAUST_SET,

--- a/source/main/gui/panels/GUI_VehicleInfoTPanel.cpp
+++ b/source/main/gui/panels/GUI_VehicleInfoTPanel.cpp
@@ -770,7 +770,7 @@ void VehicleInfoTPanel::DrawVehicleBasicsUI(RoR::GfxActor* actorx)
         }
     }
 
-    const int num_cparticles = actorx->GetActor()->ar_num_custom_particles;
+    const int num_cparticles = (int)actorx->getCParticles().size();
     const size_t num_videocams = actorx->getNumVideoCameras();
     ImGui::TextDisabled("View:");
     if (num_cparticles)

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -1754,6 +1754,13 @@ int main(int argc, char *argv[])
                 App::GetGfxScene()->BufferSimulationData();
             }
 
+            // Calculate elapsed simulation time (taking simulation speed and pause into account)
+            float dt_sim = 0.f;
+            if (App::sim_state->getEnum<SimState>() == SimState::RUNNING && !App::GetGameContext()->GetActorManager()->IsSimulationPaused())
+            {
+                dt_sim = dt * App::GetGameContext()->GetActorManager()->GetSimulationSpeed();
+            }
+
             // Advance simulation
             if (App::sim_state->getEnum<SimState>() == SimState::RUNNING)
             {
@@ -1767,7 +1774,7 @@ int main(int argc, char *argv[])
             }
             else if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
             {
-                App::GetGfxScene()->UpdateScene(dt); // Draws GUI as well
+                App::GetGfxScene()->UpdateScene(dt_sim); // Draws GUI as well
             }
 
             // Render!

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -265,54 +265,6 @@ void Actor::dispose()
     }
     this->ar_flares.clear();
 
-    // delete exhausts
-    for (std::vector<exhaust_t>::iterator it = exhausts.begin(); it != exhausts.end(); it++)
-    {
-        try
-        {
-            if (it->smokeNode)
-            {
-                it->smokeNode->removeAndDestroyAllChildren();
-                App::GetGfxScene()->GetSceneManager()->destroySceneNode(it->smokeNode);
-            }
-            if (it->smoker)
-            {
-                it->smoker->removeAllAffectors();
-                it->smoker->removeAllEmitters();
-                App::GetGfxScene()->GetSceneManager()->destroyParticleSystem(it->smoker);
-            }
-        }
-        catch (...)
-        {
-            HandleGenericException(fmt::format("Actor::dispose(); instanceID:{}, streamID:{}, filename:{}; deleting exhaust {}/{}.",
-                ar_instance_id, ar_net_stream_id, ar_filename, std::distance(exhausts.begin(), it), exhausts.size()), HANDLEGENERICEXCEPTION_LOGFILE);
-        }
-    }
-
-    // delete custom particles
-    for (int i = 0; i < ar_num_custom_particles; i++)
-    {
-        try
-        {
-            if (ar_custom_particles[i].snode)
-            {
-                ar_custom_particles[i].snode->removeAndDestroyAllChildren();
-                App::GetGfxScene()->GetSceneManager()->destroySceneNode(ar_custom_particles[i].snode);
-            }
-            if (ar_custom_particles[i].psys)
-            {
-                ar_custom_particles[i].psys->removeAllAffectors();
-                ar_custom_particles[i].psys->removeAllEmitters();
-                App::GetGfxScene()->GetSceneManager()->destroyParticleSystem(ar_custom_particles[i].psys);
-            }
-        }
-        catch (...)
-        {
-            HandleGenericException(fmt::format("Actor::dispose(); instanceID:{}, streamID:{}, filename:{}; deleting custom particle {}/{}.",
-                ar_instance_id, ar_net_stream_id, ar_filename, i, ar_num_custom_particles), HANDLEGENERICEXCEPTION_LOGFILE);
-        }
-    }
-
     // delete Rails
     for (std::vector<RailGroup*>::iterator it = m_railgroups.begin(); it != m_railgroups.end(); it++)
     {
@@ -685,7 +637,7 @@ void Actor::calcNetwork()
     }
 
     // set particle cannon
-    if (((flagmask & NETMASK_PARTICLE) != 0) != m_custom_particles_enabled)
+    if (((flagmask & NETMASK_PARTICLE) != 0) != ar_cparticles_active)
         toggleCustomParticles();
 
     m_antilockbrake = flagmask & NETMASK_ALB_ACTIVE;
@@ -3191,15 +3143,7 @@ void Actor::toggleCustomParticles()
     if (ar_state == ActorState::DISPOSED)
         return;
 
-    m_custom_particles_enabled = !m_custom_particles_enabled;
-    for (int i = 0; i < ar_num_custom_particles; i++)
-    {
-        ar_custom_particles[i].active = !ar_custom_particles[i].active;
-        for (int j = 0; j < ar_custom_particles[i].psys->getNumEmitters(); j++)
-        {
-            ar_custom_particles[i].psys->getEmitter(j)->setEnabled(ar_custom_particles[i].active);
-        }
-    }
+    ar_cparticles_active = !ar_cparticles_active;
 
     //ScriptEvent - Particle Toggle
     TRIGGER_EVENT_ASYNC(SE_TRUCK_CPARTICLES_TOGGLE, ar_instance_id);
@@ -3241,34 +3185,6 @@ void Actor::updateVisual(float dt)
         }
     }
 #endif //openAL
-
-    // update exhausts
-    // TODO: Move to GfxActor, don't forget dt*m_simulation_speed
-    if (ar_engine && exhausts.size() > 0)
-    {
-        std::vector<exhaust_t>::iterator it;
-        for (it = exhausts.begin(); it != exhausts.end(); it++)
-        {
-            if (!it->smoker)
-                continue;
-            Vector3 dir = ar_nodes[it->emitterNode].AbsPosition - ar_nodes[it->directionNode].AbsPosition;
-            //			dir.normalise();
-            ParticleEmitter* emit = it->smoker->getEmitter(0);
-            it->smokeNode->setPosition(ar_nodes[it->emitterNode].AbsPosition);
-            emit->setDirection(dir);
-            if (!m_disable_smoke && ar_engine->GetSmoke() != -1.0)
-            {
-                emit->setEnabled(true);
-                emit->setColour(ColourValue(0.0, 0.0, 0.0, 0.02 + ar_engine->GetSmoke() * 0.06));
-                emit->setTimeToLive((0.02 + ar_engine->GetSmoke() * 0.06) / 0.04);
-            }
-            else
-            {
-                emit->setEnabled(false);
-            }
-            emit->setParticleVelocity(1.0 + ar_engine->GetSmoke() * 2.0, 2.0 + ar_engine->GetSmoke() * 3.0);
-        }
-    }
 
     // Wings (only physics, graphics are updated in GfxActor)
     float autoaileron = 0;
@@ -4456,7 +4372,7 @@ Actor::Actor(
     , m_water_contact(false)
     , m_water_contact_old(false)
     , m_has_command_beams(false)
-    , m_custom_particles_enabled(false)
+    , ar_cparticles_active(false)
     , m_beam_break_debug_enabled(false)
     , m_beam_deform_debug_enabled(false)
     , m_trigger_debug_enabled(false)
@@ -4565,7 +4481,7 @@ BlinkType Actor::getBlinkType()
 
 bool Actor::getCustomParticleMode()
 {
-    return m_custom_particles_enabled;
+    return ar_cparticles_active;
 }
 
 Ogre::Real Actor::getMinimalCameraRadius()

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -296,7 +296,6 @@ public:
     wing_t*              ar_wings = nullptr;
     int                  ar_num_wings = 0;
     std::vector<authorinfo_t> authors;
-    std::vector<exhaust_t>    exhausts;
     std::vector<rope_t>       ar_ropes;
     std::vector<ropable_t>    ar_ropables;
     std::vector<tie_t>        ar_ties;
@@ -323,8 +322,6 @@ public:
     int               ar_num_contacters = 0; //!< Total number of nodes which can selfcontact cabs
     wheel_t           ar_wheels[MAX_WHEELS] = {};
     int               ar_num_wheels = 0;
-    cparticle_t       ar_custom_particles[MAX_CPARTICLES] = {};
-    int               ar_num_custom_particles = 0;
     soundsource_t     ar_soundsources[MAX_SOUNDSCRIPTS_PER_TRUCK] = {};
     int               ar_num_soundsources = 0;
     AeroEngine*       ar_aeroengines[MAX_AEROENGINES] = {};
@@ -483,6 +480,7 @@ public:
     bool ar_toggle_ropes:1;     //!< Sim state
     bool ar_toggle_ties:1;      //!< Sim state
     bool ar_physics_paused:1;   //!< Sim state
+    bool ar_cparticles_active:1;//!< Gfx state
 
 private:
 
@@ -627,7 +625,6 @@ private:
     bool m_water_contact:1;        //!< Scripting state
     bool m_water_contact_old:1;    //!< Scripting state
     bool m_has_command_beams:1;    //!< Physics attr;
-    bool m_custom_particles_enabled:1;      //!< Gfx state
     bool m_preloaded_with_terrain:1;        //!< Spawn context (TODO: remove!)
     bool m_beam_break_debug_enabled:1;  //!< Logging state
     bool m_beam_deform_debug_enabled:1; //!< Logging state

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -278,9 +278,6 @@ void ActorSpawner::InitializeRig()
 
     m_actor->ar_minimass.resize(req.num_nodes);
 
-    m_actor->exhausts.clear();
-    memset(m_actor->ar_custom_particles, 0, sizeof(cparticle_t) * MAX_CPARTICLES);
-    m_actor->ar_num_custom_particles = 0;
     memset(m_actor->ar_soundsources, 0, sizeof(soundsource_t) * MAX_SOUNDSCRIPTS_PER_TRUCK);
     m_actor->ar_num_soundsources = 0;
     memset(m_actor->ar_collcabs, 0, sizeof(int) * MAX_CABS);
@@ -1282,8 +1279,8 @@ void ActorSpawner::ProcessExhaust(RigDef::Exhaust & def)
         return;
     }
 
-    const ExhaustID_t exhaust_id = (ExhaustID_t)m_actor->exhausts.size();
-    exhaust_t exhaust;
+    const ExhaustID_t exhaust_id = (ExhaustID_t)m_actor->m_gfx_actor->m_exhausts.size();
+    Exhaust exhaust;
     exhaust.emitterNode   = this->GetNodeIndexOrThrow(def.reference_node);
     exhaust.directionNode = this->GetNodeIndexOrThrow(def.direction_node);
 
@@ -1296,7 +1293,7 @@ void ActorSpawner::ProcessExhaust(RigDef::Exhaust & def)
 
     if (!TuneupUtil::isExhaustAnyhowRemoved(m_actor->getWorkingTuneupDef(), exhaust_id))
     {
-        std::string name = this->ComposeName(template_name.c_str(), (int)m_actor->exhausts.size());
+        std::string name = this->ComposeName(template_name.c_str(), (int)m_actor->m_gfx_actor->m_exhausts.size());
         exhaust.smoker = this->CreateParticleSystem(name, template_name);
         if (exhaust.smoker == nullptr)
         {
@@ -1306,7 +1303,7 @@ void ActorSpawner::ProcessExhaust(RigDef::Exhaust & def)
             return;
         }
 
-        exhaust.smokeNode = m_particles_parent_scenenode->createChildSceneNode(this->ComposeName("exhaust", (int)m_actor->exhausts.size()));
+        exhaust.smokeNode = m_particles_parent_scenenode->createChildSceneNode(this->ComposeName("exhaust", (int)m_actor->m_gfx_actor->m_exhausts.size()));
         exhaust.smokeNode->attachObject(exhaust.smoker);
         exhaust.smokeNode->setPosition(m_actor->ar_nodes[exhaust.emitterNode].AbsPosition);
 
@@ -1314,7 +1311,7 @@ void ActorSpawner::ProcessExhaust(RigDef::Exhaust & def)
         m_actor->m_gfx_actor->SetNodeHot(exhaust.directionNode, true);
     }
 
-    m_actor->exhausts.push_back(exhaust);
+    m_actor->m_gfx_actor->m_exhausts.push_back(exhaust);
 }
 
 std::string ActorSpawner::GetSubmeshGroundmodelName()
@@ -2896,13 +2893,13 @@ void ActorSpawner::ProcessParticle(RigDef::Particle & def)
         return;
     }
 
-    int particle_index = m_actor->ar_num_custom_particles;
-    cparticle_t & particle = m_actor->ar_custom_particles[particle_index];
+    CParticleID_t particle_id = static_cast<CParticleID_t>(m_actor->m_gfx_actor->m_cparticles.size());
+    CParticle particle;
 
     particle.emitterNode = GetNodeIndexOrThrow(def.emitter_node);
     particle.directionNode = GetNodeIndexOrThrow(def.reference_node);
 
-    std::string name = this->ComposeName(def.particle_system_name.c_str(), particle_index);
+    std::string name = this->ComposeName(def.particle_system_name.c_str(), particle_id);
     particle.psys = this->CreateParticleSystem(name, def.particle_system_name);
     if (particle.psys == nullptr)
     {
@@ -2912,18 +2909,17 @@ void ActorSpawner::ProcessParticle(RigDef::Particle & def)
         return;
     }
 
-    particle.snode = m_particles_parent_scenenode->createChildSceneNode(this->ComposeName("cparticles", m_actor->ar_num_custom_particles));
+    particle.snode = m_particles_parent_scenenode->createChildSceneNode(this->ComposeName("cparticles", particle_id));
     particle.snode->attachObject(particle.psys);
     particle.snode->setPosition(m_actor->ar_nodes[particle.emitterNode].AbsPosition);
 
     /* Shut down the emitters */
-    particle.active = false; 
     for (unsigned int i = 0; i < particle.psys->getNumEmitters(); i++)
     {
         particle.psys->getEmitter(i)->setEnabled(false);
     }
 
-    ++m_actor->ar_num_custom_particles;
+    m_actor->m_gfx_actor->m_cparticles.push_back(particle);
 }
 
 void ActorSpawner::ProcessRopable(RigDef::Ropable & def)
@@ -6055,12 +6051,13 @@ void ActorSpawner::AddExhaust(
         NodeNum_t direction_node_idx
     )
 {
-    exhaust_t exhaust;
+    const ExhaustID_t exhaust_id = (ExhaustID_t)m_actor->m_gfx_actor->m_exhausts.size();
+    Exhaust exhaust;
     exhaust.emitterNode = emitter_node_idx;
     exhaust.directionNode = direction_node_idx;
 
     exhaust.smoker = App::GetGfxScene()->GetSceneManager()->createParticleSystem(
-        this->ComposeName("exhaust", (int)m_actor->exhausts.size()),
+        this->ComposeName("exhaust", exhaust_id),
         /*quota=*/500, // Default value
         m_custom_resource_group);
 
@@ -6074,14 +6071,14 @@ void ActorSpawner::AddExhaust(
     Ogre::MaterialPtr mat = this->FindOrCreateCustomizedMaterial("tracks/Smoke", m_custom_resource_group);
     exhaust.smoker->setMaterialName(mat->getName(), mat->getGroup());
 
-    exhaust.smokeNode = m_particles_parent_scenenode->createChildSceneNode(this->ComposeName("exhaust", (int)m_actor->exhausts.size()));
+    exhaust.smokeNode = m_particles_parent_scenenode->createChildSceneNode(this->ComposeName("exhaust", exhaust_id));
     exhaust.smokeNode->attachObject(exhaust.smoker);
     exhaust.smokeNode->setPosition(m_actor->ar_nodes[exhaust.emitterNode].AbsPosition);
 
     m_actor->m_gfx_actor->SetNodeHot(exhaust.emitterNode, true);
     m_actor->m_gfx_actor->SetNodeHot(exhaust.directionNode, true);
 
-    m_actor->exhausts.push_back(exhaust);
+    m_actor->m_gfx_actor->m_exhausts.push_back(exhaust);
 }
 
 void ActorSpawner::ProcessCinecam(RigDef::Cinecam & def)
@@ -6160,18 +6157,6 @@ void ActorSpawner::ProcessGlobals(RigDef::Globals & def)
 /* -------------------------------------------------------------------------- */
 // Limits.
 /* -------------------------------------------------------------------------- */
-
-bool ActorSpawner::CheckParticleLimit(unsigned int count)
-{
-    if ((m_actor->ar_num_custom_particles + count) > MAX_CPARTICLES)
-    {
-        std::stringstream msg;
-        msg << "Particle limit (" << MAX_CPARTICLES << ") exceeded";
-        AddMessage(Message::TYPE_ERROR, msg.str());
-        return false;
-    }
-    return true;
-}
 
 bool ActorSpawner::CheckAxleLimit(unsigned int count)
 {

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -362,7 +362,6 @@ private:
 
     /// @name Limit checks
     /// @{
-    bool                          CheckParticleLimit(unsigned int count);
     bool                          CheckAxleLimit(unsigned int count);
     bool                          CheckSubmeshLimit(unsigned int count);
     bool                          CheckTexcoordLimit(unsigned int count);

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -545,7 +545,7 @@ bool ActorManager::SaveScene(Ogre::String filename)
         j_entry.AddMember("wheel_speed", actor->ar_wheel_speed, j_doc.GetAllocator());
         j_entry.AddMember("wheel_spin", actor->ar_wheel_spin, j_doc.GetAllocator());
 
-        j_entry.AddMember("custom_particles", actor->m_custom_particles_enabled, j_doc.GetAllocator());
+        j_entry.AddMember("custom_particles", actor->ar_cparticles_active, j_doc.GetAllocator());
 
         // Flares
         j_entry.AddMember("lights", (int)actor->getHeadlightsVisible(), j_doc.GetAllocator());
@@ -831,7 +831,7 @@ void ActorManager::RestoreSavedState(ActorPtr actor, rapidjson::Value const& j_e
     actor->ar_wheel_speed = j_entry["wheel_speed"].GetFloat();
     actor->ar_wheel_spin = j_entry["wheel_spin"].GetFloat();
 
-    if (actor->m_custom_particles_enabled != j_entry["custom_particles"].GetBool())
+    if (actor->ar_cparticles_active != j_entry["custom_particles"].GetBool())
     {
         actor->toggleCustomParticles();
     }

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -635,25 +635,6 @@ struct flare_t
     SimpleInertia inertia; //!< Only 'flares3'
 };
 
-struct exhaust_t
-{
-    NodeNum_t emitterNode   = NODENUM_INVALID;
-    NodeNum_t directionNode = NODENUM_INVALID;
-    Ogre::SceneNode *smokeNode = nullptr;
-    Ogre::ParticleSystem* smoker = nullptr; //!< This remains `nullptr` if removed via `addonpart_unwanted_exhaust` or Tuning UI.
-    std::string particleSystemName; //!< Name in .particle file ~ for display in Tuning UI.
-};
-
-
-struct cparticle_t
-{
-    NodeNum_t emitterNode   = NODENUM_INVALID;
-    NodeNum_t directionNode = NODENUM_INVALID;
-    bool active;
-    Ogre::SceneNode *snode;
-    Ogre::ParticleSystem* psys;
-};
-
 /// User input state for animated props with 'source:event'.
 struct PropAnimKeyState
 {

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -183,6 +183,7 @@ void TurbojetVisual::UpdateVisuals(RoR::GfxActor* gfx_actor)
     if (m_smoke_particle &&
         gfx_actor->GetSimDataBuffer().simbuf_smoke_enabled)
     {
+        App::GetGfxScene()->AdjustParticleSystemTimeFactor(m_smoke_particle);
         m_smoke_scenenode->setPosition(node_buf[m_node_back].AbsPosition);
         ParticleEmitter* emit = m_smoke_particle->getEmitter(0);
         emit->setDirection(-laxis);

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -175,6 +175,7 @@ void Turboprop::updateVisuals(RoR::GfxActor* gfx_m_actor)
     //smoke
     if (smokeNode)
     {
+        App::GetGfxScene()->AdjustParticleSystemTimeFactor(smokePS);
         smokeNode->setPosition(node_buf[nodeback].AbsPosition);
         ParticleEmitter* emit = smokePS->getEmitter(0);
         Vector3 dir = node_buf[nodeback].AbsPosition - node_buf[noderef].AbsPosition;

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -764,6 +764,11 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
         SceneNode* sn = tenode->createChildSceneNode();
         sn->attachObject(pParticleSys);
         sn->pitch(Degree(90));
+
+        ParticleEffectObject peo;
+        peo.node = sn;
+        peo.psys = pParticleSys;
+        m_particle_effect_objects.push_back(peo);
     }
 
     if (!odef->mat_name.empty())
@@ -953,10 +958,10 @@ bool TerrainObjectManager::LoadTerrainScript(const Ogre::String& filename)
     return result != SCRIPTUNITID_INVALID;
 }
 
-bool TerrainObjectManager::UpdateAnimatedObjects(float dt)
+void TerrainObjectManager::UpdateAnimatedObjects(float dt)
 {
     if (m_animated_objects.size() == 0)
-        return true;
+        return;
 
     std::vector<AnimatedObject>::iterator it;
 
@@ -968,7 +973,17 @@ bool TerrainObjectManager::UpdateAnimatedObjects(float dt)
             it->anim->addTime(time);
         }
     }
-    return true;
+}
+
+void TerrainObjectManager::UpdateParticleEffectObjects()
+{
+    for (ParticleEffectObject& peo : m_particle_effect_objects)
+    {
+        if (peo.psys)
+        {
+            App::GetGfxScene()->AdjustParticleSystemTimeFactor(peo.psys);
+        }
+    }
 }
 
 void TerrainObjectManager::LoadTelepoints()
@@ -1009,6 +1024,7 @@ bool TerrainObjectManager::UpdateTerrainObjects(float dt)
     }
 #endif //USE_PAGED
     this->UpdateAnimatedObjects(dt);
+    this->UpdateParticleEffectObjects();
 
     return true;
 }

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -124,6 +124,12 @@ protected:
         float speedfactor;
     };
 
+    struct ParticleEffectObject
+    {
+        Ogre::ParticleSystem* psys = nullptr;
+        Ogre::SceneNode* node = nullptr;
+    };
+
     struct PredefinedActor
     {
         float px;
@@ -149,9 +155,10 @@ protected:
     RoR::ODefFile* FetchODef(std::string const & odef_name);
     void           ProcessODefCollisionBoxes(StaticObject* obj, ODefFile* odef, const EditorObject& params, bool race_event);
 
-    // Misc functions
+    // Update functions
 
-    bool           UpdateAnimatedObjects(float dt);
+    void           UpdateAnimatedObjects(float dt);
+    void           UpdateParticleEffectObjects();
 
     // Variables
 
@@ -161,6 +168,7 @@ protected:
     std::vector<EditorObject>             m_editor_objects;
     std::vector<PredefinedActor>          m_predefined_actors;
     std::vector<AnimatedObject>           m_animated_objects;
+    std::vector<ParticleEffectObject>     m_particle_effect_objects;
     std::vector<MeshObject*>              m_mesh_objects;
     SurveyMapEntityVec                    m_map_entities;
     Terrain*           terrainManager;


### PR DESCRIPTION
While fixing #3169 I noticed beacons run when game is paused and also ignore simulation speed, always running at wall time. I remembered there are multiple other issues like this (props/water waves moving when paused) and I figured a way to tackle everything at once - I changed the time input for the entire scene update code (which is already consolidated into `GfxScene::UpdateScene()`) - instead of inputting wall time, I now input the adjusted simulation time, and I input zero if the game is paused or physics are globally paused.

The particles had a custom code to correctly calc. sim. time and skip the update entirely when paused. I reverted all that, expecting the adjusted time input to fix particles, but that didn't work - they don't use that input. I already researched this at #3138 and figured to use `Ogre::ParticleSystem::setSpeedFactor()` - that did the trick.

UPDATE: I synced all particles to simulation time: exhausts, cparticles, turboprops, turbojets, terrain object particles.

Known issue: Particle time to live still runs on real time - this appears to be a bug in OGRE.
