### PR TITLE
Prevent cheating via `ActorSimAttr` system (used by engine_tool gadget)

### DIFF
--- a/doc/angelscript/Script2Game/globals.h
+++ b/doc/angelscript/Script2Game/globals.h
@@ -67,7 +67,7 @@ void print(const string message);
     SE_TRUCK_TELEPORT                  //!< triggered when the user teleports the truck, the argument refers to the Actor Instance ID (use `game.getTruckByNum()`)
     SE_TRUCK_MOUSE_GRAB                //!< triggered when the user uses the mouse to interact with the actor, the argument refers to the Actor Instance ID (use `game.getTruckByNum()`)
 
-    SE_ANGELSCRIPT_MANIPULATIONS       //!< triggered when the user tries to dynamically use the scripting capabilities (prevent cheating) args: #1 angelScriptManipulationType, #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 script file name (*.as), #6 associated file name (i.e. *.mission), #7 associated file resource group (i.e. *.mission).
+    SE_ANGELSCRIPT_MANIPULATIONS       //!< triggered when the user tries to dynamically use the scripting capabilities (prevent cheating) args:  #1 `angelScriptManipulationType` - see enum doc comments for more args.
     SE_ANGELSCRIPT_MSGCALLBACK         //!< The diagnostic info directly from AngelScript engine (see `asSMessageInfo`), args: #1 ScriptUnitID, #2 asEMsgType, #3 row, #4 col, #5 sectionName, #6 message
     SE_ANGELSCRIPT_LINECALLBACK        //!< The diagnostic info directly from AngelScript engine (see `SetLineCallback()`), args: #1 ScriptUnitID, #2 LineNumber, #3 CallstackSize, #4 unused, #5 FunctionName, #6 FunctionObjectTypeName #7 ObjectName
     SE_ANGELSCRIPT_EXCEPTIONCALLBACK   //!< The diagnostic info directly from AngelScript engine (see `SetExceptionCallback()`), args: #1 ScriptUnitID, #2 unused, #3 row (`GetExceptionLineNumber()`), #4 unused, #5 funcName, #6 message (`GetExceptionString()`)
@@ -88,8 +88,9 @@ void print(const string message);
 enum angelScriptManipulationType
 {
     ASMANIP_CONSOLE_SNIPPET_EXECUTED = 0, // 0 for Backwards compatibility.
-    ASMANIP_SCRIPT_LOADED,                //!< Triggered after the script's `main()` completed; may trigger additional processing (for example, it delivers the *.mission file to mission system script).
-    ASMANIP_SCRIPT_UNLOADING              //!< Triggered before unloading the script to let it clean up (important for missions).
+    ASMANIP_SCRIPT_LOADED,                //!< Triggered after the script's `main()` completed; may trigger additional processing (for example, it delivers the *.mission file to mission system script). Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
+    ASMANIP_SCRIPT_UNLOADING,              //!< Triggered before unloading the script to let it clean up (important for missions). Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
+    ASMANIP_ACTORSIMATTR_SET              //!< Triggered when `setSimAttribute()` is called; additional args: #2 `RoR::ActorSimAtr`, #3 ---, #4 ---, #5 attr name, #6 value converted to string.
 };
 
 enum angelScriptThreadStatus

--- a/resources/gadgets/engine_tool.as
+++ b/resources/gadgets/engine_tool.as
@@ -34,6 +34,7 @@ void updateEnginePlotBuffers(EngineClass@ engine)
 // #endregion
 
 // #region frameStep
+CVarClass@  g_mp_state = console.cVarFind("mp_state"); // 0=disabled, 1=connecting, 2=connected, see MpState in Application.h
 void frameStep(float dt)
 {
     
@@ -41,6 +42,11 @@ void frameStep(float dt)
     {
         // Draw the "Terminate this script?" prompt on the top (if not disabled by config).
         closeBtnHandler.draw();
+        
+        if (g_mp_state.getInt() == 2)
+        {
+            ImGui::Text("* * * This tool does not work in multiplayer! * * *");
+        }
         
         // force minimum width
         ImGui::Dummy(vector2(250, 1));

--- a/source/main/gameplay/ScriptEvents.h
+++ b/source/main/gameplay/ScriptEvents.h
@@ -51,7 +51,7 @@ enum scriptEvents
     SE_TRUCK_TELEPORT                  = BITMASK(16), //!< triggered when the user teleports the truck, the argument refers to the actor ID of the vehicle
     SE_TRUCK_MOUSE_GRAB                = BITMASK(17), //!< triggered when the user uses the mouse to interact with the actor, the argument refers to the actor ID
 
-    SE_ANGELSCRIPT_MANIPULATIONS       = BITMASK(18), //!< triggered when the user tries to dynamically use the scripting capabilities (prevent cheating) args: #1 angelScriptManipulationType, #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename
+    SE_ANGELSCRIPT_MANIPULATIONS       = BITMASK(18), //!< triggered when the user tries to dynamically use the scripting capabilities (prevent cheating) args: #1 angelScriptManipulationType - see enum doc comments for more args.
     SE_ANGELSCRIPT_MSGCALLBACK         = BITMASK(19), //!< The diagnostic info directly from AngelScript engine (see `asSMessageInfo`), args: #1 ScriptUnitID, #2 asEMsgType, #3 row, #4 col, #5 sectionName, #6 message
     SE_ANGELSCRIPT_LINECALLBACK        = BITMASK(20), //!< The diagnostic info directly from AngelScript engine (see `SetLineCallback()`), args: #1 ScriptUnitID, #2 LineNumber, #3 CallstackSize, #4 unused, #5 FunctionName, #6 FunctionObjectTypeName #7 ObjectName
     SE_ANGELSCRIPT_EXCEPTIONCALLBACK   = BITMASK(21), //!< The diagnostic info directly from AngelScript engine (see `SetExceptionCallback()`), args: #1 ScriptUnitID, #2 unused, #3 row (`GetExceptionLineNumber()`), #4 unused, #5 funcName, #6 message (`GetExceptionString()`)
@@ -72,8 +72,9 @@ enum scriptEvents
 enum angelScriptManipulationType
 {
     ASMANIP_CONSOLE_SNIPPET_EXECUTED = 0, // 0 for Backwards compatibility.
-    ASMANIP_SCRIPT_LOADED,                //!< Triggered after the script's `main()` completed; may trigger additional processing (for example, it delivers the *.mission file to mission system script).
-    ASMANIP_SCRIPT_UNLOADING              //!< Triggered before unloading the script to let it clean up (important for missions).
+    ASMANIP_SCRIPT_LOADED,                //!< Triggered after the script's `main()` completed; may trigger additional processing (for example, it delivers the *.mission file to mission system script). Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
+    ASMANIP_SCRIPT_UNLOADING,              //!< Triggered before unloading the script to let it clean up (important for missions). Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
+    ASMANIP_ACTORSIMATTR_SET              //!< Triggered when `setSimAttribute()` is called; additional args: #2 `RoR::ActorSimAtrr`, #3 ---, #4 ---, #5 attr name, #6 value converted to string.
 };
 
 enum angelScriptThreadStatus

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4736,7 +4736,16 @@ int Actor::getShockNode2(int shock_number)
 
 void Actor::setSimAttribute(ActorSimAttr attr, float val)
 {
+    if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
+    {
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            "Cannot change simulation attributes in multiplayer mode.");
+        return;
+    }
+
     LOG(fmt::format("[RoR|Actor] setSimAttribute: '{}' = {}", ActorSimAttrToString(attr), val));
+
+    TRIGGER_EVENT_ASYNC(SE_ANGELSCRIPT_MANIPULATIONS, ASMANIP_ACTORSIMATTR_SET, attr, 0, 0, ActorSimAttrToString(attr), fmt::format("{}", val));
 
     // PLEASE maintain the same order as in `enum ActorSimAttr`
     switch (attr)

--- a/source/main/scripting/bindings/ScriptEventsAngelscript.cpp
+++ b/source/main/scripting/bindings/ScriptEventsAngelscript.cpp
@@ -76,6 +76,7 @@ void RoR::RegisterScriptEvents(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("angelScriptManipulationType", "ASMANIP_CONSOLE_SNIPPET_EXECUTED", ASMANIP_CONSOLE_SNIPPET_EXECUTED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("angelScriptManipulationType", "ASMANIP_SCRIPT_LOADED", ASMANIP_SCRIPT_LOADED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("angelScriptManipulationType", "ASMANIP_SCRIPT_UNLOADING", ASMANIP_SCRIPT_UNLOADING); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("angelScriptManipulationType", "ASMANIP_ACTORSIMATTR_SET", ASMANIP_ACTORSIMATTR_SET); ROR_ASSERT(result >= 0);
 
     // enum angelScriptThreadStatus
     result = engine->RegisterEnum("angelScriptThreadStatus"); ROR_ASSERT(result>=0);


### PR DESCRIPTION
Reported by [Mike](https://discord.com/channels/136544456244461568/189904947649708032/1343333206069477426) on Discord, upvoted by DannyWerewolf.

Changes:
* When any script uses `setSimAttribute()`, game sends script event `SE_ANGELSCRIPT_MANIPULATIONS` which aborts the  current race.
* When in multiplayer, `setSimAttribute()` logs a warning to console ( appears on screen in the chatbox area) and does nothing.