### PR TITLE
:bug: Fixed exhausts on predefined actors.

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2913,12 +2913,6 @@ void ActorSpawner::ProcessParticle(RigDef::Particle & def)
     particle.snode->attachObject(particle.psys);
     particle.snode->setPosition(m_actor->ar_nodes[particle.emitterNode].AbsPosition);
 
-    /* Shut down the emitters */
-    for (unsigned int i = 0; i < particle.psys->getNumEmitters(); i++)
-    {
-        particle.psys->getEmitter(i)->setEnabled(false);
-    }
-
     m_actor->m_gfx_actor->m_cparticles.push_back(particle);
 }
 
@@ -7277,6 +7271,13 @@ Ogre::ParticleSystem* ActorSpawner::CreateParticleSystem(std::string const & nam
        name, Ogre::ParticleSystemFactory::FACTORY_TYPE_NAME, &params);
     Ogre::ParticleSystem* psys = static_cast<Ogre::ParticleSystem*>(obj);
     psys->setVisibilityFlags(DEPTHMAP_DISABLED); // disable particles in depthmap
+
+    // Shut down the emitters
+    for (size_t i = 0; i < psys->getNumEmitters(); i++)
+    {
+        psys->getEmitter(i)->setEnabled(false);
+    }
+
     return psys;
 }
 

--- a/source/main/physics/Savegame.cpp
+++ b/source/main/physics/Savegame.cpp
@@ -352,21 +352,19 @@ bool ActorManager::LoadScene(Ogre::String save_filename)
             }
         }
 
-        if (actor == nullptr)
+        // If a 'preloaded' actor isn't loaded at this point, it means it's not installed.
+        if (actor == nullptr && !j_entry["preloaded_with_terrain"].GetBool())
         {
-            bool preloaded = j_entry["preloaded_with_terrain"].GetBool();
-
             ActorSpawnRequest* rq = new ActorSpawnRequest;
-            rq->asr_filename      = rigdef_filename;
+            rq->asr_filename      = rigdef_filename_maybe_bundle_qualified;
             rq->asr_position.x    = j_entry["position"][0].GetFloat();
-            rq->asr_position.y    = preloaded ? j_entry["position"][1].GetFloat() : j_entry["min_height"].GetFloat();
+            rq->asr_position.y    = j_entry["min_height"].GetFloat();
             rq->asr_position.z    = j_entry["position"][2].GetFloat();
             rq->asr_rotation      = Quaternion(Degree(270) - Radian(j_entry["rotation"].GetFloat()), Vector3::UNIT_Y);
             rq->asr_skin_entry    = skin;
             rq->asr_working_tuneup = working_tuneup;
             rq->asr_config        = section_config;
-            rq->asr_origin        = preloaded ? ActorSpawnRequest::Origin::TERRN_DEF : ActorSpawnRequest::Origin::SAVEGAME;
-            rq->asr_free_position = preloaded;
+            rq->asr_origin        = ActorSpawnRequest::Origin::SAVEGAME;
             // Copy saved state
             rq->asr_saved_state = std::shared_ptr<rapidjson::Document>(new rapidjson::Document());
             rq->asr_saved_state->CopyFrom(j_entry, rq->asr_saved_state->GetAllocator());


### PR DESCRIPTION
Problem: The trains on Train Valley now continuously produce smoke until you activate them.
![image](https://github.com/user-attachments/assets/8d728f84-a065-4d39-b8c4-4b7088ac1a42)

Fix: shut down the particle emitters when spawning (unified code with custom-particles)

UPDATE: Also fixed savegame issues that manifested on this terrain: https://discord.com/channels/136544456244461568/189904947649708032/1323326091313545300