### PR TITLE
🐛 Fixed keyboard pause menu navigation

### DIFF
--- a/source/main/gui/panels/GUI_GameMainMenu.cpp
+++ b/source/main/gui/panels/GUI_GameMainMenu.cpp
@@ -71,7 +71,7 @@ void GameMainMenu::DrawMenuPanel()
     }
     else
     {
-        m_num_buttons = 4;
+        m_num_buttons = 5;
         if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
         {
             title = "Menu";


### PR DESCRIPTION
The addition of the Repository button made it impossible to choose "Exit game" using keyboard arrows.
<img width="226" height="215" alt="RoR_2025-12-14_21-13-40" src="https://github.com/user-attachments/assets/3112a4b4-652f-4ec2-9442-d01dbf0d8f1b" />
