### PR TITLE
Disabled "bundle-qualified" (including ZIP/dir name) mod lookup for multiplayer.

### DIFF
--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -405,7 +405,8 @@ void ActorManager::HandleActorStreamData(std::vector<RoR::NetRecvPacket> packet_
 
                     LOG("[RoR] Creating remote actor for " + TOSTRING(reg->origin_sourceid) + ":" + TOSTRING(reg->origin_streamid));
 
-                    CacheEntryPtr actor_entry = App::GetCacheSystem()->FindEntryByFilename(LT_AllBeam, /*partial:*/false, filename_maybe_bundlequalified);
+                    // Based on negative user feedback we don't check the bundle in multiplayer.
+                    CacheEntryPtr actor_entry = App::GetCacheSystem()->FindEntryByFilename(LT_AllBeam, /*partial:*/false, filename);
 
                     if (!actor_entry)
                     {


### PR DESCRIPTION
Fixes #3336

Originally Introduced in #3171