### PR TITLE
Repository selector UI: resource view remade to look like web.

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -171,6 +171,7 @@ CVar* sys_savegames_dir;
 CVar* sys_screenshot_dir;
 CVar* sys_scripts_dir;
 CVar* sys_projects_dir;
+CVar* sys_repo_attachments_dir;
 
 // OS command line
 CVar* cli_server_host;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -44,7 +44,8 @@
 // OGRE resource group names
 #define RGN_TEMP "Temp"
 #define RGN_CACHE "Cache"
-#define RGN_REPO "Repo"
+#define RGN_THUMBNAILS "Thumbnails" // Repository UI - mod previews (one per resource)
+#define RGN_REPO_ATTACHMENTS "RepoAttachments" // Repository UI - images in description text (any number per resource)
 #define RGN_CONFIG "Config"
 #define RGN_CONTENT "Content"
 #define RGN_SAVEGAMES "Savegames"
@@ -708,6 +709,7 @@ extern CVar* sys_savegames_dir;
 extern CVar* sys_screenshot_dir;
 extern CVar* sys_scripts_dir;
 extern CVar* sys_projects_dir;
+extern CVar* sys_repo_attachments_dir;
 
 // OS command line
 extern CVar* cli_server_host;

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -223,6 +223,7 @@ set(SOURCE_FILES
         utils/WriteTextToTexture.{h,cpp}
         utils/memory/RefCountingObject.h
         utils/memory/RefCountingObjectPtr.h
+        utils/bbcode/BBDocument.{h,cpp}
         )
 
 if (ROR_USE_ANGELSCRIPT)
@@ -363,6 +364,7 @@ target_include_directories(${BINNAME} PRIVATE
         threadpool
         utils
         utils/memory
+        utils/bbcode
         )
 
 

--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -32,6 +32,12 @@ static const int         TEXT_COLOR_MAX_LEN = 5000;
 // --------------------------------
 // ImTextFeeder
 
+RoR::ImTextFeeder::ImTextFeeder(ImDrawList* _drawlist, ImVec2 _origin)
+    : drawlist(_drawlist), origin(_origin), cursor(_origin)
+{
+    line_height = ImGui::GetTextLineHeight();
+}
+
 void RoR::ImTextFeeder::AddInline(ImU32 color, ImVec2 text_size, const char* text_begin, const char* text_end)
 {
     drawlist->AddText(this->cursor, color, text_begin, text_end);
@@ -116,10 +122,10 @@ void RoR::ImTextFeeder::AddMultiline(ImU32 color, float wrap_width, const char* 
 
 void RoR::ImTextFeeder::NextLine()
 {
-    const float height = ImGui::GetTextLineHeight();
-    this->size.y += height;
+    this->size.y += this->line_height;
     this->cursor.x = this->origin.x;
-    this->cursor.y += height;
+    this->cursor.y += this->line_height;
+    this->line_height = ImGui::GetTextLineHeight();
 }
 
 // --------------------------------

--- a/source/main/gui/GUIUtils.h
+++ b/source/main/gui/GUIUtils.h
@@ -26,7 +26,7 @@ namespace RoR {
 
 struct ImTextFeeder /// Helper for drawing multiline wrapped & colored text.
 {
-    ImTextFeeder(ImDrawList* _drawlist, ImVec2 _origin): drawlist(_drawlist), origin(_origin), cursor(_origin) {}
+    ImTextFeeder(ImDrawList* _drawlist, ImVec2 _origin);
 
     /// No wrapping or trimming
     void AddInline(ImU32 color, ImVec2 text_size, const char* text, const char* text_end);
@@ -36,10 +36,11 @@ struct ImTextFeeder /// Helper for drawing multiline wrapped & colored text.
     void AddMultiline(ImU32 color, float wrap_width, const char* text, const char* text_end);
     void NextLine();
 
-    ImDrawList* drawlist;
+    ImDrawList* drawlist = nullptr;
     ImVec2 cursor; //!< Next draw position, screen space
     ImVec2 origin; //!< First draw position, screen space
     ImVec2 size = ImVec2(0,0); //!< Accumulated text size
+    float line_height = 0.f;
 };
 
 /// Draws animated loading spinner

--- a/source/main/gui/panels/GUI_RepositorySelector.cpp
+++ b/source/main/gui/panels/GUI_RepositorySelector.cpp
@@ -489,6 +489,7 @@ void RepositorySelector::Draw()
 
         // Search box
         ImGui::SameLine();
+        float searchbox_x = ImGui::GetCursorPosX();
         ImGui::SetNextItemWidth(170);
         float search_pos = ImGui::GetCursorPosX();
         ImGui::InputText("##Search", m_search_input.GetBuffer(), m_search_input.GetCapacity());
@@ -573,224 +574,11 @@ void RepositorySelector::Draw()
 
         if (m_resource_view)
         {
-            // Scroll area
-            ImGui::BeginChild("resource-view-scrolling", ImVec2(0.f, table_height), false);
-
-            this->DrawResourceDescriptionBBCode(m_selected_item);
-
-            const float text_pos = 140.f;
-
-            ImGui::Text("%s", _LC("RepositorySelector", "Details:"));
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Title:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%s", m_selected_item.title.c_str());
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Resource ID:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%d", m_selected_item.resource_id);
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Category:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-
-            for (int i = 0; i < m_data.categories.size(); i++)
-            {
-                if (m_data.categories[i].resource_category_id == m_selected_item.resource_category_id)
-                {
-                    ImGui::TextColored(theme.value_blue_text_color, "%s", m_data.categories[i].title.c_str());
-                }
-            }
-
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Description:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%s", m_selected_item.tag_line.c_str());
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Downloads:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%d", m_selected_item.download_count);
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "View Count:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%d", m_selected_item.view_count);
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Rating:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%f", m_selected_item.rating_avg);
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Rating Count:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%d", m_selected_item.rating_count);
-            ImGui::Separator();
-
-            ImGui::TextDisabled(_LC("RepositorySelector", "Date Added:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            time_t a = (const time_t)m_selected_item.resource_date;
-            ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime (&a)));
-            ImGui::Separator();
-
-            ImGui::TextDisabled(_LC("RepositorySelector", "Last Update:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            time_t b = (const time_t)m_selected_item.last_update;
-            ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime (&b)));
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Version:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%s", m_selected_item.version.c_str());
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "Authors:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%s", m_selected_item.authors.c_str());
-            ImGui::Separator();
-
-            ImGui::TextDisabled("%s", _LC("RepositorySelector", "View URL:"));
-            ImGui::SameLine();
-            ImGui::SetCursorPosX(text_pos);
-            ImGui::TextColored(theme.value_blue_text_color, "%s", m_selected_item.view_url.c_str());
-            ImGui::Separator();
-
-            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 20);
-            ImGui::Text("%s", _LC("RepositorySelector", "Files:"));
-
-            // Spinner
-            if (m_data.files.empty() && m_repofiles_msg.empty())
-            {
-                ImGui::SameLine();
-                float spinner_size = 7.f;
-                LoadingIndicatorCircle("spinner", spinner_size, theme.value_blue_text_color, theme.value_blue_text_color, 10, 10);
-            }
-
-            ImGui::Separator();
-
-            if (!m_repofiles_msg.empty())
-            {
-                ImGui::TextDisabled("%s", m_repofiles_msg.c_str());
-            }
-
-            // Check for duplicate files, remove the outdated one (lower id)
-            std::sort(m_data.files.begin(), m_data.files.end(), [](ResourceFiles a, ResourceFiles b) { return a.id > b.id; });
-            auto last = std::unique(m_data.files.begin(), m_data.files.end(), [](ResourceFiles a, ResourceFiles b) { return a.filename == b.filename; });
-            m_data.files.erase(last, m_data.files.end());
-
-            for (int i = 0; i < m_data.files.size(); i++)
-            {
-                ImGui::PushID(i);
-
-                ImGui::AlignTextToFramePadding();
-                float pos_y = ImGui::GetCursorPosY();
-
-                ImGui::TextDisabled("%s", _LC("RepositorySelector", "Filename:"));
-                ImGui::SameLine();
-                ImGui::SetCursorPosX(text_pos);
-
-                // File
-                std::string path = PathCombine(App::sys_user_dir->getStr(), "mods");
-                std::string file = PathCombine(path, m_data.files[i].filename);
-
-                // Get created time
-                int file_time = 0;
-                if (FileExists(file))
-                {
-                    file_time = GetFileLastModifiedTime(file);
-                }
-
-                ImGui::TextColored(theme.value_blue_text_color, "%s", m_data.files[i].filename.c_str());
-
-                if (FileExists(file) && ImGui::IsItemHovered())
-                {
-                    ImGui::BeginTooltip();
-
-                    time_t c = (const time_t)file_time;
-                    ImGui::TextDisabled("%s %s", "Installed on", asctime(gmtime (&c)));
-
-                    ImGui::EndTooltip();
-                }
-
-                // File size
-                ImGui::SameLine();
-
-                int size = m_data.files[i].size / 1024;
-                ImGui::TextDisabled("(%d %s)", size, "KB");
-
-                // File exists show indicator
-                if (FileExists(file))
-                {
-                    ImGui::SameLine();
-                    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 3.5f);
-                    ImGui::Image(reinterpret_cast<ImTextureID>(tex2->getHandle()), ImVec2(16, 16));
-                }
-
-                // Buttons
-                ImGui::SameLine();
-                ImGui::SetCursorPosX(ImGui::GetWindowSize().x - 220);
-                ImGui::SetCursorPosY(pos_y);
-
-                std::string btn_label;
-                if (FileExists(file) && m_selected_item.last_update > file_time)
-                {
-                    btn_label = fmt::format(_LC("RepositorySelector", "Update"));
-                }
-                else if (FileExists(file))
-                {
-                    btn_label = fmt::format(_LC("RepositorySelector", "Reinstall"));
-                }
-                else
-                {
-                    btn_label = fmt::format(_LC("RepositorySelector", "Install"));
-                }
-
-                if (ImGui::Button(btn_label.c_str(), ImVec2(100, 0)))
-                {
-                    this->Download(m_selected_item.resource_id, m_data.files[i].filename, m_data.files[i].id);
-                }
-
-                ImGui::SameLine();
-
-                if (FileExists(file) && ImGui::Button(_LC("RepositorySelector", "Remove"), ImVec2(100, 0)))
-                {
-                    Ogre::ArchiveManager::getSingleton().unload(file);
-                    Ogre::FileSystemLayer::removeFile(file);
-                    m_update_cache = true;
-                }
-                else if (!FileExists(file))
-                {
-                    ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
-                    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
-                    ImGui::Button(_LC("RepositorySelector", "Remove"), ImVec2(100, 0));
-                    ImGui::PopItemFlag();
-                    ImGui::PopStyleVar();
-                }
-
-                ImGui::Separator();
-
-                ImGui::PopID();
-            }
-            ImGui::EndChild();
+            this->DrawResourceView(searchbox_x);
         }
         else
         {
+
             float col0_width = 0.40f * ImGui::GetWindowContentRegionWidth();
             float col1_width = 0.15f * ImGui::GetWindowContentRegionWidth();
             float col2_width = 0.20f * ImGui::GetWindowContentRegionWidth();
@@ -849,17 +637,17 @@ void RepositorySelector::Draw()
                 {
                     // Simple search filter: convert both title/author and input to lowercase, if input not found in the title/author continue
                     std::string title = m_data.items[i].title;
-                    for(auto& c : title)
+                    for (auto& c : title)
                     {
                         c = tolower(c);
                     }
                     std::string author = m_data.items[i].authors;
-                    for(auto& c : author)
+                    for (auto& c : author)
                     {
                         c = tolower(c);
                     }
                     std::string search = m_search_input.GetBuffer();
-                    for(auto& c : search)
+                    for (auto& c : search)
                     {
                         c = tolower(c);
                     }
@@ -934,7 +722,7 @@ void RepositorySelector::Draw()
                         ImGui::SameLine();
                         ImGui::SetCursorPosX(width);
                         time_t rawtime = (const time_t)m_data.items[i].last_update;
-                        ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime (&rawtime)));
+                        ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime(&rawtime)));
 
                         ImGui::TextDisabled("%s:", _LC("RepositorySelector", "Downloads"));
                         ImGui::SameLine();
@@ -962,7 +750,7 @@ void RepositorySelector::Draw()
                         }
 
                         // Skip to new line if at least 50% of the box can't fit on current line.
-                        if (orig_cursor_x > ImGui::GetWindowContentRegionMax().x - (box_width * 0.5)) 
+                        if (orig_cursor_x > ImGui::GetWindowContentRegionMax().x - (box_width * 0.5))
                         {
                             // Unless this is the 1st line... not much to do with such narrow window.
                             if (num_drawn_items != 0)
@@ -1005,7 +793,7 @@ void RepositorySelector::Draw()
                         {
                             pos_y = ImGui::GetCursorPosY();
                             ImGui::Image(reinterpret_cast<ImTextureID>(tex3->getHandle()), ImVec2(11, 11), ImVec2(0.f, 0.f), ImVec2(1.f, 1.f), ImVec4(1.f, 1.f, 1.f, 0.2f));
-                            if ( i < 5) { ImGui::SameLine(); }
+                            if (i < 5) { ImGui::SameLine(); }
                         }
 
                         int rating = round(m_data.items[i].rating_avg);
@@ -1039,7 +827,7 @@ void RepositorySelector::Draw()
 
                         ImGui::SetCursorPosX(ImGui::GetCursorPos().x + 86);
                         time_t rawtime = (const time_t)m_data.items[i].last_update;
-                        ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime (&rawtime)));
+                        ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime(&rawtime)));
 
                         ImGui::SetCursorPosX(ImGui::GetCursorPos().x + 86);
                         ImGui::TextColored(theme.value_blue_text_color, "%s %d %s", _LC("RepositorySelector", "Downloaded"), m_data.items[i].download_count, _LC("RepositorySelector", "times"));
@@ -1072,17 +860,17 @@ void RepositorySelector::Draw()
 
                         // Draw columns
                         ImGui::SameLine();
-                        ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 2*ImGui::GetStyle().ItemSpacing.x);
+                        ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 2 * ImGui::GetStyle().ItemSpacing.x);
                         ImGui::Text("%s", m_data.items[i].title.c_str());
 
                         ImGui::NextColumn();
 
-                        ImGui::TextColored(theme.value_blue_text_color, "%s",  m_data.items[i].version.c_str());
+                        ImGui::TextColored(theme.value_blue_text_color, "%s", m_data.items[i].version.c_str());
 
                         ImGui::NextColumn();
 
                         time_t rawtime = (const time_t)m_data.items[i].last_update;
-                        ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime (&rawtime)));
+                        ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime(&rawtime)));
 
                         ImGui::NextColumn();
 
@@ -1160,6 +948,268 @@ void RepositorySelector::Draw()
     if (!keep_open)
     {
         this->SetVisible(false);
+    }
+}
+
+void RepositorySelector::DrawResourceView(float searchbox_x)
+{
+    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    Ogre::TexturePtr tex2 = FetchIcon("accept.png");
+    Ogre::TexturePtr tex3 = FetchIcon("star.png");
+    Ogre::TexturePtr tex4 = FetchIcon("arrow_left.png");
+
+    const float INFOBAR_HEIGHT = 100.f;
+    const float INFOBAR_SPACING_LEFTSIDE = 2.f;
+    const float INFOBAR_SPACING_RIGHTSIDE = 0.f;
+
+    // --- top info bar, left side ---
+
+    // Black background
+    ImVec2 leftmost_cursor = ImGui::GetCursorPos();
+    ImVec2 backdrop_size = ImVec2(ImGui::GetContentRegionAvailWidth(), INFOBAR_HEIGHT + ImGui::GetStyle().ItemSpacing.y * 2);
+    ImGui::GetWindowDrawList()->AddRectFilled(ImGui::GetCursorScreenPos(), ImGui::GetCursorScreenPos() + backdrop_size, ImColor(0.f, 0.f, 0.f, 0.5f), /*rounding:*/5.f);
+    ImGui::SetCursorPos(ImGui::GetCursorPos() + ImGui::GetStyle().ItemSpacing);
+
+    // The thumbnail again (like on web repo)
+    ImVec2 thumbnail_cursor = ImGui::GetCursorPos();
+    ImGui::Image(reinterpret_cast<ImTextureID>(m_selected_item.preview_tex->getHandle()), ImVec2(INFOBAR_HEIGHT, INFOBAR_HEIGHT));
+
+    // Title + version (like on web repo)
+    ImGui::SameLine();
+    ImVec2 newline_cursor = ImGui::GetCursorPos();
+    ImGui::TextColored(RESOURCE_TITLE_COLOR, "%s", m_selected_item.title.c_str());
+    ImGui::SameLine();
+
+    // One line below - the tagline
+    newline_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_LEFTSIDE);
+    ImGui::SetCursorPos(newline_cursor);
+    ImGui::Text("%s", m_selected_item.tag_line.c_str()); // Also add tagline
+
+    // One line below (bigger gap) - the version and num downloads
+    newline_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_LEFTSIDE * 4);
+    ImGui::SetCursorPos(newline_cursor);
+    ImGui::TextDisabled("%s", _LC("RepositorySelector", "Version:"));
+    ImGui::SameLine();
+    ImGui::TextColored(theme.value_blue_text_color, "%s", m_selected_item.version.c_str());
+    ImGui::SameLine();
+    ImGui::TextDisabled("%s", _LC("RepositorySelector", "Downloads:"));
+    ImGui::SameLine();
+    ImGui::TextColored(theme.value_blue_text_color, "%d", m_selected_item.download_count);
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() - ImGui::GetStyle().ItemSpacing.x); // Don't put gap between the blue value and gray parentheses
+    ImGui::TextDisabled(")");
+
+    // One line below - the rating and rating count
+    newline_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_LEFTSIDE);
+    ImGui::SetCursorPos(newline_cursor);
+    ImGui::TextDisabled("%s", _LC("RepositorySelector", "Rating:"));
+    ImGui::SameLine();
+    ImGui::TextColored(theme.value_blue_text_color, "%.1f", m_selected_item.rating_avg);
+    ImGui::SameLine();
+    // (Rating stars)
+    ImVec2 stars_cursor = ImGui::GetCursorPos();
+    int rating = round(m_selected_item.rating_avg);
+    for (int i = 1; i <= 5; i++)
+    {
+        ImGui::SetCursorPosX(stars_cursor.x + 16 * (i-1));
+        ImVec4 tint_color = (i <= rating) ? ImVec4(1, 1, 1, 1) : ImVec4(1.f, 1.f, 1.f, 0.2f);
+        ImGui::Image(reinterpret_cast<ImTextureID>(tex3->getHandle()), ImVec2(16, 16), ImVec2(0.f, 0.f), ImVec2(1.f, 1.f), tint_color);
+        ImGui::SameLine();
+    }
+    ImGui::SetCursorPosX(stars_cursor.x + 16 * 5 + ImGui::GetStyle().ItemSpacing.x);
+    ImGui::TextDisabled("(%s", _LC("RepositorySelector", "Rating Count:"));
+    ImGui::SameLine();
+    ImGui::TextColored(theme.value_blue_text_color, "%d", m_selected_item.rating_count);
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() - ImGui::GetStyle().ItemSpacing.x); // Don't put gap between the blue value and gray parentheses
+    ImGui::TextDisabled(")");
+
+    // One line below - authors
+    newline_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_LEFTSIDE);
+    ImGui::SetCursorPos(newline_cursor);
+    ImGui::TextDisabled("%s", _LC("RepositorySelector", "Authors:"));
+    ImGui::SameLine();
+    ImGui::TextColored(theme.value_blue_text_color, "%s", m_selected_item.authors.c_str());
+
+    // --- top info bar, right side ---
+
+    // Right side: The detail text
+    ImVec2 rightside_cursor = ImVec2(searchbox_x, thumbnail_cursor.y);
+    ImGui::SetCursorPos(rightside_cursor);
+    ImGui::Text("%s", _LC("RepositorySelector", "Details:"));
+
+    // Right side, next line
+    rightside_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_RIGHTSIDE);
+    ImGui::SetCursorPos(rightside_cursor);
+    ImGui::TextDisabled("%s", _LC("RepositorySelector", "Resource ID:"));
+    ImGui::SameLine();
+    ImGui::TextColored(theme.value_blue_text_color, "%d", m_selected_item.resource_id);
+
+    // Right side, next line
+    rightside_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_RIGHTSIDE);
+    ImGui::SetCursorPos(rightside_cursor);
+    ImGui::TextDisabled("%s", _LC("RepositorySelector", "View Count:"));
+    ImGui::SameLine();
+    ImGui::TextColored(theme.value_blue_text_color, "%d", m_selected_item.view_count);
+
+    // Right side, next line
+    rightside_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_RIGHTSIDE);
+    ImGui::SetCursorPos(rightside_cursor);
+    ImGui::TextDisabled(_LC("RepositorySelector", "Date Added:"));
+    ImGui::SameLine();
+    time_t a = (const time_t)m_selected_item.resource_date;
+    ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime(&a)));
+
+    // Right side, next line
+    rightside_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_RIGHTSIDE);
+    ImGui::SetCursorPos(rightside_cursor);
+    ImGui::TextDisabled(_LC("RepositorySelector", "Last Update:"));
+    ImGui::SameLine();
+    time_t b = (const time_t)m_selected_item.last_update;
+    ImGui::TextColored(theme.value_blue_text_color, "%s", asctime(gmtime(&b)));
+
+    // Right side, next line
+    rightside_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_RIGHTSIDE);
+    ImGui::SetCursorPos(rightside_cursor);
+    ImGui::TextDisabled("%s", _LC("RepositorySelector", "View URL:"));
+    ImGui::SameLine();
+    ImGui::TextColored(theme.value_blue_text_color, "%s", m_selected_item.view_url.c_str());
+
+    // --- content area ---
+
+    const float table_height = ImGui::GetWindowHeight()
+        - ((2.f * ImGui::GetStyle().WindowPadding.y) + (3.f * ImGui::GetItemsLineHeightWithSpacing())
+            - ImGui::GetStyle().ItemSpacing.y);
+
+    // Scroll area
+    ImGui::SetCursorPos(leftmost_cursor + ImVec2(0.f, INFOBAR_HEIGHT + ImGui::GetStyle().ItemSpacing.y * 3));
+    ImGui::BeginChild("resource-view-scrolling", ImVec2(0.f, table_height), false);
+
+    if (!m_repofiles_msg.empty())
+    {
+        // Downloading failed
+        ImGui::TextDisabled("%s", m_repofiles_msg.c_str());
+    }
+    else if (m_data.files.empty())
+    {
+        // Downloading in progress - show spinner (centered)
+        float spinner_radius = 25.f;
+        ImGui::SetCursorPos(ImGui::GetCursorPos() + ImVec2(ImGui::GetContentRegionAvailWidth() / 2 - spinner_radius, 200.f));
+        LoadingIndicatorCircle("spinner", spinner_radius, theme.value_blue_text_color, theme.value_blue_text_color, 10, 10);
+    }
+    else
+    {
+        // Files + description downloaded OK
+        this->DrawResourceDescriptionBBCode(m_selected_item);
+        ImGui::Separator();
+        this->DrawResourceFiles();
+    }
+
+    ImGui::EndChild();
+}
+
+void RepositorySelector::DrawResourceFiles()
+{
+    GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
+    Ogre::TexturePtr tex2 = FetchIcon("accept.png");
+    ImGui::Text("%s", _LC("RepositorySelector", "Files:"));
+
+    // Check for duplicate files, remove the outdated one (lower id)
+    std::sort(m_data.files.begin(), m_data.files.end(), [](ResourceFiles a, ResourceFiles b) { return a.id > b.id; });
+    auto last = std::unique(m_data.files.begin(), m_data.files.end(), [](ResourceFiles a, ResourceFiles b) { return a.filename == b.filename; });
+    m_data.files.erase(last, m_data.files.end());
+
+    for (int i = 0; i < m_data.files.size(); i++)
+    {
+        ImGui::PushID(i);
+
+        ImGui::AlignTextToFramePadding();
+        float pos_y = ImGui::GetCursorPosY();
+
+        ImGui::TextDisabled("%s", _LC("RepositorySelector", "Filename:"));
+        ImGui::SameLine();
+
+        // File
+        std::string path = PathCombine(App::sys_user_dir->getStr(), "mods");
+        std::string file = PathCombine(path, m_data.files[i].filename);
+
+        // Get created time
+        int file_time = 0;
+        if (FileExists(file))
+        {
+            file_time = GetFileLastModifiedTime(file);
+        }
+
+        ImGui::TextColored(theme.value_blue_text_color, "%s", m_data.files[i].filename.c_str());
+
+        if (FileExists(file) && ImGui::IsItemHovered())
+        {
+            ImGui::BeginTooltip();
+
+            time_t c = (const time_t)file_time;
+            ImGui::TextDisabled("%s %s", "Installed on", asctime(gmtime(&c)));
+
+            ImGui::EndTooltip();
+        }
+
+        // File size
+        ImGui::SameLine();
+
+        int size = m_data.files[i].size / 1024;
+        ImGui::TextDisabled("(%d %s)", size, "KB");
+
+        // File exists show indicator
+        if (FileExists(file))
+        {
+            ImGui::SameLine();
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 3.5f);
+            ImGui::Image(reinterpret_cast<ImTextureID>(tex2->getHandle()), ImVec2(16, 16));
+        }
+
+        // Buttons
+        ImGui::SameLine();
+        ImGui::SetCursorPosX(ImGui::GetWindowSize().x - 220);
+        ImGui::SetCursorPosY(pos_y);
+
+        std::string btn_label;
+        if (FileExists(file) && m_selected_item.last_update > file_time)
+        {
+            btn_label = fmt::format(_LC("RepositorySelector", "Update"));
+        }
+        else if (FileExists(file))
+        {
+            btn_label = fmt::format(_LC("RepositorySelector", "Reinstall"));
+        }
+        else
+        {
+            btn_label = fmt::format(_LC("RepositorySelector", "Install"));
+        }
+
+        if (ImGui::Button(btn_label.c_str(), ImVec2(100, 0)))
+        {
+            this->Download(m_selected_item.resource_id, m_data.files[i].filename, m_data.files[i].id);
+        }
+
+        ImGui::SameLine();
+
+        if (FileExists(file) && ImGui::Button(_LC("RepositorySelector", "Remove"), ImVec2(100, 0)))
+        {
+            Ogre::ArchiveManager::getSingleton().unload(file);
+            Ogre::FileSystemLayer::removeFile(file);
+            m_update_cache = true;
+        }
+        else if (!FileExists(file))
+        {
+            ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+            ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+            ImGui::Button(_LC("RepositorySelector", "Remove"), ImVec2(100, 0));
+            ImGui::PopItemFlag();
+            ImGui::PopStyleVar();
+        }
+
+        ImGui::Separator();
+
+        ImGui::PopID();
     }
 }
 

--- a/source/main/gui/panels/GUI_RepositorySelector.h
+++ b/source/main/gui/panels/GUI_RepositorySelector.h
@@ -111,6 +111,10 @@ class RepositorySelector:
 {
 public:
     const Ogre::uint16                  WORKQUEUE_ROR_REPO_THUMBNAIL = 1; // Work queue request type, named by OGRE convention.
+    const float                         ATTACH_MAX_WIDTH = 160.f;
+    const float                         ATTACH_MAX_HEIGHT = 90.f;
+    const float                         ATTACH_SPINNER_RADIUS = 20.f;
+    const ImVec2                        ATTACH_SPINNER_PADDING = ImVec2(55.f, 25.f);
 
     RepositorySelector();
     ~RepositorySelector();

--- a/source/main/gui/panels/GUI_RepositorySelector.h
+++ b/source/main/gui/panels/GUI_RepositorySelector.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "Application.h"
+#include "BBDocument.h"
 #include "OgreImGui.h" // ImVec4
 
 #include <future>
@@ -57,6 +58,7 @@ struct ResourceItem
     std::string         icon_url;
     std::string         authors;
     std::string         version;
+    bbcpp::BBDocumentPtr description;
     int                 download_count;
     int                 last_update;
     int                 resource_category_id;
@@ -104,6 +106,7 @@ public:
     void                                UpdateFiles(ResourcesCollection* data);
     void                                ShowError(CurlFailInfo* failinfo);
     void                                DrawThumbnail(int resource_item_idx);
+    void                                DrawResourceDescriptionBBCode(const ResourceItem& item);
 
     /// Ogre::WorkQueue API
     virtual Ogre::WorkQueue::Response*  handleRequest(const Ogre::WorkQueue::Request *req, const Ogre::WorkQueue *srcQ) override; //!< Processes tasks on background thread

--- a/source/main/gui/panels/GUI_RepositorySelector.h
+++ b/source/main/gui/panels/GUI_RepositorySelector.h
@@ -115,6 +115,7 @@ public:
     const float                         ATTACH_MAX_HEIGHT = 90.f;
     const float                         ATTACH_SPINNER_RADIUS = 20.f;
     const ImVec2                        ATTACH_SPINNER_PADDING = ImVec2(55.f, 25.f);
+    const ImVec4                        RESOURCE_TITLE_COLOR = ImVec4(1.f, 1.f, 0.7f, 1.f);
 
     RepositorySelector();
     ~RepositorySelector();
@@ -122,6 +123,8 @@ public:
     void                                SetVisible(bool visible);
     bool                                IsVisible() const { return m_is_visible; }
     void                                Draw();
+    void                                DrawResourceView(float searchbox_x);
+    void                                DrawResourceFiles();
     void                                OpenResource(int resource_id);
     void                                Download(int resource_id, std::string filename, int id);
     void                                DownloadFinished();

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -106,6 +106,7 @@ int main(int argc, char *argv[])
         App::sys_screenshot_dir->setStr(PathCombine(App::sys_user_dir->getStr(), "screenshots"));
         App::sys_scripts_dir   ->setStr(PathCombine(App::sys_user_dir->getStr(), "scripts"));
         App::sys_projects_dir  ->setStr(PathCombine(App::sys_user_dir->getStr(), "projects"));
+        App::sys_repo_attachments_dir->setStr(PathCombine(App::sys_user_dir->getStr(), "repo_attachments"));
 
         // Load RoR.cfg - updates cvars
         App::GetConsole()->loadConfig();
@@ -749,7 +750,7 @@ int main(int argc, char *argv[])
                     GUI::ResourcesCollection* data = static_cast<GUI::ResourcesCollection*>(m.payload);
                     try
                     {
-                        App::GetGuiManager()->RepositorySelector.UpdateFiles(data);
+                        App::GetGuiManager()->RepositorySelector.UpdateResourceFilesAndDescription(data);
                     }
                     catch (...) 
                     {

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -262,7 +262,9 @@ void ContentManager::InitModCache(CacheValidity validity)
     ResourceGroupManager::getSingleton().addResourceLocation(
         App::sys_cache_dir->getStr(), "FileSystem", RGN_CACHE, /*recursive=*/false, /*readOnly=*/false);
     ResourceGroupManager::getSingleton().addResourceLocation(
-        App::sys_thumbnails_dir->getStr(), "FileSystem", RGN_REPO, /*recursive=*/false, /*readOnly=*/false);
+        App::sys_thumbnails_dir->getStr(), "FileSystem", RGN_THUMBNAILS, /*recursive=*/false, /*readOnly=*/false);
+    ResourceGroupManager::getSingleton().addResourceLocation(
+        App::sys_repo_attachments_dir->getStr(), "FileSystem", RGN_REPO_ATTACHMENTS, /*recursive=*/false, /*readOnly=*/false);
 
     // Add top-level ZIPs/directories to RGN_CONTENT (non-recursive)
 

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -117,6 +117,7 @@ void Console::cVarSetupBuiltins()
     App::sys_screenshot_dir      = this->cVarCreate("sys_screenshot_dir",      "",                           0);
     App::sys_scripts_dir         = this->cVarCreate("sys_scripts_dir",         "",                           0);
     App::sys_projects_dir        = this->cVarCreate("sys_projects_dir",        "",                           0);
+    App::sys_repo_attachments_dir= this->cVarCreate("sys_repo_attachments_dir","",                           0);
 
     App::cli_server_host         = this->cVarCreate("cli_server_host",         "",                           0);
     App::cli_server_port         = this->cVarCreate("cli_server_port",         "",                                          CVAR_TYPE_INT,     "0");

--- a/source/main/utils/bbcode/BBDocument.cpp
+++ b/source/main/utils/bbcode/BBDocument.cpp
@@ -1,0 +1,120 @@
+/*
+    This code is adopted from https://github.com/zethon/bbcpp
+    at commit 852a02dda37a17f458dd68ecf5461141f93edce2.
+    See reprint of original license (MIT) in README.txt
+*/
+
+#include <cstring>
+#include <cctype>
+#include "BBDocument.h"
+
+namespace bbcpp
+{
+
+BBNode::BBNode(NodeType nodeType, const std::string& name)
+    : _name(name), _nodeType(nodeType)
+{
+    // nothing to do
+}
+
+BBText &BBDocument::newText(const std::string &text)
+{
+    // first try to append this text to the item on top of the stack
+    // if that is a BBText object, if not, then see if the last element
+    // pushed to BBDocument is a text item, and if so append this to that
+    // text
+    if (_stack.size() > 0 && _stack.top()->getChildren().size() > 0)
+    {
+        auto totalChildCnt = _stack.top()->getChildren().size();
+        auto textnode = _stack.top()->getChildren().at(totalChildCnt - 1)->downCast<BBTextPtr>(false);
+        if (textnode)
+        {
+            textnode->append(text);
+            return *textnode;
+        }
+    }
+    else if (_children.size() > 0)
+    {
+        auto textnode = _children.back()->downCast<BBTextPtr>(false);
+        if (textnode)
+        {
+            textnode->append(text);
+            return *textnode;
+        }
+    }
+
+    // ok, there was no previous text element so we wil either add this text
+    // element as a child of the top item OR we'll add it to the BBDocucment
+    // object
+    auto textNode = std::make_shared<BBText>(text);
+    if (_stack.size() > 0)
+    {
+        _stack.top()->appendChild(textNode);
+    }
+    else
+    {
+        // add this node to the document-node if needed
+        appendChild(textNode);
+    }
+
+    return *textNode;
+}
+
+BBElement& BBDocument::newElement(const std::string &name)
+{
+    auto newNode = std::make_shared<BBElement>(name);
+    if (_stack.size() > 0)
+    {
+        _stack.top()->appendChild(newNode);  
+    }
+    else
+    {
+        // add this node to the document-node if needed
+        appendChild(newNode);
+    }
+ 
+    _stack.push(newNode);
+    return *newNode;
+}
+
+BBElement& BBDocument::newClosingElement(const std::string& name)
+{
+    auto newNode = std::make_shared<BBElement>(name, BBElement::CLOSING);
+    if (_stack.size() > 0)
+    {
+        _stack.top()->appendChild(newNode);  
+        _stack.pop();
+    }
+    else
+    {
+        appendChild(newNode);
+    }
+
+    return *newNode;
+}
+
+BBElement& BBDocument::newKeyValueElement(const std::string& name, const ParameterMap& pairs)
+{
+    auto newNode = std::make_shared<BBElement>(name, BBElement::PARAMETER);
+    if (_stack.size() > 0)
+    {
+        _stack.top()->appendChild(newNode);
+    }
+    else
+    {
+        // add this node to the document-node if needed
+        appendChild(newNode);
+    }
+
+    for (const auto& kv : pairs)
+    {
+        newNode->setOrAddParameter(kv.first, kv.second);
+    }
+
+    _stack.push(newNode);
+    return *newNode;
+}
+  
+
+
+} // namespace

--- a/source/main/utils/bbcode/BBDocument.h
+++ b/source/main/utils/bbcode/BBDocument.h
@@ -1,0 +1,615 @@
+/*
+    This code is adopted from https://github.com/zethon/bbcpp
+    at commit 852a02dda37a17f458dd68ecf5461141f93edce2.
+    See reprint of original license (MIT) in README.txt
+
+    Changes done in this file:
+    * Added commentary to the private default constructor of BBDocument
+    * Renamed `parseValue` to `parseAttributeValue` for clarity
+    *  - added support for quoted attributes
+    * `parseAttributeValue()` removed the `IsAlNum()` and all color/url special character checks because:
+       > '_' was missing from the original code
+       > UTF-8 characters would cause havoc
+    * `parseElementName()` - also support singular `[*]` as list item
+*/
+
+#pragma once
+#include <memory>
+#include <string>
+#include <vector>
+#include <stack>
+#include <stdexcept>
+#include <sstream>
+#include <iostream>
+#include <map>
+#include <iterator>
+#include <cctype>
+#include <cstring>
+
+namespace bbcpp
+{
+
+inline bool IsDigit(char c)
+{
+    return ('0' <= c && c <= '9');
+}
+
+inline bool IsAlpha(char c)
+{
+    static const char alpha[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    return (std::strchr(alpha, c) != nullptr);
+}
+
+inline bool IsAlNum(char c)
+{
+    return IsAlpha(c) || IsDigit(c);
+}
+
+inline bool IsSpace(char c)
+{
+    return std::isspace(static_cast<unsigned char>(c)) != 0;
+}
+
+class BBNode;
+class BBText;
+class BBElement;
+class BBDocument;
+
+using BBNodePtr = std::shared_ptr<BBNode>;
+using BBTextPtr = std::shared_ptr<BBText>;
+using BBElementPtr = std::shared_ptr<BBElement>;
+
+using BBNodeWeakPtr = std::weak_ptr<BBNode>;
+using BBNodeList = std::vector<BBNodePtr>;
+using BBNodeStack = std::stack<BBNodePtr>;
+using BBDocumentPtr = std::shared_ptr<BBDocument>;
+
+using ParameterMap = std::map<std::string, std::string>;
+
+class BBNode : public std::enable_shared_from_this<BBNode>
+{
+    template<typename NewTypePtrT>
+    NewTypePtrT cast(BBNodePtr node, bool bThrowOnFail)
+    {
+        if (node == nullptr && !bThrowOnFail)
+        {
+            return NewTypePtrT();
+        }
+        else if (node == nullptr)
+        {
+            throw std::invalid_argument("Cannot downcast BBNode, object is null");
+        }
+
+        NewTypePtrT newobj = std::dynamic_pointer_cast<typename NewTypePtrT::element_type, BBNode>(node);
+
+        if (newobj == nullptr && bThrowOnFail)
+        {
+            throw std::invalid_argument("Cannot downcast, object is not correct type");
+        }
+
+        return newobj;
+    }   
+
+    template<typename NewTypePtrT>
+    NewTypePtrT cast(BBNodePtr node, bool bThrowOnFail) const
+    {
+        if (node == nullptr && !bThrowOnFail)
+        {
+            return NewTypePtrT();
+        }
+        else if (node == nullptr)
+        {
+            throw std::invalid_argument("Cannot downcast, BBNode object is null");
+        }
+
+        NewTypePtrT newobj = std::dynamic_pointer_cast<typename NewTypePtrT::element_type, BBNode>(node);
+
+        if (newobj == nullptr && bThrowOnFail)
+        {
+            throw std::invalid_argument("Cannot downcast, object is not correct type");
+        }
+
+        return newobj;
+    }      
+        
+public:
+    enum class NodeType
+    {
+        DOCUMENT,   
+        ELEMENT,    // [b]bold[/b], [QUOTE], [QUOTE=Username;1234], [QUOTE user=Bob] 
+        TEXT,       // plain text
+        ATTRIBUTE
+    };
+
+    BBNode(NodeType nodeType, const std::string& name);
+    virtual ~BBNode() = default;
+
+    const std::string& getNodeName() const { return _name; }
+    NodeType getNodeType() const { return _nodeType; }
+    BBNodePtr getParent() const { return BBNodePtr(_parent); }
+
+    const BBNodeList& getChildren() const { return _children; }
+
+    virtual void appendChild(BBNodePtr node)
+    {
+        _children.push_back(node);
+        node->_parent = shared_from_this();
+    }
+
+    template<typename NewTypePtrT>
+	NewTypePtrT downCast(bool bThrowOnFail = true)
+	{
+		return cast<NewTypePtrT>(shared_from_this(), bThrowOnFail);
+	}
+
+    template<typename NewTypePtrT>
+	NewTypePtrT downCast(bool bThrowOnFail = true) const
+	{
+		return cast<NewTypePtrT>(shared_from_this(), bThrowOnFail);
+	}
+  
+protected:
+    std::string     _name;
+    NodeType        _nodeType;
+    BBNodeWeakPtr   _parent;
+    BBNodeList      _children;
+
+    friend class BBText;
+    friend class BBDocument;
+    friend class BBElement;
+};
+
+class BBText : public BBNode
+{
+public:
+    BBText(const std::string& value)
+        : BBNode(BBNode::NodeType::TEXT, value)
+    {
+        // nothing to do
+    }
+
+    virtual ~BBText() = default;
+
+    virtual const std::string getText() const { return _name; }
+
+    void append(const std::string& text)
+    {
+        _name.append(text);
+    }
+};
+
+class BBElement : public BBNode
+{
+public:
+    enum ElementType
+    {
+        SIMPLE,     // [b]bold[/b], [code]print("hello")[/code]
+        VALUE,      // [QUOTE=Username;12345]This is a quote[/QUOTE] (mostly used by vBulletin)
+        PARAMETER,  // [QUOTE user=Bob userid=1234]This is a quote[/QUOTE]
+        CLOSING     // [/b], [/code]
+    };
+
+    BBElement(const std::string& name, ElementType et = BBElement::SIMPLE)
+        : BBNode(BBNode::NodeType::ELEMENT, name),
+          _elementType(et)
+    {
+        // nothing to do
+    }
+
+    virtual ~BBElement() = default;
+
+    const ElementType getElementType() const { return _elementType; }
+
+    void setOrAddParameter(const std::string& key, const std::string& value, bool addIfNotExists = true)
+    {
+        _parameters.insert({key,value});
+    }
+
+    std::string getParameter(const std::string& key, bool bDoThrow = true)
+    {
+        if (_parameters.find(key) == _parameters.end() && bDoThrow)
+        {
+            throw std::invalid_argument("Undefine attribute '" + key + "'");
+        }
+
+        return _parameters.at(key);
+    }
+
+    const ParameterMap& getParameters() const { return _parameters; }
+
+private:
+    ElementType       _elementType = BBElement::SIMPLE;
+    ParameterMap      _parameters;
+};
+
+class BBDocument : public BBNode
+{
+    // Private for a good reason - this object must be managed by std::shared_ptr,
+    // otherwise parser crashes due to using `shared_from_this()`
+    // See https://stackoverflow.com/questions/25628704/enable-shared-from-this-why-the-crash
+    BBDocument()
+        : BBNode(BBNode::NodeType::DOCUMENT, "#document")
+    {
+        // nothing to do
+    }
+
+	template <typename citerator>
+    citerator parseText(citerator begin, citerator end)
+    {
+        auto endingChar = begin;
+
+        for (auto it = begin; it != end; it++)
+        {
+            if (*it == '[')
+            {
+                endingChar = it;
+                break;
+            }
+        }
+
+        if (endingChar == begin)
+        {
+            endingChar = end;
+        }
+
+        newText(std::string(begin, endingChar));
+
+        return endingChar;
+    }
+
+     template <typename citerator>
+     citerator parseElementName(citerator begin, citerator end, std::string& buf)
+     {
+         auto start = begin;
+         std::stringstream str;
+
+         for (auto it = start; it != end; it++)
+         {
+             // RIGSOFRODS: also support singular [*] as list item.
+             const char c = (char)*it;
+            if (bbcpp::IsAlNum(c) || c == '*')
+            {
+                str << *it;
+            }
+            else
+            {
+                buf.assign(str.str());
+                return it;
+            }
+         }
+
+         return start;
+     }
+
+     template <typename citerator>
+     citerator parseAttributeValue(citerator begin, citerator end, std::string& value)
+     {
+         auto start = begin;
+         while (bbcpp::IsSpace(*start) && start != end)
+         {
+             start++;
+         }
+
+         if (start == end)
+         {
+             // we got to the end and there was nothing but spaces
+             // so return our starting point so the caller can create
+             // a text node with those spaces
+             return end;
+         }
+
+         std::stringstream temp;
+
+         for (auto it = start; it != end; it++)
+         {
+             // RIGSOFRODS: removed the `IsAlNum()` and all color/url special character checks because:
+             // * '_' was missing from the original code
+             // * UTF-8 characters would cause havoc
+
+             if (*it == '\"') // RIGSOFRODS: added support for quoted attribute values
+             {
+                 // Opening or closing quotemark - skip it.
+                 continue;
+             }
+             else if (*it == ']')
+             {
+                 value.assign(temp.str());
+                 return it;
+             }
+             else
+             {
+                 temp << *it;
+             }
+         }
+
+         // if we get here then we're at the end, so we return the starting
+         // point so the callerd can create a text node
+         return end;
+     }
+
+    template <typename citerator>
+    citerator parseKey(citerator begin, citerator end, std::string& keyname)
+    {
+        auto start = begin;
+        while (bbcpp::IsSpace(*start) && start != end)
+        {
+            start++;
+        }
+
+        if (start == end)
+        {
+            // we got to the end and there was nothing but spaces
+            // so return our end point so the caller can create
+            // a text node with those spaces
+            return start;
+        }
+
+        std::stringstream temp;
+
+        // TODO: need to handle spaces after the key name and before
+        // the equal sign (ie. "[style color  =red]")
+        for (auto it = start; it != end; it++)
+        {
+            if (bbcpp::IsAlNum(*it))
+            {
+                temp << *it;
+            }
+            else if (*it == '=')
+            {
+                keyname.assign(temp.str());
+                return it;
+            }
+            else
+            {
+                // some invalid character, so return the point where
+                // we stopped parsing
+                return it;
+            }
+        }
+
+        // if we get here then we're at the end, so we return the starting
+        // point so the callerd can create a text node
+        return end;
+    }
+
+    template <typename citerator>
+    citerator parseKeyValuePairs(citerator begin, citerator end, ParameterMap& pairs)
+    {
+        auto current = begin;
+        std::string tempKey;
+        std::string tempVal;
+
+        while (current != end)
+        {
+            current = parseKey(current, end, tempKey);
+            if (tempKey.empty())
+            {
+                pairs.clear();
+                return current;
+            }
+
+            if (*current != '=')
+            {
+                pairs.clear();
+                return current;
+            }
+
+            current = std::next(current);
+            current = parseAttributeValue(current, end, tempVal);
+
+            if (tempKey.empty() || tempVal.empty())
+            {
+                pairs.clear();
+                return current;
+            }
+
+            pairs.insert(std::make_pair(tempKey, tempVal));
+            if (*current == ']')
+            {
+                // this is the only valid condition for key/value pairs so we do
+                // not want to clear `pairs` like in the other cases
+                return current;
+            }
+        }
+
+        return end;
+    }
+
+    template <typename citerator>
+    citerator parseElement(citerator begin, citerator end)
+    {
+        bool closingTag = false;
+
+        // the first non-[ and non-/ character
+        auto nameStart = std::next(begin);
+
+        std::string elementName;
+
+        // this might be a closing tag so mark it
+        if (*nameStart == '/')
+        {
+            closingTag = true;
+            nameStart = std::next(nameStart);
+        }
+
+        auto nameEnd = parseElementName(nameStart, end, elementName);
+
+        // no valid name was found, so bail out
+        if (elementName.empty())
+        {
+            newText(std::string{*begin});
+            return nameEnd;
+        }
+        else if (nameEnd == end)
+        {
+            newText(std::string(begin,end));
+            return end;
+        }
+
+        if (*nameEnd == ']')
+        {
+            // end of element
+        }
+        else if (*nameEnd == '=')
+        {
+            // possibly a QUOTE value element
+            // possibly key-value pairs of a QUOTE
+            ParameterMap pairs;
+            
+            auto kvEnd = parseKeyValuePairs(nameStart, end, pairs);
+            if (pairs.size() == 0)
+            {
+                newText(std::string(begin, kvEnd));
+                return kvEnd;
+            }
+            else
+            {
+                newKeyValueElement(elementName, pairs);
+                // TODO: add 'pairs'
+                return std::next(kvEnd);
+            }
+        }
+        else if (*nameEnd == ' ')
+        {
+            // possibly key-value pairs of a QUOTE
+            ParameterMap pairs;
+
+            auto kvEnd = parseKeyValuePairs(nameEnd, end, pairs);
+            if (pairs.size() == 0)
+            {
+                newText(std::string(begin, kvEnd));
+                return kvEnd;
+            }
+            else
+            {
+                newKeyValueElement(elementName, pairs);
+                // TODO: add 'pairs'
+                return std::next(kvEnd);
+            }
+        }
+        else
+        {
+            // some invalid char proceeded the element name, so it's not actually a
+            // valid element, so create it as text and move on
+            newText(std::string(begin,nameEnd));
+            return nameEnd;
+        }
+
+        if (closingTag)
+        {
+            newClosingElement(elementName);
+        }
+        else
+        {
+            newElement(elementName);
+        }
+
+        return std::next(nameEnd);
+    }
+
+public: 
+    static BBDocumentPtr create()
+    {
+        BBDocumentPtr doc = BBDocumentPtr(new BBDocument());
+        return doc;
+    }
+
+    void load(const std::string& bbcode)
+    {
+        load(bbcode.begin(), bbcode.end());
+    }
+
+    template<class Iterator>
+    void load(Iterator begin, Iterator end)
+    {
+        std::string buffer;
+        auto bUnknownNodeType = true;
+        auto current = begin;
+        auto nodeType = BBNode::NodeType::TEXT;
+
+        Iterator temp;
+
+        while (current != end)
+        {
+            if (bUnknownNodeType)
+            {
+                if (*current == '[')
+                {
+                    nodeType = BBNode::NodeType::ELEMENT;
+                    bUnknownNodeType = false;
+                }
+                else
+                {
+                    nodeType = BBNode::NodeType::TEXT;
+                    bUnknownNodeType = false;
+                }
+            }
+            
+            if (!bUnknownNodeType)
+            {
+                switch (nodeType)
+                {
+                    default:
+                        throw std::runtime_error("Unknown node type in BBDocument::load()");
+                    break;
+
+                    case BBNode::NodeType::TEXT:
+                    {
+                        current = parseText(current, end);
+                        bUnknownNodeType = true;
+                    }
+                    break;
+
+                    case BBNode::NodeType::ELEMENT:
+                    {
+                        temp  = parseElement(current, end);
+                        if (temp == current)
+                        {
+                            // nothing was parsed, treat as text
+                            nodeType = BBNode::NodeType::TEXT;
+                            bUnknownNodeType = false;
+                        }
+                        else
+                        {
+                            current = temp;
+                            bUnknownNodeType = true;
+                        }
+                    }
+                    break;                    
+                }
+            }
+        }
+    }
+
+private:
+    BBNodeStack     _stack;
+
+    BBText& newText(const std::string& text = std::string());
+    BBElement& newElement(const std::string& name);
+    BBElement& newClosingElement(const std::string& name);
+    BBElement& newKeyValueElement(const std::string& name, const ParameterMap& pairs);
+};
+
+namespace
+{
+
+std::ostream& operator<<(std::ostream& os, const ParameterMap& params)
+{
+    bool first = true;
+    os << "{ ";
+    for (auto& p : params)
+    {
+        os << (first ? "" : ", ") << "{" << p.first << "=" << p.second << "}";
+        if (first)
+        {
+            first = false;
+        }
+    }
+    return (os << " }");
+}
+
+}
+
+
+    
+} // namespace

--- a/source/main/utils/bbcode/README.txt
+++ b/source/main/utils/bbcode/README.txt
@@ -1,0 +1,30 @@
+This code is adopted from https://github.com/zethon/bbcpp
+at commit 852a02dda37a17f458dd68ecf5461141f93edce2.
+* Files BBDocument.{h|cpp} are taken mostly as-is, see header comment.
+* File 'bbcpputils.cpp' was integrated to GUI_RepositorySelector.cpp
+
+------------- reprint of LICENSE file from original repo -------------
+
+MIT License
+
+Copyright (c) 2016 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------- end LICENSE from original repo -------------


### PR DESCRIPTION
Not final yet but almost.
Instead of that clipped ViewURL field I'll just use hyperlink "View in browser", I have that working in scripts, I'll just recycle.
I'll also try shoving the installable files on the right.
Also, I'll make the images clickable to invoke gallery - that's not implemented yet.
<img width="1375" height="1174" alt="image" src="https://github.com/user-attachments/assets/be509610-d00e-4b9a-97d7-eeb1beb1a8ff" />
Fixes #3311