### PR TITLE
Fixed laggy dashboard HUD elements

### DIFF
--- a/source/main/gui/DashBoardManager.h
+++ b/source/main/gui/DashBoardManager.h
@@ -274,6 +274,8 @@ public:
 
     void windowResized();
 
+    float getSmoothNumeric(int controlID);
+
 protected:
     DashBoardManager* manager;
     Ogre::String filename;
@@ -336,7 +338,7 @@ protected:
         MyGUI::IntSize initialSize;
         MyGUI::IntPoint initialPosition;
 
-        float last;
+        float lastVal;
         bool lastState;
     } layoutLink_t;
 


### PR DESCRIPTION
Fixes #3230 

This removes intentionally placed update skips which were in the code since beginning of Git history (~11 years).

There is no impact on FPS (mind you, I run under Debug which is order of magnitude slower than usual), so that isn't the reason why those skips were placed. I noticed the dash inputs are jaggy at places, for example when auto-shifting the throttle goes to 0% and then back to 100% in a split second. I added some smoothing to make this look less like a glitch.