### PR TITLE
Fixed prop anims not being updated for all actor types.

### DIFF
--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -1963,11 +1963,5 @@ void GameContext::UpdateTruckInputEvents(float dt)
     {
         m_player_actor->getTyrePressure().UpdateInputEvents(dt);
     }
-
-    m_player_actor->UpdatePropAnimInputEvents();
-    for (ActorPtr linked_actor : m_player_actor->ar_linked_actors)
-    {
-        linked_actor->UpdatePropAnimInputEvents();
-    }
 }
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -1929,6 +1929,11 @@ int main(int argc, char *argv[])
                                             App::GetGameContext()->UpdateBoatInputEvents(dt);
                                         }
                                     }
+                                    App::GetGameContext()->GetPlayerActor()->UpdatePropAnimInputEvents();
+                                    for (ActorPtr linked_actor : App::GetGameContext()->GetPlayerActor()->ar_linked_actors)
+                                    {
+                                        linked_actor->UpdatePropAnimInputEvents();
+                                    }
                                 }
                             }
                             else // free cam mode


### PR DESCRIPTION
Fixes #3033

Prop animation used to be done equally for all actors, see: https://github.com/ohlidalp/rigs-of-rods/blob/retro-0407/source/main/physics/BeamForcesEuler.cpp#L105

