### PR TITLE
📐 Removed duplicate settings

### DIFF
--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -419,11 +419,6 @@ void GameSettings::DrawGraphicsSettings()
     }
 
     DrawGCheckbox(App::gfx_enable_videocams, _LC("GameSettings", "Render video cameras"));
-    DrawGCheckbox(App::gfx_surveymap_icons,  _LC("GameSettings", "Overview map icons"));
-    if (App::gfx_surveymap_icons->getBool())
-    {
-        DrawGCheckbox(App::gfx_declutter_map,  _LC("GameSettings", "Declutter overview map"));
-    }
     DrawGCheckbox(App::gfx_water_waves,      _LC("GameSettings", "Waves on water"));
     DrawGCheckbox(App::gfx_alt_actor_materials,      _LC("GameSettings", "Use alternate vehicle materials"));
 


### PR DESCRIPTION
Removed the duplicate `Overview map icons` and `Declutter overview map` settings from the Graphics settings tab, these were moved to the new UI tab.