### PR TITLE
Avoid mixing up truckfiles when filename isn't unique.

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -226,8 +226,7 @@ ActorPtr GameContext::SpawnActor(ActorSpawnRequest& rq)
         rq.asr_cache_entry = App::GetCacheSystem()->FindEntryByFilename(LT_AllBeam, /*partial:*/false, rq.asr_filename);
     }
 
-    RigDef::DocumentPtr def = m_actor_manager.FetchActorDef(
-        rq.asr_filename, rq.asr_origin == ActorSpawnRequest::Origin::TERRN_DEF);
+    RigDef::DocumentPtr def = m_actor_manager.FetchActorDef(rq);
     if (def == nullptr)
     {
         return nullptr; // Error already reported

--- a/source/main/network/RoRnet.h
+++ b/source/main/network/RoRnet.h
@@ -32,7 +32,7 @@ namespace RoRnet {
 #define RORNET_LAN_BROADCAST_PORT   13000  //!< port used to send the broadcast announcement in LAN mode
 #define RORNET_MAX_USERNAME_LEN     40     //!< port used to send the broadcast announcement in LAN mode
 
-#define RORNET_VERSION              "RoRnet_2.44"
+#define RORNET_VERSION              "RoRnet_2.45"
 
 enum MessageType
 {

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -1950,7 +1950,15 @@ void Actor::sendStreamSetup()
     reg.status = 0;
     reg.type = 0;
     reg.time = App::GetGameContext()->GetActorManager()->GetNetTime();
-    strncpy(reg.name, ar_filename.c_str(), 128);
+
+    // Send the filename in "Bundle-qualified" format, i.e. "mybundle.zip:myactor.truck"
+    std::string bname;
+    std::string bpath;
+    Ogre::StringUtil::splitFilename(m_used_actor_entry->resource_bundle_path, bname, bpath);
+    std::string bq_filename = fmt::format("{}:{}", bname, ar_filename);
+    strncpy(reg.name, bq_filename.c_str(), 128);
+    
+    // Skin and sectionconfig
     if (m_used_skin_entry != nullptr)
     {
         strncpy(reg.skin, m_used_skin_entry->dname.c_str(), 60);
@@ -4413,7 +4421,7 @@ Actor::Actor(
     , ar_instance_id(actor_id)
     , ar_vector_index(vector_index)
     , m_avg_proped_wheel_radius(0.2f)
-    , ar_filename(rq.asr_filename)
+    , ar_filename(rq.asr_cache_entry->fname)
     , m_section_config(rq.asr_config)
     , m_used_actor_entry(rq.asr_cache_entry)
     , m_used_skin_entry(rq.asr_skin_entry)

--- a/source/main/physics/ActorManager.h
+++ b/source/main/physics/ActorManager.h
@@ -104,7 +104,7 @@ public:
     
 
     void           UpdateInputEvents(float dt);
-    RigDef::DocumentPtr   FetchActorDef(std::string filename, bool predefined_on_terrain = false);
+    RigDef::DocumentPtr   FetchActorDef(RoR::ActorSpawnRequest& rq);
 
 #ifdef USE_SOCKETW
     void           HandleActorStreamData(std::vector<RoR::NetRecvPacket> packet);

--- a/source/main/physics/ActorSpawnerFlow.cpp
+++ b/source/main/physics/ActorSpawnerFlow.cpp
@@ -60,6 +60,7 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
 {
     m_actor = actor;
     m_file = def;
+    m_custom_resource_group = rq.asr_cache_entry->resource_group; // For historical/backwards-compat reasons, the instances live in the same group as the bundle.
 
     // Under OGRE, every scenenode must have globally unique name.
     m_actor_grouping_scenenode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode(this->ComposeName("Actor"));
@@ -84,9 +85,6 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     {
         m_generate_wing_position_lights = false; // Disable aerial pos. lights for land vehicles.
     }
-
-    // Get resource group name
-    App::GetCacheSystem()->CheckResourceLoaded(m_actor->ar_filename, m_custom_resource_group);
 
     // Create the built-in "renderdash" material for use in meshes.
     // Must be done before 'props' are processed because those traditionally use it.

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -846,7 +846,7 @@ struct ActorSpawnRequest
     };
 
     CacheEntryPtr       asr_cache_entry; //!< Optional, overrides 'asr_filename' and 'asr_cache_entry_num'
-    std::string         asr_filename;
+    std::string         asr_filename;    //!< Can be in "Bundle-qualified" format, i.e. "mybundle.zip:myactor.truck"
     Ogre::String        asr_config;
     Ogre::Vector3       asr_position = Ogre::Vector3::ZERO;
     Ogre::Quaternion    asr_rotation = Ogre::Quaternion::ZERO;

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -181,26 +181,15 @@ void CacheSystem::LoadModCache(CacheValidity validity)
     m_loaded = true;
 }
 
-CacheEntryPtr CacheSystem::FindEntryByFilename(LoaderType type, bool partial, const std::string& _filename)
+CacheEntryPtr CacheSystem::FindEntryByFilename(LoaderType type, bool partial, const std::string& _filename_maybe_bundlequalified)
 {
-    // The `_filename` may optionally be in "Bundle-qualified" format, i.e. "mybundle.zip:myactor.truck"
+    // "Bundle-qualified" format also specifies the ZIP/directory in modcache, i.e. "mybundle.zip:myactor.truck"
     // Like the filename, the bundle name lookup is case-insensitive.
     // -------------------------------------------------------------------------------------------------
 
     std::string filename;
     std::string bundlename;
-    size_t colon_pos = _filename.find(':');
-    if (colon_pos != std::string::npos)
-    {
-        // The name is in format "mybundle.zip:myactor.truck" - find all bundles with "myactor.truck" and choose the right one.
-        filename = _filename.substr(colon_pos + 1);
-        bundlename = _filename.substr(0, colon_pos);
-    }
-    else
-    {
-        filename = _filename;
-    }
-
+    SplitBundleQualifiedFilename(_filename_maybe_bundlequalified, bundlename, filename);
     StringUtil::toLowerCase(filename);
     StringUtil::toLowerCase(bundlename);
     size_t partial_match_length = std::numeric_limits<size_t>::max();
@@ -250,7 +239,7 @@ CacheEntryPtr CacheSystem::FindEntryByFilename(LoaderType type, bool partial, co
     if (log_candidates.size() > 0)
     {
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-            fmt::format(_LC("CacheSystem", "Mod '{}' was not found in cache; candidates ({}) are:"), _filename, log_candidates.size()));
+            fmt::format(_LC("CacheSystem", "Mod '{}' was not found in cache; candidates ({}) are:"), _filename_maybe_bundlequalified, log_candidates.size()));
         for (CacheEntryPtr& entry: log_candidates)
         {
             std::string bundle_name, bundle_path;

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -301,7 +301,7 @@ public:
 
     /// @name Lookups
     /// @{
-    CacheEntryPtr         FindEntryByFilename(RoR::LoaderType type, bool partial, const std::string& filename); //!< Returns NULL if none found
+    CacheEntryPtr         FindEntryByFilename(RoR::LoaderType type, bool partial, const std::string& _filename_maybe_bundlequalified); //!< Returns NULL if none found; "Bundle-qualified" format also specifies the ZIP/directory in modcache, i.e. "mybundle.zip:myactor.truck"
     CacheEntryPtr         GetEntryByNumber(int modid);
     CacheEntryPtr         FetchSkinByName(std::string const & skin_name);
     size_t                Query(CacheQuery& query);

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -310,8 +310,6 @@ public:
     /// @name Loading
     /// @{
     void                  LoadResource(CacheEntryPtr& t); //!< Loads the associated resource bundle if not already done.
-    bool                  CheckResourceLoaded(Ogre::String &in_out_filename); //!< Finds + loads the associated resource bundle if not already done.
-    bool                  CheckResourceLoaded(Ogre::String &in_out_filename, Ogre::String &out_group); //!< Finds given resource, outputs group name. Also loads the associated resource bundle if not already done.
     void                  ReLoadResource(CacheEntryPtr& t); //!< Forces reloading the associated bundle.
     void                  UnLoadResource(CacheEntryPtr& t); //!< Unloads associated bundle, destroying all spawned actors.
     void                  LoadSupplementaryDocuments(CacheEntryPtr& t); //!< Loads the associated .truck*, .skin and .tuneup files.

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -241,20 +241,14 @@ void TerrainObjectManager::LoadTObjFile(Ogre::String tobj_name)
     }
 
     // Vehicles
-    for (TObjVehicle veh : tobj->vehicles)
+    for (TObjVehicle const& veh : tobj->vehicles)
     {
         if ((veh.type == TObj::SpecialObject::BOAT) && (terrainManager->getWater() == nullptr))
         {
             continue; // Don't spawn boats if there's no water.
         }
 
-        Ogre::String group;
-        Ogre::String filename(veh.name);
-        if (!RoR::App::GetCacheSystem()->CheckResourceLoaded(filename, group))
-        {
-            LOG(std::string("[RoR|Terrain] Vehicle ") + veh.name + " not found. ignoring.");
-            continue;
-        }
+        // NOTE: The filename may be in "Bundle-qualified" format, i.e. "mybundle.zip:myactor.truck"
 
         PredefinedActor p;
         p.px           = veh.position.x;

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -224,3 +224,18 @@ void RoR::CvarRemoveFileFromList(CVar* cvar, const std::string& filename)
 
     cvar->setStr(JoinStrVec(files, ","));
 }
+
+void RoR::SplitBundleQualifiedFilename(const std::string& bundleQualifiedFilename, std::string& out_bundleName, std::string& out_filename)
+{
+    size_t pos = bundleQualifiedFilename.find(':');
+    if (pos != std::string::npos)
+    {
+        out_bundleName = bundleQualifiedFilename.substr(0, pos);
+        out_filename = bundleQualifiedFilename.substr(pos + 1);
+    }
+    else
+    {
+        out_bundleName = "";
+        out_filename = bundleQualifiedFilename;
+    }
+}

--- a/source/main/utils/Utils.h
+++ b/source/main/utils/Utils.h
@@ -108,4 +108,6 @@ std::string PrintMeshInfo(std::string const& title, Ogre::MeshPtr mesh);
 void CvarAddFileToList(CVar* cvar, const std::string& filename);
 void CvarRemoveFileFromList(CVar* cvar, const std::string& filename);
 
+void SplitBundleQualifiedFilename(const std::string& bundleQualifiedFilename, std::string& out_bundleName, std::string& out_filename);
+
 } // namespace RoR


### PR DESCRIPTION
Fixes #3166

**Problem1:** When spawning an actor, the cache entry was always looked up via truckfile name, even if it was already known from the Selector UI. This potentially caused mixups.

**Fix2:** Use the entry provided by Selector UI.

**Problem2**: in many scenarios, the game selects an actor by truckfile name alone:
 *   savegames
 *   preselected truck in RoR.cfg
 *   preloaded trucks on terrain (.tobj)
 *   Multiplayer spawn notifications

**Fix2**: introduce an optional "Bundle-qualified" syntax, i.e. "mybundle.zip:myactor.truck" (in case of ZIP archive) or "mysubdir:myproject.truck" (in case of subdir) and use it in all the above cases. Because it's optional, it doesn't need a version bump in savegame format or RoRnet protocol. Note that 'bundle' is RoR jargon for a ZIP archive or directory under /mods.

### Testing
Use the attached mods and spawn them using console commands:
[dafsemiMixupTest_hangar.zip](https://github.com/user-attachments/files/16480983/dafsemiMixupTest_hangar.zip)
[dafsemiMixupTest_transred.zip](https://github.com/user-attachments/files/16480984/dafsemiMixupTest_transred.zip)

This uses just filename - it will spawn the first one in your 'mods.cache' JSON file.
```
as game.pushMessage(MSG_SIM_SPAWN_ACTOR_REQUESTED, { {'filename', 'dafsemiMixupTest.truck'}, {'position', game.getPersonPosition()}, {'rotation', quaternion(game.getPersonRotation(), vector3(0,1,0))} });
```
This uses explicit bundle name, so it will spawn the Transred variant.
```
as game.pushMessage(MSG_SIM_SPAWN_ACTOR_REQUESTED, { {'filename', 'dafsemiMixupTest_transred.zip:dafsemiMixupTest.truck'}, {'position', game.getPersonPosition()}, {'rotation', quaternion(game.getPersonRotation(), vector3(0,1,0))} });
```
This uses explicit bundle name and demonstrates case-insensitive lookup - it will spawn the Hangar variant.
```
as game.pushMessage(MSG_SIM_SPAWN_ACTOR_REQUESTED, { {'filename', 'DAFSEMIMIXUPTEST_HANGAR.ZIP:DAFSEMIMIXUPTEST.TRUCK'}, {'position', game.getPersonPosition()}, {'rotation', quaternion(game.getPersonRotation(), vector3(0,1,0))} });
```