### PR TITLE
:truck: New directive 'forvert' (flexbody forset override)

### DIFF
--- a/source/main/gui/panels/GUI_FlexbodyDebug.cpp
+++ b/source/main/gui/panels/GUI_FlexbodyDebug.cpp
@@ -108,6 +108,7 @@ void FlexbodyDebug::Draw()
         mesh_name = flexbody->getOrigMeshName();
     }
 
+    ImGui::AlignTextToFramePadding();
     ImGui::Text("Mesh: '%s'", mesh_name.c_str());
     if (mat)
     {
@@ -123,6 +124,7 @@ void FlexbodyDebug::Draw()
         }
     }
 
+    ImGui::AlignTextToFramePadding();
     ImGui::Text("Base nodes: Ref=%d, X=%d, Y=%d", (int)node_ref, (int)node_x, (int)node_y);
     ImGui::SameLine();
     ImGui::Checkbox("Show##base", &this->show_base_nodes);
@@ -130,13 +132,20 @@ void FlexbodyDebug::Draw()
     bool flexbody_locators_visible = false;
     if (flexbody)
     {
+        ImGui::AlignTextToFramePadding();
         ImGui::Text("Forset nodes: (total %d)", (int)flexbody->getForsetNodes().size());
         ImGui::SameLine();
         ImGui::Checkbox("Show all##forset", &this->show_forset_nodes);
 
+        ImGui::AlignTextToFramePadding();
         ImGui::Text("Vertices: (total %d)", (int)flexbody->getVertexCount());
         ImGui::SameLine();
         ImGui::Checkbox("Show all (pick with mouse)##verts", &this->show_vertices);
+
+        if (this->show_vertices)
+        {
+            ImGui::Text("Hovered vert: %d", hovered_vert);
+        }
 
         if (ImGui::CollapsingHeader("Vertex locators table"))
         {
@@ -332,7 +341,6 @@ void FlexbodyDebug::DrawDebugView(FlexBody* flexbody, Prop* prop, NodeNum_t node
         }
     }
 
-    int hovered_vert = -1;
     float hovered_vert_dist_squared = FLT_MAX;
     ImVec2 mouse_pos = ImGui::GetMousePos();
     ImVec2 dbg_cursor_dist(0, 0);

--- a/source/main/gui/panels/GUI_FlexbodyDebug.h
+++ b/source/main/gui/panels/GUI_FlexbodyDebug.h
@@ -56,6 +56,7 @@ private:
     bool show_vertices = false;
     bool hide_other_elements = false;
     std::vector<bool> show_locator;
+    int hovered_vert = -1;
 
     // Flexbody and prop selection combobox
     std::string m_combo_items; //!< Flexbodies come first, props second

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -1523,7 +1523,7 @@ void ActorSpawner::ProcessFlexbody(RigDef::Flexbody& def)
         return;
     }
 
-    // Collect nodes
+    // Collect 'forset' nodes
     std::vector<unsigned int> node_indices;
     bool nodes_found = true;
     for (auto& node_def: def.node_list)
@@ -1535,6 +1535,34 @@ void ActorSpawner::ProcessFlexbody(RigDef::Flexbody& def)
             break;
         }
         node_indices.push_back(node);
+    }
+
+    // Resolve 'forvert' nodes
+    std::vector<ForvertTempData> forverts_tmp;
+    for (size_t i = 0; i < def.forvert.size(); i++)
+    {
+        const auto& forvert_item = def.forvert[i];
+        ForvertTempData fvtd;
+        fvtd.vert_index = forvert_item.vert_index;
+        fvtd.nref = this->ResolveNodeRef(forvert_item.node_ref);
+        fvtd.nx = this->ResolveNodeRef(forvert_item.node_x);
+        fvtd.ny = this->ResolveNodeRef(forvert_item.node_y);
+        if (fvtd.nref == NODENUM_INVALID || fvtd.nx == NODENUM_INVALID || fvtd.ny == NODENUM_INVALID)
+        {
+            // Note: although the `RigDef::Node::Ref` was designed to handle numbered/named nodes transparently,
+            //       here we assume nobody will use named nodes with 'forvert' as they're unpopular due to many bugs.
+            this->AddMessage(Message::TYPE_ERROR,
+                fmt::format("Flexbody {}({}) 'forvert'{}/{}: Some nodes not resolved (nref {}->{}, nx {}->{}, ny {}->{}).",
+                    i, def.forvert.size(), (int)flexbody_id, def.mesh_name,
+                    forvert_item.node_ref.Num(), fvtd.nref != NODENUM_INVALID,
+                    forvert_item.node_x.Num(), fvtd.nx != NODENUM_INVALID,
+                    forvert_item.node_y.Num(), fvtd.ny != NODENUM_INVALID
+                    ));
+        }
+        else
+        {
+            forverts_tmp.push_back(fvtd);
+        }
     }
 
     if (! nodes_found)
@@ -1557,6 +1585,7 @@ void ActorSpawner::ProcessFlexbody(RigDef::Flexbody& def)
             TuneupUtil::getTweakedFlexbodyOffset(m_actor->getWorkingTuneupDef(), flexbody_id, def.offset),
             TuneupUtil::getTweakedFlexbodyRotation(m_actor->getWorkingTuneupDef(), flexbody_id, def.rotation),
             node_indices,
+            forverts_tmp,
             TuneupUtil::getTweakedFlexbodyMedia(m_actor->getWorkingTuneupDef(), flexbody_id, 0, def.mesh_name),
             TuneupUtil::getTweakedFlexbodyMediaRG(m_actor->getWorkingTuneupDef(), flexbody_id, 0, this->GetCurrentElementMediaRG())
         );
@@ -5218,6 +5247,7 @@ void ActorSpawner::CreateFlexBodyWheelVisuals(
     {
         node_indices.push_back( node_base_index + i );
     }
+    std::vector<ForvertTempData> forverts;
 
     try
     {
@@ -5229,6 +5259,7 @@ void ActorSpawner::CreateFlexBodyWheelVisuals(
             Ogre::Vector3(0.5f, 0.5f, 0.f),
             Ogre::Vector3(0.f, 0.f, 0.f),
             node_indices,
+            forverts,
             tire_mesh_name,
             tire_mesh_rg
             );

--- a/source/main/physics/flex/FlexBody.h
+++ b/source/main/physics/flex/FlexBody.h
@@ -54,7 +54,8 @@ class FlexBody
         NodeNum_t ny,
         Ogre::Vector3 offset,
         Ogre::Quaternion const & rot, 
-        std::vector<unsigned int> & node_indices
+        std::vector<unsigned int>& node_indices,
+        std::vector<ForvertTempData>& forvert_data
     );
 
 public:

--- a/source/main/physics/flex/FlexFactory.cpp
+++ b/source/main/physics/flex/FlexFactory.cpp
@@ -68,6 +68,7 @@ FlexBody* FlexFactory::CreateFlexBody(
     Ogre::Vector3 offset,
     Ogre::Vector3 rotation, 
     std::vector<unsigned int> & node_indices,
+    std::vector<ForvertTempData>& forvert_data,
     const std::string& mesh_name,
     const std::string& resource_group_name)
 {
@@ -100,7 +101,8 @@ FlexBody* FlexFactory::CreateFlexBody(
         y_node,
         offset,
         rot,
-        node_indices);
+        node_indices,
+        forvert_data);
 
     if (m_is_flexbody_cache_enabled)
     {

--- a/source/main/physics/flex/FlexFactory.h
+++ b/source/main/physics/flex/FlexFactory.h
@@ -175,6 +175,7 @@ public:
         Ogre::Vector3 offset,
         Ogre::Vector3 rotation, 
         std::vector<unsigned int> & node_indices,
+        std::vector<ForvertTempData>& forvert_data,
         const std::string& mesh_name,
         const std::string& resource_group_name);
 

--- a/source/main/physics/flex/Locator_t.h
+++ b/source/main/physics/flex/Locator_t.h
@@ -7,16 +7,25 @@
 
 namespace RoR {
 
-struct Locator_t
-{
-    NodeNum_t ref;
-    NodeNum_t nx;
-    NodeNum_t ny;
-    Ogre::Vector3 coords;
+    struct Locator_t
+    {
+        NodeNum_t ref = NODENUM_INVALID;
+        NodeNum_t nx = NODENUM_INVALID;
+        NodeNum_t ny = NODENUM_INVALID;
+        Ogre::Vector3 coords = Ogre::Vector3::ZERO;
+        bool is_forvert = false;
 
-    NodeNum_t getSmallestNode() { return std::min(ref, std::min(nx, ny)); }
-    NodeNum_t getBiggestNode() { return std::min(ref, std::min(nx, ny)); }
-    NodeNum_t getMean() { return (ref + nx + ny) / 3; }
-};
+        NodeNum_t getSmallestNode() { return std::min(ref, std::min(nx, ny)); }
+        NodeNum_t getBiggestNode() { return std::min(ref, std::min(nx, ny)); }
+        NodeNum_t getMean() { return (ref + nx + ny) / 3; }
+    };
+
+    struct ForvertTempData //!< Node resolution must be done in `ActorSpawner`, but vert resolution in `FlexBody`
+    {
+        NodeNum_t nref = NODENUM_INVALID;
+        NodeNum_t nx = NODENUM_INVALID;
+        NodeNum_t ny = NODENUM_INVALID;
+        int vert_index = 0;
+    };
 
 } // namespace RoR

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -112,6 +112,7 @@ enum class Keyword
     FLEXBODY_CAMERA_MODE,
     FLEXBODYWHEELS,
     FORSET,
+    FORVERT,
     FORWARDCOMMANDS,
     FUSEDRAG,
     GLOBALS,
@@ -899,6 +900,15 @@ struct FlaregroupNoImport
     int control_number = -1; //!< Only 'u' type flares.
 };
 
+/// Manually specified (vert => node) bindings for flexbody deformation (overrides 'forset').
+struct Forvert
+{
+    Node::Ref node_ref;
+    Node::Ref node_x;
+    Node::Ref node_y;
+    int vert_index{ 0 };
+};
+
 struct Flexbody
 {
     Node::Ref reference_node;
@@ -910,6 +920,7 @@ struct Flexbody
     std::list<Animation> animations;
     std::vector<Node::Range> node_list_to_import;
     std::vector<Node::Ref> node_list;
+    std::vector<Forvert> forvert;
     CameraSettings camera_settings;
 };
 

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -907,6 +907,7 @@ struct Forvert
     Node::Ref node_x;
     Node::Ref node_y;
     int vert_index{ 0 };
+    int line_number{ 0 }; // If multiple verts are given on single 'forvert' line, multiple `Forvert` entries are inserted.
 };
 
 struct Flexbody

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -163,6 +163,9 @@ void Parser::ProcessCurrentLine()
         case Keyword::FORSET:
             this->ParseDirectiveForset();
             return;
+        case Keyword::FORVERT:
+            this->ParseDirectiveForvert();
+            return;
         case Keyword::GUID:
             this->ParseGuid();
             return;
@@ -889,6 +892,25 @@ void Parser::ParseDirectiveForset()
     }
 
     Parser::ProcessForsetLine(m_current_module->flexbodies.back(), m_current_line, m_current_line_number);
+}
+
+void Parser::ParseDirectiveForvert()
+{
+    if (m_current_module->flexbodies.size() == 0)
+    {
+        this->LogMessage(Console::CONSOLE_SYSTEM_WARNING, "ignoring 'forvert': no matching flexbody!");
+        return;
+    }
+
+    if (!this->CheckNumArguments(5)) { return; }
+
+    Forvert forvert;
+    forvert.node_ref = this->GetArgNodeRef(1);
+    forvert.node_x = this->GetArgNodeRef(2);
+    forvert.node_y = this->GetArgNodeRef(3);
+    forvert.vert_index = this->GetArgInt(4);
+
+    m_current_module->flexbodies.back().forvert.push_back(forvert);
 }
 
 void Parser::ProcessForsetLine(RigDef::Flexbody& def, const std::string& _line, int line_number /*= -1*/)

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -902,15 +902,24 @@ void Parser::ParseDirectiveForvert()
         return;
     }
 
-    if (!this->CheckNumArguments(5)) { return; }
+    if (!this->CheckNumArguments(6)) { return; }
 
-    Forvert forvert;
+    Forvert forvert; // The temp object.
+    forvert.line_number = m_current_line_number;
     forvert.node_ref = this->GetArgNodeRef(1);
     forvert.node_x = this->GetArgNodeRef(2);
     forvert.node_y = this->GetArgNodeRef(3);
-    forvert.vert_index = this->GetArgInt(4);
+    if (this->GetArgStr(4) != "verts")
+    {
+        this->LogMessage(Console::CONSOLE_SYSTEM_WARNING, "ignoring 'forvert': missing 'verts' portion.");
+        return;
+    }
 
-    m_current_module->flexbodies.back().forvert.push_back(forvert);
+    for (int i = 5; i < m_num_args; i++)
+    {
+        forvert.vert_index = this->GetArgInt(i); // Update the temp object
+        m_current_module->flexbodies.back().forvert.push_back(forvert); // Copy the temp object
+    }
 }
 
 void Parser::ProcessForsetLine(RigDef::Flexbody& def, const std::string& _line, int line_number /*= -1*/)

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.h
@@ -99,6 +99,7 @@ private:
     void ParseDirectiveDetacherGroup();
     void ParseDirectiveFlexbodyCameraMode();
     void ParseDirectiveForset();
+    void ParseDirectiveForvert();
     void ParseDirectivePropCameraMode();
     void ParseDirectiveSection();
     void ParseDirectiveSectionConfig();

--- a/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
@@ -164,6 +164,7 @@ namespace Regexes
     E_KEYWORD_INLINE("flexbody_camera_mode")                      \
     E_KEYWORD_BLOCK("flexbodywheels")                             \
     E_KEYWORD_INLINE_UNSEPARATED("forset")                        \
+    E_KEYWORD_INLINE("forvert")                                   \
     E_KEYWORD_BLOCK("forwardcommands")                            \
     E_KEYWORD_BLOCK("fusedrag")                                   \
     E_KEYWORD_BLOCK("globals")                                    \


### PR DESCRIPTION
This directive affects the previously defined flexbody, like 'forset' does, and manually overrides node bindings for single vertex. The rest of the processing works the same as forset: the game calculates the offset between the nodes and the vertex and maintains it. You can override as many verts as you like, and the nodes used don't need to be in the forset.

Example - Ranges are supported! you can specify any number of verts, the 'verts:' intermezzo is mandatory!:
```
31, 27, 73, -0.0875, 0.5, 0.5, 0, 0, 0, Box69CamaroHood.mesh
forset 11-13, 36, 48-51, 74
; forvert <ref node> <x node> <y node> <vertex number>
forvert 25, 0, 2, verts: 70-71, 28
```

This will be logged to RoR.log:
```
09:36:28: FLEXBODY vertex 70 overriden for nodes REF:25, VX:0, VY:2
09:36:28: FLEXBODY vertex 71 overriden for nodes REF:25, VX:0, VY:2
09:36:28: FLEXBODY vertex 28 overriden for nodes REF:25, VX:0, VY:2
```

Tip: Vertex numbers can be viewed visually using the "Flexbody debug" tool from Top Menubar / Tools:
![image](https://github.com/user-attachments/assets/6a30b841-b0e6-4595-b3f8-65ccea4e2bcd)
![image](https://github.com/user-attachments/assets/4f7b1bc2-d45d-4308-8b44-f324176abfe0)

Fixes #3255 
