### PR TITLE
:bug: Update/fix Doppler effect for OpenAL 1.1 implementations

### DIFF
--- a/doc/angelscript/Script2Game/globals.h
+++ b/doc/angelscript/Script2Game/globals.h
@@ -664,6 +664,8 @@ enum MsgType
     MSG_EDI_RELOAD_BUNDLE_REQUESTED,           //!< This deletes all actors using that bundle (= ZIP or directory)! Params: 'cache_entry' (CacheEntryClass@)
     MSG_EDI_UNLOAD_BUNDLE_REQUESTED,           //!< This deletes all actors using that bundle (= ZIP or directory)! Params: 'cache_entry' (CacheEntryClass@)
     MSG_EDI_CREATE_PROJECT_REQUESTED,          //!< Creates a subdir under 'projects/', pre-populates it and adds to modcache. Params: 'name' (string), 'ext' (string, optional), 'source_entry' (CacheEntryClass@)
+    // Audio
+    MSG_AUD_MODIFY_DOPPLER_FACTOR_REQUESTED    //!< Request change of doppler factor. Params: 'doppler_factor' (float). doppler_factor must not be negative.NAL
 };
 
 } // namespace Script2Game

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -209,6 +209,7 @@ CVar* io_invert_orbitcam;
 CVar* audio_master_volume;
 CVar* audio_enable_creak;
 CVar* audio_device_name;
+CVar* audio_doppler_factor;
 CVar* audio_menu_music;
 
 // Graphics
@@ -626,6 +627,8 @@ const char* MsgTypeToString(MsgType type)
     case MSG_EDI_CREATE_PROJECT_REQUESTED     : return "MSG_EDI_CREATE_PROJECT_REQUESTED";
     case MSG_EDI_MODIFY_PROJECT_REQUESTED     : return "MSG_EDI_MODIFY_PROJECT_REQUESTED";
     case MSG_EDI_DELETE_PROJECT_REQUESTED     : return "MSG_EDI_DELETE_PROJECT_REQUESTED";
+
+    case MSG_AUD_MODIFY_DOPPLER_FACTOR_REQUESTED : return "MSG_AUD_MODIFY_DOPPLER_FACTOR_REQUESTED";
 
     default: return "";
     }

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -150,6 +150,8 @@ enum MsgType
     MSG_EDI_CREATE_PROJECT_REQUESTED,      //!< Payload = RoR::CreateProjectRequest* (owner)
     MSG_EDI_MODIFY_PROJECT_REQUESTED,      //!< Payload = RoR::UpdateProjectRequest* (owner)
     MSG_EDI_DELETE_PROJECT_REQUESTED,      //!< Payload = RoR::CacheEntryPtr* (owner)
+    // Audio
+    MSG_AUD_MODIFY_DOPPLER_FACTOR_REQUESTED, //!< Payload = float*
 };
 
 const char* MsgTypeToString(MsgType type);
@@ -446,6 +448,7 @@ extern CVar* io_invert_orbitcam;
 extern CVar* audio_master_volume;
 extern CVar* audio_enable_creak;
 extern CVar* audio_device_name;
+extern CVar* audio_doppler_factor;
 extern CVar* audio_menu_music;
 
 // Graphics

--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -135,7 +135,7 @@ SoundManager::~SoundManager()
     LOG("SoundManager destroyed.");
 }
 
-void SoundManager::setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity)
+void SoundManager::setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity, bool listener_is_underwater)
 {
     if (!audio_device)
         return;
@@ -155,6 +155,15 @@ void SoundManager::setListener(Ogre::Vector3 position, Ogre::Vector3 direction, 
     alListener3f(AL_POSITION, position.x, position.y, position.z);
     alListener3f(AL_VELOCITY, velocity.x, velocity.y, velocity.z);
     alListenerfv(AL_ORIENTATION, orientation);
+
+    if(!listener_is_underwater)
+    {
+        alSpeedOfSound(343.3f); // assume listener is in air at 20° celsius
+    }
+    else
+    {
+        alSpeedOfSound(1522.0f); // assume listener is in sea water (i.e. salt water)
+    }
 }
 
 bool compareByAudibility(std::pair<int, float> a, std::pair<int, float> b)

--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -109,7 +109,7 @@ SoundManager::SoundManager()
     }
 
     alDopplerFactor(1.0f);
-    alDopplerVelocity(343.0f);
+    alSpeedOfSound(343.3f);
 
     for (int i = 0; i < MAX_HARDWARE_SOURCES; i++)
     {

--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -135,7 +135,7 @@ SoundManager::~SoundManager()
     LOG("SoundManager destroyed.");
 }
 
-void SoundManager::setCamera(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity)
+void SoundManager::setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity)
 {
     if (!audio_device)
         return;

--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -135,7 +135,7 @@ SoundManager::~SoundManager()
     LOG("SoundManager destroyed.");
 }
 
-void SoundManager::setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity, bool listener_is_underwater)
+void SoundManager::setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity)
 {
     if (!audio_device)
         return;
@@ -155,15 +155,6 @@ void SoundManager::setListener(Ogre::Vector3 position, Ogre::Vector3 direction, 
     alListener3f(AL_POSITION, position.x, position.y, position.z);
     alListener3f(AL_VELOCITY, velocity.x, velocity.y, velocity.z);
     alListenerfv(AL_ORIENTATION, orientation);
-
-    if(!listener_is_underwater)
-    {
-        alSpeedOfSound(343.3f); // assume listener is in air at 20° celsius
-    }
-    else
-    {
-        alSpeedOfSound(1522.0f); // assume listener is in sea water (i.e. salt water)
-    }
 }
 
 bool compareByAudibility(std::pair<int, float> a, std::pair<int, float> b)

--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -139,7 +139,7 @@ void SoundManager::setListener(Ogre::Vector3 position, Ogre::Vector3 direction, 
 {
     if (!audio_device)
         return;
-    camera_position = position;
+    listener_position = position;
     recomputeAllSources();
 
     float orientation[6];
@@ -180,7 +180,7 @@ void SoundManager::recomputeAllSources()
 
 	for (int i=0; i < audio_buffers_in_use_count; i++)
 	{
-		audio_sources[i]->computeAudibility(camera_position);
+		audio_sources[i]->computeAudibility(listener_position);
 		audio_sources_most_audible[i].first = i;
 		audio_sources_most_audible[i].second = audio_sources[i]->audibility;
 	}
@@ -218,7 +218,7 @@ void SoundManager::recomputeSource(int source_index, int reason, float vfl, Vect
 {
     if (!audio_device)
         return;
-    audio_sources[source_index]->computeAudibility(camera_position);
+    audio_sources[source_index]->computeAudibility(listener_position);
 
     if (audio_sources[source_index]->audibility == 0.0f)
     {

--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -108,7 +108,7 @@ SoundManager::SoundManager()
         alSourcef(hardware_sources[hardware_sources_num], AL_MAX_DISTANCE, MAX_DISTANCE);
     }
 
-    alDopplerFactor(1.0f);
+    alDopplerFactor(App::audio_doppler_factor->getFloat());
     alSpeedOfSound(343.3f);
 
     for (int i = 0; i < MAX_HARDWARE_SOURCES; i++)

--- a/source/main/audio/SoundManager.h
+++ b/source/main/audio/SoundManager.h
@@ -55,7 +55,7 @@ public:
     */
     SoundPtr createSound(Ogre::String filename, Ogre::String resource_group_name = "");
 
-    void setCamera(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity);
+    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity);
     void pauseAllSounds();
     void resumeAllSounds();
     void setMasterVolume(float v);

--- a/source/main/audio/SoundManager.h
+++ b/source/main/audio/SoundManager.h
@@ -55,7 +55,7 @@ public:
     */
     SoundPtr createSound(Ogre::String filename, Ogre::String resource_group_name = "");
 
-    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity, bool listener_is_underwater);
+    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity);
     void pauseAllSounds();
     void resumeAllSounds();
     void setMasterVolume(float v);
@@ -63,6 +63,7 @@ public:
     bool isDisabled() { return audio_device == 0; }
 
     float getSpeedOfSound() { return alGetFloat(AL_SPEED_OF_SOUND); }
+    void setSpeedOfSound(float speed_of_sound) { alSpeedOfSound(speed_of_sound); }
     float getDopplerFactor() { return alGetFloat(AL_DOPPLER_FACTOR); }
     void setDopplerFactor(float doppler_factor) { alDopplerFactor(doppler_factor); }
 

--- a/source/main/audio/SoundManager.h
+++ b/source/main/audio/SoundManager.h
@@ -55,7 +55,7 @@ public:
     */
     SoundPtr createSound(Ogre::String filename, Ogre::String resource_group_name = "");
 
-    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity);
+    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity, bool listener_is_underwater);
     void pauseAllSounds();
     void resumeAllSounds();
     void setMasterVolume(float v);

--- a/source/main/audio/SoundManager.h
+++ b/source/main/audio/SoundManager.h
@@ -63,6 +63,8 @@ public:
     bool isDisabled() { return audio_device == 0; }
 
     float getSpeedOfSound() { return alGetFloat(AL_SPEED_OF_SOUND); }
+    float getDopplerFactor() { return alGetFloat(AL_DOPPLER_FACTOR); }
+    void setDopplerFactor(float doppler_factor) { alDopplerFactor(doppler_factor); }
 
     int getNumHardwareSources() { return hardware_sources_num; }
 

--- a/source/main/audio/SoundManager.h
+++ b/source/main/audio/SoundManager.h
@@ -62,6 +62,8 @@ public:
 
     bool isDisabled() { return audio_device == 0; }
 
+    float getSpeedOfSound() { return alGetFloat(AL_SPEED_OF_SOUND); }
+
     int getNumHardwareSources() { return hardware_sources_num; }
 
     static const float MAX_DISTANCE;

--- a/source/main/audio/SoundManager.h
+++ b/source/main/audio/SoundManager.h
@@ -100,7 +100,7 @@ private:
     ALuint       audio_buffers[MAX_AUDIO_BUFFERS];
     Ogre::String audio_buffer_file_name[MAX_AUDIO_BUFFERS];
 
-    Ogre::Vector3 camera_position = Ogre::Vector3::ZERO;
+    Ogre::Vector3 listener_position = Ogre::Vector3::ZERO;
     ALCdevice*    audio_device = nullptr;
     ALCcontext*   sound_context = nullptr;
 };

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -317,15 +317,15 @@ void SoundScriptManager::update(float dt_sec)
         Ogre::Vector3 upVector = App::GetCameraManager()->GetCameraNode()->getOrientation() * Ogre::Vector3::UNIT_Y;
         // Direction points down -Z by default (adapted from Ogre::Camera)
         Ogre::Vector3 cameraDir = App::GetCameraManager()->GetCameraNode()->getOrientation() * -Ogre::Vector3::UNIT_Z;
-        this->setCamera(App::GetCameraManager()->GetCameraNode()->getPosition(), cameraDir, upVector, cameraSpeed);
+        this->setListener(App::GetCameraManager()->GetCameraNode()->getPosition(), cameraDir, upVector, cameraSpeed);
     }
 }
 
-void SoundScriptManager::setCamera(Vector3 position, Vector3 direction, Vector3 up, Vector3 velocity)
+void SoundScriptManager::setListener(Vector3 position, Vector3 direction, Vector3 up, Vector3 velocity)
 {
     if (disabled)
         return;
-    sound_manager->setCamera(position, direction, up, velocity);
+    sound_manager->setListener(position, direction, up, velocity);
 }
 
 const StringVector& SoundScriptManager::getScriptPatterns(void) const

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -310,14 +310,15 @@ void SoundScriptManager::update(float dt_sec)
     if (App::sim_state->getEnum<SimState>() == SimState::RUNNING ||
         App::sim_state->getEnum<SimState>() == SimState::EDITOR_MODE)
     {
-        Ogre::SceneNode* cam_node = App::GetCameraManager()->GetCameraNode();
-        static Vector3 lastCameraPosition;
-        Vector3 cameraSpeed = (cam_node->getPosition() - lastCameraPosition) / dt_sec;
-        lastCameraPosition = cam_node->getPosition();
-        Ogre::Vector3 upVector = App::GetCameraManager()->GetCameraNode()->getOrientation() * Ogre::Vector3::UNIT_Y;
+        Ogre::SceneNode* camera_node = App::GetCameraManager()->GetCameraNode();
+        static Vector3 last_camera_position;
+        Ogre::Vector3 camera_position = camera_node->getPosition();
+        Vector3 camera_velocity = (camera_position - last_camera_position) / dt_sec;
+        last_camera_position = camera_position;
+        Ogre::Vector3 camera_up = camera_node->getOrientation() * Ogre::Vector3::UNIT_Y;
         // Direction points down -Z by default (adapted from Ogre::Camera)
-        Ogre::Vector3 cameraDir = App::GetCameraManager()->GetCameraNode()->getOrientation() * -Ogre::Vector3::UNIT_Z;
-        this->setListener(App::GetCameraManager()->GetCameraNode()->getPosition(), cameraDir, upVector, cameraSpeed);
+        Ogre::Vector3 camera_direction = camera_node->getOrientation() * -Ogre::Vector3::UNIT_Z;
+        this->setListener(camera_position, camera_direction, camera_up, camera_velocity);
     }
 }
 

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -320,17 +320,34 @@ void SoundScriptManager::update(float dt_sec)
         Ogre::Vector3 camera_up = camera_node->getOrientation() * Ogre::Vector3::UNIT_Y;
         // Direction points down -Z by default (adapted from Ogre::Camera)
         Ogre::Vector3 camera_direction = camera_node->getOrientation() * -Ogre::Vector3::UNIT_Z;
-        const auto water = App::GetGameContext()->GetTerrain()->getWater();
-        bool camera_is_underwater = (water != nullptr ? water->IsUnderWater(camera_position) : false);
-        this->setListener(camera_position, camera_direction, camera_up, camera_velocity, camera_is_underwater);
+        this->setListener(camera_position, camera_direction, camera_up, camera_velocity);
+        this->setListenerEnvironment(camera_position);
     }
 }
 
-void SoundScriptManager::setListener(Vector3 position, Vector3 direction, Vector3 up, Vector3 velocity, bool listener_is_underwater)
+void SoundScriptManager::setListener(Vector3 position, Vector3 direction, Vector3 up, Vector3 velocity)
 {
     if (disabled)
         return;
-    sound_manager->setListener(position, direction, up, velocity, listener_is_underwater);
+    sound_manager->setListener(position, direction, up, velocity);
+}
+
+void SoundScriptManager::setListenerEnvironment(Vector3 listener_position)
+{
+    if (disabled)
+        return;
+
+    const auto water = App::GetGameContext()->GetTerrain()->getWater();
+    bool listener_is_underwater = (water != nullptr ? water->IsUnderWater(listener_position) : false);
+
+    if(listener_is_underwater)
+    {
+        sound_manager->setSpeedOfSound(1522.0f); // assume listener is in sea water (i.e. salt water)
+    }
+    else
+    {
+        sound_manager->setSpeedOfSound(343.3f); // assume listener is in air at 20° celsius
+    }
 }
 
 void SoundScriptManager::setDopplerFactor(float doppler_factor)

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -333,6 +333,13 @@ void SoundScriptManager::setListener(Vector3 position, Vector3 direction, Vector
     sound_manager->setListener(position, direction, up, velocity, listener_is_underwater);
 }
 
+void SoundScriptManager::setDopplerFactor(float doppler_factor)
+{
+    if (disabled)
+        return;
+    sound_manager->setDopplerFactor(doppler_factor);
+}
+
 const StringVector& SoundScriptManager::getScriptPatterns(void) const
 {
     return script_patterns;

--- a/source/main/audio/SoundScriptManager.cpp
+++ b/source/main/audio/SoundScriptManager.cpp
@@ -24,6 +24,8 @@
 
 #include "Actor.h"
 #include "CameraManager.h"
+#include "GameContext.h"
+#include "IWater.h"
 #include "Sound.h"
 #include "SoundManager.h"
 #include "Utils.h"
@@ -318,15 +320,17 @@ void SoundScriptManager::update(float dt_sec)
         Ogre::Vector3 camera_up = camera_node->getOrientation() * Ogre::Vector3::UNIT_Y;
         // Direction points down -Z by default (adapted from Ogre::Camera)
         Ogre::Vector3 camera_direction = camera_node->getOrientation() * -Ogre::Vector3::UNIT_Z;
-        this->setListener(camera_position, camera_direction, camera_up, camera_velocity);
+        const auto water = App::GetGameContext()->GetTerrain()->getWater();
+        bool camera_is_underwater = (water != nullptr ? water->IsUnderWater(camera_position) : false);
+        this->setListener(camera_position, camera_direction, camera_up, camera_velocity, camera_is_underwater);
     }
 }
 
-void SoundScriptManager::setListener(Vector3 position, Vector3 direction, Vector3 up, Vector3 velocity)
+void SoundScriptManager::setListener(Vector3 position, Vector3 direction, Vector3 up, Vector3 velocity, bool listener_is_underwater)
 {
     if (disabled)
         return;
-    sound_manager->setListener(position, direction, up, velocity);
+    sound_manager->setListener(position, direction, up, velocity, listener_is_underwater);
 }
 
 const StringVector& SoundScriptManager::getScriptPatterns(void) const

--- a/source/main/audio/SoundScriptManager.h
+++ b/source/main/audio/SoundScriptManager.h
@@ -327,7 +327,7 @@ public:
     void setEnabled(bool state);
 
     void setDopplerFactor(float doppler_factor);
-    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity, bool listener_is_underwater);
+    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity);
     void setLoadingBaseSounds(bool value) { loading_base = value; };
 
     bool isDisabled() { return disabled; }
@@ -366,6 +366,8 @@ private:
     // state map
     // soundLinks, soundItems, actor_ids, triggers
     std::map <int, std::map <int, std::map <int, std::map <int, bool > > > > state_map;
+
+    void setListenerEnvironment(Ogre::Vector3 position);
 
     SoundManager* sound_manager;
 };

--- a/source/main/audio/SoundScriptManager.h
+++ b/source/main/audio/SoundScriptManager.h
@@ -326,6 +326,7 @@ public:
 
     void setEnabled(bool state);
 
+    void setDopplerFactor(float doppler_factor);
     void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity, bool listener_is_underwater);
     void setLoadingBaseSounds(bool value) { loading_base = value; };
 

--- a/source/main/audio/SoundScriptManager.h
+++ b/source/main/audio/SoundScriptManager.h
@@ -326,7 +326,7 @@ public:
 
     void setEnabled(bool state);
 
-    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity);
+    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity, bool listener_is_underwater);
     void setLoadingBaseSounds(bool value) { loading_base = value; };
 
     bool isDisabled() { return disabled; }

--- a/source/main/audio/SoundScriptManager.h
+++ b/source/main/audio/SoundScriptManager.h
@@ -326,7 +326,7 @@ public:
 
     void setEnabled(bool state);
 
-    void setCamera(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity);
+    void setListener(Ogre::Vector3 position, Ogre::Vector3 direction, Ogre::Vector3 up, Ogre::Vector3 velocity);
     void setLoadingBaseSounds(bool value) { loading_base = value; };
 
     bool isDisabled() { return disabled; }

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -329,9 +329,9 @@ void GameSettings::DrawAudioSettings()
         App::audio_device_name->setStr(audio_devices[device_id]);
     }
 
-    DrawGCheckbox(App::audio_enable_creak,     _LC("GameSettings", "Creak sound"));
-    DrawGCheckbox(App::audio_menu_music,       _LC("GameSettings", "Main menu music"));
-    DrawGFloatSlider(App::audio_master_volume, _LC("GameSettings", "Master volume"), 0, 1);
+    DrawGCheckbox(App::audio_enable_creak,      _LC("GameSettings", "Creak sound"));
+    DrawGCheckbox(App::audio_menu_music,        _LC("GameSettings", "Main menu music"));
+    DrawGFloatSlider(App::audio_master_volume,  _LC("GameSettings", "Master volume"), 0, 1);
 #endif // USE_OPENAL
 }
 

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -332,6 +332,7 @@ void GameSettings::DrawAudioSettings()
     DrawGCheckbox(App::audio_enable_creak,      _LC("GameSettings", "Creak sound"));
     DrawGCheckbox(App::audio_menu_music,        _LC("GameSettings", "Main menu music"));
     DrawGFloatSlider(App::audio_master_volume,  _LC("GameSettings", "Master volume"), 0, 1);
+    DrawGFloatSlider(App::audio_doppler_factor, _LC("GameSettings", "Doppler factor (requires restart)"), 0, 10);
 #endif // USE_OPENAL
 }
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -1581,6 +1581,16 @@ int main(int argc, char *argv[])
                     break;
                 }
 
+                // -- Audio events --
+                case MSG_AUD_MODIFY_DOPPLER_FACTOR_REQUESTED:
+                {
+                    float* doppler_factor_ptr = static_cast<float*>(m.payload);
+                    LOG(fmt::format("Changing doppler factor to '{}' (from message bus)", *doppler_factor_ptr));
+                    App::GetSoundScriptManager()->getSoundManager()->setDopplerFactor(*doppler_factor_ptr);
+                    delete doppler_factor_ptr;
+                    break;
+                }
+
                 default:;
                 }
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -933,7 +933,7 @@ int main(int argc, char *argv[])
                         App::sim_terrain_name->setStr("");
                         App::sim_terrain_gui_name->setStr("");
                         App::GetOutGauge()->Close();
-                        App::GetSoundScriptManager()->setListener(/*position:*/Ogre::Vector3::ZERO, /*direction:*/Ogre::Vector3::ZERO, /*up:*/Ogre::Vector3::UNIT_Y, /*velocity:*/Ogre::Vector3::ZERO);
+                        App::GetSoundScriptManager()->setListener(/*position:*/Ogre::Vector3::ZERO, /*direction:*/Ogre::Vector3::ZERO, /*up:*/Ogre::Vector3::UNIT_Y, /*velocity:*/Ogre::Vector3::ZERO, /*is underwater:*/ false);
                     }
                     catch (...)
                     {

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -933,7 +933,7 @@ int main(int argc, char *argv[])
                         App::sim_terrain_name->setStr("");
                         App::sim_terrain_gui_name->setStr("");
                         App::GetOutGauge()->Close();
-                        App::GetSoundScriptManager()->setListener(/*position:*/Ogre::Vector3::ZERO, /*direction:*/Ogre::Vector3::ZERO, /*up:*/Ogre::Vector3::UNIT_Y, /*velocity:*/Ogre::Vector3::ZERO, /*is underwater:*/ false);
+                        App::GetSoundScriptManager()->setListener(/*position:*/Ogre::Vector3::ZERO, /*direction:*/Ogre::Vector3::ZERO, /*up:*/Ogre::Vector3::UNIT_Y, /*velocity:*/Ogre::Vector3::ZERO);
                     }
                     catch (...)
                     {

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -933,7 +933,7 @@ int main(int argc, char *argv[])
                         App::sim_terrain_name->setStr("");
                         App::sim_terrain_gui_name->setStr("");
                         App::GetOutGauge()->Close();
-                        App::GetSoundScriptManager()->setCamera(/*position:*/Ogre::Vector3::ZERO, /*direction:*/Ogre::Vector3::ZERO, /*up:*/Ogre::Vector3::UNIT_Y, /*velocity:*/Ogre::Vector3::ZERO);
+                        App::GetSoundScriptManager()->setListener(/*position:*/Ogre::Vector3::ZERO, /*direction:*/Ogre::Vector3::ZERO, /*up:*/Ogre::Vector3::UNIT_Y, /*velocity:*/Ogre::Vector3::ZERO);
                     }
                     catch (...)
                     {

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -1704,6 +1704,22 @@ bool GameScript::pushMessage(MsgType type, AngelScript::CScriptDictionary* dict)
         }
         break;
     }
+    // Audio
+    case MSG_AUD_MODIFY_DOPPLER_FACTOR_REQUESTED:
+    {
+        float* doppler_factor_ptr = new float();
+        if (GetValueFromScriptDict(log_msg, dict, /*required:*/true, "doppler_factor", "float", doppler_factor_ptr) &&
+            !(*doppler_factor_ptr < 0.0f))
+        {
+            m.payload = static_cast<void*>(doppler_factor_ptr);
+        }
+        else
+        {
+            delete doppler_factor_ptr;
+            return false;
+        }
+        break;
+    }
     
     default:;
     }

--- a/source/main/scripting/bindings/MsgQueueAngelscript.cpp
+++ b/source/main/scripting/bindings/MsgQueueAngelscript.cpp
@@ -98,6 +98,8 @@ void RoR::RegisterMessageQueue(asIScriptEngine* engine)
     result = engine->RegisterEnumValue("MsgType", "MSG_EDI_RELOAD_BUNDLE_REQUESTED", MSG_EDI_RELOAD_BUNDLE_REQUESTED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("MsgType", "MSG_EDI_UNLOAD_BUNDLE_REQUESTED", MSG_EDI_UNLOAD_BUNDLE_REQUESTED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("MsgType", "MSG_EDI_CREATE_PROJECT_REQUESTED", MSG_EDI_CREATE_PROJECT_REQUESTED); ROR_ASSERT(result >= 0);
+    // Audio
+    result = engine->RegisterEnumValue("MsgType", "MSG_AUD_MODIFY_DOPPLER_FACTOR_REQUESTED", MSG_AUD_MODIFY_DOPPLER_FACTOR_REQUESTED); ROR_ASSERT(result >= 0);
 
     // enum FreeForceType
     result = engine->RegisterEnum("FreeForceType"); ROR_ASSERT(result>=0);

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -152,6 +152,7 @@ void Console::cVarSetupBuiltins()
     App::audio_master_volume     = this->cVarCreate("audio_master_volume",     "Sound Volume",               CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "1.0");
     App::audio_enable_creak      = this->cVarCreate("audio_enable_creak",      "Creak Sound",                CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::audio_device_name       = this->cVarCreate("audio_device_name",       "AudioDevice",                CVAR_ARCHIVE);
+    App::audio_doppler_factor    = this->cVarCreate("audio_doppler_factor",    "Doppler Factor",             CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "1.0");
     App::audio_menu_music        = this->cVarCreate("audio_menu_music",        "MainMenuMusic",              CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
 
     App::gfx_flares_mode         = this->cVarCreate("gfx_flares_mode",         "Lights",                     CVAR_ARCHIVE | CVAR_TYPE_INT,     "4"/*(int)GfxFlaresMode::ALL_VEHICLES_ALL_LIGHTS*/);

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -355,6 +355,34 @@ public:
     }
 };
 
+class SpeedOfSoundCmd: public ConsoleCmd
+{
+public:
+    SpeedOfSoundCmd(): ConsoleCmd("speedofsound", "[]", _L("speedofsound - outputs the current speed of sound")) {}
+
+    void Run(Ogre::StringVector const& args) override
+    {
+        if (!this->CheckAppState(AppState::SIMULATION))
+            return;
+
+        Str<200> reply;
+        reply << m_name << ": ";
+        Console::MessageType reply_type = Console::CONSOLE_SYSTEM_REPLY;
+
+        SoundManager* sound_manager = App::GetSoundScriptManager()->getSoundManager();
+        if (sound_manager == nullptr)
+        {
+            reply << _L("unable to get sound manager");
+        }
+        else
+        {
+            reply << _L("Current speed of sound: ") << sound_manager->getSpeedOfSound();
+        }
+
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, reply_type, reply.ToCStr());
+    }
+};
+
 class QuitCmd: public ConsoleCmd
 {
 public:
@@ -666,6 +694,7 @@ void Console::regBuiltinCommands()
     // Additions
     cmd = new ClearCmd();                 m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new LoadScriptCmd();            m_commands.insert(std::make_pair(cmd->getName(), cmd));
+    cmd = new SpeedOfSoundCmd();          m_commands.insert(std::make_pair(cmd->getName(), cmd));
     // CVars
     cmd = new SetCmd();                   m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new SetstringCmd();             m_commands.insert(std::make_pair(cmd->getName(), cmd));


### PR DESCRIPTION
The doppler effect was already reported as defective in #313. Turns out OpenAL 1.1 changed the way how the doppler effect is handled from OpenAL 1.0. Using the old way did not break the build as demanded by the spec but disabled the effect for at least the OpenAL Soft implementation.

With this small change, the doppler effect works with OpenAL Soft again. I chose to drop support for the OpenAL 1.0 way of setting up the doppler effect since I don't think such old implementations see widespread use anymore.

Anyway, during testing I noticed the effect to be _unstable_ for motor sounds when vehicle become unstable under high force conditions. I don't remember this to be the case from the RoR 0.38 days. I'm not sure if this is because I run RoR in a VM (might introduce timing issues) or use the OpenGL renderer (there were some physics instabilities with OpenGL that were not present with DirectX almost 10 years ago, but they have been fixed back in the day. I'm not sure if there are still any differences between rendering systems).
Also note that the value for `alDopplerVelocity` seems to have been incorrect all this time, assuming that 1 RoR unit represents 1 meter. The formula for the frequency shift caused by the doppler effect changed with OpenAL 1.1 and if I'm not mistaken, `alSpeedOfSound = alDopplerVelocity * 343.3f`.

I'd appreciate it if somebody using Windows could test with DirectX and provide feedback. Best way to see if the effect is unstable is by making sharp turns with a fast vehicle (I used `Nissan GT-R`  and `BMW E36 Polizei Sedan` for testing).

Regardless, It might make sense to make the effect an optional setting, what do you think?