### PR TITLE
Fixed airplane beacons generated on a car wing.

### DIFF
--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -457,7 +457,7 @@ private:
     Ogre::Vector3            m_spawn_position;
     bool                     m_apply_simple_materials;
     std::string              m_custom_resource_group;
-    bool                     m_generate_wing_position_lights;
+    bool                     m_generate_wing_position_lights = true;
     ActorMemoryRequirements  m_memory_requirements;
     /// @}
 

--- a/source/main/physics/ActorSpawnerFlow.cpp
+++ b/source/main/physics/ActorSpawnerFlow.cpp
@@ -79,11 +79,20 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     m_fuse_y_max = -1000.0f;
     m_first_wing_index = -1;
 
-    m_generate_wing_position_lights = true;
-
-    if (m_file->root_module->engine.size() > 0) // Engine present => it's a land vehicle.
+    // Disable aerial pos. lights for land vehicles (detect by 'engine' element).
+    if (m_file->root_module->engine.size() > 0)
     {
-        m_generate_wing_position_lights = false; // Disable aerial pos. lights for land vehicles.
+        m_generate_wing_position_lights = false; 
+    }
+    else
+    {
+        for (auto& sel_module : m_selected_modules)
+        {
+            if (sel_module->engine.size() > 0)
+            {
+                m_generate_wing_position_lights = false;
+            }
+        }
     }
 
     // Create the built-in "renderdash" material for use in meshes.


### PR DESCRIPTION
Fixes #3307

It indeed did check for engine, but only if it's `outside section/end_section` and for that offending mod it isn't.