### PR TITLE
👼Script: Added 'forced cinecam' state for actors

### DIFF
--- a/doc/angelscript/Script2Game/BeamClass.h
+++ b/doc/angelscript/Script2Game/BeamClass.h
@@ -167,6 +167,32 @@ public:
 	 */
 	bool isLocked();      
     
+    /**
+    * Sets a forced cinecam for this actor; This disables camera hotkeys.
+    * @param cinecamId Cinecams are numbered from 0, use `getNumCinecams()`; -1 means no cinecam.
+    * @param flags Flags are reserved for future use.
+    */
+    void setForcedCinecam(int cinecamId, int flags);
+    
+    /**
+    * Resets the effect of `setForcedCinecam()`;
+    */
+    void clearForcedCinecam();
+    
+    /**
+    * Reports the values submitted by `setForcedCinecam()`;
+    * @param cinecamId Cinecams are numbered from 0, use `getNumCinecams()`; -1 means no cinecam.
+    * @param flags Flags are reserved for future use.
+    * @return True if a forced camera was set, False if not.
+    */ 
+    bool getForcedCinecam(int& inout, int& inout);
+    
+    /**
+    * Reports number of installed cinecams.
+    */
+    int getNumCinecams() const;
+    
+    
     //! @}
     
     /// @name Subsystems

--- a/resources/scripts/example_game_actorForceCinecam.as
+++ b/resources/scripts/example_game_actorForceCinecam.as
@@ -1,0 +1,82 @@
+// EXAMPLE - how to use the new 'force cinecam' API:
+//    void              setForcedCinecam(CineCameraID_t cinecam_id, BitMask_t flags);
+//    void              clearForcedCinecam();
+//    bool              getForcedCinecam(CineCameraID_t& cinecam_id, BitMask_t& flags);
+//    int               getNumCinecams();
+// ===================================================
+
+// #region Camera controls
+int inputFlags = 0;
+void drawForceCinecamPanel()
+{
+    BeamClass@ actor = game.getCurrentTruck();
+    if (@actor == null)
+    {
+        ImGui::Text("You are on foot. Enter a vehicle first.");
+        ImGui::TextDisabled("It's technically possible to control actor at any time,\nbut this script only shows it where you can see it");
+        
+        return; // nothing more to do.
+        
+    }
+    
+    ImGui::Text("You are driving '"+actor.getTruckName()+"' ("+actor.getNumCinecams()+" cinecams)");
+    int forcedCamId = -1;
+    int forcedCamFlags = 0;
+    ImGui::Separator();
+    if (actor.getForcedCinecam(forcedCamId, forcedCamFlags))
+    {
+        ImGui::Text("Forced cinecam: "+forcedCamId + " (flags: " + forcedCamFlags + ")");
+        ImGui::Text("Camera hotkeys are blocked now.");
+        if (ImGui::SmallButton("Reset"))
+        {
+            actor.clearForcedCinecam();
+        }
+    }
+    else
+    {
+        ImGui::Text("No cinecam forced at the moment");
+        
+        ImGui::InputInt("Flags (reserved for future use)", inputFlags);
+        for (int i = 0; i < actor.getNumCinecams(); i++)
+        {
+            if (    ImGui::Button("Force cinecam #"+i)    )
+            {
+                actor.setForcedCinecam(i, inputFlags);
+            }
+        }
+    }
+    
+}
+
+// #endregion
+
+//#region Game integration
+
+// Window [X] button handler
+#include "imgui_utils.as"
+imgui_utils::CloseWindowPrompt closeBtnHandler;
+
+void main()
+{
+    // Uncomment to close window without asking.
+    //closeBtnHandler.cfgCloseImmediatelly = true;
+}
+
+// `frameStep()` runs every frame; `dt` is delta time in seconds.
+void frameStep(float dt)
+{
+    // Begin drawing window
+    if (ImGui::Begin("Demo of 'forced cinecam' feature", closeBtnHandler.windowOpen, 0))
+    {
+        // Draw the "Terminate this script?" prompt on the top (if not disabled by config).
+        closeBtnHandler.draw();
+        
+        drawForceCinecamPanel();
+        
+        // End drawing window
+        ImGui::End();
+    }
+}
+
+// #endregion
+

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -76,6 +76,9 @@ namespace RoR
     typedef int CParticleID_t; //!< Index into `GfxActor::m_cparticles`, use `RoR::CPARTICLEID_INVALID` as empty value
     static const CParticleID_t CPARTICLEID_INVALID = -1;
 
+    typedef int CineCameraID_t; //!< Index into `Actor::ar_cinecam_node` and `Actor::ar_camera_node_*` arrays; use `RoR::CINECAMERAID_INVALID` as empty value
+    static const CineCameraID_t CINECAMERAID_INVALID = -1;
+
     typedef int CommandkeyID_t; //!< Index into `Actor::ar_commandkeys` (BEWARE: indexed 1-MAX_COMMANDKEYS, 0 is invalid value, negative subscript of any size is acceptable, see `class CmdKeyArray` ).
     static const CommandkeyID_t COMMANDKEYID_INVALID = 0;
 

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -404,7 +404,7 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
             this->CameraBehaviorVehicleSplineReset();
             this->CameraBehaviorVehicleSplineCreateSpline();
         }
-        m_cct_player_actor->GetCameraContext()->behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_SPLINE;
+        m_cct_player_actor->ar_camera_context.behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_SPLINE;
         break;
 
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM:
@@ -431,7 +431,7 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
         m_cct_player_actor->ar_current_cinecam = std::max(0, m_cct_player_actor->ar_current_cinecam);
         m_cct_player_actor->NotifyActorCameraChanged();
 
-        m_cct_player_actor->GetCameraContext()->behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_CINECAM;
+        m_cct_player_actor->ar_camera_context.behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_CINECAM;
         break;
 
     case CAMERA_BEHAVIOR_VEHICLE:
@@ -444,7 +444,7 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
         {
             this->ResetCurrentBehavior();
         }
-        m_cct_player_actor->GetCameraContext()->behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_3rdPERSON;
+        m_cct_player_actor->ar_camera_context.behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_3rdPERSON;
         break;
 
     case CAMERA_BEHAVIOR_CHARACTER:
@@ -493,14 +493,14 @@ void CameraManager::switchBehavior(CameraBehaviors new_behavior)
 
     if (m_cct_player_actor != nullptr)
     {
-        m_cct_player_actor->GetCameraContext()->behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_EXTERNAL;
+        m_cct_player_actor->ar_camera_context.behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_EXTERNAL;
         if (!App::GetGuiManager()->IsGuiHidden())
         {
             RoR::App::GetOverlayWrapper()->showDashboardOverlays(true, m_cct_player_actor);
         }
         if (m_current_behavior == CAMERA_BEHAVIOR_VEHICLE_CINECAM)
         {
-            m_cct_player_actor->ar_current_cinecam = -1;
+            m_cct_player_actor->ar_current_cinecam = CINECAMERAID_INVALID;
         }
     }
 
@@ -649,7 +649,7 @@ void CameraManager::NotifyVehicleChanged(ActorPtr new_vehicle)
             this->m_current_behavior != CAMERA_BEHAVIOR_FREE)
     {
         // Change camera
-        switch (new_vehicle->GetCameraContext()->behavior)
+        switch (new_vehicle->ar_camera_context.behavior)
         {
         case RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_3rdPERSON:
             this->SwitchBehaviorOnVehicleChange(CAMERA_BEHAVIOR_VEHICLE, new_vehicle);

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -253,22 +253,31 @@ void CameraManager::UpdateInputEvents(float dt) // Called every frame
     m_cct_rot_scale    = Degree(TRANS_SPEED * dt);
     m_cct_trans_scale  = ROTATE_SPEED * dt;
 
-    if ( m_current_behavior < CAMERA_BEHAVIOR_END && App::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_CHANGE) )
+    // Handle forced cinecam
+    if (m_cct_player_actor && m_cct_player_actor->ar_forced_cinecam != CINECAMERAID_INVALID)
     {
-        if ( (m_current_behavior == CAMERA_BEHAVIOR_INVALID) || this->EvaluateSwitchBehavior() )
+        this->switchBehavior(CAMERA_BEHAVIOR_VEHICLE_CINECAM);
+        m_cct_player_actor->ar_current_cinecam = m_cct_player_actor->ar_forced_cinecam;
+    }
+    else
+    {
+        if (m_current_behavior < CAMERA_BEHAVIOR_END && App::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_CHANGE))
         {
-            this->switchToNextBehavior();
+            if ((m_current_behavior == CAMERA_BEHAVIOR_INVALID) || this->EvaluateSwitchBehavior())
+            {
+                this->switchToNextBehavior();
+            }
         }
-    }
 
-    if (App::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_FREE_MODE_FIX))
-    {
-        this->ToggleCameraBehavior(CAMERA_BEHAVIOR_FIXED);
-    }
+        if (App::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_FREE_MODE_FIX))
+        {
+            this->ToggleCameraBehavior(CAMERA_BEHAVIOR_FIXED);
+        }
 
-    if (App::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_FREE_MODE))
-    {
-        this->ToggleCameraBehavior(CAMERA_BEHAVIOR_FREE);
+        if (App::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_FREE_MODE))
+        {
+            this->ToggleCameraBehavior(CAMERA_BEHAVIOR_FREE);
+        }
     }
 
     if (m_current_behavior != CAMERA_BEHAVIOR_INVALID)

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4836,3 +4836,21 @@ float Actor::getSimAttribute(ActorSimAttr attr)
     default: return 0.f;
     }
 }
+
+void Actor::setForcedCinecam(CineCameraID_t cinecam_id, BitMask_t flags)
+{
+    ar_forced_cinecam = cinecam_id;
+    ar_forced_cinecam_flags = flags;
+}
+
+void Actor::clearForcedCinecam()
+{
+    this->setForcedCinecam(CINECAMERAID_INVALID, 0);
+}
+
+bool Actor::getForcedCinecam(CineCameraID_t& cinecam_id, BitMask_t& flags)
+{
+    cinecam_id = ar_forced_cinecam;
+    flags = ar_forced_cinecam_flags;
+    return (ar_forced_cinecam != CINECAMERAID_INVALID);
+}

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -142,12 +142,16 @@ public:
     void              antilockbrakeToggle();
     void              toggleCustomParticles();
     bool              getCustomParticleMode();
+    bool              isLocked();                          //!< Are hooks locked?
+    void              setForcedCinecam(CineCameraID_t cinecam_id, BitMask_t flags);
+    void              clearForcedCinecam();
+    bool              getForcedCinecam(CineCameraID_t& cinecam_id, BitMask_t& flags);
+    int               getNumCinecams() { return ar_num_cinecams; }
     // not exported to scripting:
     void              mouseMove(NodeNum_t node, Ogre::Vector3 pos, float force);
     void              tieToggle(int group=-1, ActorLinkingRequestType mode=ActorLinkingRequestType::TIE_TOGGLE, ActorInstanceID_t forceunlock_filter=ACTORINSTANCEID_INVALID);
     bool              isTied();
     void              hookToggle(int group=-1, ActorLinkingRequestType mode=ActorLinkingRequestType::HOOK_TOGGLE,NodeNum_t mousenode=NODENUM_INVALID, ActorInstanceID_t forceunlock_filter=ACTORINSTANCEID_INVALID);
-    bool              isLocked();                          //!< Are hooks locked?
     void              ropeToggle(int group=-1, ActorLinkingRequestType mode=ActorLinkingRequestType::ROPE_TOGGLE, ActorInstanceID_t forceunlock_filter=ACTORINSTANCEID_INVALID);
     void              engineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              toggleSlideNodeLock();
@@ -436,9 +440,10 @@ public:
     // * 'camera#' specifies a reference frame for the cinecam by referencing 3 preexisting nodes: ref, x, y.
     // NOTE camera#0 is special - serves a general orientation frame for the whole actor. Cinecam#0 isn't required to exist, but camera#0 is.
     CineCameraID_t    ar_current_cinecam = CINECAMERAID_INVALID; //!< Sim state; index of current CineCam (`CINECAMERAID_INVALID` if using 3rd-person camera)
-    CineCameraID_t    ar_forced_cinecam = CINECAMERAID_INVALID; //!< Sim state; index of CineCam forced by script (`CINECAMERAID_INVALID` if not forced)
     NodeNum_t         ar_custom_camera_node = NODENUM_INVALID; //!< Sim state; custom tracking node for 3rd-person camera
     PerVehicleCameraContext ar_camera_context;
+    CineCameraID_t    ar_forced_cinecam = CINECAMERAID_INVALID; //!< Sim state; index of CineCam forced by script (`CINECAMERAID_INVALID` if not forced)
+    BitMask_t         ar_forced_cinecam_flags = 0; //!< Sim state; flags for forced CineCam supplied by script
 
     // TractionControl
     float             tc_ratio = 0.f;                   //!< Regulating force

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -268,7 +268,6 @@ public:
     void              SoftReset();
     void              SyncReset(bool reset_position);      //!< this one should be called only synchronously (without physics running in background)
     void              WriteDiagnosticDump(std::string const& filename);
-    PerVehicleCameraContext* GetCameraContext()    { return &m_camera_context; }
     Ogre::Vector3     GetCameraDir()                    { return (ar_nodes[ar_main_camera_node_pos].RelPosition - ar_nodes[ar_main_camera_node_dir].RelPosition).normalisedCopy(); }
     Ogre::Vector3     GetCameraRoll()                   { return (ar_nodes[ar_main_camera_node_pos].RelPosition - ar_nodes[ar_main_camera_node_roll].RelPosition).normalisedCopy(); }
     Ogre::Vector3     GetFFbBodyForces() const          { return m_force_sensors.out_body_forces; }
@@ -417,8 +416,6 @@ public:
     float             ar_aileron = 0.f;                     //!< Sim state; aerial controller
     int               ar_aerial_flap = 0;                 //!< Sim state; state of aircraft flaps (values: 0-5)
     Ogre::Vector3     ar_fusedrag = Ogre::Vector3::ZERO;                    //!< Physics state
-    int               ar_current_cinecam = -1;             //!< Sim state; index of current CineCam (-1 if using 3rd-person camera)
-    NodeNum_t         ar_custom_camera_node = NODENUM_INVALID; //!< Sim state; custom tracking node for 3rd-person camera
     std::string       ar_filename;                    //!< Attribute; filled at spawn
     std::string       ar_filehash;                    //!< Attribute; filled at spawn
     int               ar_airbrake_intensity = 0;          //!< Physics state; values 0-5
@@ -433,6 +430,15 @@ public:
     ground_model_t*   ar_last_fuzzy_ground_model = nullptr;     //!< GUI state
     CollisionBoxPtrVec m_potential_eventboxes;
     std::vector<std::pair<collision_box_t*, NodeNum_t>> m_active_eventboxes;
+
+    // Player camera 'cameras & cinecam'
+    // * 'cinecam#' creates dedicated node to dictate camera position + 6 attachment beams.
+    // * 'camera#' specifies a reference frame for the cinecam by referencing 3 preexisting nodes: ref, x, y.
+    // NOTE camera#0 is special - serves a general orientation frame for the whole actor. Cinecam#0 isn't required to exist, but camera#0 is.
+    CineCameraID_t    ar_current_cinecam = CINECAMERAID_INVALID; //!< Sim state; index of current CineCam (`CINECAMERAID_INVALID` if using 3rd-person camera)
+    CineCameraID_t    ar_forced_cinecam = CINECAMERAID_INVALID; //!< Sim state; index of CineCam forced by script (`CINECAMERAID_INVALID` if not forced)
+    NodeNum_t         ar_custom_camera_node = NODENUM_INVALID; //!< Sim state; custom tracking node for 3rd-person camera
+    PerVehicleCameraContext ar_camera_context;
 
     // TractionControl
     float             tc_ratio = 0.f;                   //!< Regulating force
@@ -545,7 +551,6 @@ private:
     std::vector<std::shared_ptr<Task>> m_flexbody_tasks;   //!< Gfx state
     RigDef::DocumentPtr                m_definition;
     std::unique_ptr<GfxActor>          m_gfx_actor;
-    PerVehicleCameraContext            m_camera_context;
     Ogre::String                       m_section_config;
     std::vector<SlideNode>             m_slidenodes;       //!< all the SlideNodes available on this actor
     std::vector<RailGroup*>            m_railgroups;       //!< all the available RailGroups for this actor

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -75,7 +75,7 @@ void Actor::CalcForceFeedback(bool doUpdate)
             m_force_sensors.Reset();
         }
 
-        if (ar_current_cinecam != -1)
+        if (ar_current_cinecam != CINECAMERAID_INVALID)
         {
             m_force_sensors.accu_body_forces += ar_nodes[ar_camera_node_pos[ar_current_cinecam]].Forces;
         }

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -161,6 +161,11 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "void toggleCustomParticles()", asMETHOD(Actor,toggleCustomParticles), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool getCustomParticleMode()", asMETHOD(Actor,getCustomParticleMode), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool isLocked()", asMETHOD(Actor,isLocked), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void setForcedCinecam(int, int)", asMETHOD(Actor, setForcedCinecam), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "void clearForcedCinecam()", asMETHOD(Actor, clearForcedCinecam), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "bool getForcedCinecam(int& inout, int& inout)", asMETHOD(Actor, getForcedCinecam), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "int getNumCinecams() const", asMETHOD(Actor, getNumCinecams), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+
     
     // - subsystems (PLEASE maintain the same order as 'Actor.h' and 'doc/angelscript/.../BeamClass.h')
     result = engine->RegisterObjectMethod("BeamClass", "VehicleAIClassPtr @getVehicleAI()", asMETHOD(Actor,getVehicleAI), asCALL_THISCALL); ROR_ASSERT(result>=0);


### PR DESCRIPTION
Quick doodle for DannyWerewolf on Discord. Allows scripts to force players to use specific cinecam in vehicle. May be useful for race scripts to avoid cheating or simplify passing obstacles where regular 3rd person camera doesn't work well.

See new example script 'example_game_actorForceCinecam.as' - screenshot below shows how to find it:
![image](https://github.com/user-attachments/assets/c5b02b5b-c17c-4bad-87a2-c40620af3dbe)

Reprint of the added doc:
```
    /**
    * Sets a forced cinecam for this actor; This disables camera hotkeys.
    * @param cinecamId Cinecams are numbered from 0, use `getNumCinecams()`; -1 means no cinecam.
    * @param flags Flags are reserved for future use.
    */
    void setForcedCinecam(int cinecamId, int flags);

    /**
    * Resets the effect of `setForcedCinecam()`;
    */
    void clearForcedCinecam();

    /**
    * Reports the values submitted by `setForcedCinecam()`;
    * @param cinecamId Cinecams are numbered from 0, use `getNumCinecams()`; -1 means no cinecam.
    * @param flags Flags are reserved for future use.
    * @return True if a forced camera was set, False if not.
    */
    bool getForcedCinecam(int& inout, int& inout);

    /**
    * Reports number of installed cinecams.
    */
    int getNumCinecams() const;
```