### PR TITLE
Fixed #3379 - rim radius tweak not applying to `meshwheels2`

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -4741,7 +4741,7 @@ void ActorSpawner::ProcessMeshWheel2(RigDef::MeshWheel2 & def)
         TuneupUtil::getTweakedWheelMediaRG(m_actor->getWorkingTuneupDef(), wheel_id, 0, m_actor->getTruckFileResourceGroup()),
         TuneupUtil::getTweakedWheelMedia(m_actor->getWorkingTuneupDef(), wheel_id, 1, def.material_name),
         TuneupUtil::getTweakedWheelMediaRG(m_actor->getWorkingTuneupDef(), wheel_id, 1, m_actor->getTruckFileResourceGroup()),
-        def.rim_radius
+        TuneupUtil::getTweakedWheelRimRadius(m_actor->getWorkingTuneupDef(), wheel_id, def.rim_radius)
     );
 
     CreateWheelSkidmarks(wheel_id);


### PR DESCRIPTION
<img width="845" height="422" alt="image" src="https://github.com/user-attachments/assets/02ff6824-789c-4785-a926-73ca27103316" />
