### PR TITLE
Fixed autolocking hooks not relocking on reset

### DIFF
--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3773,7 +3773,8 @@ void Actor::hookToggle(int group, ActorLinkingRequestType mode, NodeNum_t mousen
             this->RemoveInterActorBeam(it->hk_beam, mode); // OK to invoke here - hookToggle() - processing `MSG_SIM_ACTOR_LINKING_REQUESTED`
             if (it->hk_group <= -2)
             {
-                it->hk_timer = it->hk_timer_preset; //timer reset for autolock nodes
+                // autolock timer: if we're hard-resetting the actor, force immediate relock, otherwise restart the countdown.
+                it->hk_timer = (mode == ActorLinkingRequestType::HOOK_RESET) ? 0.f : it->hk_timer_preset;
             }
             it->hk_lock_node = 0;
             it->hk_locked_actor = 0;


### PR DESCRIPTION
Bug introduced in 3de983a33879c1e0ae46f229c45d4ce85048c1ed where custom unhooking code was removed in favor of using existing `hookToggle()` function, which was however made for unhooking via user input (= you want the relock timer to restart). This commit extends the function to recognize hard-reset and adjust the timer accordingly (= attempt relocking immediatelly).