### PR TITLE
🐛 Fixed melting vehicles

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -5795,7 +5795,7 @@ void ActorSpawner::SetBeamDeformationThreshold(beam_t & beam, std::shared_ptr<Ri
             default_deform = BEAM_DEFORM;
         }
 
-        if (beam_defaults->plastic_deform_coef >= BEAM_PLASTIC_COEF_DEFAULT)
+        if (beam_defaults->_is_plastic_deform_coef_user_defined && beam_defaults->plastic_deform_coef >= BEAM_PLASTIC_COEF_DEFAULT)
         {
             beam_creak = 0.f;
         }

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -527,6 +527,7 @@ struct BeamDefaults
         beam_material_name("tracks/beam"),
         breaking_threshold(-1.f),
         _enable_advanced_deformation(false),
+        _is_plastic_deform_coef_user_defined(false),
         _is_user_defined(false)
     {}
 
@@ -558,6 +559,7 @@ struct BeamDefaults
     Ogre::String beam_material_name;
     float plastic_deform_coef = BEAM_PLASTIC_COEF_DEFAULT;
     bool _enable_advanced_deformation; //!< Informs whether "enable_advanced_deformation" directive preceded these defaults.
+    bool _is_plastic_deform_coef_user_defined;
     bool _is_user_defined; //!< Informs whether these data were read from "set_beam_defaults" directive or filled in by the parser on startup.
     BeamDefaultsScale scale;
 };

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -612,6 +612,8 @@ void Parser::ParseDirectiveSetBeamDefaults()
     if (m_num_args > 6) { d.beam_material_name     = this->GetArgStr  (6); }
     if (m_num_args > 7) { d.plastic_deform_coef    = this->GetArgFloat(7); }
 
+    if (m_num_args > 7 && d.plastic_deform_coef >= 0.0f) { d._is_plastic_deform_coef_user_defined = true;       }
+
     if (d.springiness           < 0.f) { d.springiness           = DEFAULT_SPRING;                              }
     if (d.damping_constant      < 0.f) { d.damping_constant      = DEFAULT_DAMP;                                }
     if (d.deformation_threshold < 0.f) { d.deformation_threshold = BEAM_DEFORM;                                 }


### PR DESCRIPTION
Reintroduces `_is_plastic_deform_coef_user_defined`, fixes vehicles like the DI Sportster and Ford Windstar melting at spawn.