### PR TITLE
Created 'Rendering Diag' window (open from top menubar/tools)

### DIFF
--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -138,6 +138,7 @@ set(SOURCE_FILES
         gui/panels/GUI_ScriptMonitor.{h,cpp}
         gui/panels/GUI_SimPerfStats.{h,cpp}
         gui/panels/GUI_SurveyMap.{h,cpp}
+        gui/panels/GUI_RenderingDiag.{h,cpp}
         network/CurlHelpers.{h,cpp}
         network/DiscordRpc.{h,cpp}
         network/Network.{h,cpp}

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -33,13 +33,6 @@
 #include <OgreOverlayManager.h>
 #include <OgreOverlay.h>
 
-RoR::GfxEnvmap::GfxEnvmap():
-    m_update_round(0)
-{
-    memset(m_cameras, 0, sizeof(m_cameras));
-    memset(m_render_targets, 0, sizeof(m_render_targets));
-}
-
 void RoR::GfxEnvmap::SetupEnvMap()
 {
     m_rtt_texture = Ogre::TextureManager::getSingleton().getByName("EnvironmentTexture");

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -205,6 +205,28 @@ RoR::GfxEnvmap::~GfxEnvmap()
     }
 }
 
+void RoR::GfxEnvmap::AdjustSceneBeforeRender(Ogre::Vector3 center, GfxActor* gfx_actor)
+{
+    if (gfx_actor != nullptr)
+    {
+        gfx_actor->SetAllMeshesVisible(false);
+        gfx_actor->SetRodsVisible(false);
+    }
+
+    App::GetGameContext()->GetTerrain()->getObjectManager()->SetAllObjectsVisible(envmap_show_terrain_objects);
+}
+
+void RoR::GfxEnvmap::RestoreSceneAfterRender(Ogre::Vector3 center, GfxActor* gfx_actor)
+{
+    if (gfx_actor != nullptr)
+    {
+        gfx_actor->SetRodsVisible(true);
+        gfx_actor->SetAllMeshesVisible(true);
+    }
+
+    App::GetGameContext()->GetTerrain()->getObjectManager()->SetAllObjectsVisible(true);
+}
+
 void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, bool full/*=false*/)
 {
     // how many of the 6 render planes to update at once? Use cvar 'gfx_envmap_rate', unless instructed to do full render.
@@ -230,11 +252,7 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, boo
         m_cameras[i]->setPosition(center);
     }
 
-    if (gfx_actor != nullptr)
-    {
-        gfx_actor->SetAllMeshesVisible(false);
-        gfx_actor->SetRodsVisible(false);
-    }
+    this->AdjustSceneBeforeRender(center, gfx_actor);
 
     for (int i = 0; i < update_rate; i++)
     {
@@ -255,9 +273,5 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, boo
     }
 #endif // USE_CAELUM
 
-    if (gfx_actor != nullptr)
-    {
-        gfx_actor->SetRodsVisible(true);
-        gfx_actor->SetAllMeshesVisible(true);
-    }
+    this->RestoreSceneAfterRender(center, gfx_actor);
 }

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -35,6 +35,8 @@
 
 void RoR::GfxEnvmap::SetupCameras() //only needs to be done once
 {
+    envmap_camera_farclip_distance = App::GetCameraManager()->GetCamera()->getFarClipDistance();
+
     for (int face = 0; face < NUM_FACES; face++)
     {
         m_cameras[face] = App::GetGfxScene()->GetSceneManager()->createCamera("EnvironmentCamera-" + TOSTRING(face));
@@ -42,8 +44,8 @@ void RoR::GfxEnvmap::SetupCameras() //only needs to be done once
         m_cameras[face]->setProjectionType(Ogre::PT_PERSPECTIVE);
         m_cameras[face]->setFixedYawAxis(false);
         m_cameras[face]->setFOVy(Ogre::Degree(90));
-        m_cameras[face]->setNearClipDistance(0.1f);
-        m_cameras[face]->setFarClipDistance(App::GetCameraManager()->GetCamera()->getFarClipDistance());
+        m_cameras[face]->setNearClipDistance(envmap_camera_nearclip_distance);
+        m_cameras[face]->setFarClipDistance(envmap_camera_farclip_distance);
     }
 
     m_cameras[0]->setDirection(+Ogre::Vector3::UNIT_X);
@@ -250,6 +252,8 @@ void RoR::GfxEnvmap::UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, boo
     for (int i = 0; i < NUM_FACES; i++)
     {
         m_cameras[i]->setPosition(center);
+        m_cameras[i]->setNearClipDistance(envmap_camera_nearclip_distance);
+        m_cameras[i]->setFarClipDistance(envmap_camera_farclip_distance);
     }
 
     this->AdjustSceneBeforeRender(center, gfx_actor);

--- a/source/main/gfx/EnvironmentMap.cpp
+++ b/source/main/gfx/EnvironmentMap.cpp
@@ -33,13 +33,10 @@
 #include <OgreOverlayManager.h>
 #include <OgreOverlay.h>
 
-void RoR::GfxEnvmap::SetupEnvMap()
+void RoR::GfxEnvmap::SetupCameras() //only needs to be done once
 {
-    m_rtt_texture = Ogre::TextureManager::getSingleton().getByName("EnvironmentTexture");
-
     for (int face = 0; face < NUM_FACES; face++)
     {
-        m_render_targets[face] = m_rtt_texture->getBuffer(face)->getRenderTarget();
         m_cameras[face] = App::GetGfxScene()->GetSceneManager()->createCamera("EnvironmentCamera-" + TOSTRING(face));
         m_cameras[face]->setAspectRatio(1.0);
         m_cameras[face]->setProjectionType(Ogre::PT_PERSPECTIVE);
@@ -47,12 +44,6 @@ void RoR::GfxEnvmap::SetupEnvMap()
         m_cameras[face]->setFOVy(Ogre::Degree(90));
         m_cameras[face]->setNearClipDistance(0.1f);
         m_cameras[face]->setFarClipDistance(App::GetCameraManager()->GetCamera()->getFarClipDistance());
-
-        Ogre::Viewport* v = m_render_targets[face]->addViewport(m_cameras[face]);
-        v->setOverlaysEnabled(false);
-        v->setClearEveryFrame(true);
-        v->setBackgroundColour(App::GetCameraManager()->GetCamera()->getViewport()->getBackgroundColour());
-        m_render_targets[face]->setAutoUpdated(false);
     }
 
     m_cameras[0]->setDirection(+Ogre::Vector3::UNIT_X);
@@ -61,6 +52,24 @@ void RoR::GfxEnvmap::SetupEnvMap()
     m_cameras[3]->setDirection(-Ogre::Vector3::UNIT_Y);
     m_cameras[4]->setDirection(-Ogre::Vector3::UNIT_Z);
     m_cameras[5]->setDirection(+Ogre::Vector3::UNIT_Z);
+}
+
+void RoR::GfxEnvmap::SetupEnvMap()
+{
+    this->SetupCameras();
+
+    m_rtt_texture = Ogre::TextureManager::getSingleton().getByName("EnvironmentTexture");
+
+    for (int face = 0; face < NUM_FACES; face++)
+    {
+        m_render_targets[face] = m_rtt_texture->getBuffer(face)->getRenderTarget();
+
+        Ogre::Viewport* v = m_render_targets[face]->addViewport(m_cameras[face]);
+        v->setOverlaysEnabled(false);
+        v->setClearEveryFrame(true);
+        v->setBackgroundColour(App::GetCameraManager()->GetCamera()->getViewport()->getBackgroundColour());
+        m_render_targets[face]->setAutoUpdated(false);
+    }
 
     if (App::diag_envmap->getBool())
     {

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -36,6 +36,8 @@ public:
 
     ~GfxEnvmap();
 
+    bool envmap_show_terrain_objects = true; // When false, all .ODEF objects are hidden when rendering envmap.
+
     void SetupEnvMap();
     void UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, bool full = false);
 
@@ -47,6 +49,8 @@ public:
 private:
 
     void SetupCameras(); //only needs to be done once
+    void AdjustSceneBeforeRender(Ogre::Vector3 center, GfxActor* gfx_actor);
+    void RestoreSceneAfterRender(Ogre::Vector3 center, GfxActor* gfx_actor);
 
     static const unsigned int NUM_FACES = 6;
 

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -37,6 +37,8 @@ public:
     ~GfxEnvmap();
 
     bool envmap_show_terrain_objects = true; // When false, all .ODEF objects are hidden when rendering envmap.
+    float envmap_camera_nearclip_distance = 0.1f; // Loads every frame
+    float envmap_camera_farclip_distance = 0.0f; // Loads every frame (0 = infinite)
 
     void SetupEnvMap();
     void UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, bool full = false);

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -34,20 +34,24 @@ class GfxEnvmap
 {
 public:
 
-    GfxEnvmap();
     ~GfxEnvmap();
 
     void SetupEnvMap();
     void UpdateEnvMap(Ogre::Vector3 center, GfxActor* gfx_actor, bool full = false);
 
+    Ogre::RenderTarget* GetRenderTarget(int face) const
+    {
+        return m_render_targets[face];
+    }
+
 private:
 
     static const unsigned int NUM_FACES = 6;
 
-    Ogre::Camera*        m_cameras[NUM_FACES];
-    Ogre::RenderTarget*  m_render_targets[NUM_FACES];
+    std::array<Ogre::Camera*, NUM_FACES> m_cameras;
+    std::array<Ogre::RenderTarget*, NUM_FACES> m_render_targets;
     Ogre::TexturePtr     m_rtt_texture;
-    int                  m_update_round; /// Render targets are updated one-by-one; this is the index of next target to update.
+    int                  m_update_round = 0; /// Render targets are updated one-by-one; this is the index of next target to update.
 };
 
 /// @} // addtogroup Gfx

--- a/source/main/gfx/EnvironmentMap.h
+++ b/source/main/gfx/EnvironmentMap.h
@@ -46,6 +46,8 @@ public:
 
 private:
 
+    void SetupCameras(); //only needs to be done once
+
     static const unsigned int NUM_FACES = 6;
 
     std::array<Ogre::Camera*, NUM_FACES> m_cameras;

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -182,6 +182,11 @@ void GUIManager::DrawSimulationGui(float dt)
     {
         this->FlexbodyDebug.Draw();
     }
+
+    if (this->RenderingDiag.IsVisible())
+    {
+        this->RenderingDiag.Draw();
+    }
 };
 
 void GUIManager::DrawSimGuiBuffered(GfxActor* player_gfx_actor)

--- a/source/main/gui/GUIManager.h
+++ b/source/main/gui/GUIManager.h
@@ -52,6 +52,7 @@
 #include "GUI_TextureToolWindow.h"
 #include "GUI_GameControls.h"
 #include "GUI_TopMenubar.h"
+#include "GUI_RenderingDiag.h"
 
 // Deps
 #include <Bites/OgreWindowEventUtilities.h>
@@ -135,6 +136,7 @@ public:
     GUI::SurveyMap              SurveyMap;
     GUI::DirectionArrow         DirectionArrow;
     GUI::FlexbodyDebug          FlexbodyDebug;
+    GUI::RenderingDiag          RenderingDiag;
     Ogre::Overlay*              MenuWallpaper = nullptr;
 
     // GUI manipulation

--- a/source/main/gui/panels/GUI_RenderingDiag.cpp
+++ b/source/main/gui/panels/GUI_RenderingDiag.cpp
@@ -1,0 +1,126 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+/// @author Thomas Fischer (thomas{AT}thomasfischer{DOT}biz)
+/// @date   7th of September 2009
+
+// Remade using DearIMGUI by Petr Ohlidal, 10/2019
+
+
+#include "GUI_RenderingDiag.h"
+
+#include "Application.h"
+#include "SimData.h"
+#include "Collisions.h"
+#include "GameContext.h"
+#include "GUIManager.h"
+#include "Language.h"
+#include "Terrain.h"
+#include "GfxScene.h"
+#include "Utils.h"
+
+using namespace RoR;
+using namespace GUI;
+
+void RenderingDiag::Draw()
+{
+    ImGui::SetNextWindowPosCenter(ImGuiCond_FirstUseEver);
+    ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse;
+    bool keep_open = true;
+    ImGui::Begin(_LC("RenderingDiag", "Rendering Diagnostics"), &keep_open, win_flags);
+    
+    if (ImGui::BeginTabBar("RenderingDiagTabs", 0))
+    {
+        if (ImGui::BeginTabItem(_LC("RenderingDiag", "Main screen")))
+        {
+            this->DrawMainScreenTab();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem(_LC("RenderingDiag", "Envmap")))
+        {
+            this->DrawEnvmapTab();
+            ImGui::EndTabItem();
+        }        
+        ImGui::EndTabBar();
+    }
+
+    // Common window epilogue
+    m_is_hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+    App::GetGuiManager()->RequestGuiCaptureKeyboard(m_is_hovered);
+
+    ImGui::End();
+
+    if (!keep_open)
+    {
+        this->SetVisible(false);
+    }
+}
+
+void RenderingDiag::DrawMainScreenTab()
+{
+    ImGui::Text(_LC("RenderingDiag", "Main screen"));
+    ImGui::Separator();
+
+    const Ogre::RenderTarget::FrameStats& stats = App::GetAppContext()->GetRenderWindow()->getStatistics();
+    ImGui::Text("%s", fmt::format("FPS: {:5.1f}, Batch: {:5}, Tri: {:6}", stats.lastFPS, stats.batchCount, stats.triangleCount).c_str());
+}
+
+void RenderingDiag::DrawEnvmapFace(int face)
+{
+    Ogre::RenderTarget* render_target = App::GetGfxScene()->GetEnvMap().GetRenderTarget(face);
+    if (render_target)
+    {
+        const Ogre::RenderTarget::FrameStats& stats = render_target->getStatistics();
+        ImGui::Text("%s", fmt::format("FPS: {:5.1f}, Batch: {:5}, Tri: {:6}", stats.lastFPS, stats.batchCount, stats.triangleCount).c_str());
+    }
+    else
+    {
+        ImGui::TextDisabled(_LC("RenderingDiag", "No render target"));
+    }
+}
+
+void RenderingDiag::DrawEnvmapTab()
+{
+    ImGui::Text(_LC("RenderingDiag", "Envmap +X"));
+    this->DrawEnvmapFace(0);
+    ImGui::Separator();
+
+    ImGui::Text(_LC("RenderingDiag", "Envmap -X"));
+    this->DrawEnvmapFace(1);
+    ImGui::Separator();
+
+    ImGui::Text(_LC("RenderingDiag", "Envmap +Y"));
+    this->DrawEnvmapFace(2);
+    ImGui::Separator();
+
+    ImGui::Text(_LC("RenderingDiag", "Envmap -Y"));
+    this->DrawEnvmapFace(3);
+    ImGui::Separator();
+
+    ImGui::Text(_LC("RenderingDiag", "Envmap -Z"));
+    this->DrawEnvmapFace(4);
+    ImGui::Separator();
+
+    ImGui::Text(_LC("RenderingDiag", "Envmap +Z"));
+    this->DrawEnvmapFace(5);
+    ImGui::Separator();
+}
+

--- a/source/main/gui/panels/GUI_RenderingDiag.cpp
+++ b/source/main/gui/panels/GUI_RenderingDiag.cpp
@@ -43,7 +43,7 @@ using namespace GUI;
 void RenderingDiag::Draw()
 {
     ImGui::SetNextWindowPosCenter(ImGuiCond_FirstUseEver);
-    ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse;
+    ImGuiWindowFlags win_flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_AlwaysAutoResize;
     bool keep_open = true;
     ImGui::Begin(_LC("RenderingDiag", "Rendering Diagnostics"), &keep_open, win_flags);
     
@@ -101,29 +101,37 @@ void RenderingDiag::DrawEnvmapTab()
 {
     ImGui::Text(_LC("RenderingDiag", "Envmap - globals"));
     ImGui::Checkbox(_LC("RenderingDiag", "Show terrain objects"), &App::GetGfxScene()->GetEnvMap().envmap_show_terrain_objects);
+    ImGui::InputFloat(_LC("RenderingDiag", "Camera near clip"), &App::GetGfxScene()->GetEnvMap().envmap_camera_nearclip_distance, 0.01f, 2.f, "%.2f");
+    ImGui::InputFloat(_LC("RenderingDiag", "Camera far clip"), &App::GetGfxScene()->GetEnvMap().envmap_camera_farclip_distance, 10.f, 100000.0f, "%.2f");
     ImGui::Separator();
 
-    ImGui::Text(_LC("RenderingDiag", "Envmap +X"));
+    ImGui::TextDisabled(_LC("RenderingDiag", "Envmap +X"));
+    ImGui::SameLine();
     this->DrawEnvmapFace(0);
     ImGui::Separator();
 
-    ImGui::Text(_LC("RenderingDiag", "Envmap -X"));
+    ImGui::TextDisabled(_LC("RenderingDiag", "Envmap -X"));
+    ImGui::SameLine();
     this->DrawEnvmapFace(1);
     ImGui::Separator();
 
-    ImGui::Text(_LC("RenderingDiag", "Envmap +Y"));
+    ImGui::TextDisabled(_LC("RenderingDiag", "Envmap +Y"));
+    ImGui::SameLine();
     this->DrawEnvmapFace(2);
     ImGui::Separator();
 
-    ImGui::Text(_LC("RenderingDiag", "Envmap -Y"));
+    ImGui::TextDisabled(_LC("RenderingDiag", "Envmap -Y"));
+    ImGui::SameLine();
     this->DrawEnvmapFace(3);
     ImGui::Separator();
 
-    ImGui::Text(_LC("RenderingDiag", "Envmap -Z"));
+    ImGui::TextDisabled(_LC("RenderingDiag", "Envmap -Z"));
+    ImGui::SameLine();
     this->DrawEnvmapFace(4);
     ImGui::Separator();
 
-    ImGui::Text(_LC("RenderingDiag", "Envmap +Z"));
+    ImGui::TextDisabled(_LC("RenderingDiag", "Envmap +Z"));
+    ImGui::SameLine();
     this->DrawEnvmapFace(5);
     ImGui::Separator();
 }

--- a/source/main/gui/panels/GUI_RenderingDiag.cpp
+++ b/source/main/gui/panels/GUI_RenderingDiag.cpp
@@ -99,6 +99,10 @@ void RenderingDiag::DrawEnvmapFace(int face)
 
 void RenderingDiag::DrawEnvmapTab()
 {
+    ImGui::Text(_LC("RenderingDiag", "Envmap - globals"));
+    ImGui::Checkbox(_LC("RenderingDiag", "Show terrain objects"), &App::GetGfxScene()->GetEnvMap().envmap_show_terrain_objects);
+    ImGui::Separator();
+
     ImGui::Text(_LC("RenderingDiag", "Envmap +X"));
     this->DrawEnvmapFace(0);
     ImGui::Separator();

--- a/source/main/gui/panels/GUI_RenderingDiag.h
+++ b/source/main/gui/panels/GUI_RenderingDiag.h
@@ -1,0 +1,52 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// @file
+
+
+#pragma once
+
+#include "Application.h"
+
+namespace RoR {
+namespace GUI {
+
+class RenderingDiag
+{
+public:
+    void SetVisible(bool visible) { m_is_visible = visible; }
+    bool IsVisible() const { return m_is_visible; }
+    bool IsHovered() const { return IsVisible() && m_is_hovered; }
+
+
+    void Draw();
+
+private:
+    void DrawMainScreenTab();
+    void DrawEnvmapTab();
+    void DrawEnvmapFace(int face);
+
+
+    bool m_is_visible = false;
+    bool m_is_hovered = false;
+};
+
+} // namespace GUI
+} // namespace RoR

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -722,6 +722,12 @@ void TopMenubar::Draw(float dt)
                 m_open_menu = TopMenu::TOPMENU_NONE;
             }
 
+            if (ImGui::Button(_LC("TopMenubar", "Rendering diag")))
+            {
+                App::GetGuiManager()->RenderingDiag.SetVisible(true);
+                m_open_menu = TopMenu::TOPMENU_NONE;
+            }
+
             if (current_actor != nullptr)
             {
                 if (ImGui::Button(_LC("TopMenubar", "Node / Beam utility")))

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -1171,3 +1171,15 @@ TerrainEditorObjectID_t TerrainObjectManager::FindEditorObjectByInstanceName(std
     }
 }
 
+void TerrainObjectManager::SetAllObjectsVisible(bool visible)
+{
+    if (visible && !m_terrn2_grouping_node->isInSceneGraph())
+    {
+        App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->addChild(m_terrn2_grouping_node);
+    }
+    else if (!visible && m_terrn2_grouping_node->isInSceneGraph())
+    {
+        App::GetGfxScene()->GetSceneManager()->getRootSceneNode()->removeChild(m_terrn2_grouping_node);
+    }
+}
+

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -76,6 +76,7 @@ public:
     void           LoadPredefinedActors();
     bool           HasPredefinedActors() { return m_has_predefined_actors; };
     bool           UpdateTerrainObjects(float dt);
+    void           SetAllObjectsVisible(bool visible);
 
     void ProcessTree(
         float yawfrom, float yawto,
@@ -142,7 +143,7 @@ protected:
     Terrain*                  terrainManager = nullptr;
     ProceduralManagerPtr      m_procedural_manager;
     int                       m_entity_counter = 0;
-    Ogre::SceneNode*          m_terrn2_grouping_node = nullptr; //!< For a readable scene graph (via inspector script)
+    Ogre::SceneNode*          m_terrn2_grouping_node = nullptr; //!< For dynamic visibility (and nice scenegraph) ~ Base for all other scenenodes.
     Ogre::SceneNode*          m_tobj_grouping_node = nullptr; //!< For even more readable scene graph (via inspector script)
     Ogre::SceneNode*          m_angelscript_grouping_node = nullptr; //!< For even more readable scene graph (via inspector script)
 


### PR DESCRIPTION
OGRE provides render stats for any rendertarget, including Render-To-Texture, so let's use it.
I've added some realtime adjustments for environment map - the far clip distance is the most significant, hiding terrain object was easy to do so I provided it too.
![image](https://github.com/user-attachments/assets/e051afd4-b23f-4ddf-8fd0-1ffbf0e73b9d)
