### PR TITLE
Fixed player's own text not showing in chatbox.

### DIFF
--- a/source/main/gameplay/ChatSystem.cpp
+++ b/source/main/gameplay/ChatSystem.cpp
@@ -50,7 +50,8 @@ void ReceiveStreamData(unsigned int type, int source, char* buffer)
     if (type != MSG2_UTF8_CHAT && type != MSG2_UTF8_PRIVCHAT)
         return;
 
-    if (source != -1) // user ID -1 is a server broadcast message, defined as `TO_ALL` in rorserver.
+    if (source != App::GetNetwork()->GetLocalUserData().uniqueid // Skip mute check for player's own messages (server broadcasts to all by default)
+        && source != -1) // user ID -1 is a server broadcast message, defined as `TO_ALL` in rorserver.
     {
         BitMask_t peeropts = BitMask_t(0);
         if (!App::GetNetwork()->GetUserPeerOpts(source, peeropts) || BITMASK_IS_1(peeropts, RoRnet::PEEROPT_MUTE_CHAT))


### PR DESCRIPTION
Broken in 76a1af6e2b60edce3e2df38ded1a295f86e911e1 (added option to mute others in chat: https://github.com/RigsOfRods/rigs-of-rods/pull/3215)

Fixes #3320