### PR TITLE
Forward compatible OGRE13 fixes

### DIFF
--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -262,22 +262,30 @@ bool AppContext::SetUpRendering()
 
     // Load renderer configuration
     bool autodetect_resolution = false;
-    if (!m_ogre_root->restoreConfig())
+    try
     {
-        autodetect_resolution = true;
-        LOG(fmt::format("[RoR|Startup|Rendering] WARNING - invalid 'ogre.cfg', selecting render plugin manually..."));
+        if (!m_ogre_root->restoreConfig())
+        {
+            autodetect_resolution = true;
+            LOG(fmt::format("[RoR|Startup|Rendering] WARNING - invalid 'ogre.cfg', selecting render plugin manually..."));
 
-        const auto render_systems = App::GetAppContext()->GetOgreRoot()->getAvailableRenderers();
-        if (!render_systems.empty())
-        {
-            LOG(fmt::format("[RoR|Startup|Rendering] Auto-selected renderer plugin '{}'", render_systems.front()->getName()));
-            m_ogre_root->setRenderSystem(render_systems.front());
+            const auto render_systems = App::GetAppContext()->GetOgreRoot()->getAvailableRenderers();
+            if (!render_systems.empty())
+            {
+                LOG(fmt::format("[RoR|Startup|Rendering] Auto-selected renderer plugin '{}'", render_systems.front()->getName()));
+                    m_ogre_root->setRenderSystem(render_systems.front());
+            }
+            else
+            {
+                ErrorUtils::ShowError (_L("Startup error"), _L("No render system plugin available. Check your plugins.cfg"));
+                return false;
+            }
         }
-        else
-        {
-            ErrorUtils::ShowError (_L("Startup error"), _L("No render system plugin available. Check your plugins.cfg"));
-            return false;
-        }
+    }
+    catch (Ogre::Exception& e)
+    {
+        ErrorUtils::ShowError (_L("Error restoring settings from 'ogre.cfg'"), e.getDescription());
+        return false;
     }
 
     const auto rs = m_ogre_root->getRenderSystemByName(App::app_rendersys_override->getStr());

--- a/source/main/audio/Sound.cpp
+++ b/source/main/audio/Sound.cpp
@@ -122,30 +122,30 @@ void Sound::stop()
     sound_manager->recomputeSource(source_index, REASON_STOP, 0.0f, NULL);
 }
 
-void Sound::setGain(float gain)
+void Sound::setGain(float gain_)
 {
-    if (gain == this->gain)
+    if (gain_ == this->gain)
         return;
 
-    this->gain = gain;
+    this->gain = gain_;
     sound_manager->recomputeSource(source_index, REASON_GAIN, gain, NULL);
 }
 
-void Sound::setLoop(bool loop)
+void Sound::setLoop(bool loop_)
 {
-    if (loop == this->loop)
+    if (loop_ == this->loop)
         return;
 
-    this->loop = loop;
+    this->loop = loop_;
     sound_manager->recomputeSource(source_index, REASON_LOOP, (loop) ? 1.0f : 0.0f, NULL);
 }
 
-void Sound::setPitch(float pitch)
+void Sound::setPitch(float pitch_)
 {
-    if (pitch == this->pitch)
+    if (pitch_ == this->pitch)
         return;
 
-    this->pitch = pitch;
+    this->pitch = pitch_;
     sound_manager->recomputeSource(source_index, REASON_PTCH, pitch, NULL);
 }
 

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -696,7 +696,7 @@ void RoR::GfxCharacter::UpdateCharacterInScene()
         const String materialName = "tracks/" + xc_instance_name;
 
         MaterialPtr mat = MaterialManager::getSingleton().getByName(materialName);
-        if (!mat.isNull() && mat->getNumTechniques() > 0 && mat->getTechnique(0)->getNumPasses() > 1 &&
+        if (mat && mat->getNumTechniques() > 0 && mat->getTechnique(0)->getNumPasses() > 1 &&
                 mat->getTechnique(0)->getPass(1)->getNumTextureUnitStates() > 1)
         {
             const auto& state = mat->getTechnique(0)->getPass(1)->getTextureUnitState(1);

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -193,8 +193,8 @@ void Character::update(float dt)
             Vector3 base = m_prev_position + Vector3::UNIT_Y * 0.25f;
             for (int i = 1; i < numstep; i++)
             {
-                Vector3 query = base + diff * ((float)i / numstep);
-                if (App::GetGameContext()->GetTerrain()->GetCollisions()->collisionCorrect(&query, false))
+                Vector3 query_ = base + diff * ((float)i / numstep);
+                if (App::GetGameContext()->GetTerrain()->GetCollisions()->collisionCorrect(&query_, false))
                 {
                     m_character_v_speed = std::max(0.0f, m_character_v_speed);
                     position = m_prev_position + diff * ((float)(i - 1) / numstep);

--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -40,7 +40,7 @@ using namespace RoR;
 
 #define LOGSTREAM Ogre::LogManager::getSingleton().stream()
 
-Character::Character(int source, unsigned int streamid, UTFString player_name, int color_number, bool is_remote) :
+Character::Character(int source, unsigned int streamid, std::string player_name, int color_number, bool is_remote) :
       m_actor_coupling(nullptr)
     , m_can_jump(false)
     , m_character_rotation(0.0f)
@@ -407,7 +407,7 @@ void Character::move(Vector3 offset)
 void Character::ReportError(const char* detail)
 {
 #ifdef USE_SOCKETW
-    Ogre::UTFString username;
+    std::string username;
     RoRnet::UserInfo info;
     if (!App::GetNetwork()->GetUserInfo(m_source_id, info))
         username = "~~ERROR getting username~~";
@@ -417,7 +417,7 @@ void Character::ReportError(const char* detail)
     char msg_buf[300];
     snprintf(msg_buf, 300,
         "[RoR|Networking] ERROR on m_is_remote character (User: '%s', SourceID: %d, StreamID: %d): ",
-        username.asUTF8_c_str(), m_source_id, m_stream_id);
+        username.c_str(), m_source_id, m_stream_id);
 
     LOGSTREAM << msg_buf << detail;
 #endif

--- a/source/main/gameplay/Character.h
+++ b/source/main/gameplay/Character.h
@@ -24,7 +24,6 @@
 #include "ForwardDeclarations.h"
 #include "SurveyMapEntity.h"
 
-#include <OgreUTFString.h>
 #include <OgreMeshManager.h>
 #include <OgreTimer.h>
 #include <string>
@@ -41,14 +40,14 @@ class Character
 {
 public:
 
-    Character(int source = -1, unsigned int streamid = 0, Ogre::UTFString playerName = "", int color_number = 0, bool is_remote = true);
+    Character(int source = -1, unsigned int streamid = 0, std::string playerName = "", int color_number = 0, bool is_remote = true);
     ~Character();
        
     int            getSourceID() const                  { return m_source_id; }
     bool           isRemote() const                     { return m_is_remote; }
     int            GetColorNum() const                  { return m_color_number; }
     bool           GetIsRemote() const                  { return m_is_remote; }
-    Ogre::UTFString const& GetNetUsername()             { return m_net_username; }
+    std::string const& GetNetUsername()             { return m_net_username; }
     std::string const &    GetAnimName() const          { return m_anim_name; }
     float          GetAnimTime() const                  { return m_anim_time; }
     Ogre::Radian   getRotation() const                  { return m_character_rotation; }
@@ -87,7 +86,7 @@ private:
     float            m_net_last_anim_time;
     float            m_driving_anim_length;
     std::string      m_instance_name;
-    Ogre::UTFString  m_net_username;
+    std::string  m_net_username;
     Ogre::Timer      m_net_timer;
     unsigned long    m_net_last_update_time;
     GfxCharacter*    m_gfx_character;
@@ -102,7 +101,7 @@ struct GfxCharacter
     {
         Ogre::Vector3      simbuf_character_pos;
         Ogre::Radian       simbuf_character_rot; //!< When on foot
-        Ogre::UTFString    simbuf_net_username;
+        std::string    simbuf_net_username;
         bool               simbuf_is_remote;
         int                simbuf_color_number;
         ActorPtr             simbuf_actor_coupling;

--- a/source/main/gameplay/CharacterFactory.cpp
+++ b/source/main/gameplay/CharacterFactory.cpp
@@ -32,7 +32,7 @@ using namespace RoR;
 Character* CharacterFactory::CreateLocalCharacter()
 {
     int colourNum = -1;
-    Ogre::UTFString playerName = "";
+    std::string playerName = "";
 
 #ifdef USE_SOCKETW
     if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
@@ -54,7 +54,7 @@ void CharacterFactory::createRemoteInstance(int sourceid, int streamid)
     RoRnet::UserInfo info;
     App::GetNetwork()->GetUserInfo(sourceid, info);
     int colour = info.colournum;
-    Ogre::UTFString name = tryConvertUTF(info.username);
+    std::string name = tryConvertUTF(info.username);
 
     LOG(" new character for " + TOSTRING(sourceid) + ":" + TOSTRING(streamid) + ", colour: " + TOSTRING(colour));
 

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -54,7 +54,7 @@ void SceneMouse::InitializeVisuals()
     pickLineNode = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode("PickLineNode");
 
     MaterialPtr pickLineMaterial = MaterialManager::getSingleton().getByName("PickLineMaterial", ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-    if (pickLineMaterial.isNull())
+    if (!pickLineMaterial)
     {
         pickLineMaterial = MaterialManager::getSingleton().create("PickLineMaterial", ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
     }

--- a/source/main/gameplay/VehicleAI.cpp
+++ b/source/main/gameplay/VehicleAI.cpp
@@ -243,7 +243,7 @@ void VehicleAI::update(float dt, int doUpdate)
     }
 
     // Find the angle (Radian) of the upcoming turn
-    Ogre:;Vector3 dir1 = current_waypoint - prev_waypoint;
+    Ogre::Vector3 dir1 = current_waypoint - prev_waypoint;
     Ogre::Vector3 dir2 = next_waypoint - current_waypoint;
     float angle_rad = 0;
     float angle_deg = 0;

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -50,10 +50,13 @@ void RoR::GfxEnvmap::SetupEnvMap()
         m_cameras[face] = App::GetGfxScene()->GetSceneManager()->createCamera("EnvironmentCamera-" + TOSTRING(face));
         m_cameras[face]->setAspectRatio(1.0);
         m_cameras[face]->setProjectionType(Ogre::PT_PERSPECTIVE);
-        m_cameras[face]->setFixedYawAxis(false);
         m_cameras[face]->setFOVy(Ogre::Degree(90));
         m_cameras[face]->setNearClipDistance(0.1f);
         m_cameras[face]->setFarClipDistance(App::GetCameraManager()->GetCamera()->getFarClipDistance());
+
+        m_cameras_snode[face] = App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->createChildSceneNode();
+        m_cameras_snode[face]->attachObject(m_cameras[face]);
+        m_cameras_snode[face]->setFixedYawAxis(false);
 
         Ogre::Viewport* v = m_render_targets[face]->addViewport(m_cameras[face]);
         v->setOverlaysEnabled(false);
@@ -62,12 +65,12 @@ void RoR::GfxEnvmap::SetupEnvMap()
         m_render_targets[face]->setAutoUpdated(false);
     }
 
-    m_cameras[0]->setDirection(+Ogre::Vector3::UNIT_X);
-    m_cameras[1]->setDirection(-Ogre::Vector3::UNIT_X);
-    m_cameras[2]->setDirection(+Ogre::Vector3::UNIT_Y);
-    m_cameras[3]->setDirection(-Ogre::Vector3::UNIT_Y);
-    m_cameras[4]->setDirection(-Ogre::Vector3::UNIT_Z);
-    m_cameras[5]->setDirection(+Ogre::Vector3::UNIT_Z);
+    m_cameras_snode[0]->setDirection(+Ogre::Vector3::UNIT_X);
+    m_cameras_snode[1]->setDirection(-Ogre::Vector3::UNIT_X);
+    m_cameras_snode[2]->setDirection(+Ogre::Vector3::UNIT_Y);
+    m_cameras_snode[3]->setDirection(-Ogre::Vector3::UNIT_Y);
+    m_cameras_snode[4]->setDirection(-Ogre::Vector3::UNIT_Z);
+    m_cameras_snode[5]->setDirection(+Ogre::Vector3::UNIT_Z);
 
     if (App::diag_envmap->getBool())
     {
@@ -225,7 +228,7 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, boo
 
     for (int i = 0; i < NUM_FACES; i++)
     {
-        m_cameras[i]->setPosition(center);
+        m_cameras[i]->getParentSceneNode()->setPosition(center);
     }
 
     if (gfx_actor != nullptr)

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -45,6 +45,7 @@ private:
     static const unsigned int NUM_FACES = 6;
 
     Ogre::Camera*        m_cameras[NUM_FACES];
+    Ogre::SceneNode*     m_cameras_snode[NUM_FACES];
     Ogre::RenderTarget*  m_render_targets[NUM_FACES];
     Ogre::TexturePtr     m_rtt_texture;
     int                  m_update_round; /// Render targets are updated one-by-one; this is the index of next target to update.

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -510,9 +510,9 @@ void RoR::GfxActor::UpdateVideoCameras(float dt)
             Ogre::Plane plane = Ogre::Plane(normal, center);
             Ogre::Vector3 project = plane.projectVector(App::GetCameraManager()->GetCameraNode()->getPosition() - center);
 
-            vidcam.vcam_ogre_camera->setPosition(center);
-            vidcam.vcam_ogre_camera->lookAt(App::GetCameraManager()->GetCameraNode()->getPosition() - 2.0f * project);
-            vidcam.vcam_ogre_camera->roll(roll);
+            vidcam.vcam_ogre_camera->getParentSceneNode()->setPosition(center);
+            vidcam.vcam_ogre_camera->getParentSceneNode()->lookAt(App::GetCameraManager()->GetCameraNode()->getPosition() - 2.0f * project, Ogre::Node::TS_WORLD);
+            // vidcam.vcam_ogre_camera->getParentSceneNode()->roll(roll); // makes the camera spin
             vidcam.vcam_ogre_camera->setNearClipDistance(1); // fixes Caelum sky rendered black on mirrors
 
             continue; // Done processing mirror prop.
@@ -543,14 +543,14 @@ void RoR::GfxActor::UpdateVideoCameras(float dt)
         // could this be done faster&better with a plane setFrustumExtents ?
         Ogre::Vector3 frustumUP = abs_pos_center - abs_pos_y;
         frustumUP.normalise();
-        vidcam.vcam_ogre_camera->setFixedYawAxis(true, frustumUP);
+        vidcam.vcam_ogre_camera->getParentSceneNode()->setFixedYawAxis(true, frustumUP);
 
         if (vidcam.vcam_role == VCAM_ROLE_MIRROR || vidcam.vcam_role == VCAM_ROLE_MIRROR_NOFLIP)
         {
             //rotate the normal of the mirror by user rotation setting so it reflects correct
             normal = vidcam.vcam_rotation * normal;
             // merge camera direction and reflect it on our plane
-            vidcam.vcam_ogre_camera->setDirection((pos - App::GetCameraManager()->GetCameraNode()->getPosition()).reflect(normal));
+            vidcam.vcam_ogre_camera->getParentSceneNode()->setDirection((pos - App::GetCameraManager()->GetCameraNode()->getPosition()).reflect(normal));
         }
         else if (vidcam.vcam_role == VCAM_ROLE_VIDEOCAM)
         {
@@ -560,7 +560,7 @@ void RoR::GfxActor::UpdateVideoCameras(float dt)
             Ogre::Vector3 refy = abs_pos_center - abs_pos_y;
             refy.normalise();
             Ogre::Quaternion rot = Ogre::Quaternion(-refx, -refy, -normal);
-            vidcam.vcam_ogre_camera->setOrientation(rot * vidcam.vcam_rotation); // rotate the camera orientation towards the calculated cam direction plus user rotation
+            vidcam.vcam_ogre_camera->getParentSceneNode()->setOrientation(rot * vidcam.vcam_rotation); // rotate the camera orientation towards the calculated cam direction plus user rotation
         }
         else if (vidcam.vcam_role == VCAM_ROLE_TRACKING_VIDEOCAM 
             || vidcam.vcam_role == VCAM_ROLE_TRACKING_MIRROR || vidcam.vcam_role == VCAM_ROLE_TRACKING_MIRROR_NOFLIP)
@@ -574,17 +574,17 @@ void RoR::GfxActor::UpdateVideoCameras(float dt)
             Ogre::Vector3 refy = refx.crossProduct(normal);
             refy.normalise();
             Ogre::Quaternion rot = Ogre::Quaternion(-refx, -refy, -normal);
-            vidcam.vcam_ogre_camera->setOrientation(rot * vidcam.vcam_rotation); // rotate the camera orientation towards the calculated cam direction plus user rotation
+            vidcam.vcam_ogre_camera->getParentSceneNode()->setOrientation(rot * vidcam.vcam_rotation); // rotate the camera orientation towards the calculated cam direction plus user rotation
         }
 
         if (vidcam.vcam_debug_node != nullptr)
         {
             vidcam.vcam_debug_node->setPosition(pos);
-            vidcam.vcam_debug_node->setOrientation(vidcam.vcam_ogre_camera->getOrientation());
+            vidcam.vcam_debug_node->setOrientation(vidcam.vcam_ogre_camera->getParentSceneNode()->getOrientation());
         }
 
         // set the new position
-        vidcam.vcam_ogre_camera->setPosition(pos);
+        vidcam.vcam_ogre_camera->getParentSceneNode()->setPosition(pos);
     }
 }
 
@@ -2157,11 +2157,11 @@ void RoR::GfxActor::UpdateBeaconFlare(Prop & prop, float dt, bool is_player_acto
         float beacon_rotation_angle = prop.pp_beacon_rot_angle[0]; // Updated at end of block
 
         // Transform
-        pp_beacon_light->setPosition(beacon_scene_node->getPosition() + beacon_orientation * Ogre::Vector3(0, 0, 0.12));
+        pp_beacon_light->getParentSceneNode()->setPosition(beacon_scene_node->getPosition() + beacon_orientation * Ogre::Vector3(0, 0, 0.12));
         beacon_rotation_angle += dt * beacon_rotation_rate;//rotate baby!
-        pp_beacon_light->setDirection(beacon_orientation * Ogre::Vector3(cos(beacon_rotation_angle), sin(beacon_rotation_angle), 0));
+        pp_beacon_light->getParentSceneNode()->setDirection(beacon_orientation * Ogre::Vector3(cos(beacon_rotation_angle), sin(beacon_rotation_angle), 0));
         //billboard
-        Ogre::Vector3 vdir = pp_beacon_light->getPosition() - App::GetCameraManager()->GetCameraNode()->getPosition(); // TODO: verify the position is already updated here ~ only_a_ptr, 06/2018
+        Ogre::Vector3 vdir = pp_beacon_light->getParentSceneNode()->getPosition() - App::GetCameraManager()->GetCameraNode()->getPosition(); // TODO: verify the position is already updated here ~ only_a_ptr, 06/2018
         float vlen = vdir.length();
         if (vlen > 100.0)
         {
@@ -2170,8 +2170,8 @@ void RoR::GfxActor::UpdateBeaconFlare(Prop & prop, float dt, bool is_player_acto
         }
         //normalize
         vdir = vdir / vlen;
-        prop.pp_beacon_scene_node[0]->setPosition(pp_beacon_light->getPosition() - vdir * 0.1);
-        float amplitude = pp_beacon_light->getDirection().dotProduct(vdir);
+        prop.pp_beacon_scene_node[0]->setPosition(pp_beacon_light->getParentSceneNode()->getPosition() - vdir * 0.1);
+        float amplitude = pp_beacon_light->getDerivedDirection().dotProduct(vdir);
         if (amplitude > 0)
         {
             prop.pp_beacon_scene_node[0]->setVisible(true);
@@ -2195,19 +2195,19 @@ void RoR::GfxActor::UpdateBeaconFlare(Prop & prop, float dt, bool is_player_acto
             Quaternion orientation = prop.pp_scene_node->getOrientation();
             switch (k)
             {
-            case 0: prop.pp_beacon_light[k]->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(-0.64, 0, 0.14));
+            case 0: prop.pp_beacon_light[k]->getParentSceneNode()->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(-0.64, 0, 0.14));
                 break;
-            case 1: prop.pp_beacon_light[k]->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(-0.32, 0, 0.14));
+            case 1: prop.pp_beacon_light[k]->getParentSceneNode()->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(-0.32, 0, 0.14));
                 break;
-            case 2: prop.pp_beacon_light[k]->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(+0.32, 0, 0.14));
+            case 2: prop.pp_beacon_light[k]->getParentSceneNode()->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(+0.32, 0, 0.14));
                 break;
-            case 3: prop.pp_beacon_light[k]->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(+0.64, 0, 0.14));
+            case 3: prop.pp_beacon_light[k]->getParentSceneNode()->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(+0.64, 0, 0.14));
                 break;
             }
             prop.pp_beacon_rot_angle[k] += dt * prop.pp_beacon_rot_rate[k];//rotate baby!
-            prop.pp_beacon_light[k]->setDirection(orientation * Vector3(cos(prop.pp_beacon_rot_angle[k]), sin(prop.pp_beacon_rot_angle[k]), 0));
+            prop.pp_beacon_light[k]->getParentSceneNode()->setDirection(orientation * Vector3(cos(prop.pp_beacon_rot_angle[k]), sin(prop.pp_beacon_rot_angle[k]), 0));
             //billboard
-            Vector3 vdir = prop.pp_beacon_light[k]->getPosition() - App::GetCameraManager()->GetCameraNode()->getPosition();
+            Vector3 vdir = prop.pp_beacon_light[k]->getParentSceneNode()->getPosition() - App::GetCameraManager()->GetCameraNode()->getPosition();
             float vlen = vdir.length();
             if (vlen > 100.0)
             {
@@ -2216,8 +2216,8 @@ void RoR::GfxActor::UpdateBeaconFlare(Prop & prop, float dt, bool is_player_acto
             }
             //normalize
             vdir = vdir / vlen;
-            prop.pp_beacon_scene_node[k]->setPosition(prop.pp_beacon_light[k]->getPosition() - vdir * 0.2);
-            float amplitude = prop.pp_beacon_light[k]->getDirection().dotProduct(vdir);
+            prop.pp_beacon_scene_node[k]->setPosition(prop.pp_beacon_light[k]->getParentSceneNode()->getPosition() - vdir * 0.2);
+            float amplitude = prop.pp_beacon_light[k]->getDerivedDirection().dotProduct(vdir);
             if (amplitude > 0)
             {
                 prop.pp_beacon_scene_node[k]->setVisible(true);
@@ -2234,10 +2234,10 @@ void RoR::GfxActor::UpdateBeaconFlare(Prop & prop, float dt, bool is_player_acto
     {
         //update light
         Quaternion orientation = prop.pp_scene_node->getOrientation();
-        prop.pp_beacon_light[0]->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(0, 0, 0.06));
+        prop.pp_beacon_light[0]->getParentSceneNode()->setPosition(prop.pp_scene_node->getPosition() + orientation * Vector3(0, 0, 0.06));
         prop.pp_beacon_rot_angle[0] += dt * prop.pp_beacon_rot_rate[0];//rotate baby!
         //billboard
-        Vector3 vdir = prop.pp_beacon_light[0]->getPosition() - App::GetCameraManager()->GetCameraNode()->getPosition();
+        Vector3 vdir = prop.pp_beacon_light[0]->getParentSceneNode()->getPosition() - App::GetCameraManager()->GetCameraNode()->getPosition();
         float vlen = vdir.length();
         if (vlen > 100.0)
         {
@@ -2246,7 +2246,7 @@ void RoR::GfxActor::UpdateBeaconFlare(Prop & prop, float dt, bool is_player_acto
         }
         //normalize
         vdir = vdir / vlen;
-        prop.pp_beacon_scene_node[0]->setPosition(prop.pp_beacon_light[0]->getPosition() - vdir * 0.1);
+        prop.pp_beacon_scene_node[0]->setPosition(prop.pp_beacon_light[0]->getParentSceneNode()->getPosition() - vdir * 0.1);
         bool visible = false;
         if (prop.pp_beacon_rot_angle[0] > 1.0)
         {
@@ -2275,7 +2275,7 @@ void RoR::GfxActor::UpdateBeaconFlare(Prop & prop, float dt, bool is_player_acto
     else if (prop.pp_beacon_type == 'w') // Avionic navigation lights (white rotating beacon)
     {
         Vector3 mposition = nodes[prop.pp_node_ref].AbsPosition + prop.pp_offset.x * (nodes[prop.pp_node_x].AbsPosition - nodes[prop.pp_node_ref].AbsPosition) + prop.pp_offset.y * (nodes[prop.pp_node_y].AbsPosition - nodes[prop.pp_node_ref].AbsPosition);
-        prop.pp_beacon_light[0]->setPosition(mposition);
+        prop.pp_beacon_light[0]->getParentSceneNode()->setPosition(mposition);
         prop.pp_beacon_rot_angle[0] += dt * prop.pp_beacon_rot_rate[0];//rotate baby!
         //billboard
         Vector3 vdir = mposition - App::GetCameraManager()->GetCameraNode()->getPosition();
@@ -3312,9 +3312,9 @@ void RoR::GfxActor::UpdateFlares(float dt, bool is_player)
         }
         if (flare.light)
         {
-            flare.light->setPosition(mposition - 0.2 * amplitude * normal);
+            flare.light->getParentSceneNode()->setPosition(mposition - 0.2 * amplitude * normal);
             // point the real light towards the ground a bit
-            flare.light->setDirection(-normal - Ogre::Vector3(0, 0.2, 0));
+            flare.light->getParentSceneNode()->setDirection(-normal - Ogre::Vector3(0, 0.2, 0));
         }
         if (flare.intensity > 0)
         {

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -92,7 +92,7 @@ RoR::GfxActor::~GfxActor()
         {
             VideoCamera& vcam = m_videocameras.back();
             Ogre::TextureManager::getSingleton().remove(vcam.vcam_render_tex->getHandle());
-            vcam.vcam_render_tex.setNull();
+            vcam.vcam_render_tex.reset();
             vcam.vcam_render_target = nullptr; // Invalidated with parent texture
             App::GetGfxScene()->GetSceneManager()->destroyCamera(vcam.vcam_ogre_camera);
         }
@@ -420,7 +420,7 @@ void RoR::GfxActor::RegisterCabMaterial(Ogre::MaterialPtr mat, Ogre::MaterialPtr
 
 void RoR::GfxActor::SetCabLightsActive(bool state_on)
 {
-    if (m_cab_mat_template_emissive.isNull()) // Both this and '_plain' are only set when emissive pass is present.
+    if (!m_cab_mat_template_emissive) // Both this and '_plain' are only set when emissive pass is present.
         return;
 
     // NOTE: Updating material in-place like this is probably inefficient,

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -82,7 +82,7 @@ void GfxScene::ClearScene()
 void GfxScene::Init()
 {
     ROR_ASSERT(!m_scene_manager);
-    m_scene_manager = App::GetAppContext()->GetOgreRoot()->createSceneManager(Ogre::ST_EXTERIOR_CLOSE, "main_scene_manager");
+    m_scene_manager = App::GetAppContext()->GetOgreRoot()->createSceneManager();
 
     m_skidmark_conf.LoadDefaultSkidmarkDefs();
 }

--- a/source/main/gfx/IWater.h
+++ b/source/main/gfx/IWater.h
@@ -42,21 +42,21 @@ public:
 
     virtual float          GetStaticWaterHeight() = 0; //!< Returns static water level configured in 'terrn2'
     virtual void           SetStaticWaterHeight(float value) = 0;
-    virtual void           SetWaterBottomHeight(float value) {};
-    virtual void           SetWavesHeight(float value) {};
+    virtual void           SetWaterBottomHeight(float) {};
+    virtual void           SetWavesHeight(float) {};
     virtual float          CalcWavesHeight(Ogre::Vector3 pos) = 0;
     virtual Ogre::Vector3  CalcWavesVelocity(Ogre::Vector3 pos) = 0;
     virtual void           SetWaterVisible(bool value) = 0;
     virtual void           WaterSetSunPosition(Ogre::Vector3) {}
     virtual bool           IsUnderWater(Ogre::Vector3 pos) = 0;
     virtual void           FrameStepWater(float dt) = 0;
-    virtual void           SetReflectionPlaneHeight(float centerheight) {}
-    virtual void           UpdateReflectionPlane(float h) {}
+    virtual void           SetReflectionPlaneHeight(float) {}
+    virtual void           UpdateReflectionPlane(float) {}
     virtual void           WaterPrepareShutdown() {}
     virtual void           UpdateWater() = 0;
 
     // Only used by class Water for SurveyMap texture creation
-    virtual void           SetForcedCameraTransform(Ogre::Radian fovy, Ogre::Vector3 pos, Ogre::Quaternion rot) {};
+    virtual void           SetForcedCameraTransform(Ogre::Radian /*fovy*/, Ogre::Vector3 /*pos*/, Ogre::Quaternion /*rot*/) {};
     virtual void           ClearForcedCameraTransform() {};
 };
 

--- a/source/main/gfx/MovableText.cpp
+++ b/source/main/gfx/MovableText.cpp
@@ -34,7 +34,7 @@ using namespace RoR;
 #define POS_TEX_BINDING    0
 #define COLOUR_BINDING     1
 
-MovableText::MovableText(const UTFString& name, const UTFString& caption, const UTFString& fontName, Real charHeight, const ColourValue& color)
+MovableText::MovableText(const std::string& name, const std::string& caption, const std::string& fontName, Real charHeight, const ColourValue& color)
     : mpCam(NULL)
     , mpWin(NULL)
     , mpFont(NULL)
@@ -70,7 +70,7 @@ MovableText::~MovableText()
         delete mRenderOp.vertexData;
 }
 
-void MovableText::setFontName(const UTFString& fontName)
+void MovableText::setFontName(const std::string& fontName)
 {
     if ((Ogre::MaterialManager::getSingletonPtr()->resourceExists(mName + "Material")))
     {
@@ -105,7 +105,7 @@ void MovableText::setFontName(const UTFString& fontName)
     }
 }
 
-void MovableText::setCaption(const UTFString& caption)
+void MovableText::setCaption(const std::string& caption)
 {
     if (caption != mCaption)
     {
@@ -249,7 +249,7 @@ void MovableText::_setupGeometry()
     bool first = true;
 
     // Use iterator
-    UTFString::iterator i, iend;
+    std::string::iterator i, iend;
     iend = mCaption.end();
     bool newLine = true;
     Real len = 0.0f;
@@ -270,7 +270,7 @@ void MovableText::_setupGeometry()
         if (newLine)
         {
             len = 0.0f;
-            for (UTFString::iterator j = i; j != iend && *j != '\n'; j++)
+            for (std::string::iterator j = i; j != iend && *j != '\n'; j++)
             {
                 if (*j == ' ')
                     len += mSpaceWidth;

--- a/source/main/gfx/MovableText.cpp
+++ b/source/main/gfx/MovableText.cpp
@@ -80,7 +80,7 @@ void MovableText::setFontName(const UTFString& fontName)
     if (mFontName != fontName || !mpMaterial || !mpFont)
     {
         mFontName = fontName;
-        mpFont = (Ogre::Font *)FontManager::getSingleton().getResourceByName(mFontName).getPointer();
+        mpFont = (Ogre::Font *)FontManager::getSingleton().getResourceByName(mFontName).get();
 
         if (!mpFont)
             throw Exception(Exception::ERR_ITEM_NOT_FOUND, "Could not find font " + fontName, "MovableText::setFontName");

--- a/source/main/gfx/MovableText.h
+++ b/source/main/gfx/MovableText.h
@@ -126,7 +126,7 @@ protected:
 
     // from renderable
     void    getRenderOperation(Ogre::RenderOperation &op);
-    const   Ogre::MaterialPtr       &getMaterial(void) const {ROR_ASSERT(!mpMaterial.isNull());return mpMaterial;};
+    const   Ogre::MaterialPtr       &getMaterial(void) const {ROR_ASSERT(mpMaterial);return mpMaterial;};
     const   Ogre::LightList         &getLights(void) const {return mLList;};
 };
 

--- a/source/main/gfx/MovableText.h
+++ b/source/main/gfx/MovableText.h
@@ -30,7 +30,6 @@
 #include <Ogre.h>
 #include <Overlay/OgreFontManager.h>
 
-#include <OgreUTFString.h>
 namespace RoR {
 
 /// @addtogroup Gfx
@@ -44,10 +43,10 @@ public:
     enum VerticalAlignment      {V_BELOW, V_ABOVE};
 
 protected:
-    Ogre::UTFString			mFontName;
-    Ogre::UTFString			mType;
+    std::string			mFontName;
+    std::string			mType;
     Ogre::String			    mName;
-    Ogre::UTFString			mCaption;
+    std::string			mCaption;
     HorizontalAlignment	mHorizontalAlignment;
     VerticalAlignment	mVerticalAlignment;
 
@@ -75,8 +74,8 @@ protected:
 
     /******************************** public methods ******************************/
 public:
-    MovableText(const Ogre::UTFString &name, const Ogre::UTFString &caption, 
-                const Ogre::UTFString &fontName = "highcontrast_black",
+    MovableText(const std::string &name, const std::string &caption, 
+                const std::string &fontName = "highcontrast_black",
                 Ogre::Real charHeight = 1.0, const Ogre::ColourValue &color = Ogre::ColourValue::Black);
     virtual ~MovableText();
 
@@ -84,8 +83,8 @@ public:
     virtual void visitRenderables(Ogre::Renderable::Visitor*, bool) override {};
 
     // Set settings
-    void    setFontName(const Ogre::UTFString &fontName);
-    void    setCaption(const Ogre::UTFString &caption);
+    void    setFontName(const std::string &fontName);
+    void    setCaption(const std::string &caption);
     void    setColor(const Ogre::ColourValue &color);
     void    setCharacterHeight(Ogre::Real height);
     void    setSpaceWidth(Ogre::Real width);
@@ -94,8 +93,8 @@ public:
     void    showOnTop(bool show=true);
 
     // Get settings
-    const   Ogre::UTFString          &getFontName() const {return mFontName;}
-    const   Ogre::UTFString          &getCaption() const {return mCaption;}
+    const   std::string          &getFontName() const {return mFontName;}
+    const   std::string          &getCaption() const {return mCaption;}
     const   Ogre::ColourValue     &getColor() const {return mColor;}
 
     Ogre::uint    getCharacterHeight() const {return (Ogre::uint) mCharHeight;}

--- a/source/main/gfx/MovableText.h
+++ b/source/main/gfx/MovableText.h
@@ -81,7 +81,7 @@ public:
     virtual ~MovableText();
 
     // Add to build on Shoggoth:
-    virtual void visitRenderables(Ogre::Renderable::Visitor* visitor, bool debugRenderables = false) {};
+    virtual void visitRenderables(Ogre::Renderable::Visitor*, bool) override {};
 
     // Set settings
     void    setFontName(const Ogre::UTFString &fontName);
@@ -114,7 +114,7 @@ protected:
     // from MovableObject
     void    getWorldTransforms(Ogre::Matrix4 *xform) const;
     Ogre::Real    getBoundingRadius(void) const {return mRadius;};
-    Ogre::Real    getSquaredViewDepth(const Ogre::Camera *cam) const {return 0;};
+    Ogre::Real    getSquaredViewDepth(const Ogre::Camera *) const {return 0;};
     const   Ogre::Quaternion        &getWorldOrientation(void) const;
     const   Ogre::Vector3           &getWorldPosition(void) const;
     const   Ogre::AxisAlignedBox    &getBoundingBox(void) const {return mAABB;};

--- a/source/main/gfx/ShadowManager.cpp
+++ b/source/main/gfx/ShadowManager.cpp
@@ -36,7 +36,7 @@ using namespace RoR;
 
 ShadowManager::ShadowManager()
 {
-    PSSM_Shadows.mPSSMSetup.setNull();
+    PSSM_Shadows.mPSSMSetup.reset();
     PSSM_Shadows.mDepthShadows = false;
     PSSM_Shadows.ShadowsTextureNum = 3;
     PSSM_Shadows.Quality = RoR::App::gfx_shadow_quality->getInt(); //0 = Low quality, 1 = mid, 2 = hq, 3 = ultra
@@ -135,7 +135,7 @@ void ShadowManager::processPSSM()
         PSSM_Shadows.lambda = 0.98f;
     }
 
-    if (PSSM_Shadows.mPSSMSetup.isNull())
+    if (!PSSM_Shadows.mPSSMSetup)
     {
         // shadow camera setup
         Ogre::PSSMShadowCameraSetup* pssmSetup = new Ogre::PSSMShadowCameraSetup();

--- a/source/main/gfx/Skidmark.cpp
+++ b/source/main/gfx/Skidmark.cpp
@@ -180,7 +180,7 @@ void RoR::Skidmark::PopSegment()
     skid.points.clear();
     skid.faceSizes.clear();
     Ogre::MaterialManager::getSingleton().remove(skid.material->getName());
-    skid.material.setNull();
+    skid.material.reset();
     App::GetGfxScene()->GetSceneManager()->destroyManualObject(skid.obj);
     m_objects.pop();
 }

--- a/source/main/gfx/SurveyMapTextureCreator.cpp
+++ b/source/main/gfx/SurveyMapTextureCreator.cpp
@@ -57,7 +57,7 @@ bool SurveyMapTextureCreator::init(int res, int fsaa)
         Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, Ogre::TEX_TYPE_2D, res, res,
         Ogre::TU_RENDERTARGET, Ogre::PF_R8G8B8, Ogre::TU_RENDERTARGET, 0, false, fsaa);
 
-    if (mTexture.isNull())
+    if (!mTexture)
         return false;
 
     mRttTex = mTexture->getBuffer()->getRenderTarget();

--- a/source/main/gfx/Water.cpp
+++ b/source/main/gfx/Water.cpp
@@ -128,7 +128,7 @@ Water::~Water()
     {
         m_refract_rtt_texture->unload();
         Ogre::TextureManager::getSingleton().remove(m_refract_rtt_texture->getHandle());
-        m_refract_rtt_texture.setNull();
+        m_refract_rtt_texture.reset();
     }
 #endif
 
@@ -144,7 +144,7 @@ Water::~Water()
     {
         m_reflect_rtt_texture->unload();
         Ogre::TextureManager::getSingleton().remove(m_reflect_rtt_texture->getHandle());
-        m_reflect_rtt_texture.setNull();
+        m_reflect_rtt_texture.reset();
     }
 #endif
 

--- a/source/main/gfx/hydrax/GPUNormalMapManager.cpp
+++ b/source/main/gfx/hydrax/GPUNormalMapManager.cpp
@@ -36,7 +36,7 @@ namespace Hydrax
 		mRttManager->setBitsPerChannel(RttManager::RTT_GPU_NORMAL_MAP, RttManager::BPC_16);
 		mRttManager->setNumberOfChannels(RttManager::RTT_GPU_NORMAL_MAP, RttManager::NOC_3);
 
-		mNormalMapMaterial.setNull();
+		mNormalMapMaterial.reset();
 	}
 
 	GPUNormalMapManager::~GPUNormalMapManager()
@@ -80,7 +80,7 @@ namespace Hydrax
         Ogre::HighLevelGpuProgramManager::getSingleton().remove(mNormalMapMaterial->getTechnique(0)->getPass(0)->getFragmentProgramName());
 
 		Ogre::MaterialManager::getSingleton().remove(mNormalMapMaterial->getName());
-		mNormalMapMaterial.setNull();
+		mNormalMapMaterial.reset();
 
 		mCreated = false;
 	}

--- a/source/main/gfx/hydrax/GodRaysManager.cpp
+++ b/source/main/gfx/hydrax/GodRaysManager.cpp
@@ -872,8 +872,6 @@ namespace Hydrax
 		Ogre::Entity * CurrentEntity = NULL;
 		unsigned int k = 0;
 
-		mMaterials.empty();
-
 		mGodRaysManager->mHydrax->getMesh()->getEntity()->setVisible(false);
 
 		while( EntityIterator.hasMoreElements() )

--- a/source/main/gfx/hydrax/GodRaysManager.cpp
+++ b/source/main/gfx/hydrax/GodRaysManager.cpp
@@ -65,7 +65,7 @@ namespace Hydrax
 	{
 		for (int k = 0; k < 2; k++)
 		{
-			mMaterials[k].setNull();
+			mMaterials[k].reset();
 		}
 	}
 
@@ -183,17 +183,17 @@ namespace Hydrax
 
 		for (int k = 0; k < 2; k++)
 		{
-			mMaterials[k].setNull();
+			mMaterials[k].reset();
 		}
 
-		if (!mProjectorRTT.isNull())
+		if (mProjectorRTT)
 		{
 			Ogre::RenderTarget* RT = mProjectorRTT->getBuffer()->getRenderTarget();
             RT->removeAllListeners();
             RT->removeAllViewports();
 
 			Ogre::TextureManager::getSingleton().remove(mProjectorRTT->getName());
-			mProjectorRTT.setNull();
+			mProjectorRTT.reset();
 		}
 
 		mHydrax->getSceneManager()->destroyCamera(mProjectorCamera);

--- a/source/main/gfx/hydrax/MaterialManager.cpp
+++ b/source/main/gfx/hydrax/MaterialManager.cpp
@@ -66,7 +66,7 @@ namespace Hydrax
 	{
 		for (int k = 0; k < 6; k++)
 		{
-			mMaterials[k].setNull();
+			mMaterials[k].reset();
 		}
 
 		for (int k = 0; k < 1; k++)
@@ -3171,7 +3171,7 @@ namespace Hydrax
 	{
 		Ogre::MaterialPtr &Mat = getMaterial(Material);
 
-		if (Mat.isNull())
+		if (!Mat)
 		{
 			return;
 		}
@@ -3524,7 +3524,7 @@ namespace Hydrax
 	{
 		Ogre::CompositorPtr &Comp = mCompositors[static_cast<int>(Compositor)];
 
-		if (Comp.isNull())
+		if (!Comp)
 		{
 			return;
 		}

--- a/source/main/gfx/hydrax/Mesh.cpp
+++ b/source/main/gfx/hydrax/Mesh.cpp
@@ -63,13 +63,13 @@ namespace Hydrax
 		Ogre::MeshManager::getSingleton().remove("HydraxMesh");
 		mHydrax->getSceneManager()->destroyEntity(mEntity);
 
-		mMesh.setNull();
+		mMesh.reset();
 		mSubMesh = 0;
 		mEntity = 0;
 		mNumFaces = 0;
 		mNumVertices = 0;
-		mVertexBuffer.setNull();
-		mIndexBuffer.setNull();
+		mVertexBuffer.reset();
+		mIndexBuffer.reset();
 		mMaterialName = "_NULL_";
 
 		mCreated = false;

--- a/source/main/gfx/hydrax/RttManager.cpp
+++ b/source/main/gfx/hydrax/RttManager.cpp
@@ -53,7 +53,7 @@ namespace Hydrax
 		for (int k = 0; k < 6; k++)
 		{
 			mPlanes[k] = static_cast<Ogre::MovablePlane*>(NULL);
-			mTextures[k].setNull();
+			mTextures[k].reset();
 			mRttOptions[k].Name  = RttNames[k];
 			mRttOptions[k].Size_ = Size(0);
 			mRttOptions[k].NumberOfChannels_ = NOC_3;
@@ -129,7 +129,7 @@ namespace Hydrax
 	{
 		Ogre::TexturePtr &Tex = mTextures[Rtt];
 
-		if (!Tex.isNull())
+		if (Tex)
 		{
 		    Ogre::RenderTarget* RT = Tex->getBuffer()->getRenderTarget();
             RT->removeAllListeners();
@@ -138,7 +138,7 @@ namespace Hydrax
 			Ogre::TextureManager::getSingleton().remove(mRttOptions[Rtt].Name);
 			Ogre::MeshManager::getSingleton().remove(mRttOptions[Rtt].Name + "ClipPlane");
 
-			Tex.setNull();
+			Tex.reset();
 			delete mPlanes[Rtt];
 			mPlanes[Rtt] = static_cast<Ogre::MovablePlane*>(NULL);
 		}
@@ -224,7 +224,7 @@ namespace Hydrax
 	{
 		mRttOptions[static_cast<int>(Rtt)].Size_ = S;
 
-		if (!getTexture(Rtt).isNull())
+		if (getTexture(Rtt))
 		{
 			initialize(Rtt);
 
@@ -250,7 +250,8 @@ namespace Hydrax
 		{
 			mRttOptions[static_cast<RttType>(k)].Size_ = S;
 
-			if (!getTexture(static_cast<RttType>(k)).isNull())
+            Ogre::TexturePtr& Tex = mTextures[static_cast<RttType>(k)];
+			if (Tex)
 			{
 				initialize(static_cast<RttType>(k));
 

--- a/source/main/gfx/hydrax/RttManager.cpp
+++ b/source/main/gfx/hydrax/RttManager.cpp
@@ -575,8 +575,6 @@ namespace Hydrax
         Ogre::Entity* CurrentEntity;
 		unsigned int k;
 
-        mMaterials.empty();
-
         while (EntityIterator.hasMoreElements())
         {
             CurrentEntity = static_cast<Ogre::Entity*>(EntityIterator.peekNextValue());
@@ -673,8 +671,6 @@ namespace Hydrax
 			mHydrax->getSceneManager()->getMovableObjectIterator("Entity");
         Ogre::Entity* CurrentEntity;
 		unsigned int k;
-
-        mMaterials.empty();
 
         while (EntityIterator.hasMoreElements())
         {

--- a/source/main/gfx/hydrax/RttManager.h
+++ b/source/main/gfx/hydrax/RttManager.h
@@ -180,7 +180,7 @@ namespace Hydrax
 		{
 			mRttOptions[Rtt].NumberOfChannels_ = NOC;
 
-			if (!getTexture(Rtt).isNull())
+			if (getTexture(Rtt))
 			{
 				initialize(Rtt);
 			}
@@ -195,7 +195,7 @@ namespace Hydrax
 		{
 			mRttOptions[Rtt].BitsPerChannel_ = BPC;
 
-			if (!getTexture(Rtt).isNull())
+			if (getTexture(Rtt))
 			{
 				initialize(Rtt);
 			}
@@ -237,10 +237,6 @@ namespace Hydrax
 		{
 			mRttListeners.push_back(l);
 		}
-
-		void removeRttListener(RttListener *l, const bool& releaseMemory = true);
-
-		void removeAllRttListeners(const bool& releaseMemory = true);
 
 	private:
 		/** RttManager::CRefractionListener class
@@ -352,12 +348,6 @@ namespace Hydrax
 
 			return false;
 		}
-
-		/** Invoke Rtt Listeners
-		    @param Rtt Rtt type
-			@param pre true for Pre render target update, false for Post render target update
-		*/
-		void _invokeRttListeners(const RttType& Rtt, const bool& pre);
 
 		/// Hydrax parent pointer
 		Hydrax *mHydrax;

--- a/source/main/gfx/hydrax/TextureManager.cpp
+++ b/source/main/gfx/hydrax/TextureManager.cpp
@@ -34,7 +34,7 @@ namespace Hydrax
 	{
 		for (int k = 0; k < 1; k++)
 		{
-			mTextures[k].setNull();
+			mTextures[k].reset();
 		}
 
 		mTextureNames[0] = "HydraxNormalMap";
@@ -69,7 +69,7 @@ namespace Hydrax
 		for (int k = 0; k < 1; k++)
 		{
 		     Ogre::TextureManager::getSingleton().remove(mTextureNames[k]);
-			 mTextures[k].setNull();
+			 mTextures[k].reset();
 		}
 
 		mCreated = false;

--- a/source/main/gfx/particle/OgreShaderParticleRenderer.cpp
+++ b/source/main/gfx/particle/OgreShaderParticleRenderer.cpp
@@ -393,10 +393,10 @@ bool ShaderParticleRenderer::allocateBuffers(size_t iNumParticles)
         pVB = mVertexData->vertexBufferBinding->getBuffer(0);
 
     // prepare vertex buffer
-    if (pVB.isNull() || pVB->getNumVertices() < iNumParticles * 4) {
+    if (!pVB || pVB->getNumVertices() < iNumParticles * 4) {
         assert(iNumParticles * 4 < 65536); // we are using 16bit index buffer
         pVB = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(mVertexSize, 4 * iNumParticles, Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY_DISCARDABLE);
-        if (pVB.isNull())
+        if (!pVB)
             return false;
 
         mVertexData->vertexBufferBinding->setBinding(0, pVB);
@@ -404,9 +404,9 @@ bool ShaderParticleRenderer::allocateBuffers(size_t iNumParticles)
 
     // prepare index buffer
     Ogre::HardwareIndexBufferSharedPtr pIB = mIndexData->indexBuffer;
-    if (pIB.isNull() || pIB->getNumIndexes() < iNumParticles * 6) {
+    if (!pIB || pIB->getNumIndexes() < iNumParticles * 6) {
         pIB = Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(Ogre::HardwareIndexBuffer::IT_16BIT, iNumParticles * 6, Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
-        if (pIB.isNull())
+        if (!pIB)
             return false;
 
         mIndexData->indexBuffer = pIB;

--- a/source/main/gfx/skyx/GPUManager.cpp
+++ b/source/main/gfx/skyx/GPUManager.cpp
@@ -349,7 +349,7 @@ namespace SkyX
 	{
 		Ogre::TexturePtr tex = Ogre::TextureManager::getSingleton().getByName(n);
 
-		if (!tex.isNull())
+		if (tex)
 		{
 			if (g)
 			{

--- a/source/main/gfx/skyx/GPUManager.h
+++ b/source/main/gfx/skyx/GPUManager.h
@@ -116,7 +116,7 @@ namespace SkyX
 		{
 			mSkydomeMaterial = static_cast<Ogre::MaterialPtr>(Ogre::MaterialManager::getSingleton().getByName(getSkydomeMaterialName()));
 
-			if (mSkydomeMaterial.isNull())
+			if (!mSkydomeMaterial)
 			{
 				SkyXLOG("Error in SkyX::GPUManager: '" + getSkydomeMaterialName() + "' material not found");
 				return;

--- a/source/main/gfx/skyx/MeshManager.cpp
+++ b/source/main/gfx/skyx/MeshManager.cpp
@@ -67,11 +67,11 @@ namespace SkyX
 		Ogre::MeshManager::getSingleton().remove("SkyXMesh");
 		mSkyX->getSceneManager()->destroyEntity(mEntity);
 
-		mMesh.setNull();
+		mMesh.reset();
 		mSubMesh = 0;
 		mEntity = 0;
-		mVertexBuffer.setNull();
-		mIndexBuffer.setNull();
+		mVertexBuffer.reset();
+		mIndexBuffer.reset();
 		mMaterialName = "_NULL_";
 
 		delete [] mVertices;

--- a/source/main/gfx/skyx/MoonManager.cpp
+++ b/source/main/gfx/skyx/MoonManager.cpp
@@ -53,7 +53,7 @@ namespace SkyX
 
 		mMoonMaterial = static_cast<Ogre::MaterialPtr>(Ogre::MaterialManager::getSingleton().getByName("SkyX_Moon"));
 
-		if (mMoonMaterial.isNull())
+		if (!mMoonMaterial)
 		{
 			SkyXLOG("Error while creating SkyX::MoonManager, material not found");
 			return;
@@ -88,7 +88,7 @@ namespace SkyX
 		mSkyX->getSceneManager()->destroyBillboardSet(mMoonBillboard);
 		mMoonBillboard = 0;
 
-		mMoonMaterial.setNull();
+		mMoonMaterial.reset();
 
 		mCreated = false;
 	}

--- a/source/main/gfx/skyx/VClouds/DataManager.cpp
+++ b/source/main/gfx/skyx/VClouds/DataManager.cpp
@@ -43,7 +43,7 @@ namespace SkyX { namespace VClouds
 	{
 		for (int k = 0; k < 2; k++)
 		{
-			mVolTextures[k].setNull();
+			mVolTextures[k].reset();
 		}
 	}
 
@@ -62,7 +62,7 @@ namespace SkyX { namespace VClouds
 		for (int k = 0; k < 2; k++)
 		{
 			Ogre::TextureManager::getSingleton().remove(mVolTextures[k]->getName());
-			mVolTextures[k].setNull();
+			mVolTextures[k].reset();
 		}
 
 		_delete3DCellArray(mCellsCurrent, mNx, mNy);

--- a/source/main/gfx/skyx/VClouds/GeometryBlock.cpp
+++ b/source/main/gfx/skyx/VClouds/GeometryBlock.cpp
@@ -103,11 +103,11 @@ namespace SkyX { namespace VClouds
 		Ogre::MeshManager::getSingleton().remove(mMesh->getName());
 		mVClouds->getSceneManager()->destroyEntity(mEntity);
 
-		mMesh.setNull();
+		mMesh.reset();
 		mSubMesh = 0;
 		mEntity = 0;
-		mVertexBuffer.setNull();
-		mIndexBuffer.setNull();
+		mVertexBuffer.reset();
+		mIndexBuffer.reset();
 
 		delete [] mVertices;
 

--- a/source/main/gfx/skyx/VClouds/LightningManager.cpp
+++ b/source/main/gfx/skyx/VClouds/LightningManager.cpp
@@ -57,7 +57,7 @@ namespace SkyX { namespace VClouds
 		mVolCloudsLightningMaterial = static_cast<Ogre::MaterialPtr>(Ogre::MaterialManager::getSingleton().getByName("SkyX_VolClouds_Lightning"));
 		mLightningMaterial = static_cast<Ogre::MaterialPtr>(Ogre::MaterialManager::getSingleton().getByName("SkyX_Lightning"));
 
-		if (mLightningMaterial.isNull())
+		if (!mLightningMaterial)
 		{
 			SkyXLOG("Error while creating SkyX::VClouds::LightningManager, material not found");
 			return;
@@ -96,8 +96,8 @@ namespace SkyX { namespace VClouds
 
 		removeListeners();
 
-		mVolCloudsLightningMaterial.setNull();
-		mLightningMaterial.setNull();
+		mVolCloudsLightningMaterial.reset();
+		mLightningMaterial.reset();
 
 		mCreated = false;
 	}

--- a/source/main/gfx/skyx/VClouds/VClouds.cpp
+++ b/source/main/gfx/skyx/VClouds/VClouds.cpp
@@ -72,7 +72,7 @@ namespace SkyX { namespace VClouds
 		mVolCloudsMaterial = static_cast<Ogre::MaterialPtr>(Ogre::MaterialManager::getSingleton().getByName("SkyX_VolClouds"));
 		mVolCloudsLightningMaterial = static_cast<Ogre::MaterialPtr>(Ogre::MaterialManager::getSingleton().getByName("SkyX_VolClouds_Lightning"));
 
-		if (mVolCloudsMaterial.isNull() || mVolCloudsLightningMaterial.isNull())
+		if (!mVolCloudsMaterial || !mVolCloudsLightningMaterial)
 		{
 			SkyXLOG("Error while creating SkyX::VClouds::VClouds, materials are not found");
 			return;
@@ -138,8 +138,8 @@ namespace SkyX { namespace VClouds
 		mCamera = 0;
 		mCamerasData.clear();
 
-		mVolCloudsMaterial.setNull();
-		mVolCloudsLightningMaterial.setNull();
+		mVolCloudsMaterial.reset();
+		mVolCloudsLightningMaterial.reset();
 
 		mCreated = false;
 	}

--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -670,7 +670,7 @@ void DashBoard::windowResized()
     {
         // texture layers are independent from the screen size, but rather from the layer texture size
         TexturePtr tex = TextureManager::getSingleton().getByName("RTTTexture1");
-        if (!tex.isNull())
+        if (tex)
             mainWidget->setSize(tex->getWidth(), tex->getHeight());
     }
     else

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -239,7 +239,7 @@ void GUIManager::SetUpMenuWallpaper()
     // Determine image filename
     using namespace Ogre;
     FileInfoListPtr files = ResourceGroupManager::getSingleton().findResourceFileInfo("Wallpapers", "*.jpg", false);
-    if (files.isNull() || files->empty())
+    if (!files || files->empty())
     {
         files = ResourceGroupManager::getSingleton().findResourceFileInfo("Wallpapers", "*.png", false);
     }

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -253,7 +253,7 @@ void GUIManager::SetUpMenuWallpaper()
     // ...texture...
     Ogre::ResourceManager::ResourceCreateOrRetrieveResult wp_tex_result
         = Ogre::TextureManager::getSingleton().createOrRetrieve(files->at(num).filename, "Wallpapers");
-    Ogre::TexturePtr wp_tex = wp_tex_result.first.staticCast<Ogre::Texture>();
+    Ogre::TexturePtr wp_tex = Ogre::static_pointer_cast<Ogre::Texture>(wp_tex_result.first);
     // ...material...
     Ogre::MaterialPtr wp_mat = Ogre::MaterialManager::getSingleton().create("rigsofrods/WallpaperMat", Ogre::RGN_DEFAULT);
     Ogre::TextureUnitState* wp_tus = wp_mat->getTechnique(0)->getPass(0)->createTextureUnitState();

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -424,11 +424,11 @@ void OverlayWrapper::showDashboardOverlays(bool show, ActorPtr actor)
 
 void OverlayWrapper::updateStats(bool detailed)
 {
-    static UTFString currFps = _L("Current FPS: ");
-    static UTFString avgFps = _L("Average FPS: ");
-    static UTFString bestFps = _L("Best FPS: ");
-    static UTFString worstFps = _L("Worst FPS: ");
-    static UTFString tris = _L("Triangle Count: ");
+    static std::string currFps = _L("Current FPS: ");
+    static std::string avgFps = _L("Average FPS: ");
+    static std::string bestFps = _L("Best FPS: ");
+    static std::string worstFps = _L("Worst FPS: ");
+    static std::string tris = _L("Triangle Count: ");
     const RenderTarget::FrameStats& stats = win->getStatistics();
 
     // update stats when necessary
@@ -441,44 +441,44 @@ void OverlayWrapper::updateStats(bool detailed)
 
         guiAvg->setCaption(avgFps + TOSTRING(stats.avgFPS));
         guiCurr->setCaption(currFps + TOSTRING(stats.lastFPS));
-        guiBest->setCaption(bestFps + TOSTRING(stats.bestFPS) + U(" ") + TOSTRING(stats.bestFrameTime) + U(" ms"));
-        guiWorst->setCaption(worstFps + TOSTRING(stats.worstFPS) + U(" ") + TOSTRING(stats.worstFrameTime) + U(" ms"));
+        guiBest->setCaption(bestFps + TOSTRING(stats.bestFPS) + (" ") + TOSTRING(stats.bestFrameTime) + (" ms"));
+        guiWorst->setCaption(worstFps + TOSTRING(stats.worstFPS) + (" ") + TOSTRING(stats.worstFrameTime) + (" ms"));
 
         OverlayElement* guiTris = OverlayManager::getSingleton().getOverlayElement("Core/NumTris");
-        UTFString triss = tris + TOSTRING(stats.triangleCount);
+        std::string triss = tris + TOSTRING(stats.triangleCount);
         if (stats.triangleCount > 1000000)
-            triss = tris + TOSTRING(stats.triangleCount/1000000.0f) + U(" M");
+            triss = tris + TOSTRING(stats.triangleCount/1000000.0f) + (" M");
         else if (stats.triangleCount > 1000)
-            triss = tris + TOSTRING(stats.triangleCount/1000.0f) + U(" k");
+            triss = tris + TOSTRING(stats.triangleCount/1000.0f) + (" k");
         guiTris->setCaption(triss);
 
         // create some memory texts
-        UTFString memoryText;
+        std::string memoryText;
         if (TextureManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("Textures: ") + formatBytes(TextureManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(TextureManager::getSingleton().getMemoryBudget()) + U("\n");
+            memoryText = memoryText + _L("Textures: ") + formatBytes(TextureManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(TextureManager::getSingleton().getMemoryBudget()) + ("\n");
         if (CompositorManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("Compositors: ") + formatBytes(CompositorManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(CompositorManager::getSingleton().getMemoryBudget()) + U("\n");
+            memoryText = memoryText + _L("Compositors: ") + formatBytes(CompositorManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(CompositorManager::getSingleton().getMemoryBudget()) + ("\n");
         if (FontManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("Fonts: ") + formatBytes(FontManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(FontManager::getSingleton().getMemoryBudget()) + U("\n");
+            memoryText = memoryText + _L("Fonts: ") + formatBytes(FontManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(FontManager::getSingleton().getMemoryBudget()) + ("\n");
         if (GpuProgramManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("GPU Program: ") + formatBytes(GpuProgramManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(GpuProgramManager::getSingleton().getMemoryBudget()) + U("\n");
+            memoryText = memoryText + _L("GPU Program: ") + formatBytes(GpuProgramManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(GpuProgramManager::getSingleton().getMemoryBudget()) + ("\n");
         if (HighLevelGpuProgramManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("HL GPU Program: ") + formatBytes(HighLevelGpuProgramManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(HighLevelGpuProgramManager::getSingleton().getMemoryBudget()) + U("\n");
+            memoryText = memoryText + _L("HL GPU Program: ") + formatBytes(HighLevelGpuProgramManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(HighLevelGpuProgramManager::getSingleton().getMemoryBudget()) + ("\n");
         if (MaterialManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("Materials: ") + formatBytes(MaterialManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(MaterialManager::getSingleton().getMemoryBudget()) + U("\n");
+            memoryText = memoryText + _L("Materials: ") + formatBytes(MaterialManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(MaterialManager::getSingleton().getMemoryBudget()) + ("\n");
         if (MeshManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("Meshes: ") + formatBytes(MeshManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(MeshManager::getSingleton().getMemoryBudget()) + U("\n");
+            memoryText = memoryText + _L("Meshes: ") + formatBytes(MeshManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(MeshManager::getSingleton().getMemoryBudget()) + ("\n");
         if (SkeletonManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("Skeletons: ") + formatBytes(SkeletonManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(SkeletonManager::getSingleton().getMemoryBudget()) + U("\n");
+            memoryText = memoryText + _L("Skeletons: ") + formatBytes(SkeletonManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(SkeletonManager::getSingleton().getMemoryBudget()) + ("\n");
         if (MaterialManager::getSingleton().getMemoryUsage() > 1)
-            memoryText = memoryText + _L("Materials: ") + formatBytes(MaterialManager::getSingleton().getMemoryUsage()) + U(" / ") + formatBytes(MaterialManager::getSingleton().getMemoryBudget()) + U("\n");
-        memoryText = memoryText + U("\n");
+            memoryText = memoryText + _L("Materials: ") + formatBytes(MaterialManager::getSingleton().getMemoryUsage()) + (" / ") + formatBytes(MaterialManager::getSingleton().getMemoryBudget()) + ("\n");
+        memoryText = memoryText + ("\n");
 
         OverlayElement* memoryDbg = OverlayManager::getSingleton().getOverlayElement("Core/MemoryText");
         memoryDbg->setCaption(memoryText);
 
         float sumMem = TextureManager::getSingleton().getMemoryUsage() + CompositorManager::getSingleton().getMemoryUsage() + FontManager::getSingleton().getMemoryUsage() + GpuProgramManager::getSingleton().getMemoryUsage() + HighLevelGpuProgramManager::getSingleton().getMemoryUsage() + MaterialManager::getSingleton().getMemoryUsage() + MeshManager::getSingleton().getMemoryUsage() + SkeletonManager::getSingleton().getMemoryUsage() + MaterialManager::getSingleton().getMemoryUsage();
-        String sumMemoryText = _L("Memory (Ogre): ") + formatBytes(sumMem) + U("\n");
+        String sumMemoryText = _L("Memory (Ogre): ") + formatBytes(sumMem) + ("\n");
 
         OverlayElement* memorySumDbg = OverlayManager::getSingleton().getOverlayElement("Core/CurrMemory");
         memorySumDbg->setCaption(sumMemoryText);
@@ -982,7 +982,7 @@ void OverlayWrapper::HideRacingOverlay()
 void OverlayWrapper::UpdateRacingGui(RoR::GfxScene* gs)
 {
     float time = gs->GetSimDataBuffer().simbuf_race_time;
-    UTFString txt = StringUtil::format("%.2i'%.2i.%.2i", (int)(time) / 60, (int)(time) % 60, (int)(time * 100.0) % 100);
+    std::string txt = StringUtil::format("%.2i'%.2i.%.2i", (int)(time) / 60, (int)(time) % 60, (int)(time * 100.0) % 100);
     this->laptime->setCaption(txt);
     if (gs->GetSimDataBuffer().simbuf_race_best_time > 0.0f)
     {

--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -157,7 +157,7 @@ int OverlayWrapper::init()
     resizePanel(loadOverlayElement("tracks/pressureo"));
     resizePanel(loadOverlayElement("tracks/pressureneedle"));
     MaterialPtr m = MaterialManager::getSingleton().getByName("tracks/pressureneedle_mat");
-    if (!m.isNull())
+    if (m)
         pressuretexture = m->getTechnique(0)->getPass(0)->getTextureUnitState(0);
     else
         pressuretexture = nullptr;

--- a/source/main/gui/panels/GUI_CollisionsDebug.cpp
+++ b/source/main/gui/panels/GUI_CollisionsDebug.cpp
@@ -122,7 +122,7 @@ void CollisionsDebug::Draw()
         ImGui::TextColored(color, "%d ", tris);
     }
     ImGui::SetNextItemWidth(WIDTH_DRAWDIST);
-    if (ImGui::InputInt("Debug area extent (around character)", &m_cell_generator_distance_limit));
+    ImGui::InputInt("Debug area extent (around character)", &m_cell_generator_distance_limit);
     ImGui::SameLine();
     ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -447,7 +447,7 @@ void SurveyMap::CreateTerrainTextures()
             Ogre::TextureManager::getSingleton().unload(mMapTexture->getName(), mMapTexture->getGroup());
         }
         Ogre::TextureManager::getSingleton().remove(mMapTexture->getName(), mMapTexture->getGroup());
-        mMapTexture.setNull();
+        mMapTexture.reset();
     }
     mMapZoom = 0.5f;
     mMapMode = SurveyMapMode::NONE;
@@ -684,7 +684,7 @@ void SurveyMap::CacheMapIcon(SurveyMapEntity& e)
 {
     // Check if requested icon changed
     if (e.cached_icon && e.cached_icon->getName() != e.filename)
-        e.cached_icon.setNull();
+        e.cached_icon.reset();
 
     // Check if valid icon is already loaded
     if (e.cached_icon)

--- a/source/main/gui/panels/GUI_TextureToolWindow.cpp
+++ b/source/main/gui/panels/GUI_TextureToolWindow.cpp
@@ -94,7 +94,7 @@ void TextureToolWindow::Draw()
         ImGui::BeginChild("tex info", ImVec2(0, -ImGui::GetItemsLineHeightWithSpacing())); // Leave room for 1 line below us
 
         ImGui::Text("Res: %u x %u pixels", m_display_tex->getWidth(), m_display_tex->getHeight());
-        ImGui::Text("Size: %s", formatBytes(m_display_tex->getSize()).asUTF8_c_str());
+        ImGui::Text("Size: %s", formatBytes(m_display_tex->getSize()).c_str());
         ImGui::Text("Format: %s", Ogre::PixelUtil::getFormatName(m_display_tex->getFormat()).c_str());
         if (m_display_tex->getNumFaces() > 1)
             ImGui::Text("Num. faces: %d", static_cast<int>(m_display_tex->getNumFaces()));

--- a/source/main/gui/panels/GUI_TextureToolWindow.cpp
+++ b/source/main/gui/panels/GUI_TextureToolWindow.cpp
@@ -158,7 +158,7 @@ void TextureToolWindow::SaveTexture(std::string texName, bool usePNG)
     try
     {
         TexturePtr tex = TextureManager::getSingleton().getByName(texName);
-        if (tex.isNull())
+        if (!tex)
             return;
 
         Image img;

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -37,7 +37,6 @@
 #include <string>
 #include <thread>
 #include <vector>
-#include <OgreUTFString.h>
 
 namespace RoR {
 
@@ -126,7 +125,7 @@ public:
     Ogre::String         GetTerrainName();
 
     int                  GetUserColor();
-    Ogre::UTFString      GetUsername();
+    std::string      GetUsername();
     RoRnet::UserInfo     GetLocalUserData();
     std::vector<RoRnet::UserInfo> GetUserInfos();
     std::vector<BitMask_t> GetAllUsersPeerOpts();
@@ -168,7 +167,7 @@ private:
     std::vector<BitMask_t> m_users_peeropts;  //!< See `RoRnet::PeerOptions`.
     std::vector<RoRnet::UserInfo> m_disconnected_users;
 
-    Ogre::UTFString      m_username; // Shadows GVar 'mp_player_name' for multithreaded access.
+    std::string      m_username; // Shadows GVar 'mp_player_name' for multithreaded access.
     std::string          m_net_host; // Shadows GVar 'mp_server_host' for multithreaded access.
     std::string          m_password; // Shadows GVar 'mp_server_password' for multithreaded access.
     std::string          m_token;    // Shadows GVar 'mp_player_token' for multithreaded access.

--- a/source/main/pch.h
+++ b/source/main/pch.h
@@ -33,7 +33,6 @@
 #include <OgrePrerequisites.h>
 #include <Bites/OgreWindowEventUtilities.h>
 #include <Overlay/OgreFontManager.h>
-#include <OgreUTFString.h>
 #include <OIS.h>
 #include <MyGUI.h>
 #include <imgui.h>

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4310,32 +4310,31 @@ void Actor::calculateLocalGForces()
 
 void Actor::engineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue)
 {
-    // engineNumber tells us which engine
-    EnginePtr e = ar_engine; // placeholder: actors do not have multiple engines yet
+    // engineNumber = placeholder: actors do not have multiple engines yet
 
     switch (type)
     {
     case TRG_ENGINE_CLUTCH:
-        if (e)
-            e->setClutch(triggerValue);
+        if (ar_engine)
+            ar_engine->setClutch(triggerValue);
         break;
     case TRG_ENGINE_BRAKE:
         ar_brake = triggerValue;
         break;
     case TRG_ENGINE_ACC:
-        if (e)
-            e->setAcc(triggerValue);
+        if (ar_engine)
+            ar_engine->setAcc(triggerValue);
         break;
     case TRG_ENGINE_RPM:
         // TODO: Implement setTargetRPM in the Engine.cpp
         break;
     case TRG_ENGINE_SHIFTUP:
-        if (e)
-            e->shift(1);
+        if (ar_engine)
+            ar_engine->shift(1);
         break;
     case TRG_ENGINE_SHIFTDOWN:
-        if (e)
-            e->shift(-1);
+        if (ar_engine)
+            ar_engine->shift(-1);
         break;
     default:
         break;

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -625,7 +625,7 @@ private:
     float             m_net_node_compression = 0.f;     //!< For incoming/outgoing traffic; calculated on spawn
     int               m_net_first_wheel_node = 0;     //!< Network attr; Determines data buffer layout; calculated on spawn
 
-    Ogre::UTFString   m_net_username;
+    std::string       m_net_username;
     int               m_net_color_num = 0;
     /// @}
 

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -1361,7 +1361,7 @@ void ActorManager::UpdateInputEvents(float dt)
             {
                 m_last_simulation_speed = simulation_speed;
                 this->SetSimulationSpeed(1.0f);
-                UTFString ssmsg = _L("Simulation speed reset.");
+                std::string ssmsg = _L("Simulation speed reset.");
                 App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg);
             }
             else if (m_last_simulation_speed != 1.0f)

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -1261,7 +1261,7 @@ RigDef::DocumentPtr ActorManager::FetchActorDef(RoR::ActorSpawnRequest& rq)
         App::GetCacheSystem()->LoadResource(rq.asr_cache_entry);
         Ogre::DataStreamPtr stream = Ogre::ResourceGroupManager::getSingleton().openResource(rq.asr_cache_entry->fname, rq.asr_cache_entry->resource_group);
 
-        if (stream.isNull() || !stream->isReadable())
+        if (!stream || !stream->isReadable())
         {
             HandleErrorLoadingTruckfile(rq.asr_cache_entry->fname, "Unable to open/read truckfile");
             return nullptr;

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -1270,7 +1270,7 @@ RigDef::DocumentPtr ActorManager::FetchActorDef(RoR::ActorSpawnRequest& rq)
         RoR::LogFormat("[RoR] Parsing truckfile '%s'", rq.asr_cache_entry->fname.c_str());
         RigDef::Parser parser;
         parser.Prepare();
-        parser.ProcessOgreStream(stream.getPointer(), rq.asr_cache_entry->resource_group);
+        parser.ProcessOgreStream(stream.get(), rq.asr_cache_entry->resource_group);
         parser.Finalize();
 
         auto def = parser.GetFile();

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2352,6 +2352,9 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
         flare.light->setType(Ogre::Light::LT_SPOTLIGHT);
         flare.light->setSpotlightRange( Ogre::Degree(35), Ogre::Degree(45) );
         flare.light->setCastShadows(false);
+
+        Ogre::SceneNode* snode = m_flares_parent_scenenode->createChildSceneNode();
+        snode->attachObject(flare.light);
     }
     m_actor->ar_flares.push_back(flare);
 }
@@ -7040,6 +7043,9 @@ void ActorSpawner::CreateVideoCamera(RigDef::VideoCamera* def)
 
         vcam.vcam_ogre_camera = App::GetGfxScene()->GetSceneManager()->createCamera(vcam.vcam_material->getName() + "_camera");
 
+        Ogre::SceneNode* vcam_snode = m_vcams_parent_scenenode->createChildSceneNode();
+        vcam_snode->attachObject(vcam.vcam_ogre_camera);
+
         if (!App::gfx_window_videocams->getBool())
         {
             vcam.vcam_render_tex = Ogre::TextureManager::getSingleton().createManual(
@@ -7162,6 +7168,9 @@ void ActorSpawner::CreateMirrorPropVideoCam(
         vcam.vcam_ogre_camera->setFOVy(Ogre::Degree(50));
         vcam.vcam_ogre_camera->setAspectRatio(
             (App::GetCameraManager()->GetCamera()->getViewport()->getActualWidth() / App::GetCameraManager()->GetCamera()->getViewport()->getActualHeight()) / 2.0f);
+
+        Ogre::SceneNode* snode = m_vcams_parent_scenenode->createChildSceneNode();
+        snode->attachObject(vcam.vcam_ogre_camera);
 
         // Setup rendering
         vcam.vcam_render_target = vcam.vcam_render_tex->getBuffer()->getRenderTarget();

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -393,7 +393,7 @@ void ActorSpawner::InitializeRig()
     if (m_apply_simple_materials)
     {
         m_simple_material_base = Ogre::MaterialManager::getSingleton().getByName("tracks/simple"); // Built-in material
-        if (m_simple_material_base.isNull())
+        if (!m_simple_material_base)
         {
             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_WARNING,
                 "Failed to load built-in material 'tracks/simple'; disabling 'SimpleMaterials'");
@@ -900,7 +900,7 @@ void ActorSpawner::ProcessAirbrake(RigDef::Airbrake & def)
     ab->ec = nullptr;
     // mesh
     abx.abx_mesh = ab->msh;
-    ab->msh.setNull();
+    ab->msh.reset();
     // scenenode
     abx.abx_scenenode = ab->snode;
     ab->snode = nullptr;
@@ -2258,7 +2258,7 @@ void ActorSpawner::ProcessFlare2(RigDef::Flare2 & def)
         }
 
         Ogre::MaterialPtr material = this->FindOrCreateCustomizedMaterial(material_name, this->GetCurrentElementMediaRG());
-        if (!material.isNull())
+        if (material)
         {
             flare.bbs->setMaterial(material);
             flare.snode->attachObject(flare.bbs);
@@ -2394,7 +2394,7 @@ void ActorSpawner::ProcessFlaregroupNoImport(RigDef::FlaregroupNoImport& def)
 Ogre::MaterialPtr ActorSpawner::InstantiateManagedMaterial(const Ogre::String& rg_name, Ogre::String const & source_name, Ogre::String const & clone_name)
 {
     Ogre::MaterialPtr src_mat = Ogre::MaterialManager::getSingleton().getByName(source_name, rg_name);
-    if (src_mat.isNull())
+    if (!src_mat)
     {
         std::stringstream msg;
         msg << "Built-in material '" << source_name << "' missing! Skipping...";
@@ -2448,7 +2448,7 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
     for (auto& module: m_selected_modules)
     {
         std::string module_rg = (module->origin_addonpart) ? module->origin_addonpart->resource_group : m_actor->getTruckFileResourceGroup();
-        if (Ogre::MaterialManager::getSingleton().getByName(def.name, module_rg).isNull())
+        if (!Ogre::MaterialManager::getSingleton().getByName(def.name, module_rg))
         {
             LOG(fmt::format("[RoR] DBG ActorSpawner::ProcessManagedMaterial(): Creating placeholder for material '{}' in group '{}'", def.name, module_rg));
             m_managedmat_placeholder_template->clone(def.name, /*changeGroup=*/true, module_rg);
@@ -2487,7 +2487,7 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
                     material = this->InstantiateManagedMaterial(resource_group, mat_name_base + "/speculardamage_nicemetal", custom_name);
                 }
 
-                if (material.isNull())
+                if (!material)
                 {
                     return;
                 }
@@ -2510,7 +2510,7 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
             {
                 /* FLEXMESH, damage, no_specular */
                 material = this->InstantiateManagedMaterial(resource_group, mat_name_base + "/damageonly", custom_name);
-                if (material.isNull())
+                if (!material)
                 {
                     return;
                 }
@@ -2532,7 +2532,7 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
                     material = this->InstantiateManagedMaterial(resource_group, mat_name_base + "/specularonly_nicemetal", custom_name);
                 }
 
-                if (material.isNull())
+                if (!material)
                 {
                     return;
                 }
@@ -2553,7 +2553,7 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
             {
                 /* FLEXMESH, no_damage, no_specular */
                 material = this->InstantiateManagedMaterial(resource_group, mat_name_base + "/simple", custom_name);
-                if (material.isNull())
+                if (!material)
                 {
                     return;
                 }
@@ -2580,7 +2580,7 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
                 material = this->InstantiateManagedMaterial(resource_group, mat_name_base + "/specular_nicemetal", custom_name);
             }
 
-            if (material.isNull())
+            if (!material)
             {
                 return;
             }
@@ -2601,7 +2601,7 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
         {
             /* MESH, no_specular */
             material = this->InstantiateManagedMaterial(resource_group, mat_name_base + "/simple", custom_name);
-            if (material.isNull())
+            if (!material)
             {
                 return;
             }
@@ -5718,7 +5718,7 @@ void ActorSpawner::CreateBeamVisuals(beam_t const & beam, int beam_index, bool v
             if (it != m_managed_materials.end())
             {
                 auto material = it->second;
-                if (!material.isNull())
+                if (material)
                 {
                     material_name = material->getName();
                 }
@@ -6134,7 +6134,7 @@ void ActorSpawner::ProcessGlobals(RigDef::Globals & def)
     if (! def.material_name.empty())
     {
         Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().getByName(def.material_name); // Check if exists (compatibility)
-        if (!mat.isNull())
+        if (mat)
         {
             m_cab_material_name = def.material_name;
         }
@@ -6566,7 +6566,7 @@ Ogre::MaterialPtr ActorSpawner::FindOrCreateCustomizedMaterial(const std::string
                 video_mat_shared = Ogre::MaterialManager::getSingleton().getByName(mat_lookup_name);
             }
 
-            if (!video_mat_shared.isNull())
+            if (video_mat_shared)
             {
                 lookup_entry.video_camera_def = videocam_def;
                 const std::string video_mat_name = this->ComposeName(videocam_def->material_name);
@@ -6599,7 +6599,7 @@ Ogre::MaterialPtr ActorSpawner::FindOrCreateCustomizedMaterial(const std::string
             {
                 Ogre::MaterialPtr skin_mat = Ogre::MaterialManager::getSingleton().getByName(
                     skin_res->second, m_actor->m_used_skin_entry->resource_group);
-                if (!skin_mat.isNull())
+                if (skin_mat)
                 {
                     lookup_entry.material = skin_mat->clone(this->ComposeName(skin_mat->getName()), /*changeGroup=*/true, mat_lookup_rg);
                     m_material_substitutions.insert(std::make_pair(mat_lookup_name, lookup_entry));
@@ -6628,7 +6628,7 @@ Ogre::MaterialPtr ActorSpawner::FindOrCreateCustomizedMaterial(const std::string
         {
             // Generate new substitute
             Ogre::MaterialPtr orig_mat = Ogre::MaterialManager::getSingleton().getByName(mat_lookup_name, mat_lookup_rg);
-            if (orig_mat.isNull())
+            if (!orig_mat)
             {
                 std::stringstream buf;
                 buf << "Material doesn't exist:" << mat_lookup_name;
@@ -6685,7 +6685,7 @@ Ogre::MaterialPtr ActorSpawner::FindOrCreateCustomizedMaterial(const std::string
                                 {
                                     Ogre::TexturePtr tex = Ogre::TextureManager::getSingleton().getByName(
                                         query->second, m_actor->m_used_skin_entry->resource_group);
-                                    if (tex.isNull())
+                                    if (!tex)
                                     {
                                         // `Ogre::TextureManager` doesn't automatically register all images in resource groups,
                                         // it waits for `Ogre::Resource`s to be created explicitly.
@@ -6721,7 +6721,7 @@ Ogre::MaterialPtr ActorSpawner::FindOrCreateCustomizedMaterial(const std::string
 
 Ogre::MaterialPtr ActorSpawner::CreateSimpleMaterial(Ogre::ColourValue color)
 {
-    ROR_ASSERT(!m_simple_material_base.isNull());
+    ROR_ASSERT(m_simple_material_base);
 
     static unsigned int simple_mat_counter = 0;
     Ogre::MaterialPtr newmat = m_simple_material_base->clone(this->ComposeName("simple material", simple_mat_counter++));
@@ -6777,10 +6777,10 @@ void ActorSpawner::SetupNewEntity(Ogre::Entity* ent, Ogre::ColourValue simple_co
     {
         Ogre::SubEntity* subent = ent->getSubEntity(i);
 
-        if (!subent->getMaterial().isNull())
+        if (subent->getMaterial())
         {
             Ogre::MaterialPtr own_mat = this->FindOrCreateCustomizedMaterial(subent->getMaterialName(), subent->getSubMesh()->parent->getGroup());
-            if (!own_mat.isNull())
+            if (own_mat)
             {
                 subent->setMaterial(own_mat);
             }
@@ -6991,7 +6991,7 @@ void ActorSpawner::CreateVideoCamera(RigDef::VideoCamera* def)
 
         vcam.vcam_mat_name_orig = def->material_name;
         vcam.vcam_material = this->FindOrCreateCustomizedMaterial(def->material_name, m_custom_resource_group);
-        if (vcam.vcam_material.isNull())
+        if (!vcam.vcam_material)
         {
             this->AddMessage(Message::TYPE_ERROR, "Failed to create VideoCamera with material: " + def->material_name);
             return;
@@ -7253,7 +7253,7 @@ void ActorSpawner::CreateCabVisual()
     //2: emissive
 
     Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().getByName(m_cab_material_name);
-    if (mat.isNull())
+    if (!mat)
     {
         Ogre::String msg = "Material '"+m_cab_material_name+"' missing!";
         AddMessage(Message::TYPE_ERROR, msg);
@@ -7358,7 +7358,7 @@ void ActorSpawner::CreateMaterialFlare(int flareid, Ogre::MaterialPtr m)
     binding.flare_index = flareid;
     binding.mat_instance = m;
 
-    if (m.isNull())
+    if (!m)
         return;
     Ogre::Technique* tech = m->getTechnique(0);
     if (!tech)

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -1566,7 +1566,7 @@ void ActorSpawner::ProcessFlexbody(RigDef::Flexbody& def)
         flexbody->fb_camera_mode_active = def.camera_settings.mode;
         m_actor->m_gfx_actor->m_flexbodies.emplace_back(flexbody);
     }
-    catch (Ogre::Exception& e)
+    catch (Ogre::Exception&)
     {
         // Ogre::Exception description already logged by OGRE
         this->AddMessage(Message::TYPE_ERROR, "Failed to create flexbody '" + def.mesh_name + "'");

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -501,6 +501,7 @@ private:
     Ogre::SceneNode*                          m_flexbodies_parent_scenenode = nullptr; //!< this isn't used for moving/hiding things, just helps developers inspect the scene graph.
     Ogre::SceneNode*                          m_flares_parent_scenenode = nullptr; //!< this isn't used for moving/hiding things, just helps developers inspect the scene graph.
     Ogre::SceneNode*                          m_particles_parent_scenenode = nullptr; //!< this isn't used for moving/hiding things, just helps developers inspect the scene graph.
+    Ogre::SceneNode*                          m_vcams_parent_scenenode = nullptr; //!< this isn't used for moving/hiding things, just helps developers inspect the scene graph.
     /// @}
 };
 

--- a/source/main/physics/ActorSpawnerFlow.cpp
+++ b/source/main/physics/ActorSpawnerFlow.cpp
@@ -69,6 +69,7 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     m_flexbodies_parent_scenenode = m_actor_grouping_scenenode->createChildSceneNode(this->ComposeName("Flexbodies"));
     m_props_parent_scenenode = m_actor_grouping_scenenode->createChildSceneNode(this->ComposeName("Props"));
     m_flares_parent_scenenode = m_actor_grouping_scenenode->createChildSceneNode(this->ComposeName("Flares"));
+    m_vcams_parent_scenenode = m_actor_grouping_scenenode->createChildSceneNode(this->ComposeName("VideoCameras"));
 
     m_spawn_position = rq.asr_position;
     m_current_keyword = RigDef::Keyword::INVALID;

--- a/source/main/physics/Differentials.cpp
+++ b/source/main/physics/Differentials.cpp
@@ -46,7 +46,7 @@ void Differential::CalcAxleTorque(DifferentialData& diff_data)
     }
 }
 
-Ogre::UTFString Differential::GetDifferentialTypeName()
+std::string Differential::GetDifferentialTypeName()
 {
     if (m_available_diffs.empty())
         return _L("invalid");

--- a/source/main/physics/Differentials.h
+++ b/source/main/physics/Differentials.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <vector>
-#include <OgreUTFString.h>
 
 namespace RoR {
 
@@ -75,7 +74,7 @@ public:
     void             AddDifferentialType(DiffType diff) { m_available_diffs.push_back(diff); }
     void             ToggleDifferentialMode();
     void             CalcAxleTorque(DifferentialData& diff_data);
-    Ogre::UTFString  GetDifferentialTypeName();
+    std::string      GetDifferentialTypeName();
     DiffType         GetActiveDiffType() const { return m_available_diffs[0]; }
     int              GetNumDiffTypes() { return static_cast<int>(m_available_diffs.size()); }
     

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -37,7 +37,6 @@
 
 #include <memory>
 #include <Ogre.h>
-#include <OgreUTFString.h>
 #include <rapidjson/document.h>
 
 namespace RoR {
@@ -838,7 +837,7 @@ struct ActorSpawnRequest
     TuneupDefPtr        asr_working_tuneup; //!< Only filled when editing tuneup via Tuning menu.
     Origin              asr_origin = Origin::UNKNOWN;
     int                 asr_debugview = 0; //(int)DebugViewType::DEBUGVIEW_NONE;
-    Ogre::UTFString     asr_net_username;
+    std::string     asr_net_username;
     int                 asr_net_color = 0;
     BitMask_t           asr_net_peeropts = BitMask_t(0); //!< `RoRnet::PeerOptions` to be applied after spawn.
     int                 net_source_id = 0;

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -1420,7 +1420,7 @@ void Collisions::addCollisionMesh(Ogre::String const& srcname, Ogre::String cons
     Vector3* vertices;
     unsigned* indices;
 
-    getMeshInformation(ent->getMesh().getPointer(),vertex_count,vertices,index_count,indices, pos, q, scale);
+    getMeshInformation(ent->getMesh().get(),vertex_count,vertices,index_count,indices, pos, q, scale);
 
     // Generate collision triangles
     int collision_tri_start = (int)m_collision_tris.size();

--- a/source/main/physics/flex/FlexAirfoil.cpp
+++ b/source/main/physics/flex/FlexAirfoil.cpp
@@ -682,11 +682,11 @@ void FlexAirfoil::updateForces()
 FlexAirfoil::~FlexAirfoil()
 {
     if (airfoil) delete airfoil;
-    if (!msh.isNull())
+    if (msh)
     {
         msh->unload();
         Ogre::MeshManager::getSingleton().remove(msh->getHandle()); // Necessary to truly erase manually created resource.
-        msh.setNull(); // Important! It's a shared pointer.
+        msh.reset(); // Important! It's a shared pointer.
     }
 
     if (vertices          != nullptr) { free (vertices); }

--- a/source/main/physics/flex/FlexBody.cpp
+++ b/source/main/physics/flex/FlexBody.cpp
@@ -210,10 +210,10 @@ FlexBody::FlexBody(
 
     //print mesh information
     //LOG("FLEXBODY Printing modififed mesh informations:");
-    //printMeshInfo(ent->getMesh().getPointer());
+    //printMeshInfo(ent->getMesh().get());
 
     //get the buffers
-    //getMeshInformation(ent->getMesh().getPointer(),m_vertex_count,vertices,index_count,indices, position, orientation, Vector3(1,1,1));
+    //getMeshInformation(ent->getMesh().get(),m_vertex_count,vertices,index_count,indices, position, orientation, Vector3(1,1,1));
 
     //getting vertex counts
     if (preloaded_from_cache == nullptr)

--- a/source/main/physics/flex/FlexMesh.cpp
+++ b/source/main/physics/flex/FlexMesh.cpp
@@ -233,10 +233,10 @@ FlexMesh::FlexMesh(
 
 FlexMesh::~FlexMesh()
 {
-    if (!m_mesh.isNull())
+    if (m_mesh)
     {
         Ogre::MeshManager::getSingleton().remove(m_mesh->getName());
-        m_mesh.setNull();
+        m_mesh.reset();
     }
 }
 

--- a/source/main/physics/flex/FlexMeshWheel.cpp
+++ b/source/main/physics/flex/FlexMeshWheel.cpp
@@ -181,7 +181,7 @@ FlexMeshWheel::~FlexMeshWheel()
     // Delete tyre mesh
     m_mesh->unload();
     Ogre::MeshManager::getSingleton().remove(m_mesh->getHandle());
-    m_mesh.setNull();
+    m_mesh.reset();
 }
 
 Vector3 FlexMeshWheel::updateVertices()

--- a/source/main/physics/flex/FlexObj.cpp
+++ b/source/main/physics/flex/FlexObj.cpp
@@ -236,10 +236,10 @@ Vector3 FlexObj::UpdateFlexObj()
 
 FlexObj::~FlexObj()
 {
-    if (!m_mesh.isNull())
+    if (m_mesh)
     {
         Ogre::MeshManager::getSingleton().remove(m_mesh->getHandle());
-        m_mesh.setNull();
+        m_mesh.reset();
     }
 
     if (m_vertices_raw != nullptr) { free (m_vertices_raw); }

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -850,7 +850,7 @@ void CacheSystem::FillTruckDetailInfo(CacheEntryPtr& entry, Ogre::DataStreamPtr 
     /* LOAD AND PARSE THE VEHICLE */
     RigDef::Parser parser;
     parser.Prepare();
-    parser.ProcessOgreStream(stream.getPointer(), group);
+    parser.ProcessOgreStream(stream.get(), group);
     parser.GetSequentialImporter()->Disable();
     parser.Finalize();
 

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -540,7 +540,7 @@ int GameScript::setMaterialAmbient(const String& materialName, float red, float 
     try
     {
         MaterialPtr m = MaterialManager::getSingleton().getByName(materialName);
-        if (m.isNull())
+        if (!m)
             return 0;
         m->setAmbient(red, green, blue);
     }
@@ -557,7 +557,7 @@ int GameScript::setMaterialDiffuse(const String& materialName, float red, float 
     try
     {
         MaterialPtr m = MaterialManager::getSingleton().getByName(materialName);
-        if (m.isNull())
+        if (!m)
             return 0;
         m->setDiffuse(red, green, blue, alpha);
     }
@@ -574,7 +574,7 @@ int GameScript::setMaterialSpecular(const String& materialName, float red, float
     try
     {
         MaterialPtr m = MaterialManager::getSingleton().getByName(materialName);
-        if (m.isNull())
+        if (!m)
             return 0;
         m->setSpecular(red, green, blue, alpha);
     }
@@ -591,7 +591,7 @@ int GameScript::setMaterialEmissive(const String& materialName, float red, float
     try
     {
         MaterialPtr m = MaterialManager::getSingleton().getByName(materialName);
-        if (m.isNull())
+        if (!m)
             return 0;
         m->setSelfIllumination(red, green, blue);
     }
@@ -609,7 +609,7 @@ int GameScript::getTextureUnitState(TextureUnitState** tu, const String material
     // ========================================================================================================
     
     MaterialPtr m = MaterialManager::getSingleton().getByName(materialName);
-    if (m.isNull())
+    if (!m)
         return 1;
 
     // verify technique
@@ -1875,7 +1875,7 @@ std::string GameScript::loadTextResourceAsString(const std::string& filename, co
 
         Ogre::DataStreamPtr stream = Ogre::ResourceGroupManager::getSingleton().openResource(resource_name, resource_group);
 
-        if (stream.isNull() || !stream->isReadable())
+        if (!stream || !stream->isReadable())
         {
             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_SCRIPT, Console::CONSOLE_SYSTEM_ERROR,
                 fmt::format("loadTextResourceAsString() could not read resource '{}' in group '{}'",
@@ -1923,7 +1923,7 @@ bool GameScript::createTextResourceFromString(const std::string& data, const std
 
         Ogre::DataStreamPtr stream = Ogre::ResourceGroupManager::getSingleton().createResource(resource_name, resource_group, overwrite);
 
-        if (stream.isNull() || !stream->isWriteable())
+        if (!stream || !stream->isWriteable())
         {
             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_SCRIPT, Console::CONSOLE_SYSTEM_ERROR,
                 fmt::format("createTextResourceFromString() could not create resource '{}' in group '{}'",

--- a/source/main/scripting/OgreScriptBuilder.cpp
+++ b/source/main/scripting/OgreScriptBuilder.cpp
@@ -68,7 +68,7 @@ int OgreScriptBuilder::LoadScriptSection(const char* full_path_cstr)
         return -2;
     }
     // In some cases (i.e. when fed a full path with '/'-s on Windows), `openResource()` will silently return NULL for datastream. ~ only_a_ptr, 08/2017
-    if (ds.isNull())
+    if (!ds)
     {
         LOG("[RoR|Scripting] Failed to load file '"+filename+"', reason unknown.");
         return -1;

--- a/source/main/terrain/OgreTerrainPSSMMaterialGenerator.cpp
+++ b/source/main/terrain/OgreTerrainPSSMMaterialGenerator.cpp
@@ -238,7 +238,7 @@ MaterialPtr TerrainPSSMMaterialGenerator::SM2Profile::generate(const Terrain* te
 {
     // re-use old material if exists
     MaterialPtr mat = terrain->_getMaterial();
-    if (mat.isNull())
+    if (!mat)
     {
         MaterialManager& matMgr = MaterialManager::getSingleton();
 
@@ -246,7 +246,7 @@ MaterialPtr TerrainPSSMMaterialGenerator::SM2Profile::generate(const Terrain* te
         // use the terrain pointer as an ID
         const String& matName = terrain->getMaterialName();
         mat = matMgr.getByName(matName);
-        if (mat.isNull())
+        if (!mat)
         {
             mat = matMgr.create(matName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
         }
@@ -287,7 +287,7 @@ MaterialPtr TerrainPSSMMaterialGenerator::SM2Profile::generateForCompositeMap(co
 {
     // re-use old material if exists
     MaterialPtr mat = terrain->_getCompositeMapMaterial();
-    if (mat.isNull())
+    if (!mat)
     {
         MaterialManager& matMgr = MaterialManager::getSingleton();
 
@@ -295,7 +295,7 @@ MaterialPtr TerrainPSSMMaterialGenerator::SM2Profile::generateForCompositeMap(co
         // use the terrain pointer as an ID
         const String& matName = terrain->getMaterialName() + "/comp";
         mat = matMgr.getByName(matName);
-        if (mat.isNull())
+        if (!mat)
         {
             mat = matMgr.create(matName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
         }
@@ -734,7 +734,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::createVertexProgram(
     HighLevelGpuProgramManager& mgr = HighLevelGpuProgramManager::getSingleton();
     String progName = getVertexProgramName(prof, terrain, tt);
     HighLevelGpuProgramPtr ret = mgr.getByName(progName);
-    if (ret.isNull())
+    if (!ret)
     {
         ret = mgr.createProgram(progName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             "cg", GPT_VERTEX_PROGRAM);
@@ -759,7 +759,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::createFragmentProgram(
     String progName = getFragmentProgramName(prof, terrain, tt);
 
     HighLevelGpuProgramPtr ret = mgr.getByName(progName);
-    if (ret.isNull())
+    if (!ret)
     {
         ret = mgr.createProgram(progName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             "cg", GPT_FRAGMENT_PROGRAM);
@@ -1581,7 +1581,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperHLSL::createVertexProgram(
     String progName = getVertexProgramName(prof, terrain, tt);
 
     HighLevelGpuProgramPtr ret = mgr.getByName(progName);
-    if (ret.isNull())
+    if (!ret)
     {
         ret = mgr.createProgram(progName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             "hlsl", GPT_VERTEX_PROGRAM);
@@ -1611,7 +1611,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperHLSL::createFragmentProgra
     String progName = getFragmentProgramName(prof, terrain, tt);
 
     HighLevelGpuProgramPtr ret = mgr.getByName(progName);
-    if (ret.isNull())
+    if (!ret)
     {
         ret = mgr.createProgram(progName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             "hlsl", GPT_FRAGMENT_PROGRAM);
@@ -1655,7 +1655,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperGLSL::createVertexProgram(
     }
 
     HighLevelGpuProgramPtr ret = mgr.getByName(progName);
-    if (ret.isNull())
+    if (!ret)
     {
         ret = mgr.createProgram(progName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             "glsl", GPT_VERTEX_PROGRAM);
@@ -1677,7 +1677,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperGLSL::createFragmentProgra
     String progName = getFragmentProgramName(prof, terrain, tt);
 
     HighLevelGpuProgramPtr ret = mgr.getByName(progName);
-    if (ret.isNull())
+    if (!ret)
     {
         ret = mgr.createProgram(progName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             "glsl", GPT_FRAGMENT_PROGRAM);
@@ -1713,7 +1713,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperGLSLES::createVertexProgra
     }
 
     HighLevelGpuProgramPtr ret = mgr.getByName(progName);
-    if (ret.isNull())
+    if (!ret)
     {
         ret = mgr.createProgram(progName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             "glsles", GPT_VERTEX_PROGRAM);
@@ -1735,7 +1735,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperGLSLES::createFragmentProg
     String progName = getFragmentProgramName(prof, terrain, tt);
 
     HighLevelGpuProgramPtr ret = mgr.getByName(progName);
-    if (ret.isNull())
+    if (!ret)
     {
         ret = mgr.createProgram(progName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
             "glsles", GPT_FRAGMENT_PROGRAM);

--- a/source/main/terrain/OgreTerrainPSSMMaterialGenerator.cpp
+++ b/source/main/terrain/OgreTerrainPSSMMaterialGenerator.cpp
@@ -447,7 +447,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelper::generateVertexProgram(
 {
     HighLevelGpuProgramPtr ret = createVertexProgram(prof, terrain, tt);
 
-    StringUtil::StrStreamType sourceStr;
+    Ogre::StringStream sourceStr;
     generateVertexProgramSource(prof, terrain, tt, sourceStr);
     ret->setSource(sourceStr.str());
     ret->load();
@@ -467,7 +467,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelper::generateFragmentProgram(
 {
     HighLevelGpuProgramPtr ret = createFragmentProgram(prof, terrain, tt);
 
-    StringUtil::StrStreamType sourceStr;
+    Ogre::StringStream sourceStr;
     generateFragmentProgramSource(prof, terrain, tt, sourceStr);
     ret->setSource(sourceStr.str());
     ret->load();
@@ -483,7 +483,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelper::generateFragmentProgram(
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelper::generateVertexProgramSource(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     generateVpHeader(prof, terrain, tt, outStream);
 
@@ -501,7 +501,7 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelper::generateVertexProgr
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelper::generateFragmentProgramSource(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     generateFpHeader(prof, terrain, tt, outStream);
 
@@ -780,7 +780,7 @@ TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::createFragmentProgram(
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpHeader(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     outStream <<
         "void main_vp(\n";
@@ -936,7 +936,7 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpHeader(
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpHeader(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     // Main header
     outStream <<
@@ -1136,14 +1136,14 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpHeader(
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpLayer(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream)
 {
     // nothing to do
 }
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpLayer(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream)
 {
     uint uvIdx = layer / 2;
     String uvChannels = (layer % 2) ? ".zw" : ".xy";
@@ -1211,7 +1211,7 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpLayer(
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpFooter(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     outStream <<
         "	oPos = mul(viewProjMatrix, worldPos);\n"
@@ -1241,7 +1241,7 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpFooter(
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpFooter(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     if (tt == LOW_LOD)
     {
@@ -1313,7 +1313,7 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpFooter(
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpDynamicShadowsHelpers(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     // TODO make filtering configurable
     outStream <<
@@ -1430,7 +1430,7 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpDynamic
 
 //---------------------------------------------------------------------
 uint TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpDynamicShadowsParams(
-    uint texCoord, const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    uint texCoord, const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     // out semantics & params
     uint numTextures = 1;
@@ -1456,7 +1456,7 @@ uint TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpDynamic
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpDynamicShadows(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     uint numTextures = 1;
     if (prof->getReceiveDynamicShadowsPSSM())
@@ -1488,7 +1488,7 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateVpDynamic
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpDynamicShadowsParams(
-    uint* texCoord, uint* sampler, const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    uint* texCoord, uint* sampler, const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     if (tt == HIGH_LOD)
         mShadowSamplerStartHi = *sampler;
@@ -1520,7 +1520,7 @@ void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpDynamic
 
 //---------------------------------------------------------------------
 void TerrainPSSMMaterialGenerator::SM2Profile::ShaderHelperCg::generateFpDynamicShadows(
-    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream)
+    const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream)
 {
     if (prof->getReceiveDynamicShadowsPSSM())
     {

--- a/source/main/terrain/OgreTerrainPSSMMaterialGenerator.h
+++ b/source/main/terrain/OgreTerrainPSSMMaterialGenerator.h
@@ -178,14 +178,14 @@ public:
             virtual String getFragmentProgramName(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt);
             virtual HighLevelGpuProgramPtr createVertexProgram(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt) = 0;
             virtual HighLevelGpuProgramPtr createFragmentProgram(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt) = 0;
-            virtual void generateVertexProgramSource(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            virtual void generateFragmentProgramSource(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            virtual void generateVpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) = 0;
-            virtual void generateFpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) = 0;
-            virtual void generateVpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream) = 0;
-            virtual void generateFpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream) = 0;
-            virtual void generateVpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) = 0;
-            virtual void generateFpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) = 0;
+            virtual void generateVertexProgramSource(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            virtual void generateFragmentProgramSource(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            virtual void generateVpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) = 0;
+            virtual void generateFpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) = 0;
+            virtual void generateVpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream) = 0;
+            virtual void generateFpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream) = 0;
+            virtual void generateVpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) = 0;
+            virtual void generateFpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) = 0;
             virtual void defaultVpParams(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, const HighLevelGpuProgramPtr& prog);
             virtual void defaultFpParams(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, const HighLevelGpuProgramPtr& prog);
             virtual void updateVpParams(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, const GpuProgramParametersSharedPtr& params);
@@ -202,17 +202,17 @@ public:
         protected:
             HighLevelGpuProgramPtr createVertexProgram(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt);
             HighLevelGpuProgramPtr createFragmentProgram(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt);
-            void generateVpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            void generateFpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            void generateVpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream);
-            void generateFpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream);
-            void generateVpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            void generateFpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            uint generateVpDynamicShadowsParams(uint texCoordStart, const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            void generateVpDynamicShadows(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            void generateFpDynamicShadowsHelpers(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            void generateFpDynamicShadowsParams(uint* texCoord, uint* sampler, const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
-            void generateFpDynamicShadows(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream);
+            void generateVpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            void generateFpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            void generateVpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream);
+            void generateFpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream);
+            void generateVpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            void generateFpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            uint generateVpDynamicShadowsParams(uint texCoordStart, const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            void generateVpDynamicShadows(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            void generateFpDynamicShadowsHelpers(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            void generateFpDynamicShadowsParams(uint* texCoord, uint* sampler, const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
+            void generateFpDynamicShadows(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream);
         };
 
         class ShaderHelperHLSL : public ShaderHelperCg
@@ -229,17 +229,17 @@ public:
             HighLevelGpuProgramPtr createVertexProgram(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt);
             HighLevelGpuProgramPtr createFragmentProgram(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt);
 
-            void generateVpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) {}
+            void generateVpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) {}
 
-            void generateFpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) {}
+            void generateFpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) {}
 
-            void generateVpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream) {}
+            void generateVpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream) {}
 
-            void generateFpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream) {}
+            void generateFpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream) {}
 
-            void generateVpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) {}
+            void generateVpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) {}
 
-            void generateFpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) {}
+            void generateFpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) {}
         };
 
         /// Utility class to help with generating shaders for GLSL ES.
@@ -249,17 +249,17 @@ public:
             HighLevelGpuProgramPtr createVertexProgram(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt);
             HighLevelGpuProgramPtr createFragmentProgram(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt);
 
-            void generateVpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) {}
+            void generateVpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) {}
 
-            void generateFpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) {}
+            void generateFpHeader(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) {}
 
-            void generateVpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream) {}
+            void generateVpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream) {}
 
-            void generateFpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, StringUtil::StrStreamType& outStream) {}
+            void generateFpLayer(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, uint layer, Ogre::StringStream& outStream) {}
 
-            void generateVpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) {}
+            void generateVpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) {}
 
-            void generateFpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, StringUtil::StrStreamType& outStream) {}
+            void generateFpFooter(const SM2Profile* prof, const Terrain* terrain, TechniqueType tt, Ogre::StringStream& outStream) {}
         };
 
         ShaderHelper* mShaderGen;

--- a/source/main/terrain/ProceduralRoad.cpp
+++ b/source/main/terrain/ProceduralRoad.cpp
@@ -47,10 +47,10 @@ ProceduralRoad::~ProceduralRoad()
         App::GetGfxScene()->GetSceneManager()->destroySceneNode(snode);
         snode = nullptr;
     }
-    if (!msh.isNull())
+    if (msh)
     {
         MeshManager::getSingleton().remove(msh->getName());
-        msh.setNull();
+        msh.reset();
     }
     for (int number : registeredCollTris)
     {

--- a/source/main/terrain/Terrain.cpp
+++ b/source/main/terrain/Terrain.cpp
@@ -370,7 +370,8 @@ void RoR::Terrain::fixCompositorClearColor()
                 CompositionTargetPass* ctp = ct->getOutputTargetPass();
                 if (ctp)
                 {
-                    CompositionPass* p = ctp->getPass(0);
+                    ROR_ASSERT(ctp->getPasses().size() > 0);
+                    CompositionPass* p = ctp->getPasses()[0];
                     if (p)
                     {
                         p->setClearColour(Ogre::ColourValue::Black);

--- a/source/main/terrain/TerrainEditor.cpp
+++ b/source/main/terrain/TerrainEditor.cpp
@@ -124,7 +124,7 @@ void TerrainEditor::UpdateInputEvents(float dt)
     }
     if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESCUE_TRUCK))
     {
-        UTFString axis = _L("ry");
+        std::string axis = _L("ry");
         if (m_rotation_axis == 0)
         {
             axis = _L("ry");
@@ -140,13 +140,13 @@ void TerrainEditor::UpdateInputEvents(float dt)
             axis = _L("rx");
             m_rotation_axis = 0;
         }
-        UTFString ssmsg = _L("Rotating: ") + axis;
+        std::string ssmsg = _L("Rotating: ") + axis;
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "information.png");
     }
     if (App::GetInputEngine()->isKeyDownValueBounce(OIS::KC_SPACE))
     {
         m_object_tracking = !m_object_tracking;
-        UTFString ssmsg = m_object_tracking ? _L("Enabled object tracking") : _L("Disabled object tracking");
+        std::string ssmsg = m_object_tracking ? _L("Enabled object tracking") : _L("Disabled object tracking");
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, ssmsg, "information.png");
     }
     if (m_selected_object_id != -1 && App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_RESET_TRUCK))

--- a/source/main/terrain/TerrainGeometryManager.cpp
+++ b/source/main/terrain/TerrainGeometryManager.cpp
@@ -101,7 +101,7 @@ Ogre::MaterialPtr Terrn2CustomMaterial::Profile::generate(const Ogre::Terrain* t
     const Ogre::String& matName = terrain->getMaterialName();
 
     Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().getByName(matName);
-    if (!mat.isNull()) 
+    if (mat) 
         Ogre::MaterialManager::getSingleton().remove(matName);
 
     Terrn2CustomMaterial* parent = static_cast<Terrn2CustomMaterial*>(this->getParent());
@@ -261,7 +261,7 @@ bool TerrainGeometryManager::InitTerrain(std::string otc_filename)
     try
     {
         DataStreamPtr ds_config = ResourceGroupManager::getSingleton().openResource(otc_filename);
-        if (ds_config.isNull() || !ds_config->isReadable())
+        if (!ds_config || !ds_config->isReadable())
         {
             RoR::LogFormat("[RoR|Terrain] Cannot read main *.otc file [%s].", otc_filename.c_str());
             return false;
@@ -289,7 +289,7 @@ bool TerrainGeometryManager::InitTerrain(std::string otc_filename)
         try
         {
             DataStreamPtr ds_page = ResourceGroupManager::getSingleton().openResource(page.pageconf_filename);
-            if (ds_page.isNull() || !ds_page->isReadable())
+            if (!ds_page || !ds_page->isReadable())
             {
                 RoR::LogFormat("[RoR|Terrain] Cannot read file [%s].", page.pageconf_filename.c_str());
                 return false;

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -850,13 +850,13 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
             continue;
         String matName = mo->getEntity()->getSubEntity(0)->getMaterialName();
         MaterialPtr m = MaterialManager::getSingleton().getByName(matName);
-        if (m.getPointer() == 0)
+        if (m.get() == 0)
         {
             LOG("[ODEF] problem with drawTextOnMeshTexture command: mesh material not found: "+odefname+" : "+matName);
             continue;
         }
         String texName = m->getTechnique(0)->getPass(0)->getTextureUnitState(0)->getTextureName();
-        Texture* background = (Texture *)TextureManager::getSingleton().getByName(texName).getPointer();
+        Texture* background = (Texture *)TextureManager::getSingleton().getByName(texName).get();
         if (!background)
         {
             LOG("[ODEF] problem with drawTextOnMeshTexture command: mesh texture not found: "+odefname+" : "+texName);
@@ -869,7 +869,7 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
         sprintf(tmpTextName, "TextOnTexture_%d_Texture", textureNumber);
         sprintf(tmpMatName, "TextOnTexture_%d_Material", textureNumber); // Make sure the texture is not WRITE_ONLY, we need to read the buffer to do the blending with the font (get the alpha for example)
         TexturePtr texture = TextureManager::getSingleton().createManual(tmpTextName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, TEX_TYPE_2D, (Ogre::uint)background->getWidth(), (Ogre::uint)background->getHeight(), MIP_UNLIMITED, PF_X8R8G8B8, Ogre::TU_STATIC | Ogre::TU_AUTOMIPMAP);
-        if (texture.getPointer() == 0)
+        if (texture.get() == 0)
         {
             LOG("[ODEF] problem with drawTextOnMeshTexture command: could not create texture: "+odefname+" : "+tmpTextName);
             continue;
@@ -889,7 +889,7 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
         while (*text_pointer!=0) {if (*text_pointer=='_') *text_pointer=' ';text_pointer++;};
 
         String font_name_str(tex_print.font_name);
-        Ogre::Font* font = (Ogre::Font *)FontManager::getSingleton().getByName(font_name_str).getPointer();
+        Ogre::Font* font = (Ogre::Font *)FontManager::getSingleton().getByName(font_name_str).get();
         if (!font)
         {
             LOG("[ODEF] problem with drawTextOnMeshTexture command: font not found: "+odefname+" : "+font_name_str);

--- a/source/main/utils/ErrorUtils.cpp
+++ b/source/main/utils/ErrorUtils.cpp
@@ -26,6 +26,7 @@
 */
 
 #include "ErrorUtils.h"
+#include "Utils.h"
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
 #include <windows.h>
@@ -38,21 +39,23 @@
 #include "Language.h"
 #endif
 
+#include <string>
+
 using namespace Ogre;
 
-int ErrorUtils::ShowError(Ogre::UTFString title, Ogre::UTFString err)
+int ErrorUtils::ShowError(const std::string& title, const std::string& err)
 {
-    LOG(fmt::format("[RoR|ErrorPopupDialog] {}: {}", title.asUTF8(), err.asUTF8()));
-    Ogre::UTFString infoText = _L("An internal error occured in Rigs of Rods.\n\nTechnical details below: \n\n");
+    LOG(fmt::format("[RoR|ErrorPopupDialog] {}: {}", title, err));
+    std::string infoText = _L("An internal error occured in Rigs of Rods.\n\nTechnical details below: \n\n");
     return ErrorUtils::ShowMsgBox(_L("FATAL ERROR"), infoText + err, 0);
 }
 
-int ErrorUtils::ShowInfo(Ogre::UTFString title, Ogre::UTFString err)
+int ErrorUtils::ShowInfo(const std::string& title, const std::string& err)
 {
     return ErrorUtils::ShowMsgBox(title, err, 1);
 }
 
-int ErrorUtils::ShowMsgBox(Ogre::UTFString title, Ogre::UTFString err, int type)
+int ErrorUtils::ShowMsgBox(const std::string& title, const std::string& err, int type)
 {
     // we might call the ErrorUtils::ShowMsgBox without having ogre created yet!
     //LOG("message box: " + title + ": " + err);
@@ -60,11 +63,13 @@ int ErrorUtils::ShowMsgBox(Ogre::UTFString title, Ogre::UTFString err, int type)
     int mtype = MB_ICONERROR;
     if (type == 1)
         mtype = MB_ICONINFORMATION;
-    MessageBoxW(NULL, err.asWStr_c_str(), title.asWStr_c_str(), MB_OK | mtype | MB_TOPMOST);
+    std::wstring title_w = RoR::Utf8ToWideChar(title);
+    std::wstring err_w = RoR::Utf8ToWideChar(err);
+    MessageBoxW(NULL, err_w.c_str(), title_w.c_str(), MB_OK | mtype | MB_TOPMOST);
 #elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX
-	printf("\n\n%s: %s\n\n", title.asUTF8_c_str(), err.asUTF8_c_str());
+	printf("\n\n%s: %s\n\n", title.c_str(), err.c_str());
 #elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE
-	printf("\n\n%s: %s\n\n", title.asUTF8_c_str(), err.asUTF8_c_str());
+	printf("\n\n%s: %s\n\n", title.c_str(), err.c_str());
     //CFOptionFlags flgs;
     //CFUserNotificationDisplayAlert(0, kCFUserNotificationStopAlertLevel, NULL, NULL, NULL, T("A network error occured"), T("Bad server port."), NULL, NULL, NULL, &flgs);
 #endif

--- a/source/main/utils/ErrorUtils.h
+++ b/source/main/utils/ErrorUtils.h
@@ -29,8 +29,6 @@
 
 #include "Application.h"
 
-#include <OgreUTFString.h>
-
 /// @addtogroup Application
 /// @{
 
@@ -40,20 +38,20 @@ struct ErrorUtils
      * shows a simple error message box
      * @return 0 on success, everything else on error
      */
-    static int ShowError(Ogre::UTFString title, Ogre::UTFString message);
+    static int ShowError(const std::string& title, const std::string& message);
 
     /**
      * shows a simple info message box
      * @return 0 on success, everything else on error
      */
-    static int ShowInfo(Ogre::UTFString title, Ogre::UTFString message);
+    static int ShowInfo(const std::string& title, const std::string& message);
 
     /**
      * shows a generic message box
      * @param type 0 for error, 1 for info
      * @return 0 on success, everything else on error
      */
-    static int ShowMsgBox(Ogre::UTFString title, Ogre::UTFString err, int type);
+    static int ShowMsgBox(const std::string& title, const std::string& err, int type);
 };
 
 /// @} // addtogroup Application

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -29,7 +29,6 @@
 #include "Application.h"
 #include "ForceFeedback.h"
 
-#include <OgreUTFString.h>
 #include "OISEvents.h"
 #include "OISForceFeedback.h"
 #include "OISInputManager.h"
@@ -413,7 +412,7 @@ struct InputEvent
     Ogre::String name;
     int eventID;
     Ogre::String defaultKey;
-    Ogre::UTFString description;
+    std::string description;
 };
 
 struct event_trigger_t

--- a/source/main/utils/Language.h
+++ b/source/main/utils/Language.h
@@ -27,13 +27,9 @@
 
 #include "Application.h"
 
-#include <OgreUTFString.h>
-
 // three configurations currently supported:
 // #define NOLANG            = no language translations at all, removes any special parsing tags
 // #define USE_MOFILEREADER  = windows gettext replacement
-
-# define U(str) Ogre::UTFString(L##str)
 
 // using mofilereader as gettext replacement
 #include <moFileReader.hpp>

--- a/source/main/utils/Utils.cpp
+++ b/source/main/utils/Utils.cpp
@@ -30,6 +30,9 @@
 #include <Ogre.h>
 #include <string>
 
+#include <codecvt> // https://en.cppreference.com/w/cpp/locale/codecvt_utf8_utf16
+#include <locale>
+
 #ifndef _WIN32
 #   include <iconv.h>
 #endif
@@ -55,20 +58,20 @@ String RoR::HashData(const char *key, int len)
     return result.str();
 }
 
-UTFString RoR::tryConvertUTF(const char* buffer)
+std::string RoR::tryConvertUTF(const char* buffer)
 {
     std::string str_in(buffer);
-    return UTFString(SanitizeUtf8String(str_in));
+    return std::string(SanitizeUtf8String(str_in));
 }
 
-UTFString RoR::formatBytes(double bytes)
+std::string RoR::formatBytes(double bytes)
 {
-    wchar_t tmp[128] = L"";
-    const wchar_t* si_prefix[] = {L"B", L"KB", L"MB", L"GB", L"TB", L"EB", L"ZB", L"YB"};
+    char tmp[128] = "";
+    const char* si_prefix[] = {"B", "KB", "MB", "GB", "TB", "EB", "ZB", "YB"};
     int base = 1024;
     int c = bytes > 0 ? std::min((int)(log(bytes) / log((float)base)), (int)sizeof(si_prefix) - 1) : 0;
-    swprintf(tmp, 128, L"%1.2f %ls", bytes / pow((float)base, c), si_prefix[c]);
-    return UTFString(tmp);
+    snprintf(tmp, 128, "%1.2f %s", bytes / pow((float)base, c), si_prefix[c]);
+    return std::string(tmp);
 }
 
 std::time_t RoR::getTimeStamp()
@@ -141,6 +144,14 @@ std::string RoR::Sha1Hash(std::string const & input)
     sha1.UpdateHash((uint8_t *)input.c_str(), (int)input.length());
     sha1.Final();
     return sha1.ReportHash();
+}
+
+std::wstring RoR::Utf8ToWideChar(std::string input_utf8)
+{
+    // https://stackoverflow.com/a/14809553
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t> convert;
+    std::wstring temp_utf16 = convert.from_bytes(input_utf8);
+    return std::wstring(reinterpret_cast<const wchar_t*>(temp_utf16.c_str()));
 }
 
 std::string RoR::JoinStrVec(Ogre::StringVector tokens, const std::string& delim)

--- a/source/main/utils/Utils.h
+++ b/source/main/utils/Utils.h
@@ -33,7 +33,6 @@
 #include "utf8/unchecked.h"
 
 #include <MyGUI.h>
-#include <OgreUTFString.h>
 
 namespace RoR {
 
@@ -41,9 +40,9 @@ Ogre::String sha1sum(const char *key, int len);
 
 Ogre::String HashData(const char *key, int len);
 
-Ogre::UTFString tryConvertUTF(const char* buffer);
+std::string tryConvertUTF(const char* buffer);
 
-Ogre::UTFString formatBytes(double bytes);
+std::string formatBytes(double bytes);
 
 std::time_t getTimeStamp();
 
@@ -63,6 +62,8 @@ Ogre::Real Round(Ogre::Real value, unsigned short ndigits = 0);
 
 std::string SanitizeUtf8String(std::string const& str_in);
 std::string SanitizeUtf8CString(const char* start, const char* end = nullptr);
+
+std::wstring Utf8ToWideChar(std::string input_utf8);
 
 inline std::string& TrimStr(std::string& s) { Ogre::StringUtil::trim(s); return s; }
 std::string Sha1Hash(std::string const & data);

--- a/source/main/utils/WriteTextToTexture.cpp
+++ b/source/main/utils/WriteTextToTexture.cpp
@@ -63,7 +63,7 @@ void WriteToTexture(const String& str, TexturePtr destTexture, Ogre::Box destRec
     FontPtr font = FontManager::getSingleton().getByName(fontname);
 
     // Font not found, let's created it :)
-    if (font.isNull())
+    if (!font)
     {
         font = FontManager::getSingleton().create(fontname, "General");
         font->setType(FT_TRUETYPE);


### PR DESCRIPTION
This fixes a lot of compiler warnings, including deprecated OGRE stuff (like node-less positioning of lights & cameras which becomes unbuildable under OGRE13+).

What to test:
* Player camera
* Videocams and rear view mirrors
* Envmap