### PR TITLE
New input event `EV_TRUCK_CYCLE_GEAR_RANGES`

### DIFF
--- a/source/main/gameplay/EngineSim.cpp
+++ b/source/main/gameplay/EngineSim.cpp
@@ -1455,24 +1455,46 @@ void EngineSim::UpdateInputEvents(float dt)
         // one can select range only if in neutral
         if (shiftmode == SimGearboxMode::MANUAL_RANGES && curgear == 0)
         {
-            //  maybe this should not be here, but should experiment
             if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_LOWRANGE) && curgearrange != 0)
             {
                 this->SetGearRange(0);
                 gear_changed = true;
-                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png");
             }
             else if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_MIDRANGE) && curgearrange != 1 && this->getNumGearsRanges() > 1)
             {
                 this->SetGearRange(1);
                 gear_changed = true;
-                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png");
             }
             else if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_SHIFT_HIGHRANGE) && curgearrange != 2 && this->getNumGearsRanges() > 2)
             {
                 this->SetGearRange(2);
                 gear_changed = true;
-                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png");
+            }
+            else if (App::GetInputEngine()->getEventBoolValueBounce(EV_TRUCK_CYCLE_GEAR_RANGES))
+            {
+                this->SetGearRange((curgearrange + 1) % this->getNumGearsRanges());
+                gear_changed = true;
+                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
+                    fmt::format(_L("Range cycled (current: {}/available: {})"),
+                        this->GetGearRange(), this->getNumGearsRanges()), "cog.png");
+            }
+
+            if (gear_changed)
+            {
+                switch (this->GetGearRange())
+                {
+                case 0:
+                    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Low range selected"), "cog.png");
+                    break;
+                case 1:
+                    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("Mid range selected"), "cog.png");
+                    break;
+                case 2:
+                    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, _L("High range selected"), "cog.png");
+                    break;
+                default:
+                    break;
+                }
             }
         }
         //zaxxon

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -197,6 +197,7 @@ InputEvent eventInfo[] = {
     {"TRUCK_SHIFT_LOWRANGE",          EV_TRUCK_SHIFT_LOWRANGE,          "",                             _LC("InputEvent", "sets low range (1-6) for H-shaft")},
     {"TRUCK_SHIFT_MIDRANGE",          EV_TRUCK_SHIFT_MIDRANGE,          "",                             _LC("InputEvent", "sets middle range (7-12) for H-shaft")},
     {"TRUCK_SHIFT_HIGHRANGE",         EV_TRUCK_SHIFT_HIGHRANGE,         "",                             _LC("InputEvent", "sets high range (13-18) for H-shaft")},
+    {"TRUCK_CYCLE_GEAR_RANGES",       EV_TRUCK_CYCLE_GEAR_RANGES,       "",                             _LC("InputEvent", "cycle through gear ranges") },
     {"TRUCK_SWITCH_SHIFT_MODES",      EV_TRUCK_SWITCH_SHIFT_MODES,      "Keyboard Q",                   _LC("InputEvent", "toggle between transmission modes")},
 
     // Airplane

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -351,6 +351,7 @@ enum events
     EV_TRUCK_SHIFT_HIGHRANGE,     //!< select high range (13-18) for H-shaft
     EV_TRUCK_SHIFT_LOWRANGE,      //!< select low range (1-6) for H-shaft
     EV_TRUCK_SHIFT_MIDRANGE,      //!< select middle range (7-12) for H-shaft
+    EV_TRUCK_CYCLE_GEAR_RANGES,   //!< cycle through the ranges
     EV_TRUCK_SHIFT_NEUTRAL,       //!< shift to neutral gear in manual transmission mode
     EV_TRUCK_SHIFT_UP,            //!< shift one gear up in manual transmission mode
     EV_TRUCK_STARTER,             //!< hold to start the engine


### PR DESCRIPTION
Fixes #3179
No binding by default - intended for controllers.

@Goetterescu Please download test build from the "Checks" tab above - find it under the "Artifacts" dropdown (ror-win.ZIP)
UPDATE: [Direct download link (you must be signed in).](https://github.com/RigsOfRods/rigs-of-rods/suites/29292867066/artifacts/2023226078)