### PR TITLE
Aerial HUD fixes + new mouse-hover highlights

### DIFF
--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -356,13 +356,11 @@ void OverlayWrapper::showPressureOverlay(bool show)
         {
             m_truck_pressure_overlay->show();
             m_truck_pressure_needle_overlay->show();
-            BITMASK_SET_1(m_visible_overlays, VisibleOverlays::TRUCK_TIRE_PRESSURE_OVERLAY);
         }
         else
         {
             m_truck_pressure_overlay->hide();
             m_truck_pressure_needle_overlay->hide();
-            BITMASK_SET_0(m_visible_overlays, VisibleOverlays::TRUCK_TIRE_PRESSURE_OVERLAY);
         }
     }
 }
@@ -953,13 +951,11 @@ void OverlayWrapper::UpdateMarineHUD(ActorPtr vehicle)
 void OverlayWrapper::ShowRacingOverlay()
 {
     m_racing_overlay->show();
-    BITMASK_SET_1(m_visible_overlays, VisibleOverlays::RACING);
 }
 
 void OverlayWrapper::HideRacingOverlay()
 {
     m_racing_overlay->hide();
-    BITMASK_SET_0(m_visible_overlays, VisibleOverlays::RACING);
 }
 
 void OverlayWrapper::UpdateRacingGui(RoR::GfxScene* gs)

--- a/source/main/gui/OverlayWrapper.h
+++ b/source/main/gui/OverlayWrapper.h
@@ -106,6 +106,20 @@ struct AeroDashOverlay
 
     float thrust_track_top;
     float thrust_track_height;
+
+    /// @name Mouse-hover highlighting and dragging
+    /// @{
+    void SetupHoverableElements();
+    bool IsElementHoverable(Ogre::OverlayElement* element) const;
+    void SetHoveredElement(Ogre::OverlayElement* element);
+    Ogre::OverlayElement* GetHoveredElement() const { return m_hovered_element; }
+
+    bool mouse_drag_in_progress = false;
+    std::vector<Ogre::OverlayElement*> hoverable_elements;
+    /// @}
+
+private:
+    Ogre::OverlayElement* m_hovered_element = nullptr;
 };
 
 class OverlayWrapper

--- a/source/main/gui/OverlayWrapper.h
+++ b/source/main/gui/OverlayWrapper.h
@@ -148,15 +148,6 @@ public:
 
 protected:
 
-    /// RoR needs to temporarily hide all overlays when player enters editor. 
-    /// However, OGRE only provides per-overlay show() and hide() functionality.
-    /// Thus, an external state must be kept to restore overlays after exiting the editor.
-    struct VisibleOverlays
-    {
-        static const int RACING                       = BITMASK(4);
-        static const int TRUCK_TIRE_PRESSURE_OVERLAY  = BITMASK(5);
-    };
-
     int init();
     void resizePanel(Ogre::OverlayElement *oe);
     void reposPanel(Ogre::OverlayElement *oe);
@@ -175,8 +166,6 @@ protected:
     // -------------------------------------------------------------
     // Overlays
     // -------------------------------------------------------------
-
-    unsigned int  m_visible_overlays = 0;
 
     Ogre::Overlay *m_truck_pressure_overlay = nullptr;
     Ogre::Overlay *m_truck_pressure_needle_overlay = nullptr;

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -64,17 +64,14 @@ void GameChatBox::Draw()
         msg_pos.y -= chat_size.y;
         msg_size.y -= 6.f; // prevents partially bottom chat messages
     }
+    else
+    {
+        msg_flags |= ImGuiWindowFlags_NoInputs;
+    }
     ImGui::SetNextWindowPos(msg_pos);
     ImGui::SetNextWindowSize(msg_size);
 
-    if (m_is_visible)
-    {
-        ImGui::Begin("ChatMessages", nullptr, msg_flags);
-    }
-    else
-    {
-        ImGui::Begin("ChatMessages", nullptr, msg_flags | ImGuiWindowFlags_NoInputs);
-    }
+    ImGui::Begin("ChatMessages", nullptr, msg_flags);
 
     if (initialized)
     {
@@ -128,6 +125,10 @@ void GameChatBox::Draw()
     // Draw chat box
     ImGuiWindowFlags chat_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
         ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+    if (!m_is_visible)
+    {
+        chat_flags |= ImGuiWindowFlags_NoInputs;
+    }
 
     ImGui::SetNextWindowSize(chat_size);
     ImGui::SetNextWindowPos(ImVec2(theme.screen_edge_padding.x, ImGui::GetIO().DisplaySize.y - (chat_size.y + theme.screen_edge_padding.y)));

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -609,6 +609,10 @@ OIS::MouseState InputEngine::getMouseState()
     // See commentary in `resetKeysAndMouseButtons()`
     // To work around, we keep internal button states and pay attention not to get them polluted by OIS.
     // -----------------------------------------------------------------------------------------------------
+
+    mouseState.width = (int)App::GetAppContext()->GetRenderWindow()->getWidth();
+    mouseState.height = (int)App::GetAppContext()->GetRenderWindow()->getHeight();
+
     return mouseState;
 }
 


### PR DESCRIPTION
Fixes #3216 - Airplane dashboard not reacting to mouse.

Fixed the chatbox obstructing bottom area of the aerial HUD, even if not open for input.

Fixed throttles sliders slipping off mouse cursor when you make a quicker move.

Additional goodie: I've added a mouse hover highlights to all elements which are interactable by mouse.
![aeroThrottleHover](https://github.com/user-attachments/assets/aef7afe1-219f-49ae-a5fd-28414c5bf2b8)
