### PR TITLE
Fixed excess icons on survey map

### DIFF
--- a/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
+++ b/source/main/resources/tobj_fileformat/TObjFileFormat.cpp
@@ -442,11 +442,6 @@ bool TObjParser::ParseObjectLine(TObjEntry& object)
     if (instance_name == "")
     {
         instance_name << "auto^" << m_filename << "(line:" << m_line_number << ")";
-        // Also set 'type' arg to non-empty (same reason).
-        if (special == TObjSpecialObject::NONE)
-        {
-            type << "-";
-        }
     }
 
     object = TObjEntry(pos, rot, odef.ToCStr(), special, type, instance_name);

--- a/source/main/terrain/TerrainEditor.h
+++ b/source/main/terrain/TerrainEditor.h
@@ -38,7 +38,7 @@ public:
     // Variables are not accessible from AngelScript
     std::string name;
     std::string instance_name;
-    std::string type;
+    std::string type; //!< Accepts "-" as placeholder, otherwise a surveymap icon is registered.
     Ogre::Vector3 position = Ogre::Vector3::ZERO;
     Ogre::Vector3 rotation = Ogre::Vector3::ZERO;
     Ogre::Vector3 initial_position = Ogre::Vector3::ZERO;

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -729,7 +729,7 @@ bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogr
         int race_id = res.size() > 1 ? StringConverter::parseInt(res[1], -1) : -1;
         m_map_entities.push_back(SurveyMapEntity(type, /*caption:*/type, fmt::format("icon_{}.dds", type), /*resource_group:*/"", object->position, Ogre::Radian(0), race_id));
     }
-    else if (!object->type.empty())
+    else if (object->type != "" && object->type != "-")
     {
         String caption = "";
         if (object->type == "station" || object->type == "hotel" || object->type == "village" ||


### PR DESCRIPTION
Broken in 3b681f3 - the 'type' parameter from TOBJ file was given a default placeholder value "-" to export correctly, but surveymap expected empty string where icon wasn't desired.

Fixes #3221 