### PR TITLE
Repo UI: Enabled wrapping of long lines in description.

### DIFF
--- a/source/main/gui/GUIUtils.cpp
+++ b/source/main/gui/GUIUtils.cpp
@@ -121,6 +121,25 @@ void RoR::ImTextFeeder::AddMultiline(ImU32 color, float wrap_width, const char* 
     }
 }
 
+void RoR::ImTextFeeder::AddRectWrapped(ImVec2 size, ImVec2 spacing, float wrap_width, ImVec2& out_rect_min)
+{
+    // Wrap if requested and if we're not on far left side
+    const float cur_width = this->cursor.x - this->origin.x;
+    if (wrap_width > 0.f && cur_width > 0.f && cur_width + size.x > wrap_width)
+    {
+        this->NextLine();
+    }
+
+    // Output the cursor for drawing
+    out_rect_min = this->cursor;
+
+    // Update cursor
+    this->cursor.x += size.x + spacing.x;
+    this->line_height = std::max(this->line_height, size.y + spacing.y);
+    this->size.x = std::max(this->size.x, this->cursor.x - this->origin.x);
+    this->size.y = std::max(this->size.y, (this->cursor.y + this->line_height) - this->origin.y);
+}
+
 void RoR::ImTextFeeder::NextLine()
 {
     this->size.y += this->line_height;

--- a/source/main/gui/GUIUtils.h
+++ b/source/main/gui/GUIUtils.h
@@ -34,6 +34,8 @@ struct ImTextFeeder /// Helper for drawing multiline wrapped & colored text.
     void AddWrapped(ImU32 color, float wrap_width, const char* text, const char* text_end);
     /// Wraps substrings separated by blanks. `wrap_width=-1.f` disables wrapping.
     void AddMultiline(ImU32 color, float wrap_width, const char* text, const char* text_end);
+    /// Reserves space for i.e. an image. `wrap_width=-1.f` disables wrapping.
+    void AddRectWrapped(ImVec2 size, ImVec2 spacing, float wrap_width, ImVec2& out_rect_min);
     void NextLine();
 
     ImDrawList* drawlist = nullptr;

--- a/source/main/gui/panels/GUI_RepositorySelector.cpp
+++ b/source/main/gui/panels/GUI_RepositorySelector.cpp
@@ -1033,10 +1033,28 @@ void RepositorySelector::DrawResourceView(float searchbox_x)
     ImGui::SetCursorPosX(searchbox_x - (ImGui::CalcTextSize(browser_text.c_str()).x + ImGui::GetStyle().ItemSpacing.x + ImGui::GetStyle().WindowPadding.x));
     ImHyperlink(selected_item.view_url, browser_text);
 
-    // One line below - the tagline
+    // One line below - the tagline (with [..] tooltip button if oversize)
     newline_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_LEFTSIDE);
     ImGui::SetCursorPos(newline_cursor);
-    ImGui::Text("%s", selected_item.tag_line.c_str()); // Also add tagline
+    const ImVec2 tagline_btnsize = ImGui::CalcTextSize("[...]") + ImGui::GetStyle().ItemSpacing * 2;
+    const ImVec2 tagline_size = ImGui::CalcTextSize(selected_item.tag_line.c_str());
+    const ImVec2 tagline_clipmin = ImGui::GetCursorScreenPos();
+    const ImVec2 tagline_clipmax((ImGui::GetWindowPos().x + searchbox_x) - (tagline_btnsize.x + ImGui::GetStyle().FramePadding.x), tagline_clipmin.y + ImGui::GetTextLineHeight());
+    ImGui::PushClipRect(tagline_clipmin, tagline_clipmax, /* intersect_with_current_cliprect:*/ false);
+    ImGui::Text("%s", selected_item.tag_line.c_str());
+    ImGui::PopClipRect();
+    if (tagline_size.x > tagline_clipmax.x - tagline_clipmin.x)
+    {
+        // tagline is oversize - draw [...] tooltip (same line, far right)
+        ImGui::SetCursorPos(ImVec2(searchbox_x - (tagline_btnsize.x + ImGui::GetStyle().FramePadding.x), newline_cursor.y));
+        ImGui::TextDisabled("[...]");
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::BeginTooltip();
+            ImGui::Text("%s", selected_item.tag_line.c_str()); // no clipping this time
+            ImGui::EndTooltip();
+        }
+    }
 
     // One line below (bigger gap) - the version and num downloads
     newline_cursor += ImVec2(0.f, ImGui::GetTextLineHeight() + INFOBAR_SPACING_LEFTSIDE * 4);


### PR DESCRIPTION
Since the header has fixed size, an overlong 'tagline' text will be clipped and [...] will be shown. Hover it with mouse to see a tooltip with full tagline.
<img width="1097" height="868" alt="image" src="https://github.com/user-attachments/assets/299946a1-7e29-4fd6-bfb4-94c5fa3b2535" />
