### PR TITLE
:bug: nullptr type and missing include at compiling on Linux 18.04 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ CPackSourceConfig.cmake
 CMakeTmp
 build_x86
 build_x64
+build_clang
 dependencies/
+Dependencies_Linux/
 bin/RoR
 bin/RoRConfig
 bin/libangelscript_addons.a
@@ -35,3 +37,8 @@ tools/l10n/ror\.pot
 CMakeUserPresets.json
 tools/l10n/TMP.pot
 redist/
+tmp
+Stamp
+Source
+*.tar.gz
+*.zip

--- a/source/main/scripting/ScriptUtils.h
+++ b/source/main/scripting/ScriptUtils.h
@@ -24,6 +24,7 @@
 #ifdef USE_ANGELSCRIPT
 
 #include <angelscript.h>
+#include "ScriptEngine.h"
 #include "scriptdictionary/scriptdictionary.h"
 #include "scriptarray/scriptarray.h"
 #include "scriptbuilder/scriptbuilder.h"

--- a/source/main/utils/memory/RefCountingObjectPtr.h
+++ b/source/main/utils/memory/RefCountingObjectPtr.h
@@ -43,8 +43,8 @@ public:
     bool operator!=(const T* o) const { return m_ref != o; }
 
     // Compare nullptr
-    bool operator==(const nullptr_t) const { return m_ref == nullptr; }
-    bool operator!=(const nullptr_t) const { return m_ref != nullptr; }
+    bool operator==(const std::nullptr_t) const { return m_ref == nullptr; }
+    bool operator!=(const std::nullptr_t) const { return m_ref != nullptr; }
 
     // Get the reference
     T *GetRef() { return m_ref; } // To be invoked from C++ only!!


### PR DESCRIPTION
### Steps to reproduce
1. Make and build with clang on linux 18.04 LTS (other versions not tested)
2. Used build desciption for [Linux](https://github.com/RigsOfRods/rigs-of-rods/wiki/Compile-(Linux))
3. gitignore had to be exteded in order to get rid the hundreds of newly generated files in the git staging window.

### Expected behaviour
Building should run without errors

### Actual behaviour
Building fails

### System configuration
OS: Linux 18.04 LTS 64bit
Renderer used: OpenGL