### PR TITLE
:truck: New directive 'wings_disable_nav_lights'

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -821,6 +821,7 @@ const char * KeywordToString(RigDef::Keyword keyword)
         case Keyword::WHEELS:               return "wheels";
         case Keyword::WHEELS2:              return "wheels2";
         case Keyword::WINGS:                return "wings";
+        case Keyword::WINGS_DISABLE_NAV_LIGHTS: return "wings_disable_nav_lights";
 
         default:                           return "";
     }

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -292,7 +292,8 @@ enum class Keyword
     WHEELDETACHERS,
     WHEELS,
     WHEELS2,
-    WINGS
+    WINGS,
+    WINGS_DISABLE_NAV_LIGHTS
 };
 
 const char* KeywordToString(Keyword keyword);

--- a/source/main/physics/ActorSpawnerFlow.cpp
+++ b/source/main/physics/ActorSpawnerFlow.cpp
@@ -108,6 +108,7 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     m_actor->ar_rescuer_flag             = m_file->rescuer;
     m_actor->m_disable_default_sounds    = m_file->disable_default_sounds;
     m_actor->ar_hide_in_actor_list       = m_file->hide_in_chooser;
+    m_generate_wing_position_lights      = !m_file->wings_disable_nav_lights;
 
     PROCESS_ELEMENT(RigDef::Keyword::MINIMASS, minimass, ProcessMinimass);
     PROCESS_ELEMENT(RigDef::Keyword::SET_COLLISION_RANGE, set_collision_range, ProcessCollisionRange);

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -1462,6 +1462,7 @@ struct Document
     bool lockgroup_default_nolock;
     bool rescuer;
     bool disable_default_sounds;
+    bool wings_disable_nav_lights = false;
     Ogre::String name;
 
     // File hash

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -114,6 +114,7 @@ void Parser::ProcessCurrentLine()
         case Keyword::RESCUER:
         case Keyword::ROLLON:
         case Keyword::SLIDENODE_CONNECT_INSTANTLY:
+        case Keyword::WINGS_DISABLE_NAV_LIGHTS:
             this->ProcessGlobalDirective(keyword);
             return;
         case Keyword::END_SECTION:
@@ -670,6 +671,7 @@ void Parser::ProcessGlobalDirective(Keyword keyword)   // Directives that should
     case Keyword::RESCUER:                   m_definition->rescuer = true;                       return;
     case Keyword::ROLLON:                    m_definition->rollon = true;                        return;
     case Keyword::SLIDENODE_CONNECT_INSTANTLY: m_definition->slide_nodes_connect_instantly = true; return;
+    case Keyword::WINGS_DISABLE_NAV_LIGHTS: m_definition->wings_disable_nav_lights = true; return;
 
     default: return;
     }

--- a/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_Regexes.h
@@ -236,7 +236,8 @@ namespace Regexes
     E_KEYWORD_BLOCK("wheeldetachers")                             \
     E_KEYWORD_BLOCK("wheels")                                     \
     E_KEYWORD_BLOCK("wheels2")                                    \
-    E_KEYWORD_BLOCK("wings")
+    E_KEYWORD_BLOCK("wings")                                      \
+    E_KEYWORD_BLOCK("wings_disable_nav_lights")
 
 DEFINE_REGEX_IGNORECASE( IDENTIFY_KEYWORD_IGNORE_CASE,  IDENTIFY_KEYWORD_REGEX_STRING )
 


### PR DESCRIPTION
By default the aerial navigation beacons appear on the first wing installed if there is more than 1 wing. Putting the new directive anywhere in file will prevent it.

Example:
```
; By default the aerial navigation beacons appear on the first wing installed if there is more than 1 wing.
wings_disable_nav_lights
```

Fixes #3307