### PR TITLE
Improved T-menu stats display

### DIFF
--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -344,7 +344,7 @@ void GameSettings::DrawUiSettings()
     ImGui::Separator();
 
     DrawGCheckbox(App::gfx_speedo_digital, _LC("GameSettings", "Digital speedometer"));
-    DrawGCheckbox(App::gfx_speedo_imperial, _LC("GameSettings", "Imperial speedometer"));
+    DrawGCheckbox(App::gfx_speedo_imperial, _LC("GameSettings", "Imperial units"));
 
     DrawGCheckbox(App::ui_show_live_repair_controls, _LC("GameSettings", "Show controls in live repair box"));
     


### PR DESCRIPTION
This PR:

- Restores displaying both mph and km/h (reverts c15069a5fddb8a928969fcf95916c409d362e1b3)
- Mass display now includes pounds
- `Imperial speedometer` under Settings -> Gameplay has been renamed to `Imperial units`. 
The mass/speed/power values are swapped depending on this setting:
![2025-01-19_11-42-54](https://github.com/user-attachments/assets/1ff68d55-5352-446c-a725-94823e2a41ed)

![2025-01-19_11-47-09](https://github.com/user-attachments/assets/485c83ea-0ae0-44a4-a872-168bba4e63d2)
