### PR TITLE
:scroll: script_editor gadget: fixed losing folded regions.

### DIFF
--- a/resources/gadgets/script_editor.as
+++ b/resources/gadgets/script_editor.as
@@ -1632,7 +1632,7 @@ private void mergeCollectedFoldingRegionsWithExisting(dictionary&in collectedReg
                 RegionInfo@ newRegionInfo = findRegion(collectedRegions, newRegionNames[j]);
                 if (oldRegionInfo.regionStartsAtLineIndex == newRegionInfo.regionStartsAtLineIndex)
                 {
-                    game.log ("DBG mergeCollectedFoldingRegionsWithExisting(): region '" + oldRegionNames[i] + "' was renamed to '"+newRegionNames[j]+"'");
+                    // game.log ("DBG mergeCollectedFoldingRegionsWithExisting(): region '" + oldRegionNames[i] + "' was renamed to '"+newRegionNames[j]+"'");
                     isGone = false;
                     renamedRegionsOldName.insertLast(oldRegionNames[i]);
                     renamedRegionsNewName.insertLast(newRegionNames[j]);
@@ -1650,9 +1650,9 @@ private void mergeCollectedFoldingRegionsWithExisting(dictionary&in collectedReg
     // Resolve renamed regions
     for (uint i = 0; i < renamedRegionsOldName.length(); i++)
     {
+        RegionInfo@ regionInfo = findRegion(this.workBufferRegions, renamedRegionsOldName[i]);
         this.workBufferRegions.delete(renamedRegionsOldName[i]);
-        RegionInfo@ newRegionInfo = findRegion(collectedRegions, renamedRegionsNewName[i]);
-        this.workBufferRegions.set(renamedRegionsNewName[i], newRegionInfo);
+        this.workBufferRegions.set(renamedRegionsNewName[i], regionInfo);
     }
 
     // Find regions that were (re)created
@@ -1676,6 +1676,7 @@ private void mergeCollectedFoldingRegionsWithExisting(dictionary&in collectedReg
             */
 
             existingRegionInfo.regionBodyStartOffset = newRegionInfo.regionBodyStartOffset;
+            existingRegionInfo.regionStartsAtLineIndex = newRegionInfo.regionStartsAtLineIndex;
 
             if (!existingRegionInfo.isFolded)
             {
@@ -2053,17 +2054,17 @@ private void unFoldRegionInternal(string regionName) //  do NOT invoke during dr
     "NumChars:"+regionInfo.regionBodyNumChars+", isFolded:"+regionInfo.isFolded+", regionBodyStartOffset:"+regionInfo.regionBodyStartOffset+", regionBodyNumChars:"+regionInfo.regionBodyNumChars));
     // END DEBUG //*/
     
-    if (!regionInfo.isFolded)
-    {
-        return; // nothing to do
-    }
-    
     if (@regionInfo == null) // sanity check - this means `#endregion` isn't available
     {
         game.log("ERROR|script_editor.as|`unFoldRegionInternal()` ~ regionName='"+regionName
             +"' ~ regionInfo null - this means `#endregion` isn't available");
         return;
     }
+    
+    if (!regionInfo.isFolded)
+    {
+        return; // nothing to do
+    }    
     
     // DEBUG // Investigating a C++ exception triggered by bad `string::insert` args 
     if (regionInfo.regionBodyStartOffset < 0


### PR DESCRIPTION
First problem: any time folded region was renamed, its content was truncated.
Cause: in `mergeCollectedFoldingRegionsWithExisting()`, renamed regions were correctly identified but incorrectly handled - instead of renaming existing RegionInfo objects, they were replaced with the newly created objects which were considered unfolded and empty.

Second Problem: if lines got added/removed before folded region and that region was then renamed, its content was truncated.
Cause: in `mergeCollectedFoldingRegionsWithExisting()`, renamed regions were detected using `RegionInfo::regionStartsAtLineIndex`, but this value wasn't regularly updated.

Additional problem: in `unFoldRegionInternal()`, the null pointer check was done _after_ the pointer was dereferenced.