### PR TITLE
Hotfix: mishandled `set_node_defaults` weight override

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -6153,7 +6153,6 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
     NodeGfx nfx(node.pos);
     nfx.nx_no_particles = BITMASK_IS_1(options, RigDef::Node::OPTION_p_NO_PARTICLES);
     nfx.nx_may_get_wet  = BITMASK_IS_0(options, RigDef::Node::OPTION_c_NO_GROUND_CONTACT);
-    nfx.nx_no_particles = BITMASK_IS_1(options, RigDef::Node::OPTION_p_NO_PARTICLES);
     nfx.nx_no_sparks    = BITMASK_IS_1(options, RigDef::Node::OPTION_f_NO_SPARKS);
     m_actor->m_gfx_actor->m_gfx_nodes.push_back(nfx);
 }

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -6064,18 +6064,18 @@ void ActorSpawner::ProcessNode(RigDef::Node & def)
 
     if (def.node_defaults->load_weight >= 0.f) // The `>=` operator is intentional (negative value => use default).
     {
-        // orig = further override of hardcoded default.
-        node.mass = def.node_defaults->load_weight; 
+        node.mass = def.node_defaults->load_weight;
         node.nd_override_mass = true;
         node.nd_loaded_mass = true;
+        m_actor->ar_nodes_override_loadweights[inserted_node.first] = def.node_defaults->load_weight;
     }
     else
     {
         node.mass = NODE_LOADWEIGHT_DEFAULT;
         node.nd_loaded_mass = false;
+        m_actor->ar_nodes_override_loadweights[inserted_node.first] = -1.f;
     }
     m_actor->ar_nodes_default_loadweights[inserted_node.first] = def.node_defaults->load_weight;
-    m_actor->ar_nodes_override_loadweights[inserted_node.first] = -1.f;
 
     /* Lockgroup */
     node.nd_lockgroup = (m_file->lockgroup_default_nolock) ? RigDef::Lockgroup::LOCKGROUP_NOLOCK : RigDef::Lockgroup::LOCKGROUP_DEFAULT;

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -286,8 +286,8 @@ private:
         float wheel_mass,
         float wheel_width = -1.f);
 
-    /// @return First: node index, second: True if the node was inserted, false if duplicate.
-    std::pair<unsigned int, bool> AddNode(RigDef::Node::Id & id);
+    /// @return Valid node number if resolved, or `NODENUM_INVALID` if not.
+    NodeNum_t                     RegisterNode(RigDef::Node::Id & id);
     void                          InitNode(node_t & node, Ogre::Vector3 const & position);
     void                          InitNode(unsigned int node_index, Ogre::Vector3 const & position);
     void                          InitNode(node_t & node, Ogre::Vector3 const & position, std::shared_ptr<RigDef::NodeDefaults> node_defaults);


### PR DESCRIPTION
When introducing the `ar_nodes_override_loadweights` array needed for NBUtil tuning/export, I correctly assigned values from nodes with 'l' flag but forgot to assign values from 'set_node_defaults' too.

Fixes https://github.com/RigsOfRods/rigs-of-rods/issues/3298