### PR TITLE
Terrain objects: new eventbox collision-filter type 'truck_wheels'

### DIFF
--- a/source/main/gui/panels/GUI_CollisionsDebug.cpp
+++ b/source/main/gui/panels/GUI_CollisionsDebug.cpp
@@ -328,10 +328,30 @@ void CollisionsDebug::DrawCollisionBoxDebugText(collision_box_t const& coll_box)
     eventsource_t const& eventsource = App::GetGameContext()->GetTerrain()->GetCollisions()->getEventSource(coll_box.eventsourcenum);
     const char* type_str = (m_labels_draw_types) ? "EVENTBOX\n" : "";
 
-    this->DrawLabelAtWorldPos(
-        fmt::format("{}event:{}\ninstance:{}\nhandler:{}", type_str,
-            eventsource.es_box_name, eventsource.es_instance_name, eventsource.es_script_handler),
-        this->GetCollBoxWorldPos(coll_box), COLOR_EVENTBOX);
+    std::string label = fmt::format("{}event: {}\ninstance: {}\nhandler: {}", type_str,
+            eventsource.es_box_name, eventsource.es_instance_name, eventsource.es_script_handler);
+
+    switch (coll_box.event_filter)
+    {
+    case CollisionEventFilter::EVENT_AVATAR:
+        label += "\nfilter: avatar";
+        break;
+    case CollisionEventFilter::EVENT_TRUCK:
+        label += "\nfilter: truck";
+        break;
+    case CollisionEventFilter::EVENT_TRUCK_WHEELS:
+        label += "\nfilter: truck_wheels";
+        break;
+    case CollisionEventFilter::EVENT_AIRPLANE:
+        label += "\nfilter: airplane";
+        break;
+    case CollisionEventFilter::EVENT_BOAT:
+        label += "\nfilter: boat";
+        break;
+    default:;
+    }
+
+    this->DrawLabelAtWorldPos(label, this->GetCollBoxWorldPos(coll_box), COLOR_EVENTBOX);
 }
 
 void CollisionsDebug::DrawLabelAtWorldPos(std::string const& caption, Ogre::Vector3 const& world_pos, ImVec4 const& text_color)

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -1626,6 +1626,15 @@ void Actor::CalcNodes()
     }
 }
 
+bool TestNodeEventBoxCollision(const node_t& node, collision_box_t* cbox)
+{
+    // Test eventbox collision and extra 'only wheel nodes' filtering condition
+    // ------------------------------------------------------------------------
+
+    return App::GetGameContext()->GetTerrain()->GetCollisions()->isInside(node.AbsPosition, cbox)
+        && (cbox->event_filter != EVENT_TRUCK_WHEELS || node.nd_tyre_node);
+}
+
 void Actor::CalcEventBoxes()
 {
     // Assumption: node positions and bounding boxes are up to date.
@@ -1650,7 +1659,7 @@ void Actor::CalcEventBoxes()
             if (itor->first == cbox)
             {
                 // Existing record found - check if the node still collides
-                has_collision = App::GetGameContext()->GetTerrain()->GetCollisions()->isInside(ar_nodes[itor->second].AbsPosition, cbox);
+                has_collision = TestNodeEventBoxCollision(ar_nodes[itor->second], cbox);
                 if (!has_collision)
                 {
                     // Erase the collision record
@@ -1672,7 +1681,7 @@ void Actor::CalcEventBoxes()
             // Find if any node collides
             for (NodeNum_t i = 0; i < ar_num_nodes; i++)
             {
-                has_collision = App::GetGameContext()->GetTerrain()->GetCollisions()->isInside(ar_nodes[i].AbsPosition, cbox);
+                has_collision = TestNodeEventBoxCollision(ar_nodes[i], cbox);
                 if (has_collision)
                 {
                     do_callback_exit = false;

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -42,15 +42,15 @@
 
 namespace RoR {
 
+/// Specified in terrain object (.ODEF) file, syntax: 'event <type> <filter>'
 enum CollisionEventFilter: short
 {
-    EVENT_NONE = 0,
-    EVENT_ALL,
-    EVENT_AVATAR,
-    EVENT_TRUCK,
-    EVENT_AIRPLANE,
-    EVENT_BOAT,
-    EVENT_DELETE
+    EVENT_NONE = 0,   //!< Invalid value.
+    EVENT_ALL,        //!< (default) ~ Triggered by any node on any vehicle
+    EVENT_AVATAR,     //!< 'avatar' ~ Triggered by the character only
+    EVENT_TRUCK,      //!< 'truck' ~ Triggered by any node of land vehicle (`ActorType::TRUCK`)
+    EVENT_AIRPLANE,   //!< 'airplane' ~ Triggered by any node of airplane (`ActorType::AIRPLANE`)
+    EVENT_BOAT,       //!< 'boat' ~ Triggered by any node of boats (`ActorType::BOAT`)
 };
 
 enum class ExtCameraMode

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -45,12 +45,13 @@ namespace RoR {
 /// Specified in terrain object (.ODEF) file, syntax: 'event <type> <filter>'
 enum CollisionEventFilter: short
 {
-    EVENT_NONE = 0,   //!< Invalid value.
-    EVENT_ALL,        //!< (default) ~ Triggered by any node on any vehicle
-    EVENT_AVATAR,     //!< 'avatar' ~ Triggered by the character only
-    EVENT_TRUCK,      //!< 'truck' ~ Triggered by any node of land vehicle (`ActorType::TRUCK`)
-    EVENT_AIRPLANE,   //!< 'airplane' ~ Triggered by any node of airplane (`ActorType::AIRPLANE`)
-    EVENT_BOAT,       //!< 'boat' ~ Triggered by any node of boats (`ActorType::BOAT`)
+    EVENT_NONE = 0,          //!< Invalid value.
+    EVENT_ALL,               //!< (default) ~ Triggered by any node on any vehicle
+    EVENT_AVATAR,            //!< 'avatar' ~ Triggered by the character only
+    EVENT_TRUCK,             //!< 'truck' ~ Triggered by any node of land vehicle (`ActorType::TRUCK`)
+    EVENT_TRUCK_WHEELS,      //!< 'truck_wheels' ~ Triggered only by wheel nodes of land vehicle (`ActorType::TRUCK`)
+    EVENT_AIRPLANE,          //!< 'airplane' ~ Triggered by any node of airplane (`ActorType::AIRPLANE`)
+    EVENT_BOAT,              //!< 'boat' ~ Triggered by any node of boats (`ActorType::BOAT`)
 };
 
 enum class ExtCameraMode
@@ -306,8 +307,8 @@ struct node_t
 
     // Bit flags
     bool            nd_cab_node:1;           //!< Attr; This node is part of collision triangle
-    bool            nd_rim_node:1;           //!< Attr; This node is part of a rim
-    bool            nd_tyre_node:1;          //!< Attr; This node is part of a tyre
+    bool            nd_rim_node:1;           //!< Attr; This node is part of a rim (only wheel types with separate rim nodes)
+    bool            nd_tyre_node:1;          //!< Attr; This node is part of a tyre (note some wheel types don't use rim nodes at all)
     bool            nd_contacter:1;          //!< Attr; User-defined
     bool            nd_contactable:1;        //!< Attr; This node will be treated as contacter on inter truck collisions
     bool            nd_has_ground_contact:1; //!< Physics state

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -917,8 +917,6 @@ bool Collisions::permitEvent(Actor* b, CollisionEventFilter filter)
         return b && b->ar_driveable == AIRPLANE;
     case EVENT_BOAT:
         return b && b->ar_driveable == BOAT;
-    case EVENT_DELETE:
-        return !b;
     default:
         return false;
     }

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -912,6 +912,7 @@ bool Collisions::permitEvent(Actor* b, CollisionEventFilter filter)
     case EVENT_AVATAR:
         return !b;
     case EVENT_TRUCK:
+    case EVENT_TRUCK_WHEELS: // The wheelnode check must be done separately
         return b && b->ar_driveable == TRUCK;
     case EVENT_AIRPLANE:
         return b && b->ar_driveable == AIRPLANE;

--- a/source/main/resources/odef_fileformat/ODefFileFormat.cpp
+++ b/source/main/resources/odef_fileformat/ODefFileFormat.cpp
@@ -272,7 +272,6 @@ bool ODefParser::ProcessCurrentLine()
         else if (!strncmp(ev_type, "truck",     5)) { m_ctx.cbox_event_filter = EVENT_TRUCK;    }
         else if (!strncmp(ev_type, "airplane",  8)) { m_ctx.cbox_event_filter = EVENT_AIRPLANE; }
         else if (!strncmp(ev_type, "boat",      4)) { m_ctx.cbox_event_filter = EVENT_BOAT;     }
-        else if (!strncmp(ev_type, "delete",    6)) { m_ctx.cbox_event_filter = EVENT_DELETE;   }
         else                                        { m_ctx.cbox_event_filter = EVENT_ALL;      }
 
         // hack to avoid fps drops near spawnzones

--- a/source/main/resources/odef_fileformat/ODefFileFormat.cpp
+++ b/source/main/resources/odef_fileformat/ODefFileFormat.cpp
@@ -268,12 +268,12 @@ bool ODefParser::ProcessCurrentLine()
         sscanf(line_str.c_str(), "event %300s %300s", ev_name, ev_type);
         m_ctx.cbox_event_name = ev_name;
 
-             if (!strncmp(ev_type, "avatar",    6)) { m_ctx.cbox_event_filter = EVENT_AVATAR;   }
-        else if (!strncmp(ev_type, "truck",     5)) { m_ctx.cbox_event_filter = EVENT_TRUCK;    }
-        else if (!strncmp(ev_type, "truck_wheels", 12)) { m_ctx.cbox_event_filter = EVENT_TRUCK_WHEELS;    }
-        else if (!strncmp(ev_type, "airplane",  8)) { m_ctx.cbox_event_filter = EVENT_AIRPLANE; }
-        else if (!strncmp(ev_type, "boat",      4)) { m_ctx.cbox_event_filter = EVENT_BOAT;     }
-        else                                        { m_ctx.cbox_event_filter = EVENT_ALL;      }
+             if (!strncmp(ev_type, "avatar",        6)) { m_ctx.cbox_event_filter = EVENT_AVATAR;       }
+        else if (!strncmp(ev_type, "truck_wheels", 12)) { m_ctx.cbox_event_filter = EVENT_TRUCK_WHEELS; }
+        else if (!strncmp(ev_type, "truck",         5)) { m_ctx.cbox_event_filter = EVENT_TRUCK;        }
+        else if (!strncmp(ev_type, "airplane",      8)) { m_ctx.cbox_event_filter = EVENT_AIRPLANE;     }
+        else if (!strncmp(ev_type, "boat",          4)) { m_ctx.cbox_event_filter = EVENT_BOAT;         }
+        else                                            { m_ctx.cbox_event_filter = EVENT_ALL;          }
 
         // hack to avoid fps drops near spawnzones
         if (!strncmp(ev_name, "spawnzone", 9)) { m_ctx.cbox_event_filter = EVENT_AVATAR; }

--- a/source/main/resources/odef_fileformat/ODefFileFormat.cpp
+++ b/source/main/resources/odef_fileformat/ODefFileFormat.cpp
@@ -270,6 +270,7 @@ bool ODefParser::ProcessCurrentLine()
 
              if (!strncmp(ev_type, "avatar",    6)) { m_ctx.cbox_event_filter = EVENT_AVATAR;   }
         else if (!strncmp(ev_type, "truck",     5)) { m_ctx.cbox_event_filter = EVENT_TRUCK;    }
+        else if (!strncmp(ev_type, "truck_wheels", 12)) { m_ctx.cbox_event_filter = EVENT_TRUCK_WHEELS;    }
         else if (!strncmp(ev_type, "airplane",  8)) { m_ctx.cbox_event_filter = EVENT_AIRPLANE; }
         else if (!strncmp(ev_type, "boat",      4)) { m_ctx.cbox_event_filter = EVENT_BOAT;     }
         else                                        { m_ctx.cbox_event_filter = EVENT_ALL;      }


### PR DESCRIPTION
Works the same like 'truck', but instead of registering collision from any node, only registers collision from wheel nodes (wheel tire node specifically, which for simpler wheel types is any node).

Requested by DannyWerewolf on Discord: https://discord.com/channels/136544456244461568/189904947649708032/1288229860359016612

See also documentation of the terrain object (.ODEF) file format: https://docs.rigsofrods.org/terrain-creation/object-format/

Attached is a test terrain (modified simple2) which I tested with.
[simple2-truck_wheels-test.zip](https://github.com/user-attachments/files/17157817/simple2-truck_wheels-test.zip)

**What needs testing:** eventboxes of all sorts - spawners, race checkpoints etc...
