### PR TITLE
Hotfix - don't update ActorPtr refcount from a thread.

### DIFF
--- a/source/main/audio/SoundManager.cpp
+++ b/source/main/audio/SoundManager.cpp
@@ -1076,7 +1076,7 @@ bool SoundManager::IsHardwareSourceObstructed(const int hardware_index) const
         // perform line of sight check against actors
         const ActorPtrVec& actors = App::GetGameContext()->GetActorManager()->GetActors();
         bool soundsource_belongs_to_current_actor = false;
-        for (const ActorPtr actor : actors)
+        for (const ActorPtr& actor : actors)
         {
             // Trucks shouldn't obstruct their own sound sources since the
             // obstruction is most likely already contained in the recording.


### PR DESCRIPTION
While working on the HALFBEAM_ freeforces, I entered an actor with commands and bumped into an assert:
![image](https://github.com/user-attachments/assets/70a8e295-65c1-47bf-8f88-d12df418ef04)
The code hitting this was introduced in https://github.com/RigsOfRods/rigs-of-rods/pull/3182. While it's technically no big deal (locking a mostly unlocked mutex), it's something I have an opinion about, hence why I added the assert.

Thread never really needs to manipulate the refcount, it can always just create a reference (`ActorPtr& myref`) or use `ActorInstanceID_t` to refer to the actor. Doing otherwise IMO hints at bad design, like in this case - the obstruction/occlusion check is done directly from physics thread `CalcCommands()`. While it's completely legit to do OpenAL calls from any thread (audio is a threaded thing by nature), our additional logic shouldn't be invoked ad-hoc while doing physics but later in bulk. 
@Hiradur I've written up a GitHub issue https://github.com/RigsOfRods/rigs-of-rods/issues/3290 to summarize my thoughts.