### PR TITLE
Converted shader 'nicemetal.cg' to HLSL/GLSL.

### DIFF
--- a/resources/managed_materials/CgConversionsMM.txt
+++ b/resources/managed_materials/CgConversionsMM.txt
@@ -1,0 +1,26 @@
+
+-- hlsl --
+
+cgc -profile hlslv -entry main_nicemetal_vp nicemetal_mm.cg >> mm_nicemetal_vert.hlsl
+cgc -profile hlslf -entry main_nicemetal_fp nicemetal_mm.cg >> mm_nicemetal_frag.hlsl
+cgc -profile hlslf -entry main_nicemetal_transp_fp nicemetal_mm.cg >> mm_nicemetal_transp_frag.hlsl
+cgc -profile hlslf -entry main_nicemetal_fp_nodmg nicemetal_mm.cg >> mm_nicemetal_nodmg_frag.hlsl
+cgc -profile hlslf -entry main_nicemetal_transp_fp_nodmg nicemetal_mm.cg >> mm_nicemetal_transp_nodmg_frag.hlsl
+cgc -profile hlslv -entry reflect_nicemetal_vp nicemetal_mm.cg >> mm_reflect_nicemetal_vert.hlsl
+cgc -profile hlslf -entry reflect_nicemetal_fp nicemetal_mm.cg >> mm_reflect_nicemetal_frag.hlsl
+cgc -profile hlslf -entry reflect_nicemetal_nocolor_fp nicemetal_mm.cg >> mm_reflect_nicemetal_nocolor_frag.hlsl
+cgc -profile hlslf -entry main_simplemetal_fp nicemetal_mm.cg >> mm_simplemetal_frag.hlsl
+cgc -profile hlslf -entry main_simplemetal_transp_fp nicemetal_mm.cg >> mm_simplemetal_transp_frag.hlsl
+
+-- glsl --
+
+cgc -profile glslv -entry main_nicemetal_vp nicemetal_mm.cg >> mm_nicemetal_vert.glsl
+cgc -profile glslf -entry main_nicemetal_fp nicemetal_mm.cg >> mm_nicemetal_frag.glsl
+cgc -profile glslf -entry main_nicemetal_transp_fp nicemetal_mm.cg >> mm_nicemetal_transp_frag.glsl
+cgc -profile glslf -entry main_nicemetal_fp_nodmg nicemetal_mm.cg >> mm_nicemetal_nodmg_frag.glsl
+cgc -profile glslf -entry main_nicemetal_transp_fp_nodmg nicemetal_mm.cg >> mm_nicemetal_transp_nodmg_frag.glsl
+cgc -profile glslv -entry reflect_nicemetal_vp nicemetal_mm.cg >> mm_reflect_nicemetal_vert.glsl
+cgc -profile glslf -entry reflect_nicemetal_fp nicemetal_mm.cg >> mm_reflect_nicemetal_frag.glsl
+cgc -profile glslf -entry reflect_nicemetal_nocolor_fp nicemetal_mm.cg >> mm_reflect_nicemetal_nocolor_frag.glsl
+cgc -profile glslf -entry main_simplemetal_fp nicemetal_mm.cg >> mm_simplemetal_frag.glsl
+cgc -profile glslf -entry main_simplemetal_transp_fp nicemetal_mm.cg >> mm_simplemetal_transp_frag.glsl

--- a/resources/managed_materials/managed_mats_vehicles_nicemetal.material
+++ b/resources/managed_materials/managed_mats_vehicles_nicemetal.material
@@ -2,9 +2,9 @@ import * from "shadows.material"
 
 material managed/flexmesh_standard/specularonly_nicemetal
 {
-    technique BaseTechnique
+    technique BaseTechnique_hlsl
     {
-        pass BaseRender
+        pass BaseRender_hlsl
         {
             // Makes the pixel shader alpha output be used for alpha blending
             scene_blend alpha_blend
@@ -12,11 +12,11 @@ material managed/flexmesh_standard/specularonly_nicemetal
             //specular 0.5 0.5 0.5 1 12.5
 
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_VS_mm
+            vertex_program_ref NiceMetal_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-            fragment_program_ref NiceMetal_PS_nodmg_mm
+            fragment_program_ref NiceMetal_PS_nodmg_mm_hlsl
             {
             }
            texture_unit Diffuse_Map
@@ -31,18 +31,18 @@ material managed/flexmesh_standard/specularonly_nicemetal
                 texture_alias specular_tex
                 tex_coord_set 1
             }
-        }
-        pass Specular
+        } 
+        pass Specular_hlsl
         {
             scene_blend add
             diffuse vertexcolour
   
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_Reflect_VS_mm
+            vertex_program_ref NiceMetal_Reflect_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-             fragment_program_ref NiceMetal_Reflect_PS_mm
+             fragment_program_ref NiceMetal_Reflect_PS_mm_hlsl
               {
               }
               texture_unit Specular_Map
@@ -58,14 +58,11 @@ material managed/flexmesh_standard/specularonly_nicemetal
                   tex_coord_set 1
               }
           }
+    
     }
-}
-
-material managed/flexmesh_standard/speculardamage_nicemetal
-{
-    technique BaseTechnique
+    technique BaseTechnique_glsl
     {
-        pass BaseRender
+        pass BaseRender_glsl
         {
             // Makes the pixel shader alpha output be used for alpha blending
             scene_blend alpha_blend
@@ -73,11 +70,72 @@ material managed/flexmesh_standard/speculardamage_nicemetal
             //specular 0.5 0.5 0.5 1 12.5
 
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_VS_mm
+            vertex_program_ref NiceMetal_VS_mm_glsl
             {
             }
             // Make this pass use the pixel shader
-            fragment_program_ref NiceMetal_PS_mm
+            fragment_program_ref NiceMetal_PS_nodmg_mm_glsl
+            {
+            }
+           texture_unit Diffuse_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture unknown.dds
+                tex_coord_set 0
+            }
+            texture_unit Specular_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture_alias specular_tex
+                tex_coord_set 1
+            }
+        }       
+        pass Specular_glsl
+        {
+            scene_blend add
+            diffuse vertexcolour
+  
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_Reflect_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+             fragment_program_ref NiceMetal_Reflect_PS_mm_glsl
+              {
+              }
+              texture_unit Specular_Map
+              {
+                  // This pass will use this 2D texture as its input
+                  texture_alias specular_tex
+                  tex_coord_set 0
+              }
+              texture_unit envmaptex
+              {
+                  cubic_texture EnvironmentTexture combinedUVW
+                  tex_address_mode clamp
+                  tex_coord_set 1
+              }
+          }          
+    }
+}
+
+material managed/flexmesh_standard/speculardamage_nicemetal
+{
+    technique BaseTechnique_hlsl
+    {
+        pass BaseRender_hlsl
+        {
+            // Makes the pixel shader alpha output be used for alpha blending
+            scene_blend alpha_blend
+            diffuse vertexcolour
+            //specular 0.5 0.5 0.5 1 12.5
+
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_VS_mm_hlsl
+            {
+            }
+            // Make this pass use the pixel shader
+            fragment_program_ref NiceMetal_PS_mm_hlsl
             {
             }
            texture_unit Diffuse_Map
@@ -99,17 +157,83 @@ material managed/flexmesh_standard/speculardamage_nicemetal
                 tex_coord_set 2
             }
         }
-        pass Specular
+        
+        
+        pass Specular_hlsl
         {
             scene_blend add
             diffuse vertexcolour
   
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_Reflect_VS_mm
+            vertex_program_ref NiceMetal_Reflect_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-             fragment_program_ref NiceMetal_Reflect_PS_mm
+             fragment_program_ref NiceMetal_Reflect_PS_mm_hlsl
+              {
+              }
+              texture_unit Specular_Map
+              {
+                  // This pass will use this 2D texture as its input
+                  texture_alias specular_tex
+                  tex_coord_set 0
+              }
+              texture_unit envmaptex
+              {
+                  cubic_texture EnvironmentTexture combinedUVW
+                  tex_address_mode clamp
+                  tex_coord_set 1
+              }
+          }
+    }
+    
+    technique BaseTechnique_glsl
+    {
+        pass BaseRender_glsl
+        {
+            // Makes the pixel shader alpha output be used for alpha blending
+            scene_blend alpha_blend
+            diffuse vertexcolour
+            //specular 0.5 0.5 0.5 1 12.5
+
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+            fragment_program_ref NiceMetal_PS_mm_glsl
+            {
+            }
+           texture_unit Diffuse_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture unknown.dds
+                tex_coord_set 0
+            }
+            texture_unit Specular_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture_alias specular_tex
+                tex_coord_set 1
+            }
+            texture_unit Dmg_Diffuse_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture unknown.dds 2d
+                tex_coord_set 2
+            }
+        }       
+        pass Specular_glsl
+        {
+            scene_blend add
+            diffuse vertexcolour
+  
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_Reflect_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+             fragment_program_ref NiceMetal_Reflect_PS_mm_glsl
               {
               }
               texture_unit Specular_Map
@@ -130,19 +254,19 @@ material managed/flexmesh_standard/speculardamage_nicemetal
 
 material managed/mesh_standard/specular_nicemetal
 {
-    technique BaseTechnique
+    technique BaseTechnique_hlsl
     {
-        pass BaseRender
+        pass BaseRender_hlsl
         {
             // Makes the pixel shader alpha output be used for alpha blending
             scene_blend alpha_blend
 
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_VS_mm
+            vertex_program_ref NiceMetal_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-            fragment_program_ref SimpleMetal_PS_mm
+            fragment_program_ref SimpleMetal_PS_mm_hlsl
             {
             }
            texture_unit Diffuse_Map
@@ -158,16 +282,75 @@ material managed/mesh_standard/specular_nicemetal
                 tex_coord_set 1
             }
         }
-        pass Specular
+        
+
+        
+        pass Specular_hlsl
         {
             scene_blend add
             
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_Reflect_VS_mm
+            vertex_program_ref NiceMetal_Reflect_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-             fragment_program_ref NiceMetal_Reflect_nocolor_PS_mm
+             fragment_program_ref NiceMetal_Reflect_nocolor_PS_mm_hlsl
+              {
+              }
+              texture_unit Specular_Map
+              {
+                  // This pass will use this 2D texture as its input
+                  texture_alias specular_tex
+                  tex_coord_set 0
+              }
+              texture_unit envmaptex
+              {
+                  cubic_texture EnvironmentTexture combinedUVW
+                  tex_address_mode clamp
+                  tex_coord_set 1
+              }
+        }
+    }
+    
+    technique BaseTechnique_glsl
+    {
+        pass BaseRender_glsl
+        {
+            // Makes the pixel shader alpha output be used for alpha blending
+            scene_blend alpha_blend
+
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+            fragment_program_ref SimpleMetal_PS_mm_glsl
+            {
+            }
+           texture_unit Diffuse_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture_alias unknown.dds
+                tex_coord_set 0
+            }
+            texture_unit Specular_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture_alias specular_tex
+                tex_coord_set 1
+            }
+        }    
+    
+        pass Specular_glsl
+        {
+            scene_blend add
+            
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_Reflect_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+             fragment_program_ref NiceMetal_Reflect_nocolor_PS_mm_glsl
               {
               }
               texture_unit Specular_Map

--- a/resources/managed_materials/managed_mats_vehicles_transparent_nicemetal.material
+++ b/resources/managed_materials/managed_mats_vehicles_transparent_nicemetal.material
@@ -2,9 +2,9 @@ import * from "shadows.material"
 
 material managed/flexmesh_transparent/specularonly_nicemetal
 {
-    technique BaseTechnique
+    technique BaseTechnique_hlsl
     {
-        pass BaseRender
+        pass BaseRender_hlsl
         {
 			alpha_rejection greater 0
 			depth_write off
@@ -14,11 +14,11 @@ material managed/flexmesh_transparent/specularonly_nicemetal
             //specular 0.5 0.5 0.5 1 12.5
 
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_VS_mm
+            vertex_program_ref NiceMetal_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-            fragment_program_ref NiceMetal_transp_PS_nodmg_mm
+            fragment_program_ref NiceMetal_transp_PS_nodmg_mm_hlsl
             {
             }
            texture_unit Diffuse_Map
@@ -34,18 +34,81 @@ material managed/flexmesh_transparent/specularonly_nicemetal
                 tex_coord_set 1
             }
         }
-        pass Specular
+
+        pass Specular_hlsl
         {
 			depth_write off
             scene_blend add
             diffuse vertexcolour
   
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_Reflect_VS_mm
+            vertex_program_ref NiceMetal_Reflect_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-             fragment_program_ref NiceMetal_Reflect_PS_mm
+             fragment_program_ref NiceMetal_Reflect_PS_mm_hlsl
+              {
+              }
+              texture_unit Specular_Map
+              {
+                  // This pass will use this 2D texture as its input
+                  texture_alias specular_tex
+                  tex_coord_set 0
+              }
+              texture_unit envmaptex
+              {
+                  cubic_texture EnvironmentTexture combinedUVW
+                  tex_address_mode clamp
+                  tex_coord_set 1
+              }
+          }
+    }
+    
+    technique BaseTechnique_glsl
+    {
+        pass BaseRender_glsl
+        {
+			alpha_rejection greater 0
+			depth_write off
+            // Makes the pixel shader alpha output be used for alpha blending
+            scene_blend alpha_blend
+            diffuse vertexcolour
+            //specular 0.5 0.5 0.5 1 12.5
+
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+            fragment_program_ref NiceMetal_transp_PS_nodmg_mm_glsl
+            {
+            }
+           texture_unit Diffuse_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture unknown.dds
+                tex_coord_set 0
+            }
+            texture_unit Specular_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture_alias specular_tex
+                tex_coord_set 1
+            }
+        }
+        
+        pass Specular_glsl
+        {
+			depth_write off
+            scene_blend add
+            diffuse vertexcolour
+  
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_Reflect_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+             fragment_program_ref NiceMetal_Reflect_PS_mm_glsl
               {
               }
               texture_unit Specular_Map
@@ -66,9 +129,9 @@ material managed/flexmesh_transparent/specularonly_nicemetal
 
 material managed/flexmesh_transparent/speculardamage_nicemetal
 {
-    technique BaseTechnique
+    technique BaseTechnique_hlsl
     {
-        pass BaseRender
+        pass BaseRender_hlsl
         {
 			alpha_rejection greater 0
 			depth_write off
@@ -79,11 +142,11 @@ material managed/flexmesh_transparent/speculardamage_nicemetal
             //specular 0.5 0.5 0.5 1 12.5
 
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_VS_mm
+            vertex_program_ref NiceMetal_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-            fragment_program_ref NiceMetal_transp_PS_mm
+            fragment_program_ref NiceMetal_transp_PS_mm_hlsl
             {
             }
            texture_unit Diffuse_Map
@@ -105,18 +168,89 @@ material managed/flexmesh_transparent/speculardamage_nicemetal
                 tex_coord_set 2
             }
         }
-        pass Specular
+        
+        
+        
+        pass Specular_hlsl
         {
 			depth_write off
             scene_blend add
             diffuse vertexcolour
   
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_Reflect_VS_mm
+            vertex_program_ref NiceMetal_Reflect_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-             fragment_program_ref NiceMetal_Reflect_PS_mm
+             fragment_program_ref NiceMetal_Reflect_PS_mm_hlsl
+              {
+              }
+              texture_unit Specular_Map
+              {
+                  // This pass will use this 2D texture as its input
+                  texture_alias specular_tex 2d
+                  tex_coord_set 0
+              }
+              texture_unit envmaptex
+              {
+                  cubic_texture EnvironmentTexture combinedUVW
+                  tex_address_mode clamp
+                  tex_coord_set 1
+              }
+          }
+    }
+    
+    technique BaseTechnique_glsl
+    {
+        pass BaseRender_glsl
+        {
+			alpha_rejection greater 0
+			depth_write off
+
+			// Makes the pixel shader alpha output be used for alpha blending
+            scene_blend alpha_blend
+            diffuse vertexcolour
+            //specular 0.5 0.5 0.5 1 12.5
+
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+            fragment_program_ref NiceMetal_transp_PS_mm_glsl
+            {
+            }
+           texture_unit Diffuse_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture unknown.dds
+                tex_coord_set 0
+            }
+            texture_unit Specular_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture_alias specular_tex
+                tex_coord_set 1
+            }
+            texture_unit Dmg_Diffuse_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture unknown.dds
+                tex_coord_set 2
+            }
+        }            
+        pass Specular_glsl
+        {
+			depth_write off
+            scene_blend add
+            diffuse vertexcolour
+  
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_Reflect_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+             fragment_program_ref NiceMetal_Reflect_PS_mm_glsl
               {
               }
               texture_unit Specular_Map
@@ -137,9 +271,9 @@ material managed/flexmesh_transparent/speculardamage_nicemetal
 
 material managed/mesh_transparent/specular_nicemetal
 {
-    technique BaseTechnique
+    technique BaseTechnique_hlsl
     {
-        pass BaseRender
+        pass BaseRender_hlsl
         {
 			alpha_rejection greater 0
 			depth_write off
@@ -147,11 +281,11 @@ material managed/mesh_transparent/specular_nicemetal
             scene_blend alpha_blend
 
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_VS_mm
+            vertex_program_ref NiceMetal_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-            fragment_program_ref SimpleMetal_transp_PS_mm
+            fragment_program_ref SimpleMetal_transp_PS_mm_hlsl
             {
             }
            texture_unit Diffuse_Map
@@ -167,17 +301,79 @@ material managed/mesh_transparent/specular_nicemetal
                 tex_coord_set 1
             }
         }
-        pass Specular
+        
+        
+        pass Specular_hlsl
         {
 			depth_write off
             scene_blend add
             
             // Make this pass use the vertex shader
-            vertex_program_ref NiceMetal_Reflect_VS_mm
+            vertex_program_ref NiceMetal_Reflect_VS_mm_hlsl
             {
             }
             // Make this pass use the pixel shader
-             fragment_program_ref NiceMetal_Reflect_nocolor_PS_mm
+             fragment_program_ref NiceMetal_Reflect_nocolor_PS_mm_hlsl
+              {
+              }
+              texture_unit Specular_Map
+              {
+                  // This pass will use this 2D texture as its input
+                  texture_alias specular_tex
+                  tex_coord_set 0
+              }
+              texture_unit envmaptex
+              {
+                  cubic_texture EnvironmentTexture combinedUVW
+                  tex_address_mode clamp
+                  tex_coord_set 1
+              }
+          }
+          
+    }
+    
+    technique BaseTechnique_glsl
+    {
+    pass BaseRender_glsl
+        {
+			alpha_rejection greater 0
+			depth_write off
+            // Makes the pixel shader alpha output be used for alpha blending
+            scene_blend alpha_blend
+
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+            fragment_program_ref SimpleMetal_transp_PS_mm_glsl
+            {
+            }
+           texture_unit Diffuse_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture unknown.dds 2d
+                tex_coord_set 0
+            }
+            texture_unit Specular_Map
+            {
+                // This pass will use this 2D texture as its input
+                texture_alias specular_tex
+                tex_coord_set 1
+            }
+        }
+        
+        pass Specular_glsl
+        {
+			depth_write off
+            scene_blend add
+            
+            // Make this pass use the vertex shader
+            vertex_program_ref NiceMetal_Reflect_VS_mm_glsl
+            {
+            }
+            // Make this pass use the pixel shader
+             fragment_program_ref NiceMetal_Reflect_nocolor_PS_mm_glsl
               {
               }
               texture_unit Specular_Map

--- a/resources/managed_materials/mm_nicemetal_frag.glsl
+++ b/resources/managed_materials/mm_nicemetal_frag.glsl
@@ -1,0 +1,109 @@
+
+// glslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslf
+//program main_nicemetal_fp
+//semantic main_nicemetal_fp.lightDiffuse
+//semantic main_nicemetal_fp.lightSpecular
+//semantic main_nicemetal_fp.exponent
+//semantic main_nicemetal_fp.ambient
+//semantic main_nicemetal_fp.Diffuse_Map : TEXUNIT0
+//semantic main_nicemetal_fp.Specular_Map : TEXUNIT1
+//semantic main_nicemetal_fp.Dmg_Diffuse_Map : TEXUNIT2
+//var float4 lightDiffuse :  : _lightDiffuse1 : 6 : 1
+//var float4 lightSpecular :  : _lightSpecular1 : 7 : 1
+//var float exponent :  : _exponent1 : 8 : 1
+//var float4 ambient :  : _ambient1 : 9 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : _Diffuse_Map1 0 : 10 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : _Specular_Map1 1 : 11 : 1
+//var sampler2D Dmg_Diffuse_Map : TEXUNIT2 : _Dmg_Diffuse_Map1 2 : 12 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEX0 : 0 : 1
+//var float4 incol : $vin.COLOR : COL0 : 1 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEX1 : 2 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEX2 : 3 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEX3 : 4 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEX4 : 5 : 1
+//var float4 oColor : $vout.COLOR : COL : 13 : 1
+
+#version 110
+
+vec4 _oColor1;
+vec4 _TMP2;
+vec4 _TMP1;
+vec4 _TMP0;
+float _TMP7;
+float _TMP5;
+float _TMP6;
+float _TMP4;
+float _TMP3;
+uniform vec4 _lightDiffuse1;
+uniform vec4 _lightSpecular1;
+uniform float _exponent1;
+uniform vec4 _ambient1;
+uniform sampler2D _Diffuse_Map1;
+uniform sampler2D _Specular_Map1;
+uniform sampler2D _Dmg_Diffuse_Map1;
+vec3 _v0022;
+vec3 _v0028;
+vec3 _v0034;
+vec4 _TMP43;
+vec4 _tmp0044;
+vec4 _a0060;
+vec4 _b0060;
+
+ // main procedure, the original name was main_nicemetal_fp
+void main()
+{
+
+    vec3 _N;
+    vec3 _EyeDir;
+    vec3 _LightDir;
+    vec3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    vec4 _textColour;
+    vec4 _specColour;
+
+    _TMP3 = dot(gl_TexCoord[1].xyz, gl_TexCoord[1].xyz);
+    _TMP4 = inversesqrt(_TMP3);
+    _N = _TMP4*gl_TexCoord[1].xyz;
+    _v0022 = gl_TexCoord[3].xyz - gl_TexCoord[0].xyz;
+    _TMP3 = dot(_v0022, _v0022);
+    _TMP4 = inversesqrt(_TMP3);
+    _EyeDir = _TMP4*_v0022;
+    _v0028 = gl_TexCoord[2].xyz - (gl_TexCoord[0]*gl_TexCoord[2].w).xyz;
+    _TMP3 = dot(_v0028, _v0028);
+    _TMP4 = inversesqrt(_TMP3);
+    _LightDir = _TMP4*_v0028;
+    _v0034 = _LightDir + _EyeDir;
+    _TMP3 = dot(_v0034, _v0034);
+    _TMP4 = inversesqrt(_TMP3);
+    _HalfAngle = _TMP4*_v0034;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0044 = vec4(_NdotL, _NdotH, _exponent1, _exponent1);
+    if (_tmp0044.x > 0.00000000E+000) { // if begin
+        _TMP6 = max(0.00000000E+000, _tmp0044.y);
+        _TMP5 = pow(_TMP6, _tmp0044.z);
+    } else {
+        _TMP5 = 0.00000000E+000;
+    } // end if
+    _TMP7 = max(0.00000000E+000, _tmp0044.x);
+    _TMP43 = vec4(1.00000000E+000, _TMP7, _TMP5, 1.00000000E+000);
+    _TMP0 = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _textColour = _TMP0*(1.00000000E+000 - gl_Color.w);
+    _TMP1 = texture2D(_Dmg_Diffuse_Map1, gl_TexCoord[4].xy);
+    _textColour = _textColour + _TMP1*gl_Color.w;
+    _textColour = _textColour*(1.00000000E+000 - gl_Color.z/3.00000000E+000);
+    _TMP2 = texture2D(_Specular_Map1, gl_TexCoord[4].xy);
+    _specColour = (_TMP2 + gl_Color.z/3.00000000E+000) - gl_Color.w/2.00000000E+000;
+    _a0060 = (_lightDiffuse1*_textColour)*_TMP43.y + _textColour*_ambient1;
+    _b0060 = _lightSpecular1*_TMP43.z;
+    _oColor1 = _a0060 + _specColour*(_b0060 - _a0060);
+    _oColor1.w = 1.00000000E+000;
+    gl_FragColor = _oColor1;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_frag.hlsl
+++ b/resources/managed_materials/mm_nicemetal_frag.hlsl
@@ -1,0 +1,109 @@
+
+// hlslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile hlslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile hlslf
+//program main_nicemetal_fp
+//semantic main_nicemetal_fp.lightDiffuse
+//semantic main_nicemetal_fp.lightSpecular
+//semantic main_nicemetal_fp.exponent
+//semantic main_nicemetal_fp.ambient
+//semantic main_nicemetal_fp.Diffuse_Map : TEXUNIT0
+//semantic main_nicemetal_fp.Specular_Map : TEXUNIT1
+//semantic main_nicemetal_fp.DmgDiffuse_Map : TEXUNIT2
+//var float4 lightDiffuse :  : lightDiffuse : 6 : 1
+//var float4 lightSpecular :  : lightSpecular : 7 : 1
+//var float exponent :  : exponent : 8 : 1
+//var float4 ambient :  : ambient : 9 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : Diffuse_Map 0 : 10 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : Specular_Map 1 : 11 : 1
+//var sampler2D DmgDiffuse_Map : TEXUNIT2 : DmgDiffuse_Map 2 : 12 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEXCOORD0 : 0 : 1
+//var float4 incol : $vin.COLOR : COLOR : 1 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEXCOORD1 : 2 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEXCOORD2 : 3 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEXCOORD3 : 4 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEXCOORD4 : 5 : 1
+//var float4 oColor : $vout.COLOR : COLOR : 13 : 1
+
+#pragma pack_matrix(row_major)
+
+
+
+ // main procedure, the original name was main_nicemetal_fp
+void main(in float4 _pos : TEXCOORD0, in float4 _incol : COLOR0, in float3 _normal : TEXCOORD1, in float4 _lightpos : TEXCOORD2, in float3 _eyepos : TEXCOORD3, in float2 _uv : TEXCOORD4, 
+    uniform float4 lightDiffuse,
+    uniform float4 lightSpecular, 
+    uniform float exponent, 
+    uniform float4 ambient, 
+    uniform sampler2D Diffuse_Map : TEXUNIT0, 
+    uniform sampler2D Specular_Map : TEXUNIT1, 
+    uniform sampler2D DmgDiffuse_Map : TEXUNIT2,
+    out float4 _oColor : COLOR0)
+{
+float4 _TMP2;
+float4 _TMP1;
+float4 _TMP0;
+float _TMP7;
+float _TMP5;
+float _TMP6;
+float _TMP4;
+float _TMP3;
+float3 _v0011;
+float3 _v0013;
+float3 _v0015;
+float4 _TMP16;
+float4 _tmp0017;
+float4 _a0021;
+float4 _b0021;
+
+    float3 _N;
+    float3 _EyeDir;
+    float3 _LightDir;
+    float3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    float4 _textColour;
+    float4 _specColour;
+
+    _TMP3 = dot(_normal, _normal);
+    _TMP4 = rsqrt(_TMP3);
+    _N = _TMP4*_normal;
+    _v0011 = _eyepos - _pos.xyz;
+    _TMP3 = dot(_v0011, _v0011);
+    _TMP4 = rsqrt(_TMP3);
+    _EyeDir = _TMP4*_v0011;
+    _v0013 = _lightpos.xyz - (_pos*_lightpos.w).xyz;
+    _TMP3 = dot(_v0013, _v0013);
+    _TMP4 = rsqrt(_TMP3);
+    _LightDir = _TMP4*_v0013;
+    _v0015 = _LightDir + _EyeDir;
+    _TMP3 = dot(_v0015, _v0015);
+    _TMP4 = rsqrt(_TMP3);
+    _HalfAngle = _TMP4*_v0015;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0017 = float4(_NdotL, _NdotH, exponent, exponent);
+    if (_tmp0017.x >  0.00000000000000000E000f) { // if begin
+        _TMP6 = max( 0.00000000000000000E000f, _tmp0017.y);
+        _TMP5 = pow(_TMP6, _tmp0017.z);
+    } else {
+        _TMP5 =  0.00000000000000000E000f;
+    } // end if
+    _TMP7 = max( 0.00000000000000000E000f, _tmp0017.x);
+    _TMP16 = float4( 1.00000000000000000E000f, _TMP7, _TMP5,  1.00000000000000000E000f);
+    _TMP0 = tex2D(Diffuse_Map, _uv);
+    _textColour = _TMP0*( 1.00000000000000000E000f - _incol.w);
+    _TMP1 = tex2D(DmgDiffuse_Map, _uv);
+    _textColour = _textColour + _TMP1*_incol.w;
+    _textColour = _textColour*( 1.00000000000000000E000f - _incol.z/ 3.00000000000000000E000f);
+    _TMP2 = tex2D(Specular_Map, _uv);
+    _specColour = (_TMP2 + _incol.z/ 3.00000000000000000E000f) - _incol.w/ 2.00000000000000000E000f;
+    _a0021 = (lightDiffuse*_textColour)*_TMP16.y + _textColour*ambient;
+    _b0021 = lightSpecular*_TMP16.z;
+    _oColor = _a0021 + _specColour*(_b0021 - _a0021);
+    _oColor.w =  1.00000000000000000E000f;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_nodmg_frag.glsl
+++ b/resources/managed_materials/mm_nicemetal_nodmg_frag.glsl
@@ -1,0 +1,101 @@
+
+// glslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslf
+//program main_nicemetal_fp_nodmg
+//semantic main_nicemetal_fp_nodmg.lightDiffuse
+//semantic main_nicemetal_fp_nodmg.lightSpecular
+//semantic main_nicemetal_fp_nodmg.exponent
+//semantic main_nicemetal_fp_nodmg.ambient
+//semantic main_nicemetal_fp_nodmg.Diffuse_Map : TEXUNIT0
+//semantic main_nicemetal_fp_nodmg.Specular_Map : TEXUNIT1
+//var float4 lightDiffuse :  : _lightDiffuse1 : 6 : 1
+//var float4 lightSpecular :  : _lightSpecular1 : 7 : 1
+//var float exponent :  : _exponent1 : 8 : 1
+//var float4 ambient :  : _ambient1 : 9 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : _Diffuse_Map1 0 : 10 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : _Specular_Map1 1 : 11 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEX0 : 0 : 1
+//var float4 incol : $vin.COLOR : COL0 : 1 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEX1 : 2 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEX2 : 3 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEX3 : 4 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEX4 : 5 : 1
+//var float4 oColor : $vout.COLOR : COL : 12 : 1
+
+#version 110
+
+vec4 _oColor1;
+vec4 _TMP0;
+float _TMP5;
+float _TMP3;
+float _TMP4;
+float _TMP2;
+float _TMP1;
+uniform vec4 _lightDiffuse1;
+uniform vec4 _lightSpecular1;
+uniform float _exponent1;
+uniform vec4 _ambient1;
+uniform sampler2D _Diffuse_Map1;
+uniform sampler2D _Specular_Map1;
+vec3 _v0019;
+vec3 _v0025;
+vec3 _v0031;
+vec4 _TMP40;
+vec4 _tmp0041;
+vec4 _a0055;
+vec4 _b0055;
+
+ // main procedure, the original name was main_nicemetal_fp_nodmg
+void main()
+{
+
+    vec3 _N;
+    vec3 _EyeDir;
+    vec3 _LightDir;
+    vec3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    vec4 _textColour;
+    vec4 _specColour;
+
+    _TMP1 = dot(gl_TexCoord[1].xyz, gl_TexCoord[1].xyz);
+    _TMP2 = inversesqrt(_TMP1);
+    _N = _TMP2*gl_TexCoord[1].xyz;
+    _v0019 = gl_TexCoord[3].xyz - gl_TexCoord[0].xyz;
+    _TMP1 = dot(_v0019, _v0019);
+    _TMP2 = inversesqrt(_TMP1);
+    _EyeDir = _TMP2*_v0019;
+    _v0025 = gl_TexCoord[2].xyz - (gl_TexCoord[0]*gl_TexCoord[2].w).xyz;
+    _TMP1 = dot(_v0025, _v0025);
+    _TMP2 = inversesqrt(_TMP1);
+    _LightDir = _TMP2*_v0025;
+    _v0031 = _LightDir + _EyeDir;
+    _TMP1 = dot(_v0031, _v0031);
+    _TMP2 = inversesqrt(_TMP1);
+    _HalfAngle = _TMP2*_v0031;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0041 = vec4(_NdotL, _NdotH, _exponent1, _exponent1);
+    if (_tmp0041.x > 0.00000000E+000) { // if begin
+        _TMP4 = max(0.00000000E+000, _tmp0041.y);
+        _TMP3 = pow(_TMP4, _tmp0041.z);
+    } else {
+        _TMP3 = 0.00000000E+000;
+    } // end if
+    _TMP5 = max(0.00000000E+000, _tmp0041.x);
+    _TMP40 = vec4(1.00000000E+000, _TMP5, _TMP3, 1.00000000E+000);
+    _textColour = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _textColour = _textColour*(1.00000000E+000 - gl_Color.z/3.00000000E+000);
+    _TMP0 = texture2D(_Specular_Map1, gl_TexCoord[4].xy);
+    _specColour = (_TMP0 + gl_Color.z/3.00000000E+000) - gl_Color.w/2.00000000E+000;
+    _a0055 = (_lightDiffuse1*_textColour)*_TMP40.y + _textColour*_ambient1;
+    _b0055 = _lightSpecular1*_TMP40.z;
+    _oColor1 = _a0055 + _specColour*(_b0055 - _a0055);
+    _oColor1.w = 1.00000000E+000;
+    gl_FragColor = _oColor1;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_nodmg_frag.hlsl
+++ b/resources/managed_materials/mm_nicemetal_nodmg_frag.hlsl
@@ -1,0 +1,101 @@
+
+// hlslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile hlslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile hlslf
+//program main_nicemetal_fp_nodmg
+//semantic main_nicemetal_fp_nodmg.lightDiffuse
+//semantic main_nicemetal_fp_nodmg.lightSpecular
+//semantic main_nicemetal_fp_nodmg.exponent
+//semantic main_nicemetal_fp_nodmg.ambient
+//semantic main_nicemetal_fp_nodmg.Diffuse_Map : TEXUNIT0
+//semantic main_nicemetal_fp_nodmg.Specular_Map : TEXUNIT1
+//var float4 lightDiffuse :  : lightDiffuse : 6 : 1
+//var float4 lightSpecular :  : lightSpecular : 7 : 1
+//var float exponent :  : exponent : 8 : 1
+//var float4 ambient :  : ambient : 9 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : Diffuse_Map 0 : 10 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : Specular_Map 1 : 11 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEXCOORD0 : 0 : 1
+//var float4 incol : $vin.COLOR : COLOR : 1 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEXCOORD1 : 2 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEXCOORD2 : 3 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEXCOORD3 : 4 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEXCOORD4 : 5 : 1
+//var float4 oColor : $vout.COLOR : COLOR : 12 : 1
+
+#pragma pack_matrix(row_major)
+
+
+
+ // main procedure, the original name was main_nicemetal_fp_nodmg
+void main(in float4 _pos : TEXCOORD0, in float4 _incol : COLOR0, in float3 _normal : TEXCOORD1, in float4 _lightpos : TEXCOORD2, in float3 _eyepos : TEXCOORD3, in float2 _uv : TEXCOORD4, 
+    uniform float4 lightDiffuse, 
+    uniform float4 lightSpecular, 
+    uniform float exponent, 
+    uniform float4 ambient, 
+    uniform sampler2D Diffuse_Map : TEXUNIT0, 
+    uniform sampler2D Specular_Map : TEXUNIT1, 
+    out float4 _oColor : COLOR0)
+{
+float4 _TMP0;
+float _TMP5;
+float _TMP3;
+float _TMP4;
+float _TMP2;
+float _TMP1;
+float3 _v0009;
+float3 _v0011;
+float3 _v0013;
+float4 _TMP14;
+float4 _tmp0015;
+float4 _a0019;
+float4 _b0019;
+
+    float3 _N;
+    float3 _EyeDir;
+    float3 _LightDir;
+    float3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    float4 _textColour;
+    float4 _specColour;
+
+    _TMP1 = dot(_normal, _normal);
+    _TMP2 = rsqrt(_TMP1);
+    _N = _TMP2*_normal;
+    _v0009 = _eyepos - _pos.xyz;
+    _TMP1 = dot(_v0009, _v0009);
+    _TMP2 = rsqrt(_TMP1);
+    _EyeDir = _TMP2*_v0009;
+    _v0011 = _lightpos.xyz - (_pos*_lightpos.w).xyz;
+    _TMP1 = dot(_v0011, _v0011);
+    _TMP2 = rsqrt(_TMP1);
+    _LightDir = _TMP2*_v0011;
+    _v0013 = _LightDir + _EyeDir;
+    _TMP1 = dot(_v0013, _v0013);
+    _TMP2 = rsqrt(_TMP1);
+    _HalfAngle = _TMP2*_v0013;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0015 = float4(_NdotL, _NdotH, exponent, exponent);
+    if (_tmp0015.x >  0.00000000000000000E000f) { // if begin
+        _TMP4 = max( 0.00000000000000000E000f, _tmp0015.y);
+        _TMP3 = pow(_TMP4, _tmp0015.z);
+    } else {
+        _TMP3 =  0.00000000000000000E000f;
+    } // end if
+    _TMP5 = max( 0.00000000000000000E000f, _tmp0015.x);
+    _TMP14 = float4( 1.00000000000000000E000f, _TMP5, _TMP3,  1.00000000000000000E000f);
+    _textColour = tex2D(Diffuse_Map, _uv);
+    _textColour = _textColour*( 1.00000000000000000E000f - _incol.z/ 3.00000000000000000E000f);
+    _TMP0 = tex2D(Specular_Map, _uv);
+    _specColour = (_TMP0 + _incol.z/ 3.00000000000000000E000f) - _incol.w/ 2.00000000000000000E000f;
+    _a0019 = (lightDiffuse*_textColour)*_TMP14.y + _textColour*ambient;
+    _b0019 = lightSpecular*_TMP14.z;
+    _oColor = _a0019 + _specColour*(_b0019 - _a0019);
+    _oColor.w =  1.00000000000000000E000f;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_reflect_frag.glsl
+++ b/resources/managed_materials/mm_nicemetal_reflect_frag.glsl
@@ -1,0 +1,51 @@
+
+// glslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslf
+//program reflect_nicemetal_fp
+//semantic reflect_nicemetal_fp.Specular_Map : TEXUNIT0
+//semantic reflect_nicemetal_fp.cubeMap : TEXUNIT1
+//var sampler2D Specular_Map : TEXUNIT0 : _Specular_Map1 0 : 5 : 1
+//var samplerCUBE cubeMap : TEXUNIT1 : _cubeMap1 1 : 6 : 1
+//var float2 uv : $vin.TEXCOORD0 : TEX0 : 0 : 1
+//var float3 viewDirection : $vin.TEXCOORD1 : TEX1 : 1 : 1
+//var float3 normal : $vin.TEXCOORD2 : TEX2 : 2 : 1
+//var float4 incol : $vin.COLOR : COL0 : 3 : 1
+//var float4 oColor : $vout.COLOR : COL : 4 : 1
+
+#version 110
+
+vec4 _oColor1;
+vec4 _TMP0;
+float _TMP3;
+float _TMP2;
+float _TMP1;
+uniform sampler2D _Specular_Map1;
+uniform samplerCube _cubeMap1;
+
+ // main procedure, the original name was reflect_nicemetal_fp
+void main()
+{
+
+    vec3 _N;
+    vec3 _R;
+    vec4 _reflectedColor;
+    vec4 _emissiveColor;
+
+    _TMP1 = dot(gl_TexCoord[2].xyz, gl_TexCoord[2].xyz);
+    _TMP2 = inversesqrt(_TMP1);
+    _N = _TMP2*gl_TexCoord[2].xyz;
+    _TMP3 = dot(_N, gl_TexCoord[1].xyz);
+    _R = gl_TexCoord[1].xyz - (2.00000000E+000*_N)*_TMP3;
+    _R.z = -_R.z;
+    _reflectedColor = textureCube(_cubeMap1, _R);
+    _TMP0 = texture2D(_Specular_Map1, gl_TexCoord[0].xy);
+    _emissiveColor = (_TMP0 + gl_Color.z/3.00000000E+000) - gl_Color.w/2.00000000E+000;
+    _oColor1 = _reflectedColor*_emissiveColor;
+    _oColor1.w = 1.00000000E+000;
+    gl_FragColor = _oColor1;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_reflect_frag.hlsl
+++ b/resources/managed_materials/mm_nicemetal_reflect_frag.hlsl
@@ -1,0 +1,50 @@
+
+// hlslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile hlslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile hlslf
+//program reflect_nicemetal_fp
+//semantic reflect_nicemetal_fp.Specular_Map : TEXUNIT0
+//semantic reflect_nicemetal_fp.cubeMap : TEXUNIT1
+//var sampler2D Specular_Map : TEXUNIT0 : Specular_Map 0 : 5 : 1
+//var samplerCUBE cubeMap : TEXUNIT1 : cubeMap 1 : 6 : 1
+//var float2 uv : $vin.TEXCOORD0 : TEXCOORD0 : 0 : 1
+//var float3 viewDirection : $vin.TEXCOORD1 : TEXCOORD1 : 1 : 1
+//var float3 normal : $vin.TEXCOORD2 : TEXCOORD2 : 2 : 1
+//var float4 incol : $vin.COLOR : COLOR : 3 : 1
+//var float4 oColor : $vout.COLOR : COLOR : 4 : 1
+
+#pragma pack_matrix(row_major)
+
+
+
+ // main procedure, the original name was reflect_nicemetal_fp
+void main(in float2 _uv : TEXCOORD0, in float3 _viewDirection : TEXCOORD1, in float3 _normal : TEXCOORD2, in float4 _incol : COLOR0, out float4 _oColor : COLOR0, 
+    uniform sampler2D Specular_Map : TEXUNIT0, 
+    uniform samplerCUBE cubeMap : TEXUNIT1)
+{
+float4 _TMP0;
+float _TMP3;
+float _TMP2;
+float _TMP1;
+
+    float3 _N;
+    float3 _R;
+    float4 _reflectedColor;
+    float4 _emissiveColor;
+
+    _TMP1 = dot(_normal, _normal);
+    _TMP2 = rsqrt(_TMP1);
+    _N = _TMP2*_normal;
+    _TMP3 = dot(_N, _viewDirection);
+    _R = _viewDirection - ( 2.00000000000000000E000f*_N)*_TMP3;
+    _R.z = -_R.z;
+    _reflectedColor = texCUBE(cubeMap, _R);
+    _TMP0 = tex2D(Specular_Map, _uv);
+    _emissiveColor = (_TMP0 + _incol.z/ 3.00000000000000000E000f) - _incol.w/ 2.00000000000000000E000f;
+    _oColor = _reflectedColor*_emissiveColor;
+    _oColor.w =  1.00000000000000000E000f;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_reflect_nocolor_frag.glsl
+++ b/resources/managed_materials/mm_nicemetal_reflect_nocolor_frag.glsl
@@ -1,0 +1,48 @@
+
+// glslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslf
+//program reflect_nicemetal_nocolor_fp
+//semantic reflect_nicemetal_nocolor_fp.Specular_Map : TEXUNIT0
+//semantic reflect_nicemetal_nocolor_fp.cubeMap : TEXUNIT1
+//var sampler2D Specular_Map : TEXUNIT0 : _Specular_Map1 0 : 4 : 1
+//var samplerCUBE cubeMap : TEXUNIT1 : _cubeMap1 1 : 5 : 1
+//var float2 uv : $vin.TEXCOORD0 : TEX0 : 0 : 1
+//var float3 viewDirection : $vin.TEXCOORD1 : TEX1 : 1 : 1
+//var float3 normal : $vin.TEXCOORD2 : TEX2 : 2 : 1
+//var float4 oColor : $vout.COLOR : COL : 3 : 1
+
+#version 110
+
+vec4 _oColor1;
+float _TMP2;
+float _TMP1;
+float _TMP0;
+uniform sampler2D _Specular_Map1;
+uniform samplerCube _cubeMap1;
+
+ // main procedure, the original name was reflect_nicemetal_nocolor_fp
+void main()
+{
+
+    vec3 _N;
+    vec3 _R;
+    vec4 _reflectedColor;
+    vec4 _emissiveColor;
+
+    _TMP0 = dot(gl_TexCoord[2].xyz, gl_TexCoord[2].xyz);
+    _TMP1 = inversesqrt(_TMP0);
+    _N = _TMP1*gl_TexCoord[2].xyz;
+    _TMP2 = dot(_N, gl_TexCoord[1].xyz);
+    _R = gl_TexCoord[1].xyz - (2.00000000E+000*_N)*_TMP2;
+    _R.z = -_R.z;
+    _reflectedColor = textureCube(_cubeMap1, _R);
+    _emissiveColor = texture2D(_Specular_Map1, gl_TexCoord[0].xy);
+    _oColor1 = _reflectedColor*_emissiveColor;
+    _oColor1.w = 1.00000000E+000;
+    gl_FragColor = _oColor1;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_reflect_nocolor_frag.hlsl
+++ b/resources/managed_materials/mm_nicemetal_reflect_nocolor_frag.hlsl
@@ -1,0 +1,47 @@
+
+// hlslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile hlslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile hlslf
+//program reflect_nicemetal_nocolor_fp
+//semantic reflect_nicemetal_nocolor_fp.Specular_Map : TEXUNIT0
+//semantic reflect_nicemetal_nocolor_fp.cubeMap : TEXUNIT1
+//var sampler2D Specular_Map : TEXUNIT0 : Specular_Map 0 : 4 : 1
+//var samplerCUBE cubeMap : TEXUNIT1 : cubeMap 1 : 5 : 1
+//var float2 uv : $vin.TEXCOORD0 : TEXCOORD0 : 0 : 1
+//var float3 viewDirection : $vin.TEXCOORD1 : TEXCOORD1 : 1 : 1
+//var float3 normal : $vin.TEXCOORD2 : TEXCOORD2 : 2 : 1
+//var float4 oColor : $vout.COLOR : COLOR : 3 : 1
+
+#pragma pack_matrix(row_major)
+
+
+
+ // main procedure, the original name was reflect_nicemetal_nocolor_fp
+void main(in float2 _uv : TEXCOORD0, in float3 _viewDirection : TEXCOORD1, in float3 _normal : TEXCOORD2, out float4 _oColor : COLOR0, 
+    uniform sampler2D Specular_Map : TEXUNIT0,
+    uniform samplerCUBE cubeMap : TEXUNIT1)
+{
+float _TMP2;
+float _TMP1;
+float _TMP0;
+
+    float3 _N;
+    float3 _R;
+    float4 _reflectedColor;
+    float4 _emissiveColor;
+
+    _TMP0 = dot(_normal, _normal);
+    _TMP1 = rsqrt(_TMP0);
+    _N = _TMP1*_normal;
+    _TMP2 = dot(_N, _viewDirection);
+    _R = _viewDirection - ( 2.00000000000000000E000f*_N)*_TMP2;
+    _R.z = -_R.z;
+    _reflectedColor = texCUBE(cubeMap, _R);
+    _emissiveColor = tex2D(Specular_Map, _uv);
+    _oColor = _reflectedColor*_emissiveColor;
+    _oColor.w =  1.00000000000000000E000f;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_reflect_vert.glsl
+++ b/resources/managed_materials/mm_nicemetal_reflect_vert.glsl
@@ -1,0 +1,91 @@
+
+// glslv output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslv
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslv
+//program reflect_nicemetal_vp
+//semantic reflect_nicemetal_vp.camPosition
+//semantic reflect_nicemetal_vp.world
+//semantic reflect_nicemetal_vp.worldViewProj
+//var float3 camPosition :  : _camPosition1 : 9 : 1
+//var float4x4 world :  : _world1[0], 4 : 10 : 1
+//var float4x4 worldViewProj :  : _worldViewProj1[0], 4 : 11 : 1
+//var float4 position : $vin.POSITION : ATTR0 : 0 : 1
+//var float3 normal : $vin.NORMAL : ATTR2 : 1 : 1
+//var float2 uv : $vin.TEXCOORD0 : ATTR8 : 2 : 1
+//var float4 cols : $vin.COLOR : ATTR3 : 3 : 1
+//var float4 oPosition : $vout.POSITION : HPOS : 4 : 1
+//var float2 oUv : $vout.TEXCOORD0 : TEX0 : 5 : 1
+//var float3 oViewDirection : $vout.TEXCOORD1 : TEX1 : 6 : 1
+//var float3 oNormal : $vout.TEXCOORD2 : TEX2 : 7 : 1
+//var float4 ocols : $vout.COLOR : COL0 : 8 : 1
+
+#version 110
+
+vec4 _ocols1;
+vec4 _oPosition1;
+vec3 _oViewDirection1;
+vec2 _oUv1;
+vec3 _oNormal1;
+uniform vec3 _camPosition1;
+uniform vec4 _world1[4];
+uniform vec4 _worldViewProj1[4];
+vec4 _r0006;
+vec3 _r0016;
+vec3 _r0024;
+vec3 _v0024;
+vec3 _TMP31;
+vec3 _TMP32;
+vec3 _TMP33;
+vec3 _TMP34;
+vec3 _TMP35;
+vec3 _TMP36;
+
+ // main procedure, the original name was reflect_nicemetal_vp
+void main()
+{
+
+
+    _oUv1 = gl_MultiTexCoord0.xy;
+    _ocols1 = gl_Color;
+    _r0006.x = dot(_worldViewProj1[0], gl_Vertex);
+    _r0006.y = dot(_worldViewProj1[1], gl_Vertex);
+    _r0006.z = dot(_worldViewProj1[2], gl_Vertex);
+    _r0006.w = dot(_worldViewProj1[3], gl_Vertex);
+    _oPosition1 = _r0006;
+    _TMP31.x = _world1[0].x;
+    _TMP31.y = _world1[0].y;
+    _TMP31.z = _world1[0].z;
+    _r0016.x = dot(_TMP31, gl_Normal);
+    _TMP32.x = _world1[1].x;
+    _TMP32.y = _world1[1].y;
+    _TMP32.z = _world1[1].z;
+    _r0016.y = dot(_TMP32, gl_Normal);
+    _TMP33.x = _world1[2].x;
+    _TMP33.y = _world1[2].y;
+    _TMP33.z = _world1[2].z;
+    _r0016.z = dot(_TMP33, gl_Normal);
+    _oNormal1 = _r0016;
+    _v0024 = gl_Vertex.xyz - _camPosition1;
+    _TMP34.x = _world1[0].x;
+    _TMP34.y = _world1[0].y;
+    _TMP34.z = _world1[0].z;
+    _r0024.x = dot(_TMP34, _v0024);
+    _TMP35.x = _world1[1].x;
+    _TMP35.y = _world1[1].y;
+    _TMP35.z = _world1[1].z;
+    _r0024.y = dot(_TMP35, _v0024);
+    _TMP36.x = _world1[2].x;
+    _TMP36.y = _world1[2].y;
+    _TMP36.z = _world1[2].z;
+    _r0024.z = dot(_TMP36, _v0024);
+    _oViewDirection1 = _r0024;
+    gl_TexCoord[2].xyz = _r0016;
+    gl_TexCoord[0].xy = gl_MultiTexCoord0.xy;
+    gl_TexCoord[1].xyz = _r0024;
+    gl_Position = _r0006;
+    gl_FrontColor = gl_Color;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_reflect_vert.hlsl
+++ b/resources/managed_materials/mm_nicemetal_reflect_vert.hlsl
@@ -1,0 +1,23 @@
+
+void main(
+       in  float4   position         : POSITION,
+       in  float3   normal         : NORMAL,
+       in  float2 uv : TEXCOORD0,
+       in  float4 cols     : COLOR,
+
+   out      float4   oPosition         : POSITION,
+   out      float2   oUv         : TEXCOORD0,
+   out      float3   oViewDirection      : TEXCOORD1,
+   out      float3   oNormal         : TEXCOORD2,
+   out         float4 ocols     : COLOR,
+
+   uniform   float3   camPosition,
+   uniform   float4x4   world,
+   uniform   float4x4   worldViewProj)
+{
+	oUv=uv;
+	ocols=cols;
+   oPosition = mul(worldViewProj, position);
+   oNormal = mul((float3x3)world, normal);
+   oViewDirection = mul((float3x3)world, position.xyz - camPosition);
+} 

--- a/resources/managed_materials/mm_nicemetal_transp_frag.glsl
+++ b/resources/managed_materials/mm_nicemetal_transp_frag.glsl
@@ -1,0 +1,111 @@
+
+// glslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslf
+//program main_nicemetal_transp_fp
+//semantic main_nicemetal_transp_fp.lightDiffuse
+//semantic main_nicemetal_transp_fp.lightSpecular
+//semantic main_nicemetal_transp_fp.exponent
+//semantic main_nicemetal_transp_fp.ambient
+//semantic main_nicemetal_transp_fp.Diffuse_Map : TEXUNIT0
+//semantic main_nicemetal_transp_fp.Specular_Map : TEXUNIT1
+//semantic main_nicemetal_transp_fp.Dmg_Diffuse_Map : TEXUNIT2
+//var float4 lightDiffuse :  : _lightDiffuse1 : 6 : 1
+//var float4 lightSpecular :  : _lightSpecular1 : 7 : 1
+//var float exponent :  : _exponent1 : 8 : 1
+//var float4 ambient :  : _ambient1 : 9 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : _Diffuse_Map1 0 : 10 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : _Specular_Map1 1 : 11 : 1
+//var sampler2D Dmg_Diffuse_Map : TEXUNIT2 : _Dmg_Diffuse_Map1 2 : 12 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEX0 : 0 : 1
+//var float4 incol : $vin.COLOR : COL0 : 1 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEX1 : 2 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEX2 : 3 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEX3 : 4 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEX4 : 5 : 1
+//var float4 oColor : $vout.COLOR : COL : 13 : 1
+
+#version 110
+
+vec4 _oColor1;
+vec4 _TMP3;
+vec4 _TMP2;
+vec4 _TMP1;
+vec4 _TMP0;
+float _TMP8;
+float _TMP6;
+float _TMP7;
+float _TMP5;
+float _TMP4;
+uniform vec4 _lightDiffuse1;
+uniform vec4 _lightSpecular1;
+uniform float _exponent1;
+uniform vec4 _ambient1;
+uniform sampler2D _Diffuse_Map1;
+uniform sampler2D _Specular_Map1;
+uniform sampler2D _Dmg_Diffuse_Map1;
+vec3 _v0023;
+vec3 _v0029;
+vec3 _v0035;
+vec4 _TMP44;
+vec4 _tmp0045;
+vec4 _a0061;
+vec4 _b0061;
+
+ // main procedure, the original name was main_nicemetal_transp_fp
+void main()
+{
+
+    vec3 _N;
+    vec3 _EyeDir;
+    vec3 _LightDir;
+    vec3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    vec4 _textColour;
+    vec4 _specColour;
+
+    _TMP4 = dot(gl_TexCoord[1].xyz, gl_TexCoord[1].xyz);
+    _TMP5 = inversesqrt(_TMP4);
+    _N = _TMP5*gl_TexCoord[1].xyz;
+    _v0023 = gl_TexCoord[3].xyz - gl_TexCoord[0].xyz;
+    _TMP4 = dot(_v0023, _v0023);
+    _TMP5 = inversesqrt(_TMP4);
+    _EyeDir = _TMP5*_v0023;
+    _v0029 = gl_TexCoord[2].xyz - (gl_TexCoord[0]*gl_TexCoord[2].w).xyz;
+    _TMP4 = dot(_v0029, _v0029);
+    _TMP5 = inversesqrt(_TMP4);
+    _LightDir = _TMP5*_v0029;
+    _v0035 = _LightDir + _EyeDir;
+    _TMP4 = dot(_v0035, _v0035);
+    _TMP5 = inversesqrt(_TMP4);
+    _HalfAngle = _TMP5*_v0035;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0045 = vec4(_NdotL, _NdotH, _exponent1, _exponent1);
+    if (_tmp0045.x > 0.00000000E+000) { // if begin
+        _TMP7 = max(0.00000000E+000, _tmp0045.y);
+        _TMP6 = pow(_TMP7, _tmp0045.z);
+    } else {
+        _TMP6 = 0.00000000E+000;
+    } // end if
+    _TMP8 = max(0.00000000E+000, _tmp0045.x);
+    _TMP44 = vec4(1.00000000E+000, _TMP8, _TMP6, 1.00000000E+000);
+    _TMP0 = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _textColour = _TMP0*(1.00000000E+000 - gl_Color.w);
+    _TMP1 = texture2D(_Dmg_Diffuse_Map1, gl_TexCoord[4].xy);
+    _textColour = _textColour + _TMP1*gl_Color.w;
+    _textColour = _textColour*(1.00000000E+000 - gl_Color.z/3.00000000E+000);
+    _TMP2 = texture2D(_Specular_Map1, gl_TexCoord[4].xy);
+    _specColour = (_TMP2 + gl_Color.z/3.00000000E+000) - gl_Color.w/2.00000000E+000;
+    _a0061 = (_lightDiffuse1*_textColour)*_TMP44.y + _textColour*_ambient1;
+    _b0061 = _lightSpecular1*_TMP44.z;
+    _oColor1 = _a0061 + _specColour*(_b0061 - _a0061);
+    _TMP3 = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _oColor1.w = _TMP3.w;
+    gl_FragColor = _oColor1;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_transp_frag.hlsl
+++ b/resources/managed_materials/mm_nicemetal_transp_frag.hlsl
@@ -1,0 +1,111 @@
+
+// hlslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile hlslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile hlslf
+//program main_nicemetal_transp_fp
+//semantic main_nicemetal_transp_fp.lightDiffuse
+//semantic main_nicemetal_transp_fp.lightSpecular
+//semantic main_nicemetal_transp_fp.exponent
+//semantic main_nicemetal_transp_fp.ambient
+//semantic main_nicemetal_transp_fp.Diffuse_Map : TEXUNIT0
+//semantic main_nicemetal_transp_fp.Specular_Map : TEXUNIT1
+//semantic main_nicemetal_transp_fp.DmgDiffuse_Map : TEXUNIT2
+//var float4 lightDiffuse :  : lightDiffuse : 6 : 1
+//var float4 lightSpecular :  : lightSpecular : 7 : 1
+//var float exponent :  : exponent : 8 : 1
+//var float4 ambient :  : ambient : 9 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : Diffuse_Map 0 : 10 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : Specular_Map 1 : 11 : 1
+//var sampler2D DmgDiffuse_Map : TEXUNIT2 : DmgDiffuse_Map 2 : 12 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEXCOORD0 : 0 : 1
+//var float4 incol : $vin.COLOR : COLOR : 1 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEXCOORD1 : 2 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEXCOORD2 : 3 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEXCOORD3 : 4 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEXCOORD4 : 5 : 1
+//var float4 oColor : $vout.COLOR : COLOR : 13 : 1
+
+#pragma pack_matrix(row_major)
+
+
+
+ // main procedure, the original name was main_nicemetal_transp_fp
+void main(in float4 _pos : TEXCOORD0, in float4 _incol : COLOR0, in float3 _normal : TEXCOORD1, in float4 _lightpos : TEXCOORD2, in float3 _eyepos : TEXCOORD3, in float2 _uv : TEXCOORD4, 
+    uniform float4 lightDiffuse, 
+    uniform float4 lightSpecular, 
+    uniform float exponent, 
+    uniform float4 ambient, 
+    uniform sampler2D Diffuse_Map : TEXUNIT0, 
+    uniform sampler2D Specular_Map : TEXUNIT1, 
+    uniform sampler2D DmgDiffuse_Map : TEXUNIT2, 
+    out float4 _oColor : COLOR0)
+{
+float4 _TMP3;
+float4 _TMP2;
+float4 _TMP1;
+float4 _TMP0;
+float _TMP8;
+float _TMP6;
+float _TMP7;
+float _TMP5;
+float _TMP4;
+float3 _v0012;
+float3 _v0014;
+float3 _v0016;
+float4 _TMP17;
+float4 _tmp0018;
+float4 _a0022;
+float4 _b0022;
+
+    float3 _N;
+    float3 _EyeDir;
+    float3 _LightDir;
+    float3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    float4 _textColour;
+    float4 _specColour;
+
+    _TMP4 = dot(_normal, _normal);
+    _TMP5 = rsqrt(_TMP4);
+    _N = _TMP5*_normal;
+    _v0012 = _eyepos - _pos.xyz;
+    _TMP4 = dot(_v0012, _v0012);
+    _TMP5 = rsqrt(_TMP4);
+    _EyeDir = _TMP5*_v0012;
+    _v0014 = _lightpos.xyz - (_pos*_lightpos.w).xyz;
+    _TMP4 = dot(_v0014, _v0014);
+    _TMP5 = rsqrt(_TMP4);
+    _LightDir = _TMP5*_v0014;
+    _v0016 = _LightDir + _EyeDir;
+    _TMP4 = dot(_v0016, _v0016);
+    _TMP5 = rsqrt(_TMP4);
+    _HalfAngle = _TMP5*_v0016;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0018 = float4(_NdotL, _NdotH, exponent, exponent);
+    if (_tmp0018.x >  0.00000000000000000E000f) { // if begin
+        _TMP7 = max( 0.00000000000000000E000f, _tmp0018.y);
+        _TMP6 = pow(_TMP7, _tmp0018.z);
+    } else {
+        _TMP6 =  0.00000000000000000E000f;
+    } // end if
+    _TMP8 = max( 0.00000000000000000E000f, _tmp0018.x);
+    _TMP17 = float4( 1.00000000000000000E000f, _TMP8, _TMP6,  1.00000000000000000E000f);
+    _TMP0 = tex2D(Diffuse_Map, _uv);
+    _textColour = _TMP0*( 1.00000000000000000E000f - _incol.w);
+    _TMP1 = tex2D(DmgDiffuse_Map, _uv);
+    _textColour = _textColour + _TMP1*_incol.w;
+    _textColour = _textColour*( 1.00000000000000000E000f - _incol.z/ 3.00000000000000000E000f);
+    _TMP2 = tex2D(Specular_Map, _uv);
+    _specColour = (_TMP2 + _incol.z/ 3.00000000000000000E000f) - _incol.w/ 2.00000000000000000E000f;
+    _a0022 = (lightDiffuse*_textColour)*_TMP17.y + _textColour*ambient;
+    _b0022 = lightSpecular*_TMP17.z;
+    _oColor = _a0022 + _specColour*(_b0022 - _a0022);
+    _TMP3 = tex2D(Diffuse_Map, _uv);
+    _oColor.w = _TMP3.w;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_transp_nodmg_frag.glsl
+++ b/resources/managed_materials/mm_nicemetal_transp_nodmg_frag.glsl
@@ -1,0 +1,103 @@
+
+// glslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslf
+//program main_nicemetal_transp_fp_nodmg
+//semantic main_nicemetal_transp_fp_nodmg.lightDiffuse
+//semantic main_nicemetal_transp_fp_nodmg.lightSpecular
+//semantic main_nicemetal_transp_fp_nodmg.exponent
+//semantic main_nicemetal_transp_fp_nodmg.ambient
+//semantic main_nicemetal_transp_fp_nodmg.Diffuse_Map : TEXUNIT0
+//semantic main_nicemetal_transp_fp_nodmg.Specular_Map : TEXUNIT1
+//var float4 lightDiffuse :  : _lightDiffuse1 : 6 : 1
+//var float4 lightSpecular :  : _lightSpecular1 : 7 : 1
+//var float exponent :  : _exponent1 : 8 : 1
+//var float4 ambient :  : _ambient1 : 9 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : _Diffuse_Map1 0 : 10 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : _Specular_Map1 1 : 11 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEX0 : 0 : 1
+//var float4 incol : $vin.COLOR : COL0 : 1 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEX1 : 2 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEX2 : 3 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEX3 : 4 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEX4 : 5 : 1
+//var float4 oColor : $vout.COLOR : COL : 12 : 1
+
+#version 110
+
+vec4 _oColor1;
+vec4 _TMP1;
+vec4 _TMP0;
+float _TMP6;
+float _TMP4;
+float _TMP5;
+float _TMP3;
+float _TMP2;
+uniform vec4 _lightDiffuse1;
+uniform vec4 _lightSpecular1;
+uniform float _exponent1;
+uniform vec4 _ambient1;
+uniform sampler2D _Diffuse_Map1;
+uniform sampler2D _Specular_Map1;
+vec3 _v0020;
+vec3 _v0026;
+vec3 _v0032;
+vec4 _TMP41;
+vec4 _tmp0042;
+vec4 _a0056;
+vec4 _b0056;
+
+ // main procedure, the original name was main_nicemetal_transp_fp_nodmg
+void main()
+{
+
+    vec3 _N;
+    vec3 _EyeDir;
+    vec3 _LightDir;
+    vec3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    vec4 _textColour;
+    vec4 _specColour;
+
+    _TMP2 = dot(gl_TexCoord[1].xyz, gl_TexCoord[1].xyz);
+    _TMP3 = inversesqrt(_TMP2);
+    _N = _TMP3*gl_TexCoord[1].xyz;
+    _v0020 = gl_TexCoord[3].xyz - gl_TexCoord[0].xyz;
+    _TMP2 = dot(_v0020, _v0020);
+    _TMP3 = inversesqrt(_TMP2);
+    _EyeDir = _TMP3*_v0020;
+    _v0026 = gl_TexCoord[2].xyz - (gl_TexCoord[0]*gl_TexCoord[2].w).xyz;
+    _TMP2 = dot(_v0026, _v0026);
+    _TMP3 = inversesqrt(_TMP2);
+    _LightDir = _TMP3*_v0026;
+    _v0032 = _LightDir + _EyeDir;
+    _TMP2 = dot(_v0032, _v0032);
+    _TMP3 = inversesqrt(_TMP2);
+    _HalfAngle = _TMP3*_v0032;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0042 = vec4(_NdotL, _NdotH, _exponent1, _exponent1);
+    if (_tmp0042.x > 0.00000000E+000) { // if begin
+        _TMP5 = max(0.00000000E+000, _tmp0042.y);
+        _TMP4 = pow(_TMP5, _tmp0042.z);
+    } else {
+        _TMP4 = 0.00000000E+000;
+    } // end if
+    _TMP6 = max(0.00000000E+000, _tmp0042.x);
+    _TMP41 = vec4(1.00000000E+000, _TMP6, _TMP4, 1.00000000E+000);
+    _textColour = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _textColour = _textColour*(1.00000000E+000 - gl_Color.z/3.00000000E+000);
+    _TMP0 = texture2D(_Specular_Map1, gl_TexCoord[4].xy);
+    _specColour = (_TMP0 + gl_Color.z/3.00000000E+000) - gl_Color.w/2.00000000E+000;
+    _a0056 = (_lightDiffuse1*_textColour)*_TMP41.y + _textColour*_ambient1;
+    _b0056 = _lightSpecular1*_TMP41.z;
+    _oColor1 = _a0056 + _specColour*(_b0056 - _a0056);
+    _TMP1 = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _oColor1.w = _TMP1.w;
+    gl_FragColor = _oColor1;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_transp_nodmg_frag.hlsl
+++ b/resources/managed_materials/mm_nicemetal_transp_nodmg_frag.hlsl
@@ -1,0 +1,103 @@
+
+// hlslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile hlslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile hlslf
+//program main_nicemetal_transp_fp_nodmg
+//semantic main_nicemetal_transp_fp_nodmg.lightDiffuse
+//semantic main_nicemetal_transp_fp_nodmg.lightSpecular
+//semantic main_nicemetal_transp_fp_nodmg.exponent
+//semantic main_nicemetal_transp_fp_nodmg.ambient
+//semantic main_nicemetal_transp_fp_nodmg.Diffuse_Map : TEXUNIT0
+//semantic main_nicemetal_transp_fp_nodmg.Specular_Map : TEXUNIT1
+//var float4 lightDiffuse :  : lightDiffuse : 6 : 1
+//var float4 lightSpecular :  : lightSpecular : 7 : 1
+//var float exponent :  : exponent : 8 : 1
+//var float4 ambient :  : ambient : 9 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : Diffuse_Map 0 : 10 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : Specular_Map 1 : 11 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEXCOORD0 : 0 : 1
+//var float4 incol : $vin.COLOR : COLOR : 1 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEXCOORD1 : 2 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEXCOORD2 : 3 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEXCOORD3 : 4 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEXCOORD4 : 5 : 1
+//var float4 oColor : $vout.COLOR : COLOR : 12 : 1
+
+#pragma pack_matrix(row_major)
+
+
+ // main procedure, the original name was main_nicemetal_transp_fp_nodmg
+void main(in float4 _pos : TEXCOORD0, in float4 _incol : COLOR0, in float3 _normal : TEXCOORD1, in float4 _lightpos : TEXCOORD2, in float3 _eyepos : TEXCOORD3, in float2 _uv : TEXCOORD4, 
+    uniform float4 lightDiffuse, 
+    uniform float4 lightSpecular, 
+    uniform float exponent, 
+    uniform float4 ambient, 
+    uniform sampler2D Diffuse_Map : TEXUNIT0, 
+    uniform sampler2D Specular_Map : TEXUNIT1, 
+    out float4 _oColor : COLOR0)
+{
+float4 _TMP1;
+float4 _TMP0;
+float _TMP6;
+float _TMP4;
+float _TMP5;
+float _TMP3;
+float _TMP2;
+float3 _v0010;
+float3 _v0012;
+float3 _v0014;
+float4 _TMP15;
+float4 _tmp0016;
+float4 _a0020;
+float4 _b0020;
+
+
+    float3 _N;
+    float3 _EyeDir;
+    float3 _LightDir;
+    float3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    float4 _textColour;
+    float4 _specColour;
+
+    _TMP2 = dot(_normal, _normal);
+    _TMP3 = rsqrt(_TMP2);
+    _N = _TMP3*_normal;
+    _v0010 = _eyepos - _pos.xyz;
+    _TMP2 = dot(_v0010, _v0010);
+    _TMP3 = rsqrt(_TMP2);
+    _EyeDir = _TMP3*_v0010;
+    _v0012 = _lightpos.xyz - (_pos*_lightpos.w).xyz;
+    _TMP2 = dot(_v0012, _v0012);
+    _TMP3 = rsqrt(_TMP2);
+    _LightDir = _TMP3*_v0012;
+    _v0014 = _LightDir + _EyeDir;
+    _TMP2 = dot(_v0014, _v0014);
+    _TMP3 = rsqrt(_TMP2);
+    _HalfAngle = _TMP3*_v0014;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0016 = float4(_NdotL, _NdotH, exponent, exponent);
+    if (_tmp0016.x >  0.00000000000000000E000f) { // if begin
+        _TMP5 = max( 0.00000000000000000E000f, _tmp0016.y);
+        _TMP4 = pow(_TMP5, _tmp0016.z);
+    } else {
+        _TMP4 =  0.00000000000000000E000f;
+    } // end if
+    _TMP6 = max( 0.00000000000000000E000f, _tmp0016.x);
+    _TMP15 = float4( 1.00000000000000000E000f, _TMP6, _TMP4,  1.00000000000000000E000f);
+    _textColour = tex2D(Diffuse_Map, _uv);
+    _textColour = _textColour*( 1.00000000000000000E000f - _incol.z/ 3.00000000000000000E000f);
+    _TMP0 = tex2D(Specular_Map, _uv);
+    _specColour = (_TMP0 + _incol.z/ 3.00000000000000000E000f) - _incol.w/ 2.00000000000000000E000f;
+    _a0020 = (lightDiffuse*_textColour)*_TMP15.y + _textColour*ambient;
+    _b0020 = lightSpecular*_TMP15.z;
+    _oColor = _a0020 + _specColour*(_b0020 - _a0020);
+    _TMP1 = tex2D(Diffuse_Map, _uv);
+    _oColor.w = _TMP1.w;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_vert.glsl
+++ b/resources/managed_materials/mm_nicemetal_vert.glsl
@@ -1,0 +1,65 @@
+
+// glslv output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslv
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslv
+//program main_nicemetal_vp
+//semantic main_nicemetal_vp.lightPosition
+//semantic main_nicemetal_vp.eyePosition
+//semantic main_nicemetal_vp.worldviewproj
+//var float4 lightPosition :  : _lightPosition1 : 4 : 1
+//var float3 eyePosition :  : _eyePosition1 : 5 : 1
+//var float4x4 worldviewproj :  : _worldviewproj1[0], 4 : 6 : 1
+//var float2 uv : $vin.TEXCOORD0 : ATTR8 : 0 : 1
+//var float4 position : $vin.POSITION : ATTR0 : 1 : 1
+//var float3 normal : $vin.NORMAL : ATTR2 : 2 : 1
+//var float4 cols : $vin.COLOR : ATTR3 : 3 : 1
+//var float4 oClipPos : $vout.POSITION : HPOS : 7 : 1
+//var float4 oCols : $vout.COLOR : COL0 : 8 : 1
+//var float4 oPos : $vout.TEXCOORD0 : TEX0 : 9 : 1
+//var float3 oNorm : $vout.TEXCOORD1 : TEX1 : 10 : 1
+//var float4 oLightPos : $vout.TEXCOORD2 : TEX2 : 11 : 1
+//var float3 oEyePos : $vout.TEXCOORD3 : TEX3 : 12 : 1
+//var float2 oUv : $vout.TEXCOORD4 : TEX4 : 13 : 1
+
+#version 110
+
+vec4 _oCols1;
+vec4 _oClipPos1;
+vec2 _oUv1;
+vec3 _oNorm1;
+vec3 _oEyePos1;
+vec4 _oPos1;
+vec4 _oLightPos1;
+uniform vec4 _lightPosition1;
+uniform vec3 _eyePosition1;
+uniform vec4 _worldviewproj1[4];
+vec4 _r0004;
+
+ // main procedure, the original name was main_nicemetal_vp
+void main()
+{
+
+
+    _r0004.x = dot(_worldviewproj1[0], gl_Vertex);
+    _r0004.y = dot(_worldviewproj1[1], gl_Vertex);
+    _r0004.z = dot(_worldviewproj1[2], gl_Vertex);
+    _r0004.w = dot(_worldviewproj1[3], gl_Vertex);
+    _oClipPos1 = _r0004;
+    _oPos1 = gl_Vertex;
+    _oNorm1 = gl_Normal;
+    _oLightPos1 = _lightPosition1;
+    _oEyePos1 = _eyePosition1;
+    _oCols1 = gl_Color;
+    _oUv1 = gl_MultiTexCoord0.xy;
+    gl_TexCoord[2] = _lightPosition1;
+    gl_TexCoord[0] = gl_Vertex;
+    gl_TexCoord[3].xyz = _eyePosition1;
+    gl_TexCoord[1].xyz = gl_Normal;
+    gl_TexCoord[4].xy = gl_MultiTexCoord0.xy;
+    gl_Position = _r0004;
+    gl_FrontColor = gl_Color;
+} // main end

--- a/resources/managed_materials/mm_nicemetal_vert.hlsl
+++ b/resources/managed_materials/mm_nicemetal_vert.hlsl
@@ -1,0 +1,30 @@
+
+
+ // vertex shader main entry
+void main(
+       in    float2 uv : TEXCOORD0,
+       in     float4 position : POSITION, 
+       in     float3 normal   : NORMAL,
+       in     float4 cols     : COLOR0,
+            uniform float4 lightPosition,
+            uniform float3 eyePosition,
+            uniform float4x4 worldviewproj,
+
+            out float4 oClipPos : POSITION,
+            out float4 oCols : COLOR0,
+            out float4 oPos : TEXCOORD0,
+            out float3 oNorm    : TEXCOORD1,
+            out float4 oLightPos    : TEXCOORD2,            
+            out float3 oEyePos  : TEXCOORD3,
+            out float2 oUv     : TEXCOORD4
+ ) 
+{ 
+    oClipPos = mul(worldviewproj, position);
+    
+    oPos = position;
+    oNorm     = normal; 
+    oLightPos = lightPosition;
+    oEyePos = eyePosition;
+    oCols=cols;
+    oUv = uv;
+} 

--- a/resources/managed_materials/mm_simplemetal_frag.glsl
+++ b/resources/managed_materials/mm_simplemetal_frag.glsl
@@ -1,0 +1,97 @@
+
+// glslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslf
+//program main_simplemetal_fp
+//semantic main_simplemetal_fp.lightDiffuse
+//semantic main_simplemetal_fp.lightSpecular
+//semantic main_simplemetal_fp.exponent
+//semantic main_simplemetal_fp.ambient
+//semantic main_simplemetal_fp.Diffuse_Map : TEXUNIT0
+//semantic main_simplemetal_fp.Specular_Map : TEXUNIT1
+//var float4 lightDiffuse :  : _lightDiffuse1 : 5 : 1
+//var float4 lightSpecular :  : _lightSpecular1 : 6 : 1
+//var float exponent :  : _exponent1 : 7 : 1
+//var float4 ambient :  : _ambient1 : 8 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : _Diffuse_Map1 0 : 9 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : _Specular_Map1 1 : 10 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEX0 : 0 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEX1 : 1 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEX2 : 2 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEX3 : 3 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEX4 : 4 : 1
+//var float4 oColor : $vout.COLOR : COL : 11 : 1
+
+#version 110
+
+vec4 _oColor1;
+float _TMP4;
+float _TMP2;
+float _TMP3;
+float _TMP1;
+float _TMP0;
+uniform vec4 _lightDiffuse1;
+uniform vec4 _lightSpecular1;
+uniform float _exponent1;
+uniform vec4 _ambient1;
+uniform sampler2D _Diffuse_Map1;
+uniform sampler2D _Specular_Map1;
+vec3 _v0018;
+vec3 _v0024;
+vec3 _v0030;
+vec4 _TMP39;
+vec4 _tmp0040;
+vec4 _a0054;
+vec4 _b0054;
+
+ // main procedure, the original name was main_simplemetal_fp
+void main()
+{
+
+    vec3 _N;
+    vec3 _EyeDir;
+    vec3 _LightDir;
+    vec3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    vec4 _textColour;
+    vec4 _specColour;
+
+    _TMP0 = dot(gl_TexCoord[1].xyz, gl_TexCoord[1].xyz);
+    _TMP1 = inversesqrt(_TMP0);
+    _N = _TMP1*gl_TexCoord[1].xyz;
+    _v0018 = gl_TexCoord[3].xyz - gl_TexCoord[0].xyz;
+    _TMP0 = dot(_v0018, _v0018);
+    _TMP1 = inversesqrt(_TMP0);
+    _EyeDir = _TMP1*_v0018;
+    _v0024 = gl_TexCoord[2].xyz - (gl_TexCoord[0]*gl_TexCoord[2].w).xyz;
+    _TMP0 = dot(_v0024, _v0024);
+    _TMP1 = inversesqrt(_TMP0);
+    _LightDir = _TMP1*_v0024;
+    _v0030 = _LightDir + _EyeDir;
+    _TMP0 = dot(_v0030, _v0030);
+    _TMP1 = inversesqrt(_TMP0);
+    _HalfAngle = _TMP1*_v0030;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0040 = vec4(_NdotL, _NdotH, _exponent1, _exponent1);
+    if (_tmp0040.x > 0.00000000E+000) { // if begin
+        _TMP3 = max(0.00000000E+000, _tmp0040.y);
+        _TMP2 = pow(_TMP3, _tmp0040.z);
+    } else {
+        _TMP2 = 0.00000000E+000;
+    } // end if
+    _TMP4 = max(0.00000000E+000, _tmp0040.x);
+    _TMP39 = vec4(1.00000000E+000, _TMP4, _TMP2, 1.00000000E+000);
+    _textColour = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _specColour = texture2D(_Specular_Map1, gl_TexCoord[4].xy);
+    _a0054 = (_lightDiffuse1*_textColour)*_TMP39.y + _textColour*_ambient1;
+    _b0054 = _lightSpecular1*_TMP39.z;
+    _oColor1 = _a0054 + _specColour*(_b0054 - _a0054);
+    _oColor1.w = 1.00000000E+000;
+    gl_FragColor = _oColor1;
+} // main end

--- a/resources/managed_materials/mm_simplemetal_frag.hlsl
+++ b/resources/managed_materials/mm_simplemetal_frag.hlsl
@@ -1,0 +1,97 @@
+
+// hlslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile hlslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile hlslf
+//program main_simplemetal_fp
+//semantic main_simplemetal_fp.lightDiffuse
+//semantic main_simplemetal_fp.lightSpecular
+//semantic main_simplemetal_fp.exponent
+//semantic main_simplemetal_fp.ambient
+//semantic main_simplemetal_fp.Diffuse_Map : TEXUNIT0
+//semantic main_simplemetal_fp.Specular_Map : TEXUNIT1
+//var float4 lightDiffuse :  : lightDiffuse : 5 : 1
+//var float4 lightSpecular :  : lightSpecular : 6 : 1
+//var float exponent :  : exponent : 7 : 1
+//var float4 ambient :  : ambient : 8 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : Diffuse_Map 0 : 9 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : Specular_Map 1 : 10 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEXCOORD0 : 0 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEXCOORD1 : 1 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEXCOORD2 : 2 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEXCOORD3 : 3 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEXCOORD4 : 4 : 1
+//var float4 oColor : $vout.COLOR : COLOR : 11 : 1
+
+#pragma pack_matrix(row_major)
+
+
+
+ // main procedure, the original name was main_simplemetal_fp
+void main(in float4 _pos : TEXCOORD0, in float3 _normal : TEXCOORD1, in float4 _lightpos : TEXCOORD2, in float3 _eyepos : TEXCOORD3, in float2 _uv : TEXCOORD4, 
+    uniform float4 lightDiffuse, 
+    uniform float4 lightSpecular, 
+    uniform float exponent, 
+    uniform float4 ambient, 
+    uniform sampler2D Diffuse_Map : TEXUNIT0, 
+    uniform sampler2D Specular_Map : TEXUNIT1, 
+    out float4 _oColor : COLOR0)
+{
+float _TMP4;
+float _TMP2;
+float _TMP3;
+float _TMP1;
+float _TMP0;
+float3 _v0008;
+float3 _v0010;
+float3 _v0012;
+float4 _TMP13;
+float4 _tmp0014;
+float4 _a0018;
+float4 _b0018;
+
+    float3 _N;
+    float3 _EyeDir;
+    float3 _LightDir;
+    float3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    float4 _textColour;
+    float4 _specColour;
+
+    _TMP0 = dot(_normal, _normal);
+    _TMP1 = rsqrt(_TMP0);
+    _N = _TMP1*_normal;
+    _v0008 = _eyepos - _pos.xyz;
+    _TMP0 = dot(_v0008, _v0008);
+    _TMP1 = rsqrt(_TMP0);
+    _EyeDir = _TMP1*_v0008;
+    _v0010 = _lightpos.xyz - (_pos*_lightpos.w).xyz;
+    _TMP0 = dot(_v0010, _v0010);
+    _TMP1 = rsqrt(_TMP0);
+    _LightDir = _TMP1*_v0010;
+    _v0012 = _LightDir + _EyeDir;
+    _TMP0 = dot(_v0012, _v0012);
+    _TMP1 = rsqrt(_TMP0);
+    _HalfAngle = _TMP1*_v0012;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0014 = float4(_NdotL, _NdotH, exponent, exponent);
+    if (_tmp0014.x >  0.00000000000000000E000f) { // if begin
+        _TMP3 = max( 0.00000000000000000E000f, _tmp0014.y);
+        _TMP2 = pow(_TMP3, _tmp0014.z);
+    } else {
+        _TMP2 =  0.00000000000000000E000f;
+    } // end if
+    _TMP4 = max( 0.00000000000000000E000f, _tmp0014.x);
+    _TMP13 = float4( 1.00000000000000000E000f, _TMP4, _TMP2,  1.00000000000000000E000f);
+    _textColour = tex2D(Diffuse_Map, _uv);
+    _specColour = tex2D(Specular_Map, _uv);
+    _a0018 = (lightDiffuse*_textColour)*_TMP13.y + _textColour*ambient;
+    _b0018 = lightSpecular*_TMP13.z;
+    _oColor = _a0018 + _specColour*(_b0018 - _a0018);
+    _oColor.w =  1.00000000000000000E000f;
+} // main end

--- a/resources/managed_materials/mm_simplemetal_transp_frag.glsl
+++ b/resources/managed_materials/mm_simplemetal_transp_frag.glsl
@@ -1,0 +1,99 @@
+
+// glslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile glslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile glslf
+//program main_simplemetal_transp_fp
+//semantic main_simplemetal_transp_fp.lightDiffuse
+//semantic main_simplemetal_transp_fp.lightSpecular
+//semantic main_simplemetal_transp_fp.exponent
+//semantic main_simplemetal_transp_fp.ambient
+//semantic main_simplemetal_transp_fp.Diffuse_Map : TEXUNIT0
+//semantic main_simplemetal_transp_fp.Specular_Map : TEXUNIT1
+//var float4 lightDiffuse :  : _lightDiffuse1 : 5 : 1
+//var float4 lightSpecular :  : _lightSpecular1 : 6 : 1
+//var float exponent :  : _exponent1 : 7 : 1
+//var float4 ambient :  : _ambient1 : 8 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : _Diffuse_Map1 0 : 9 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : _Specular_Map1 1 : 10 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEX0 : 0 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEX1 : 1 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEX2 : 2 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEX3 : 3 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEX4 : 4 : 1
+//var float4 oColor : $vout.COLOR : COL : 11 : 1
+
+#version 110
+
+vec4 _oColor1;
+vec4 _TMP0;
+float _TMP5;
+float _TMP3;
+float _TMP4;
+float _TMP2;
+float _TMP1;
+uniform vec4 _lightDiffuse1;
+uniform vec4 _lightSpecular1;
+uniform float _exponent1;
+uniform vec4 _ambient1;
+uniform sampler2D _Diffuse_Map1;
+uniform sampler2D _Specular_Map1;
+vec3 _v0019;
+vec3 _v0025;
+vec3 _v0031;
+vec4 _TMP40;
+vec4 _tmp0041;
+vec4 _a0055;
+vec4 _b0055;
+
+ // main procedure, the original name was main_simplemetal_transp_fp
+void main()
+{
+
+    vec3 _N;
+    vec3 _EyeDir;
+    vec3 _LightDir;
+    vec3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    vec4 _textColour;
+    vec4 _specColour;
+
+    _TMP1 = dot(gl_TexCoord[1].xyz, gl_TexCoord[1].xyz);
+    _TMP2 = inversesqrt(_TMP1);
+    _N = _TMP2*gl_TexCoord[1].xyz;
+    _v0019 = gl_TexCoord[3].xyz - gl_TexCoord[0].xyz;
+    _TMP1 = dot(_v0019, _v0019);
+    _TMP2 = inversesqrt(_TMP1);
+    _EyeDir = _TMP2*_v0019;
+    _v0025 = gl_TexCoord[2].xyz - (gl_TexCoord[0]*gl_TexCoord[2].w).xyz;
+    _TMP1 = dot(_v0025, _v0025);
+    _TMP2 = inversesqrt(_TMP1);
+    _LightDir = _TMP2*_v0025;
+    _v0031 = _LightDir + _EyeDir;
+    _TMP1 = dot(_v0031, _v0031);
+    _TMP2 = inversesqrt(_TMP1);
+    _HalfAngle = _TMP2*_v0031;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0041 = vec4(_NdotL, _NdotH, _exponent1, _exponent1);
+    if (_tmp0041.x > 0.00000000E+000) { // if begin
+        _TMP4 = max(0.00000000E+000, _tmp0041.y);
+        _TMP3 = pow(_TMP4, _tmp0041.z);
+    } else {
+        _TMP3 = 0.00000000E+000;
+    } // end if
+    _TMP5 = max(0.00000000E+000, _tmp0041.x);
+    _TMP40 = vec4(1.00000000E+000, _TMP5, _TMP3, 1.00000000E+000);
+    _textColour = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _specColour = texture2D(_Specular_Map1, gl_TexCoord[4].xy);
+    _a0055 = (_lightDiffuse1*_textColour)*_TMP40.y + _textColour*_ambient1;
+    _b0055 = _lightSpecular1*_TMP40.z;
+    _oColor1 = _a0055 + _specColour*(_b0055 - _a0055);
+    _TMP0 = texture2D(_Diffuse_Map1, gl_TexCoord[4].xy);
+    _oColor1.w = _TMP0.w;
+    gl_FragColor = _oColor1;
+} // main end

--- a/resources/managed_materials/mm_simplemetal_transp_frag.hlsl
+++ b/resources/managed_materials/mm_simplemetal_transp_frag.hlsl
@@ -1,0 +1,99 @@
+
+// hlslf output by Cg compiler
+// cgc version 3.1.0013, build date Apr 18 2012
+// command line args: -profile hlslf
+// source file: nicemetal_mm.cg
+//vendor NVIDIA Corporation
+//version 3.1.0.13
+//profile hlslf
+//program main_simplemetal_transp_fp
+//semantic main_simplemetal_transp_fp.lightDiffuse
+//semantic main_simplemetal_transp_fp.lightSpecular
+//semantic main_simplemetal_transp_fp.exponent
+//semantic main_simplemetal_transp_fp.ambient
+//semantic main_simplemetal_transp_fp.Diffuse_Map : TEXUNIT0
+//semantic main_simplemetal_transp_fp.Specular_Map : TEXUNIT1
+//var float4 lightDiffuse :  : lightDiffuse : 5 : 1
+//var float4 lightSpecular :  : lightSpecular : 6 : 1
+//var float exponent :  : exponent : 7 : 1
+//var float4 ambient :  : ambient : 8 : 1
+//var sampler2D Diffuse_Map : TEXUNIT0 : Diffuse_Map 0 : 9 : 1
+//var sampler2D Specular_Map : TEXUNIT1 : Specular_Map 1 : 10 : 1
+//var float4 pos : $vin.TEXCOORD0 : TEXCOORD0 : 0 : 1
+//var float3 normal : $vin.TEXCOORD1 : TEXCOORD1 : 1 : 1
+//var float4 lightpos : $vin.TEXCOORD2 : TEXCOORD2 : 2 : 1
+//var float3 eyepos : $vin.TEXCOORD3 : TEXCOORD3 : 3 : 1
+//var float2 uv : $vin.TEXCOORD4 : TEXCOORD4 : 4 : 1
+//var float4 oColor : $vout.COLOR : COLOR : 11 : 1
+
+#pragma pack_matrix(row_major)
+
+
+
+ // main procedure, the original name was main_simplemetal_transp_fp
+void main(in float4 _pos : TEXCOORD0, in float3 _normal : TEXCOORD1, in float4 _lightpos : TEXCOORD2, in float3 _eyepos : TEXCOORD3, in float2 _uv : TEXCOORD4, 
+    uniform float4 lightDiffuse, 
+    uniform float4 lightSpecular, 
+    uniform float exponent, 
+    uniform float4 ambient, 
+    uniform sampler2D Diffuse_Map : TEXUNIT0, 
+    uniform sampler2D Specular_Map : TEXUNIT1, 
+    out float4 _oColor : COLOR0)
+{
+float4 _TMP0;
+float _TMP5;
+float _TMP3;
+float _TMP4;
+float _TMP2;
+float _TMP1;
+float3 _v0009;
+float3 _v0011;
+float3 _v0013;
+float4 _TMP14;
+float4 _tmp0015;
+float4 _a0019;
+float4 _b0019;
+
+    float3 _N;
+    float3 _EyeDir;
+    float3 _LightDir;
+    float3 _HalfAngle;
+    float _NdotL;
+    float _NdotH;
+    float4 _textColour;
+    float4 _specColour;
+
+    _TMP1 = dot(_normal, _normal);
+    _TMP2 = rsqrt(_TMP1);
+    _N = _TMP2*_normal;
+    _v0009 = _eyepos - _pos.xyz;
+    _TMP1 = dot(_v0009, _v0009);
+    _TMP2 = rsqrt(_TMP1);
+    _EyeDir = _TMP2*_v0009;
+    _v0011 = _lightpos.xyz - (_pos*_lightpos.w).xyz;
+    _TMP1 = dot(_v0011, _v0011);
+    _TMP2 = rsqrt(_TMP1);
+    _LightDir = _TMP2*_v0011;
+    _v0013 = _LightDir + _EyeDir;
+    _TMP1 = dot(_v0013, _v0013);
+    _TMP2 = rsqrt(_TMP1);
+    _HalfAngle = _TMP2*_v0013;
+    _NdotL = dot(_LightDir, _N);
+    _NdotH = dot(_HalfAngle, _N);
+    _tmp0015 = float4(_NdotL, _NdotH, exponent, exponent);
+    if (_tmp0015.x >  0.00000000000000000E000f) { // if begin
+        _TMP4 = max( 0.00000000000000000E000f, _tmp0015.y);
+        _TMP3 = pow(_TMP4, _tmp0015.z);
+    } else {
+        _TMP3 =  0.00000000000000000E000f;
+    } // end if
+    _TMP5 = max( 0.00000000000000000E000f, _tmp0015.x);
+    _TMP14 = float4( 1.00000000000000000E000f, _TMP5, _TMP3,  1.00000000000000000E000f);
+    _textColour = tex2D(Diffuse_Map, _uv);
+    _specColour = tex2D(Specular_Map, _uv);
+    _a0019 = (lightDiffuse*_textColour)*_TMP14.y + _textColour*ambient;
+    _b0019 = lightSpecular*_TMP14.z;
+    _oColor = _a0019 + _specColour*(_b0019 - _a0019);
+    _TMP0 = tex2D(Diffuse_Map, _uv);
+    _oColor.w = _TMP0.w;
+} // main end

--- a/resources/managed_materials/nicemetal_mm.program
+++ b/resources/managed_materials/nicemetal_mm.program
@@ -1,8 +1,10 @@
-vertex_program NiceMetal_VS_mm cg
+// -- mm_nicemetal_vert --
+
+vertex_program NiceMetal_VS_mm_hlsl hlsl
 {
-    source nicemetal_mm.cg
-    entry_point main_nicemetal_vp
-    profiles vs_1_1 arbvp1
+    source mm_nicemetal_vert.hlsl
+    entry_point main
+    target vs_1_1
     default_params
     {
         param_named_auto worldviewproj worldviewproj_matrix
@@ -11,11 +13,25 @@ vertex_program NiceMetal_VS_mm cg
     }
 }
 
-fragment_program NiceMetal_PS_mm cg
+vertex_program NiceMetal_VS_mm_glsl glsl
 {
-    source nicemetal_mm.cg
-    entry_point main_nicemetal_fp
-    profiles ps_2_0 arbfp1
+    source mm_nicemetal_vert.glsl
+    entry_point main
+    default_params
+    {
+        param_named_auto worldviewproj worldviewproj_matrix
+        param_named_auto lightPosition light_position_object_space 0
+        param_named_auto eyePosition camera_position_object_space
+    }
+}
+
+// -- mm_nicemetal_frag --
+
+fragment_program NiceMetal_PS_mm_hlsl hlsl
+{
+    source mm_nicemetal_frag.hlsl
+    entry_point main
+    target ps_2_0
     default_params
     {
         param_named_auto lightDiffuse light_diffuse_colour 0
@@ -25,11 +41,10 @@ fragment_program NiceMetal_PS_mm cg
     }
 }
 
-fragment_program NiceMetal_transp_PS_mm cg
+fragment_program NiceMetal_PS_mm_glsl glsl
 {
-    source nicemetal_mm.cg
-    entry_point main_nicemetal_transp_fp
-    profiles ps_2_0 arbfp1
+    source mm_nicemetal_frag.glsl
+    entry_point main
     default_params
     {
         param_named_auto lightDiffuse light_diffuse_colour 0
@@ -39,11 +54,13 @@ fragment_program NiceMetal_transp_PS_mm cg
     }
 }
 
-fragment_program NiceMetal_PS_nodmg_mm cg
+// -- mm_nicemetal_transp_frag --
+
+fragment_program NiceMetal_transp_PS_mm_hlsl hlsl
 {
-    source nicemetal_mm.cg
-    entry_point main_nicemetal_fp_nodmg
-    profiles ps_2_0 arbfp1
+    source mm_nicemetal_transp_frag.hlsl
+    entry_point main
+    target ps_2_0
     default_params
     {
         param_named_auto lightDiffuse light_diffuse_colour 0
@@ -53,11 +70,10 @@ fragment_program NiceMetal_PS_nodmg_mm cg
     }
 }
 
-fragment_program NiceMetal_transp_PS_nodmg_mm cg
+fragment_program NiceMetal_transp_PS_mm_glsl glsl
 {
-    source nicemetal_mm.cg
-    entry_point main_nicemetal_fp_nodmg
-    profiles ps_2_0 arbfp1
+    source mm_nicemetal_transp_frag.glsl
+    entry_point main
     default_params
     {
         param_named_auto lightDiffuse light_diffuse_colour 0
@@ -67,11 +83,71 @@ fragment_program NiceMetal_transp_PS_nodmg_mm cg
     }
 }
 
-vertex_program NiceMetal_Reflect_VS_mm cg
+// -- mm_nicemetal_nodmg_frag --
+
+fragment_program NiceMetal_PS_nodmg_mm_hlsl hlsl
 {
-    source nicemetal_mm.cg
-    entry_point reflect_nicemetal_vp
-    profiles vs_1_1 arbvp1
+    source mm_nicemetal_nodmg_frag.hlsl
+    entry_point main
+    target ps_2_0
+    default_params
+    {
+        param_named_auto lightDiffuse light_diffuse_colour 0
+        param_named_auto lightSpecular light_specular_colour 0
+        param_named exponent float 127
+        param_named_auto ambient ambient_light_colour
+    }
+}
+
+fragment_program NiceMetal_PS_nodmg_mm_glsl glsl
+{
+    source mm_nicemetal_nodmg_frag.glsl
+    entry_point main
+    default_params
+    {
+        param_named_auto lightDiffuse light_diffuse_colour 0
+        param_named_auto lightSpecular light_specular_colour 0
+        param_named exponent float 127
+        param_named_auto ambient ambient_light_colour
+    }
+}
+
+// -- mm_nicemetal_transp_nodmg_frag --
+
+fragment_program NiceMetal_transp_PS_nodmg_mm_hlsl hlsl
+{
+    source mm_nicemetal_transp_nodmg_frag.hlsl
+    entry_point main
+    target ps_2_0
+    default_params
+    {
+        param_named_auto lightDiffuse light_diffuse_colour 0
+        param_named_auto lightSpecular light_specular_colour 0
+        param_named exponent float 127
+        param_named_auto ambient ambient_light_colour
+    }
+}
+
+fragment_program NiceMetal_transp_PS_nodmg_mm_glsl glsl
+{
+    source mm_nicemetal_transp_nodmg_frag.glsl
+    entry_point main
+    default_params
+    {
+        param_named_auto lightDiffuse light_diffuse_colour 0
+        param_named_auto lightSpecular light_specular_colour 0
+        param_named exponent float 127
+        param_named_auto ambient ambient_light_colour
+    }
+}
+
+// -- mm_nicemetal_reflect_vert --
+
+vertex_program NiceMetal_Reflect_VS_mm_hlsl hlsl
+{
+    source mm_nicemetal_reflect_vert.hlsl
+    entry_point main
+    target vs_1_1
     default_params
     {
 	  param_named_auto camPosition camera_position_object_space
@@ -79,35 +155,74 @@ vertex_program NiceMetal_Reflect_VS_mm cg
       param_named_auto worldViewProj worldviewproj_matrix
         //param_named_auto worldviewproj worldviewproj_matrix
         //param_named_auto eyePositionW camera_position
-        //param_named_auto modelToWorld inverse_transpose_world_matrix
+        //param_named_auto modelToWorld inverse_transposeworld_matrix
     }
 }
 
-fragment_program NiceMetal_Reflect_PS_mm cg
+vertex_program NiceMetal_Reflect_VS_mm_glsl glsl
 {
-    source nicemetal_mm.cg
-    entry_point reflect_nicemetal_fp
-    profiles ps_2_0 arbfp1
+    source mm_nicemetal_reflect_vert.glsl
+    entry_point main
+    default_params
+    {
+	  param_named_auto camPosition camera_position_object_space
+      param_named_auto world world_matrix
+      param_named_auto worldViewProj worldviewproj_matrix
+        //param_named_auto worldviewproj worldviewproj_matrix
+        //param_named_auto eyePositionW camera_position
+        //param_named_auto modelToWorld inverse_transposeworld_matrix
+    }
+}
+
+// -- mm_nicemetal_reflect_frag --
+
+fragment_program NiceMetal_Reflect_PS_mm_hlsl hlsl
+{
+    source mm_nicemetal_reflect_frag.hlsl
+    entry_point main
+    target ps_2_0
     default_params
     {
     }
 }
 
-fragment_program NiceMetal_Reflect_nocolor_PS_mm cg
+fragment_program NiceMetal_Reflect_PS_mm_glsl glsl
 {
-    source nicemetal_mm.cg
-    entry_point reflect_nicemetal_nocolor_fp
-    profiles ps_2_0 arbfp1
+    source mm_nicemetal_reflect_frag.glsl
+    entry_point main
     default_params
     {
     }
 }
 
-fragment_program SimpleMetal_PS_mm cg
+// -- mm_nicemetal_reflect_nocolor_frag --
+
+fragment_program NiceMetal_Reflect_nocolor_PS_mm_hlsl hlsl
 {
-    source nicemetal_mm.cg
-    entry_point main_simplemetal_fp
-    profiles ps_2_0 arbfp1
+    source mm_nicemetal_reflect_nocolor_frag.hlsl
+    entry_point main
+    target ps_2_0
+    default_params
+    {
+    }
+}
+
+fragment_program NiceMetal_Reflect_nocolor_PS_mm_glsl glsl
+{
+    source mm_nicemetal_reflect_nocolor_frag.glsl
+    entry_point main
+    default_params
+    {
+    }
+}
+
+// -- mm_simplemetal_frag --
+
+fragment_program SimpleMetal_PS_mm_hlsl hlsl
+{
+    source mm_simplemetal_frag.hlsl
+    entry_point main
+    target ps_2_0
     default_params
     {
         param_named_auto lightDiffuse light_diffuse_colour 0
@@ -117,11 +232,39 @@ fragment_program SimpleMetal_PS_mm cg
     }
 }
 
-fragment_program SimpleMetal_transp_PS_mm cg
+fragment_program SimpleMetal_PS_mm_glsl glsl
 {
-    source nicemetal_mm.cg
-    entry_point main_simplemetal_transp_fp
-    profiles ps_2_0 arbfp1
+    source mm_simplemetal_frag.glsl
+    entry_point main
+    default_params
+    {
+        param_named_auto lightDiffuse light_diffuse_colour 0
+        param_named_auto lightSpecular light_specular_colour 0
+        param_named exponent float 127
+        param_named_auto ambient ambient_light_colour
+    }
+}
+
+// -- mm_simplemetal_transp_frag --
+
+fragment_program SimpleMetal_transp_PS_mm_hlsl hlsl
+{
+    source mm_simplemetal_transp_frag.hlsl
+    entry_point main
+    target ps_2_0
+    default_params
+    {
+        param_named_auto lightDiffuse light_diffuse_colour 0
+        param_named_auto lightSpecular light_specular_colour 0
+        param_named exponent float 127
+        param_named_auto ambient ambient_light_colour
+    }
+}
+
+fragment_program SimpleMetal_transp_PS_mm_glsl glsl
+{
+    source mm_simplemetal_transp_frag.glsl
+    entry_point main
     default_params
     {
         param_named_auto lightDiffuse light_diffuse_colour 0

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2462,6 +2462,14 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
         }
     }
 
+    std::string shaderlang = "_glsl";
+    // Choose shader language based on renderer
+    if (Ogre::Root::getSingleton().getRenderSystem()->getName() == "Direct3D9 Rendering Subsystem"
+        || Ogre::Root::getSingleton().getRenderSystem()->getName() == "Direct3D11 Rendering Subsystem")
+    {
+        shaderlang = "_hlsl";
+    }
+
     std::string custom_name = this->ComposeName(def.name);
     Ogre::MaterialPtr material;
     if (TuneupUtil::isManagedMatAnyhowRemoved(m_actor->getWorkingTuneupDef(), def.name))
@@ -2503,10 +2511,10 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
                 }
                 else
                 {
-                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map"), def.name, 0, def.diffuse_map);
-                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Dmg_Diffuse_Map"), def.name, 2, def.damaged_diffuse_map);
-                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map"), def.name, 1, def.specular_map);
-                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map"), def.name, 1, def.specular_map);
+                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Diffuse_Map"), def.name, 0, def.diffuse_map);
+                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Dmg_Diffuse_Map"), def.name, 2, def.damaged_diffuse_map);
+                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Specular_Map"), def.name, 1, def.specular_map);
+                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("Specular" + shaderlang)->getTextureUnitState("Specular_Map"), def.name, 1, def.specular_map);
                 }
             }
             else
@@ -2517,8 +2525,8 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
                 {
                     return;
                 }
-                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map"), def.name, 0, def.diffuse_map);
-                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Dmg_Diffuse_Map"), def.name, 2, def.damaged_diffuse_map);
+                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Diffuse_Map"), def.name, 0, def.diffuse_map);
+                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Dmg_Diffuse_Map"), def.name, 2, def.damaged_diffuse_map);
             }
         }
         else
@@ -2547,9 +2555,9 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
                 }
                 else
                 {
-                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map") , def.name, 0, def.diffuse_map);
-                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map"), def.name, 1, def.specular_map);
-                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map")  , def.name, 1, def.specular_map);
+                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Diffuse_Map") , def.name, 0, def.diffuse_map);
+                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Specular_Map"), def.name, 1, def.specular_map);
+                    this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("Specular" + shaderlang)->getTextureUnitState("Specular_Map")  , def.name, 1, def.specular_map);
                 }
             }
             else
@@ -2595,9 +2603,9 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
             }
             else
             {
-                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Diffuse_Map") ,def.name, 0, def.diffuse_map);
-                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("BaseRender")->getTextureUnitState("Specular_Map"),def.name, 1, def.specular_map);
-                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique")->getPass("Specular")->getTextureUnitState("Specular_Map")  ,def.name, 1, def.specular_map);
+                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Diffuse_Map") ,def.name, 0, def.diffuse_map);
+                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("BaseRender" + shaderlang)->getTextureUnitState("Specular_Map"),def.name, 1, def.specular_map);
+                this->AssignManagedMaterialTexture(material->getTechnique("BaseTechnique" + shaderlang)->getPass("Specular" + shaderlang)->getTextureUnitState("Specular_Map")  ,def.name, 1, def.specular_map);
             }
         }
         else
@@ -2627,7 +2635,7 @@ void ActorSpawner::ProcessManagedMaterial(RigDef::ManagedMaterial & def)
                 }
                 else
                 {
-                    material->getTechnique("BaseTechnique")->getPass("Specular")->setCullingMode(Ogre::CULL_NONE);
+                    material->getTechnique("BaseTechnique" + shaderlang)->getPass("Specular" + shaderlang)->setCullingMode(Ogre::CULL_NONE);
                 }
             }
         }


### PR DESCRIPTION
Status: HLSL tested under Win10 + Dx9 renderer, GLSL not tested.

Converted on command line using Cg toolkit.
The commands issued are listed in CgConversionsMM.txt.
Manual adjustments of the generated code were needed:
* the first line was always uncommented source filename, probably related to the way I redirected standard output to file... I deleted it manually.
* All parameter names got prefixed with underscore '_' ... there may be some commandline option to get rid of this, but I fixed it by hand.
* All temporary variables got output as globals (outside the main function) which generated error "globals are constant by default, enable compatibility mode blah blah..." ~ I just manually moved them into the bodies of the functions. 
* The vertex shaders were unusable, generating a very trippy effect. I ended up using the original Cg shaders with just minor adjustments based on the generated code.
 
On the OGRE side, I did things the dirty way by duplicating everything before reading on unified shaders: https://ogrecave.github.io/ogre/api/latest/_high-level-_programs.html#Unified-High_002dlevel-Programs - cleanup needed.