### PR TITLE
Fixed GenericDocument incorrectly parsing filenames (" " vs "_" substitution)

### DIFF
--- a/doc/angelscript/Script2Game/GenericDocumentClass.h
+++ b/doc/angelscript/Script2Game/GenericDocumentClass.h
@@ -17,8 +17,7 @@ enum GenericDocumentOptions
     GENERIC_DOCUMENT_OPTION_PARENTHESES_CAPTURE_SPACES, //!< If non-empty NAKED string encounters '(', following spaces will be captured until matching ')' is found.    
     GENERIC_DOCUMENT_OPTION_ALLOW_BRACED_KEYWORDS, //!< Allow INI-like '[keyword]' tokens.
     GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_EQUALS, //!< Allow '=' as separator between tokens.
-    GENERIC_DOCUMENT_OPTION_ALLOW_HASH_COMMENTS, //!< Allow comments starting with `#`.
-    GENERIC_DOCUMENT_OPTION_NAKEDSTR_USCORES_TO_SPACES //!< Only for OPTION_ALLOW_NAKED_STRINGS: Replace underscores with spaces in naked strings (classic behavior of the truck format).
+    GENERIC_DOCUMENT_OPTION_ALLOW_HASH_COMMENTS //!< Allow comments starting with `#`.     
 };
 
 /**

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1342,8 +1342,7 @@ void CacheSystem::FillGadgetDetailInfo(CacheEntryPtr& entry, Ogre::DataStreamPtr
     GenericDocumentPtr doc = new GenericDocument();
     BitMask_t options 
         = GenericDocument::OPTION_ALLOW_SLASH_COMMENTS 
-        | GenericDocument::OPTION_ALLOW_NAKED_STRINGS
-        | GenericDocument::OPTION_NAKEDSTR_USCORES_TO_SPACES;
+        | GenericDocument::OPTION_ALLOW_NAKED_STRINGS;
     doc->loadFromDataStream(ds, options);
 
     GenericDocContextPtr ctx = new GenericDocContext(doc);

--- a/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
+++ b/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
@@ -64,7 +64,6 @@ void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_BRACED_KEYWORDS", GenericDocument::OPTION_ALLOW_BRACED_KEYWORDS);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_EQUALS", GenericDocument::OPTION_ALLOW_SEPARATOR_EQUALS);
     engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_ALLOW_HASH_COMMENTS", GenericDocument::OPTION_ALLOW_HASH_COMMENTS);
-    engine->RegisterEnumValue("GenericDocumentOptions", "GENERIC_DOCUMENT_OPTION_NAKEDSTR_USCORES_TO_SPACES", GenericDocument::OPTION_NAKEDSTR_USCORES_TO_SPACES);
 
 
     // class GenericDocument

--- a/source/main/utils/GenericFileFormat.cpp
+++ b/source/main/utils/GenericFileFormat.cpp
@@ -408,17 +408,6 @@ void DocumentParser::UpdateString(const char c)
         line_pos++;
         break;
 
-    case '_':
-        if (partial_tok_type == PartialToken::STRING_NAKED
-            && options & GenericDocument::OPTION_NAKEDSTR_USCORES_TO_SPACES)
-        {
-            tok.push_back(' ');
-        }
-        else
-        {
-            tok.push_back(c);
-        }
-
     default:
         tok.push_back(c);
         line_pos++;

--- a/source/main/utils/GenericFileFormat.h
+++ b/source/main/utils/GenericFileFormat.h
@@ -72,8 +72,7 @@ struct GenericDocument: public RefCountingObject<GenericDocument>
     static const BitMask_t OPTION_PARENTHESES_CAPTURE_SPACES = BITMASK(5); //!< If non-empty NAKED string encounters '(', following spaces will be captured until matching ')' is found.
     static const BitMask_t OPTION_ALLOW_BRACED_KEYWORDS = BITMASK(6); //!< Allow INI-like '[keyword]' tokens.
     static const BitMask_t OPTION_ALLOW_SEPARATOR_EQUALS = BITMASK(7); //!< Allow '=' as separator between tokens.
-    static const BitMask_t OPTION_ALLOW_HASH_COMMENTS = BITMASK(8); //!< Allow comments starting with `#`.
-    static const BitMask_t OPTION_NAKEDSTR_USCORES_TO_SPACES = BITMASK(9); //!< Only for OPTION_ALLOW_NAKED_STRINGS: Replace underscores with spaces in naked strings (classic behavior of the truck format).
+    static const BitMask_t OPTION_ALLOW_HASH_COMMENTS = BITMASK(8); //!< Allow comments starting with `#`. 
 
     virtual ~GenericDocument() {};
 


### PR DESCRIPTION
This reverts commit 00fbddd65faeb237c27f9b189a80be4f87305d09 "GenericFileFormat: new `OPTION_NAKEDSTR_USCORES_TO_SPACES`"

Reason: The majority of strings doesn't expect this transformation (i.e. filenames or identifiers) so this completely breaks i.e. addonpart file parsing.

Fixes #3251