### PR TITLE
Fixed rogue mouse-grab in windowed mode, after switching out & back in

### DIFF
--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -77,7 +77,7 @@ bool AppContext::mouseMoved(const OIS::MouseEvent& arg) // overrides OIS::MouseL
 {
     App::GetGuiManager()->WakeUpGUI();
     App::GetGuiManager()->GetImGui().InjectMouseMoved(arg);
-    App::GetInputEngine()->ProcessMouseMotionEvent(arg);
+    App::GetInputEngine()->processMouseMotionEvent(arg);
 
     if (!ImGui::GetIO().WantCaptureMouse) // true if mouse is over any window
     {
@@ -97,7 +97,7 @@ bool AppContext::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID _id
 {
     App::GetGuiManager()->WakeUpGUI();
     App::GetGuiManager()->GetImGui().SetMouseButtonState(_id, /*down:*/true);
-    App::GetInputEngine()->ProcessMouseButtonEvent(arg);
+    App::GetInputEngine()->processMousePressEvent(arg, _id);
 
     if (!ImGui::GetIO().WantCaptureMouse) // true if mouse is over any window
     {
@@ -118,7 +118,7 @@ bool AppContext::mouseReleased(const OIS::MouseEvent& arg, OIS::MouseButtonID _i
 {
     App::GetGuiManager()->WakeUpGUI();
     App::GetGuiManager()->GetImGui().SetMouseButtonState(_id, /*down:*/false);
-    App::GetInputEngine()->ProcessMouseButtonEvent(arg);
+    App::GetInputEngine()->processMouseReleaseEvent(arg, _id);
 
     if (!ImGui::GetIO().WantCaptureMouse) // true if mouse is over any window
     {
@@ -186,8 +186,10 @@ void AppContext::windowResized(Ogre::RenderWindow* rw)
 
 void AppContext::windowFocusChange(Ogre::RenderWindow* rw)
 {
+    const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
     App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("Window focus change; isActive={}", rw->isActive()));
+        fmt::format("Window focus change; isActive={}, LMB={}, MMB={}, RMB={}",
+            rw->isActive(), ms.buttonDown(OIS::MB_Left), ms.buttonDown(OIS::MB_Middle), ms.buttonDown(OIS::MB_Right)));
     
     // If you alt+TAB out of the window while any mouse button is down, OIS will not release it until you click in the window again.
     // See https://github.com/RigsOfRods/rigs-of-rods/issues/2468

--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -186,11 +186,6 @@ void AppContext::windowResized(Ogre::RenderWindow* rw)
 
 void AppContext::windowFocusChange(Ogre::RenderWindow* rw)
 {
-    const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("Window focus change; isActive={}, LMB={}, MMB={}, RMB={}",
-            rw->isActive(), ms.buttonDown(OIS::MB_Left), ms.buttonDown(OIS::MB_Middle), ms.buttonDown(OIS::MB_Right)));
-    
     // If you alt+TAB out of the window while any mouse button is down, OIS will not release it until you click in the window again.
     // See https://github.com/RigsOfRods/rigs-of-rods/issues/2468
     // To work around, we reset all internal mouse button states here and pay attention not to get them polluted by OIS again.

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -111,11 +111,13 @@ void SceneMouse::reset()
     mouseGrabState = 0;
 }
 
-bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
+bool SceneMouse::handleMouseMoved()
 {
-    const OIS::MouseState ms = _arg.state;
+    // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
+    //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
+    const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
 
-    // experimental mouse hack
+
     if (ms.buttonDown(OIS::MB_Left) && mouseGrabState == 0)
     {
         lastMouseY = ms.Y.abs;
@@ -176,7 +178,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
             }
         }
     }
-    else if (ms.buttonDown(OIS::MB_Left) && mouseGrabState == 1)
+    else if (App::GetInputEngine()->getMouseState().buttonDown(OIS::MB_Left) && mouseGrabState == 1)
     {
         // force applying and so forth happens in update()
         lastMouseY = ms.Y.abs;
@@ -184,7 +186,7 @@ bool SceneMouse::mouseMoved(const OIS::MouseEvent& _arg)
         // not fixed
         return false;
     }
-    else if (!ms.buttonDown(OIS::MB_Left) && mouseGrabState == 1)
+    else if (!App::GetInputEngine()->getMouseState().buttonDown(OIS::MB_Left) && mouseGrabState == 1)
     {
         releaseMousePick();
         // not fixed
@@ -224,11 +226,13 @@ void SceneMouse::UpdateVisuals()
     }
 }
 
-bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id)
+bool SceneMouse::handleMousePressed()
 {
     if (App::sim_state->getEnum<SimState>() == SimState::PAUSED) { return true; } // Do nothing when paused
 
-    const OIS::MouseState ms = _arg.state;
+    // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
+    //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
+    const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
 
     if (ms.buttonDown(OIS::MB_Middle))
     {
@@ -300,7 +304,7 @@ bool SceneMouse::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _i
     return true;
 }
 
-bool SceneMouse::mouseReleased(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id)
+bool SceneMouse::handleMouseReleased()
 {
     if (App::sim_state->getEnum<SimState>() == SimState::PAUSED) { return true; } // Do nothing when paused
 

--- a/source/main/gameplay/SceneMouse.h
+++ b/source/main/gameplay/SceneMouse.h
@@ -40,9 +40,9 @@ public:
 
     SceneMouse();
 
-    bool mouseMoved(const OIS::MouseEvent& _arg);
-    bool mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id);
-    bool mouseReleased(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id);
+    bool handleMouseMoved();
+    bool handleMousePressed();
+    bool handleMouseReleased();
 
     void InitializeVisuals();
     void UpdateSimulation();

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -67,11 +67,11 @@ public:
     void NotifyVehicleChanged(ActorPtr new_vehicle);
 
     void CameraBehaviorOrbitReset();
-    bool CameraBehaviorOrbitMouseMoved(const OIS::MouseEvent& _arg);
+    bool CameraBehaviorOrbitMouseMoved();
     void CameraBehaviorOrbitUpdate();
 
-    bool mouseMoved(const OIS::MouseEvent& _arg);
-    bool mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id);
+    bool handleMouseMoved();
+    bool handleMousePressed();
 
     void ResetAllBehaviors();
     void ReCreateCameraNode(); //!< Needed since we call `Ogre::SceneManager::ClearScene()` after end of sim. session
@@ -89,14 +89,14 @@ protected:
     void ResetCurrentBehavior();
     void DeactivateCurrentBehavior();
     void UpdateCameraBehaviorStatic();
-    bool CameraBehaviorStaticMouseMoved(const OIS::MouseEvent& _arg);
+    bool CameraBehaviorStaticMouseMoved();
     void UpdateCameraBehaviorFree();
     void UpdateCameraBehaviorFixed();
     void UpdateCameraBehaviorVehicle();
     void CameraBehaviorVehicleReset();
-    bool CameraBehaviorVehicleMousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id);
+    bool CameraBehaviorVehicleMousePressed();
     void CameraBehaviorVehicleSplineUpdate();
-    bool CameraBehaviorVehicleSplineMouseMoved(const OIS::MouseEvent& _arg);
+    bool CameraBehaviorVehicleSplineMouseMoved();
     void CameraBehaviorVehicleSplineReset();
     void CameraBehaviorVehicleSplineCreateSpline();
     void CameraBehaviorVehicleSplineUpdateSpline();

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -163,7 +163,7 @@ void GUIManager::DrawSimGuiBuffered(GfxActor* player_gfx_actor)
 {
     this->DrawCommonGui();
 
-    if (player_gfx_actor)
+    if (player_gfx_actor && !this->GameMainMenu.IsVisible())
     {
         this->VehicleInfoTPanel.Draw(player_gfx_actor);
     }

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -490,12 +490,15 @@ void OverlayWrapper::updateStats(bool detailed)
     }
 }
 
-bool OverlayWrapper::mouseMoved(const OIS::MouseEvent& _arg)
+bool OverlayWrapper::handleMouseMoved()
 {
     if (!m_aerial_dashboard.needles_overlay->isVisible())
         return false;
     bool res = false;
-    const OIS::MouseState ms = _arg.state;
+
+    // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
+    //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
+    const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
     
     ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
 
@@ -630,14 +633,14 @@ bool OverlayWrapper::mouseMoved(const OIS::MouseEvent& _arg)
     return res;
 }
 
-bool OverlayWrapper::mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id)
+bool OverlayWrapper::handleMousePressed()
 {
-    return mouseMoved(_arg);
+    return handleMouseMoved();
 }
 
-bool OverlayWrapper::mouseReleased(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id)
+bool OverlayWrapper::handleMouseReleased()
 {
-    return mouseMoved(_arg);
+    return handleMouseMoved();
 }
 
 void OverlayWrapper::UpdatePressureOverlay(RoR::GfxActor* ga)

--- a/source/main/gui/OverlayWrapper.h
+++ b/source/main/gui/OverlayWrapper.h
@@ -129,9 +129,9 @@ public:
     void windowResized();
     void resizeOverlay(LoadedOverlay & overlay);
 
-    bool mouseMoved(const OIS::MouseEvent& _arg);
-    bool mousePressed(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id);
-    bool mouseReleased(const OIS::MouseEvent& _arg, OIS::MouseButtonID _id);
+    bool handleMouseMoved();
+    bool handleMousePressed();
+    bool handleMouseReleased();
     
 
     void UpdatePressureOverlay(RoR::GfxActor* ga);

--- a/source/main/gui/imgui/OgreImGui.cpp
+++ b/source/main/gui/imgui/OgreImGui.cpp
@@ -96,22 +96,23 @@ void OgreImGui::InjectMouseMoved( const OIS::MouseEvent &arg )
     io.MouseWheel = Ogre::Math::Clamp((float)arg.state.Z.rel, -1/3.f, 1/3.f);
 }
 
-void OgreImGui::InjectMousePressed( const OIS::MouseEvent &arg, OIS::MouseButtonID id )
+void OgreImGui::SetMouseButtonState( OIS::MouseButtonID id, bool down )
 {
     ImGuiIO& io = ImGui::GetIO();
-    if (id<5)
+    if (id >= 0 && id < 5)
     {
-        io.MouseDown[id] = true;
+        io.MouseDown[id] = down;
     }
 }
 
-void OgreImGui::InjectMouseReleased( const OIS::MouseEvent &arg, OIS::MouseButtonID id )
+void OgreImGui::ResetAllMouseButtons()
 {
     ImGuiIO& io = ImGui::GetIO();
-    if (id<5)
-    {
-        io.MouseDown[id] = false;
-    }
+    io.MouseDown[0] = false;
+    io.MouseDown[1] = false;
+    io.MouseDown[2] = false;
+    io.MouseDown[3] = false;
+    io.MouseDown[4] = false;
 }
 
 void OgreImGui::InjectKeyPressed( const OIS::KeyEvent &arg )

--- a/source/main/gui/imgui/OgreImGui.h
+++ b/source/main/gui/imgui/OgreImGui.h
@@ -58,8 +58,8 @@ public:
 
     // Input-injecting functions
     void InjectMouseMoved( const OIS::MouseEvent &arg );
-    void InjectMousePressed( const OIS::MouseEvent &arg, OIS::MouseButtonID id );
-    void InjectMouseReleased( const OIS::MouseEvent &arg, OIS::MouseButtonID id );
+    void SetMouseButtonState(OIS::MouseButtonID id, bool down);
+    void ResetAllMouseButtons();
     void InjectKeyPressed( const OIS::KeyEvent &arg );
     void InjectKeyReleased( const OIS::KeyEvent &arg );
 

--- a/source/main/gui/panels/GUI_CollisionsDebug.cpp
+++ b/source/main/gui/panels/GUI_CollisionsDebug.cpp
@@ -43,6 +43,7 @@ void CollisionsDebug::Draw()
 {
     GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
 
+    ImGui::SetNextWindowPosCenter(ImGuiCond_FirstUseEver);
     ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize;
     bool keep_open = true;
     ImGui::Begin(_LC("About", "Static collision debug"), &keep_open, win_flags);

--- a/source/main/gui/panels/GUI_FlexbodyDebug.cpp
+++ b/source/main/gui/panels/GUI_FlexbodyDebug.cpp
@@ -39,6 +39,7 @@ using namespace GUI;
 
 void FlexbodyDebug::Draw()
 {
+    ImGui::SetNextWindowPosCenter(ImGuiCond_FirstUseEver);
     ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse;
     bool keep_open = true;
     ImGui::Begin(_LC("FlexbodyDebug", "Flexbody/Prop debug"), &keep_open, win_flags);

--- a/source/main/gui/panels/GUI_FrictionSettings.cpp
+++ b/source/main/gui/panels/GUI_FrictionSettings.cpp
@@ -41,6 +41,7 @@ using namespace GUI;
 
 void FrictionSettings::Draw()
 {
+    ImGui::SetNextWindowPosCenter(ImGuiCond_FirstUseEver);
     ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse;
     bool keep_open = true;
     ImGui::Begin(_LC("FrictionSettings", "Friction Settings"), &keep_open, win_flags);

--- a/source/main/gui/panels/GUI_GameControls.cpp
+++ b/source/main/gui/panels/GUI_GameControls.cpp
@@ -55,7 +55,7 @@ void GameControls::Draw()
                 m_active_buffer = keys_pressed;
             }
             this->ApplyChanges();
-            App::GetInputEngine()->resetKeys(); // Do not leak the pressed keys to gameplay.
+            App::GetInputEngine()->resetKeysAndMouseButtons(); // Do not leak the pressed keys to gameplay.
         }
         else
         {

--- a/source/main/gui/panels/GUI_NodeBeamUtils.cpp
+++ b/source/main/gui/panels/GUI_NodeBeamUtils.cpp
@@ -37,9 +37,9 @@ void NodeBeamUtils::Draw()
         this->SetVisible(false);
         return;
     }
-
-    const int flags = ImGuiWindowFlags_NoCollapse;
+    ImGui::SetNextWindowPosCenter(ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize(ImVec2(600.f, 675.f), ImGuiCond_FirstUseEver);
+    const int flags = ImGuiWindowFlags_NoCollapse;
     bool keep_open = true;
     ImGui::Begin(_LC("NodeBeamUtils", "Node/Beam Utils"), &keep_open, flags);
 

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -703,22 +703,11 @@ void InputEngine::processMouseMotionEvent(const OIS::MouseEvent& arg)
 
 void InputEngine::processMousePressEvent(const OIS::MouseEvent& arg, OIS::MouseButtonID _id)
 {
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("InputEngine: mouse pressed; old state: LMB={}, MMB={}, RMB={}, framesSinceReset={}, lmbDownsSinceReset={}",
-            mouseState.buttonDown(OIS::MB_Left), mouseState.buttonDown(OIS::MB_Middle), mouseState.buttonDown(OIS::MB_Right),
-            m_oisworkaround_frames_since_reset, m_oisworkaround_lmbdowns_since_reset));
-
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("InputEngine: mouse pressed; _arg: LMB={}, MMB={}, RMB={}",
-            arg.state.buttonDown(OIS::MB_Left), arg.state.buttonDown(OIS::MB_Middle), arg.state.buttonDown(OIS::MB_Right)));
-
     // Skip false 'LMB press' event after restoring window focus; see commentary in `resetKeysAndMouseButtons()`.
     if (_id == OIS::MB_Left)
     {
         if (m_oisworkaround_lmbdowns_since_reset == 0 && m_oisworkaround_frames_since_reset < 1)
         {
-            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                "InputEngine: mouse pressed, but it's a fake event, ignoring it.");
             return;
         }
         m_oisworkaround_lmbdowns_since_reset++;
@@ -727,35 +716,13 @@ void InputEngine::processMousePressEvent(const OIS::MouseEvent& arg, OIS::MouseB
     // Only update the one particular button, OIS's persistent state may be dirty, see commentary in `getMouseState()`
     BitMask_t btnmask = 1 << _id;
     BITMASK_SET_1(mouseState.buttons, btnmask);
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("InputEngine: mouse pressed, btn={}", (int)_id));
-
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("InputEngine: mouse pressed; new state: LMB={}, MMB={}, RMB={}",
-            mouseState.buttonDown(OIS::MB_Left), mouseState.buttonDown(OIS::MB_Middle), mouseState.buttonDown(OIS::MB_Right)));
-
-
 }
 
 void InputEngine::processMouseReleaseEvent(const OIS::MouseEvent& arg, OIS::MouseButtonID _id)
 {
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("InputEngine: mouse released; old state: LMB={}, MMB={}, RMB={}",
-            mouseState.buttonDown(OIS::MB_Left), mouseState.buttonDown(OIS::MB_Middle), mouseState.buttonDown(OIS::MB_Right)));
-
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("InputEngine: mouse released; _arg: LMB={}, MMB={}, RMB={}",
-            arg.state.buttonDown(OIS::MB_Left), arg.state.buttonDown(OIS::MB_Middle), arg.state.buttonDown(OIS::MB_Right)));
-
     // Only update the one particular button, OIS's persistent state may be dirty, see commentary in `getMouseState()`
     BitMask_t btnmask = 1 << _id;
     BITMASK_SET_0(mouseState.buttons, btnmask);
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("InputEngine: mouse released, btn={}", (int)_id));
-
-    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-        fmt::format("InputEngine: mouse released; new state: LMB={}, MMB={}, RMB={}",
-            mouseState.buttonDown(OIS::MB_Left), mouseState.buttonDown(OIS::MB_Right), mouseState.buttonDown(OIS::MB_Right)));
 }
 
 /* --- Custom Methods ------------------------------------------ */

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -481,8 +481,9 @@ public:
     /// @{
     void                Capture();
     void                updateKeyBounces(float dt);
-    void                ProcessMouseMotionEvent(const OIS::MouseEvent& arg);
-    void                ProcessMouseButtonEvent(const OIS::MouseEvent& arg);
+    void                processMouseMotionEvent(const OIS::MouseEvent& arg);
+    void                processMousePressEvent(const OIS::MouseEvent& arg, OIS::MouseButtonID _id);
+    void                processMouseReleaseEvent(const OIS::MouseEvent& arg, OIS::MouseButtonID _id);
     void                ProcessKeyPress(const OIS::KeyEvent& arg);
     void                ProcessKeyRelease(const OIS::KeyEvent& arg);
     void                ProcessJoystickEvent(const OIS::JoyStickEvent& arg);
@@ -608,6 +609,13 @@ protected:
     std::string composeEventCommandString(event_trigger_t const& trig);
 
     event_trigger_t newEvent();
+
+    // OIS WORKAROUND: After a window focus is restored for the 2nd+ time, OIS delivers a fabricated 'LMB pressed' event,
+    //    without ever sending matching 'LMB released', see analysis: https://github.com/RigsOfRods/rigs-of-rods/pull/3184#issuecomment-2380397463
+    // This has a very prominent negative effect, see https://github.com/RigsOfRods/rigs-of-rods/issues/2468
+    // There's no way to recognize the event as fake, we must track number of frames and LMB presses since last reset.
+    size_t m_oisworkaround_frames_since_reset = 0u;
+    size_t m_oisworkaround_lmbdowns_since_reset = 0u;
 };
 
 /// @} // @addtogroup Input

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -481,11 +481,12 @@ public:
     /// @{
     void                Capture();
     void                updateKeyBounces(float dt);
-    void                ProcessMouseEvent(const OIS::MouseEvent& arg);
+    void                ProcessMouseMotionEvent(const OIS::MouseEvent& arg);
+    void                ProcessMouseButtonEvent(const OIS::MouseEvent& arg);
     void                ProcessKeyPress(const OIS::KeyEvent& arg);
     void                ProcessKeyRelease(const OIS::KeyEvent& arg);
     void                ProcessJoystickEvent(const OIS::JoyStickEvent& arg);
-    void                resetKeys();
+    void                resetKeysAndMouseButtons();
     void                setEventSimulatedValue(events eventID, float value);
     void                setEventStatusSupressed(events eventID, bool supress);
     /// @}


### PR DESCRIPTION
Fixes 2 nuissances reported by DannyWerewolf on Discord: https://discord.com/channels/136544456244461568/189904947649708032/1289311318536486982
1. **The new T-panel interferes with other windows** -> I made all optional windows appear in the middle of the screen instead of top left corner of screen. I also supressed it when pause menu is visible (on lower resolutions it may obstruct the menu).
2. **The mouse-grab glitch when you're in windowed mode and switch out and back in** -> this needed deeper dive, but I did it. Fixes #2468

**What needs testing:** The mouse grab, camera controls and airplane dashboard - these needed a small rework of mouse input handling.