### PR TITLE
Removed "Source"  from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,5 @@ tools/l10n/TMP.pot
 redist/
 tmp
 Stamp
-Source
 *.tar.gz
 *.zip


### PR DESCRIPTION
Added in https://github.com/RigsOfRods/rigs-of-rods/commit/d9d7f69663df91b126e772454cf2f210c56170b4, prevented the creation of new files in the `source` directory.