### PR TITLE
 Lowered max reflection update rate setting

### DIFF
--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -443,7 +443,7 @@ void GameSettings::DrawGraphicsSettings()
     if (App::gfx_envmap_enabled->getBool())
     {
         ImGui::PushItemWidth(125.f); // Width includes [+/-] buttons
-        DrawGIntSlider(App::gfx_envmap_rate, _LC("GameSettings", "Realtime refl. update rate"), 0, 6);
+        DrawGIntSlider(App::gfx_envmap_rate, _LC("GameSettings", "Realtime refl. update rate"), 0, 2);
         ImGui::PopItemWidth();
     }
 

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -580,7 +580,7 @@ void TopMenubar::Draw(float dt)
             ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Frames per second:"));
             if (App::gfx_envmap_enabled->getBool())
             {
-                DrawGIntSlider(App::gfx_envmap_rate, _LC("TopMenubar", "Reflections"), 0, 6);
+                DrawGIntSlider(App::gfx_envmap_rate, _LC("TopMenubar", "Reflections"), 0, 2);
             }
             DrawGIntSlider(App::gfx_fps_limit, _LC("TopMenubar", "Game"), 0, 240);
 

--- a/source/main/system/AppConfig.cpp
+++ b/source/main/system/AppConfig.cpp
@@ -305,7 +305,7 @@ void ParseHelper(CVar* cvar, std::string const & val)
     {
         int rate = Ogre::StringConverter::parseInt(val);
         if (rate < 0) { rate = 0; }
-        if (rate > 6) { rate = 6; }
+        if (rate > 2) { rate = 2; }
         AssignHelper(App::gfx_envmap_rate, rate);
     }
     else if (cvar->getName() == App::gfx_shadow_quality->getName())


### PR DESCRIPTION
This lowers the max reflection update rate setting from 6 to 2. High reflection update rate values greatly impact performance, players often max out this setting and ask why their game now runs poorly. The setting doesn't improve reflection quality, only how fast the envmap updates.