### PR TITLE
T-Panel: restored custom-light buttons

### DIFF
--- a/source/main/gui/panels/GUI_VehicleInfoTPanel.cpp
+++ b/source/main/gui/panels/GUI_VehicleInfoTPanel.cpp
@@ -220,13 +220,15 @@ void VehicleInfoTPanel::DrawVehicleCommandsUI(RoR::GfxActor* actorx)
         ImGui::SetCursorPosX(MIN_PANEL_WIDTH - (ImGui::CalcTextSize(_LC("VehicleDescription", "Full size")).x + 25.f));
         ImGui::Checkbox(_LC("VehicleDescription", "Full size"), &m_helptext_fullsize);
         
-        ImTextureID im_tex = reinterpret_cast<ImTextureID>(actorx->GetHelpTex()->getHandle());
         if (m_helptext_fullsize)
         {
-            ImGui::Image(im_tex, ImVec2(HELP_TEXTURE_WIDTH, HELP_TEXTURE_HEIGHT));
+            m_helptext_fullsize_screenpos = ImGui::GetCursorScreenPos();
+            ImGui::Dummy(ImVec2(MIN_PANEL_WIDTH, HELP_TEXTURE_HEIGHT));
+            this->DrawVehicleHelpTextureFullsize(actorx);
         }
         else
         {
+            ImTextureID im_tex = reinterpret_cast<ImTextureID>(actorx->GetHelpTex()->getHandle());
             ImGui::Image(im_tex, ImVec2(MIN_PANEL_WIDTH, HELP_TEXTURE_HEIGHT));
         }
     }
@@ -800,6 +802,26 @@ void VehicleInfoTPanel::DrawVehicleCommandHighlights(RoR::GfxActor* actorx)
             draw_list->AddLine(p1_pos, p2_pos, ImColor(m_cmdbeam_highlight_color), m_cmdbeam_highlight_thickness);
         }    
     }
+}
+
+void VehicleInfoTPanel::DrawVehicleHelpTextureFullsize(RoR::GfxActor* actorx)
+{
+    // In order to draw the image on top of the T-panel, the window must be focusable, 
+    // so we can't simply use `GetImDummyFullscreenWindow()`
+    // ===============================================================================
+
+    int window_flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar
+        | ImGuiWindowFlags_NoSavedSettings ;
+    ImGui::SetNextWindowPos(m_helptext_fullsize_screenpos - ImGui::GetStyle().WindowPadding);
+    ImGui::SetNextWindowSize(ImVec2(HELP_TEXTURE_WIDTH, HELP_TEXTURE_HEIGHT) + ImGui::GetStyle().WindowPadding);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0, 0, 0, 0)); // Fully transparent background!
+    ImGui::Begin("T-Panel help tex fullsize", NULL, window_flags);
+    ImDrawList* drawlist = ImGui::GetWindowDrawList();
+    ImTextureID im_tex = reinterpret_cast<ImTextureID>(actorx->GetHelpTex()->getHandle());
+    drawlist->AddImage(im_tex, m_helptext_fullsize_screenpos,
+        m_helptext_fullsize_screenpos + ImVec2(HELP_TEXTURE_WIDTH, HELP_TEXTURE_HEIGHT));
+    ImGui::End();
+    ImGui::PopStyleColor(1); // WindowBg
 }
 
 bool DrawSingleButtonRow(bool active, const Ogre::TexturePtr& icon, const char* name, RoR::events ev, bool* btn_active = nullptr)

--- a/source/main/gui/panels/GUI_VehicleInfoTPanel.h
+++ b/source/main/gui/panels/GUI_VehicleInfoTPanel.h
@@ -121,6 +121,7 @@ private:
     void DrawSecureButton(RoR::GfxActor* actorx);
     void DrawCruiseControlButton(RoR::GfxActor* actorx);
     void DrawCameraButton();
+    void DrawCustomLightButtons(RoR::GfxActor* actorx);
     void CacheIcons();
     bool m_horn_btn_active = false;
     bool m_icons_cached = false;

--- a/source/main/gui/panels/GUI_VehicleInfoTPanel.h
+++ b/source/main/gui/panels/GUI_VehicleInfoTPanel.h
@@ -61,6 +61,7 @@ private:
     /// @{
     void DrawVehicleCommandsUI(RoR::GfxActor* actorx);
     void DrawVehicleCommandHighlights(RoR::GfxActor* actorx);
+    void DrawVehicleHelpTextureFullsize(RoR::GfxActor* actorx);
     
     CommandkeyID_t m_active_commandkey = COMMANDKEYID_INVALID;
     CommandkeyID_t m_hovered_commandkey = COMMANDKEYID_INVALID;
@@ -70,6 +71,7 @@ private:
     float m_cmdbeam_highlight_thickness = 15.f;
     ImVec4 m_command_hovered_text_color = ImVec4(0.1f, 0.1f, 0.1f, 1.f);
     bool m_helptext_fullsize = false;
+    ImVec2 m_helptext_fullsize_screenpos; //!< The image is drawn into separate window
     /// @}
    
     /// @name 'Vehicle stats' tab


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2cfe185d-3816-4a2a-bd6c-f01d6e601f7d)

These were originally present in the VehicleButtons pop-up panel. I made them narrow to fit into single row. Unlike other lines the icon isn't a button and the hotkey hint is also dummy (static text, not updated from key bindings)