### PR TITLE
Fix building with gcc on Linux

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -5903,9 +5903,9 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
 
     /* Positioning */
     Ogre::Vector3 node_position = m_spawn_position + TuneupUtil::getTweakedNodePosition(m_actor->getWorkingTuneupDef(), node.pos, def.position);
-    ROR_ASSERT(!isnan(node_position.x));
-    ROR_ASSERT(!isnan(node_position.y));
-    ROR_ASSERT(!isnan(node_position.z));
+    ROR_ASSERT(!std::isnan(node_position.x));
+    ROR_ASSERT(!std::isnan(node_position.y));
+    ROR_ASSERT(!std::isnan(node_position.z));
     node.AbsPosition = node_position; 
     node.RelPosition = node_position - m_actor->ar_origin;
 

--- a/source/main/resources/addonpart_fileformat/AddonPartFileFormat.h
+++ b/source/main/resources/addonpart_fileformat/AddonPartFileFormat.h
@@ -41,6 +41,13 @@ struct AddonPartConflict //!< Conflict between two addonparts tweaking the same 
     CacheEntryPtr   atc_addonpart2;
     std::string     atc_keyword;
     int             atc_element_id = -1;
+
+    AddonPartConflict(CacheEntryPtr addonpart1, CacheEntryPtr addonpart2, std::string keyword, int element_id):
+        atc_addonpart1(addonpart1),
+        atc_addonpart2(addonpart2),
+        atc_keyword(keyword),
+        atc_element_id(element_id)
+    {}
 };
 
 typedef std::vector<AddonPartConflict> AddonPartConflictVec;


### PR DESCRIPTION
Hi guys,

good to see that RoR is still alive. :)

I'm trying to build RoR on Debian 12 with `gcc (Debian 12.2.0-14) 12.2.0`  but ran into some compiler errors.

This PR fixes some of them, however the following errors do still remain and I am unsure how to fix them:
```console
ninja | grep error
/home/deb/rigs-of-rods/source/main/scripting/bindings/OgreAngelscript.cpp:1647:86: error: invalid ‘static_cast’ from type ‘Ogre::SceneNode* (Ogre::SceneNode::*)() const’ to type ‘Ogre::SceneNode* (Ogre::SceneNode::*)()’
/home/deb/rigs-of-rods/source/main/scripting/bindings/OgreAngelscript.cpp:1648:90: error: invalid ‘static_cast’ from type ‘const Ogre::Vector3& (Ogre::SceneNode::*)() const’ {aka ‘const Ogre::Vector<3, float>& (Ogre::SceneNode::*)() const’} to type ‘const Ogre::Vector3& (Ogre::SceneNode::*)()’ {aka ‘const Ogre::Vector<3, float>& (Ogre::SceneNode::*)()’}
/home/deb/rigs-of-rods/source/main/scripting/bindings/OgreAngelscript.cpp:1649:98: error: invalid ‘static_cast’ from type ‘const Ogre::Vector3& (Ogre::SceneNode::*)() const’ {aka ‘const Ogre::Vector<3, float>& (Ogre::SceneNode::*)() const’} to type ‘const Ogre::Vector3& (Ogre::SceneNode::*)()’ {aka ‘const Ogre::Vector<3, float>& (Ogre::SceneNode::*)()’}
/home/deb/rigs-of-rods/source/main/scripting/bindings/OgreAngelscript.cpp:1651:97: error: invalid ‘static_cast’ from type ‘void (Ogre::SceneNode::*)(bool, bool) const’ to type ‘void (Ogre::SceneNode::*)(bool, bool)’
/home/deb/rigs-of-rods/source/main/scripting/bindings/OgreAngelscript.cpp:1652:87: error: invalid ‘static_cast’ from type ‘void (Ogre::SceneNode::*)(bool) const’ to type ‘void (Ogre::SceneNode::*)(bool)’
/home/deb/rigs-of-rods/source/main/scripting/bindings/OgreAngelscript.cpp:1653:109: error: invalid ‘static_cast’ from type ‘void (Ogre::SceneNode::*)(bool, bool) const’ to type ‘void (Ogre::SceneNode::*)(bool, bool)’
```