### PR TITLE
Run rorserver scripts locally (for singleplayer)

### DIFF
--- a/doc/angelscript/Script2Game/AngelOgre/AngelOgre_Light.h
+++ b/doc/angelscript/Script2Game/AngelOgre/AngelOgre_Light.h
@@ -9,17 +9,6 @@ namespace AngelOgre { // Dummy namespace, just to distinguish AngelScript from C
  *  @{
  */  
 
-    /// Enumerates the types of light sources available.
-    enum LightTypes
-    {
-        /// Point light sources give off light equally in all directions, so require only position not direction
-        LT_POINT,
-        /// Directional lights simulate parallel light beams from a distant source, hence have direction but no position
-        LT_DIRECTIONAL,
-        /// Spotlights simulate a cone of light from a source so require position and direction, plus extra values for falloff
-        LT_SPOTLIGHT
-    };
-
     /** Representation of a dynamic light source in the scene.
         @remarks
             Lights are added to the scene like any other MovableObject. They contain various 

--- a/doc/angelscript/Script2Game/AngelOgre/AngelOgre_OverlayElement.h
+++ b/doc/angelscript/Script2Game/AngelOgre/AngelOgre_OverlayElement.h
@@ -8,22 +8,6 @@ namespace AngelOgre { // Dummy namespace, just to distinguish AngelScript from C
 /** \addtogroup Script2Game
  *  @{
  */  
- 
-    // Register the GuiMetricsMode enum
-    enum GuiMetricsMode
-    {
-        GMM_PIXELS,
-        GMM_RELATIVE,
-        GMM_RELATIVE_ASPECT_ADJUSTED
-    }
-
-    // Register the GuiHorizontalAlignment enum
-    enum GuiHorizontalAlignment
-    {
-        GHA_LEFT,
-        GHA_CENTER,
-        GHA_RIGHT
-    }
 
 
     class  OverlayElement

--- a/doc/angelscript/Script2Game/AngelOgre/AngelOgre_enums.h
+++ b/doc/angelscript/Script2Game/AngelOgre/AngelOgre_enums.h
@@ -1,0 +1,132 @@
+
+  // =================================================== //
+  // THIS IS NOT A C++ HEADER! Only a dummy for Doxygen. //
+  // =================================================== //
+
+namespace AngelOgre { // Dummy namespace, just to distinguish AngelScript from C++
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */  
+ 
+ // PLEASE maintain the same order as in 'OgreAngelscript.cpp'
+ 
+     enum IndexType
+     {
+        IT_16BIT,
+        IT_32BIT
+    };
+    
+    /** Enumeration denoting the spaces which a transform can be relative to.
+    */
+    enum TransformSpace
+    {
+        /// Transform is relative to the local space
+        TS_LOCAL,
+        /// Transform is relative to the space of the parent node
+        TS_PARENT,
+        /// Transform is relative to world space
+        TS_WORLD
+    };    
+    
+
+    /// The rendering operation type to perform; binding of `Ogre::RenderOperation::OperationType`
+    enum RenderOperation
+    {
+        /// A list of points, 1 vertex per point
+        OT_POINT_LIST = 1,
+        /// A list of lines, 2 vertices per line
+        OT_LINE_LIST = 2,
+        /// A strip of connected lines, 1 vertex per line plus 1 start vertex
+        OT_LINE_STRIP = 3,
+        /// A list of triangles, 3 vertices per triangle
+        OT_TRIANGLE_LIST = 4,
+        /// A strip of triangles, 3 vertices for the first triangle, and 1 per triangle after that
+        OT_TRIANGLE_STRIP = 5,
+        /// A fan of triangles, 3 vertices for the first triangle, and 1 per triangle after that
+        OT_TRIANGLE_FAN = 6
+    };      
+
+    /// Binding of `enum Ogre::Image::Filter`
+    enum ImageFilter
+    {
+        FILTER_NEAREST,
+        FILTER_LINEAR,
+        FILTER_BILINEAR
+    };   
+
+    /// Locking options (binding of `enum Ogre::HardwareBuffer::LockOptions`)
+    enum HardwareBufferLockOptions
+    {
+        /** Normal mode, ie allows read/write and contents are preserved.
+         This kind of lock allows reading and writing from the buffer - it’s also the least
+         optimal because basically you’re telling the card you could be doing anything at
+         all. If you’re not using a shadow buffer, it requires the buffer to be transferred
+         from the card and back again. If you’re using a shadow buffer the effect is
+         minimal.
+         */
+        HBL_NORMAL,
+        /** Discards the <em>entire</em> buffer while locking.
+        This means you are happy for the card to discard the entire current contents of the
+        buffer. Implicitly this means you are not going to read the data - it also means
+        that the card can avoid any stalls if the buffer is currently being rendered from,
+        because it will actually give you an entirely different one. Use this wherever
+        possible when you are locking a buffer which was not created with a shadow buffer.
+        If you are using a shadow buffer it matters less, although with a shadow buffer it’s
+        preferable to lock the entire buffer at once, because that allows the shadow buffer
+        to use HBL_DISCARD when it uploads the updated contents to the real buffer.
+        @note Only useful on buffers created with the HBU_CPU_TO_GPU flag.
+        */
+        HBL_DISCARD,
+        /** Lock the buffer for reading only. Not allowed in buffers which are created with
+        HBU_GPU_ONLY.
+        Mandatory on static buffers, i.e. those created without the HBU_DYNAMIC flag.
+        */
+        HBL_READ_ONLY,
+        /** As HBL_WRITE_ONLY, except the application guarantees not to overwrite any
+        region of the buffer which has already been used in this frame, can allow
+        some optimisation on some APIs.
+        @note Only useful on buffers with no shadow buffer.*/
+        HBL_NO_OVERWRITE,
+        /** Lock the buffer for writing only.*/
+        HBL_WRITE_ONLY
+
+    };    
+    
+    /// Enumerates the types of light sources available.
+    enum LightTypes
+    {
+        /// Point light sources give off light equally in all directions, so require only position not direction
+        LT_POINT,
+        /// Directional lights simulate parallel light beams from a distant source, hence have direction but no position
+        LT_DIRECTIONAL,
+        /// Spotlights simulate a cone of light from a source so require position and direction, plus extra values for falloff
+        LT_SPOTLIGHT
+    };    
+        
+    // Register the GuiMetricsMode enum
+    enum GuiMetricsMode
+    {
+        GMM_PIXELS,
+        GMM_RELATIVE,
+        GMM_RELATIVE_ASPECT_ADJUSTED
+    };
+
+    // Register the GuiHorizontalAlignment enum
+    enum GuiHorizontalAlignment
+    {
+        GHA_LEFT,
+        GHA_CENTER,
+        GHA_RIGHT
+    };
+    
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs
+    
+} // namespace AngelOgre (dummy, just to distinguish AngelScript from C++)
+
+

--- a/doc/angelscript/Script2Game/enums/ScriptCategory.h
+++ b/doc/angelscript/Script2Game/enums/ScriptCategory.h
@@ -19,9 +19,11 @@ namespace Script2Game {
 enum ScriptCategory
 {
     SCRIPT_CATEGORY_INVALID,
-    SCRIPT_CATEGORY_ACTOR,  //!< Defined in truck file under 'scripts', contains global variable `BeamClass@ thisActor`.
+    SCRIPT_CATEGORY_ACTOR,   //!< Defined in truck file under 'scripts', contains global variable `BeamClass@ thisActor`.
     SCRIPT_CATEGORY_TERRAIN, //!< Defined in terrn2 file under '[Scripts]', receives terrain eventbox notifications.
-    SCRIPT_CATEGORY_CUSTOM, //!< Loaded by user via either: A) ingame console 'loadscript'; B) RoR.cfg 'diag_custom_scripts'; C) commandline '-runscript'.
+    SCRIPT_CATEGORY_GADGET,  //!< Associated with a .gadget mod file, launched via UI or any method given below for CUSTOM scripts (use .gadget suffix - game will fix up category to `GADGET`).
+    SCRIPT_CATEGORY_AI_BOT,  //!< Only valid under `RoR::MpState::LOCAL_SCRIPT`; registers as RoRnet user in the server script (i.e. for competitive racing).
+    SCRIPT_CATEGORY_CUSTOM,  //!< Loaded by user via either: A) ingame console 'loadscript'; B) RoR.cfg 'diag_custom_scripts'; C) commandline '-runscript'.
 };
 
 } // namespace Script2Game

--- a/external/angelscript_addons/scriptmath3d/scriptmath3d.cpp
+++ b/external/angelscript_addons/scriptmath3d/scriptmath3d.cpp
@@ -1,0 +1,496 @@
+#include <assert.h>
+#include <string.h> // strstr
+#include <new> // new()
+#include <math.h>
+#include "scriptmath3d.h"
+
+#ifdef __BORLANDC__
+// C++Builder doesn't define a non-standard "sqrtf" function but rather an overload of "sqrt"
+// for float arguments.
+inline float sqrtf (float x) { return sqrt (x); }
+#endif
+
+BEGIN_AS_NAMESPACE
+
+Vector3::Vector3()
+{
+	x = 0;
+	y = 0;
+	z = 0;
+}
+
+Vector3::Vector3(const Vector3 &other)
+{
+	x = other.x;
+	y = other.y;
+	z = other.z;
+}
+
+Vector3::Vector3(float _x, float _y, float _z)
+{
+	x = _x;
+	y = _y;
+	z = _z;
+}
+
+bool operator==(const Vector3 &a, const Vector3 &b)
+{
+	return (a.x == b.x) && (a.y == b.y) && (a.z == b.z);
+}
+
+bool operator!=(const Vector3 &a, const Vector3 &b)
+{
+	return !(a == b);
+}
+
+Vector3 &Vector3::operator=(const Vector3 &other)
+{
+	x = other.x;
+	y = other.y;
+	z = other.z;
+	return *this;
+}
+
+Vector3 &Vector3::operator+=(const Vector3 &other)
+{
+	x += other.x;
+	y += other.y;
+	z += other.z;
+	return *this;
+}
+
+Vector3 &Vector3::operator-=(const Vector3 &other)
+{
+	x -= other.x;
+	y -= other.y;
+	z -= other.z;
+	return *this;
+}
+
+Vector3 &Vector3::operator*=(float s)
+{
+	x *= s;
+	y *= s;
+	z *= s;
+	return *this;
+}
+
+Vector3 &Vector3::operator/=(float s)
+{
+	x /= s;
+	y /= s;
+	z /= s;
+	return *this;
+}
+
+float Vector3::length() const
+{
+	return sqrtf(x*x + y*y + z*z);
+}
+
+Vector3 operator+(const Vector3 &a, const Vector3 &b)
+{
+	// Return a new object as a script handle
+	Vector3 res(a.x + b.x, a.y + b.y, a.z + b.z);
+	return res;
+}
+
+Vector3 operator-(const Vector3 &a, const Vector3 &b)
+{
+	// Return a new object as a script handle
+	Vector3 res(a.x - b.x, a.y - b.y, a.z - b.z);
+	return res;
+}
+
+Vector3 operator*(float s, const Vector3 &v)
+{
+	// Return a new object as a script handle
+	Vector3 res(v.x * s, v.y * s, v.z * s);
+	return res;
+}
+
+Vector3 operator*(const Vector3 &v, float s)
+{
+	// Return a new object as a script handle
+	Vector3 res(v.x * s, v.y * s, v.z * s);
+	return res;
+}
+
+Vector3 operator/(const Vector3 &v, float s)
+{
+	// Return a new object as a script handle
+	Vector3 res(v.x / s, v.y / s, v.z / s);
+	return res;
+}
+
+//-----------------------
+// Swizzle operators
+//-----------------------
+
+Vector3 Vector3::get_xyz() const
+{
+	return Vector3(x,y,z);
+}
+Vector3 Vector3::get_yzx() const
+{
+	return Vector3(y,z,x);
+}
+Vector3 Vector3::get_zxy() const
+{
+	return Vector3(z,x,y);
+}
+Vector3 Vector3::get_zyx() const
+{
+	return Vector3(z,y,x);
+}
+Vector3 Vector3::get_yxz() const
+{
+	return Vector3(y,x,z);
+}
+Vector3 Vector3::get_xzy() const
+{
+	return Vector3(x,z,y);
+}
+void Vector3::set_xyz(const Vector3 &v)
+{
+	x = v.x; y = v.y; z = v.z;
+}
+void Vector3::set_yzx(const Vector3 &v)
+{
+	y = v.x; z = v.y; x = v.z;
+}
+void Vector3::set_zxy(const Vector3 &v)
+{
+	z = v.x; x = v.y; y = v.z;
+}
+void Vector3::set_zyx(const Vector3 &v)
+{
+	z = v.x; y = v.y; x = v.z;
+}
+void Vector3::set_yxz(const Vector3 &v)
+{
+	y = v.x; x = v.y; z = v.z;
+}
+void Vector3::set_xzy(const Vector3 &v)
+{
+	x = v.x; z = v.y; y = v.z;
+}
+
+//-----------------------
+// AngelScript functions
+//-----------------------
+
+static void Vector3DefaultConstructor(Vector3 *self)
+{
+	new(self) Vector3();
+}
+
+static void Vector3CopyConstructor(const Vector3 &other, Vector3 *self)
+{
+	new(self) Vector3(other);
+}
+
+static void Vector3InitConstructor(float x, float y, float z, Vector3 *self)
+{
+	new(self) Vector3(x,y,z);
+}
+
+//-----------------------
+// Generic calling convention
+//-----------------------
+
+static void Vector3DefaultConstructor_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *self = (Vector3*)gen->GetObject();
+	new(self) Vector3();
+}
+
+static void Vector3CopyConstructor_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *other = (Vector3*)gen->GetArgObject(0);
+	Vector3 *self = (Vector3*)gen->GetObject();
+	Vector3CopyConstructor(*other, self);
+}
+
+static void Vector3InitConstructor_Generic(asIScriptGeneric *gen)
+{
+	float x = gen->GetArgFloat(0);
+	float y = gen->GetArgFloat(1);
+	float z = gen->GetArgFloat(2);
+	Vector3 *self = (Vector3*)gen->GetObject();
+	Vector3InitConstructor(x,y,z,self);
+}
+
+static void Vector3Equal_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *a = (Vector3*)gen->GetObject();
+	Vector3 *b = (Vector3*)gen->GetArgAddress(0);
+	bool r = *a == *b;
+    *(bool*)gen->GetAddressOfReturnLocation() = r;
+}
+
+static void Vector3Length_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *s = (Vector3*)gen->GetObject();
+	gen->SetReturnFloat(s->length());
+}
+
+static void Vector3AddAssign_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *a = (Vector3*)gen->GetArgAddress(0);
+	Vector3 *thisPointer = (Vector3*)gen->GetObject();
+	*thisPointer += *a;
+	gen->SetReturnAddress(thisPointer);
+}
+
+static void Vector3SubAssign_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *a = (Vector3*)gen->GetArgAddress(0);
+	Vector3 *thisPointer = (Vector3*)gen->GetObject();
+	*thisPointer -= *a;
+	gen->SetReturnAddress(thisPointer);
+}
+
+static void Vector3MulAssign_Generic(asIScriptGeneric *gen)
+{
+	float s = gen->GetArgFloat(0);
+	Vector3 *thisPointer = (Vector3*)gen->GetObject();
+	*thisPointer *= s;
+	gen->SetReturnAddress(thisPointer);
+}
+
+static void Vector3DivAssign_Generic(asIScriptGeneric *gen)
+{
+	float s = gen->GetArgFloat(0);
+	Vector3 *thisPointer = (Vector3*)gen->GetObject();
+	*thisPointer /= s;
+	gen->SetReturnAddress(thisPointer);
+}
+
+static void Vector3Add_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *a = (Vector3*)gen->GetObject();
+	Vector3 *b = (Vector3*)gen->GetArgAddress(0);
+	Vector3 res = *a + *b;
+	gen->SetReturnObject(&res);
+}
+
+static void Vector3Sub_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *a = (Vector3*)gen->GetObject();
+	Vector3 *b = (Vector3*)gen->GetArgAddress(0);
+	Vector3 res = *a - *b;
+	gen->SetReturnObject(&res);
+}
+
+static void Vector3FloatMulVector3_Generic(asIScriptGeneric *gen)
+{
+	float s = gen->GetArgFloat(0);
+	Vector3 *v = (Vector3*)gen->GetObject();
+	Vector3 res = s * *v;
+	gen->SetReturnObject(&res);
+}
+
+static void Vector3Vector3MulFloat_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	float s = gen->GetArgFloat(0);
+	Vector3 res = *v * s;
+	gen->SetReturnObject(&res);
+}
+
+static void Vector3Vector3DivFloat_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	float s = gen->GetArgFloat(0);
+	Vector3 res = *v / s;
+	gen->SetReturnObject(&res);
+}
+
+static void Vector3_get_xyz_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	*(Vector3*)gen->GetAddressOfReturnLocation() = v->get_xyz();
+}
+
+static void Vector3_get_yzx_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	*(Vector3*)gen->GetAddressOfReturnLocation() = v->get_yzx();
+}
+
+static void Vector3_get_zxy_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	*(Vector3*)gen->GetAddressOfReturnLocation() = v->get_zxy();
+}
+
+static void Vector3_get_zyx_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	*(Vector3*)gen->GetAddressOfReturnLocation() = v->get_zyx();
+}
+
+static void Vector3_get_yxz_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	*(Vector3*)gen->GetAddressOfReturnLocation() = v->get_yxz();
+}
+
+static void Vector3_get_xzy_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	*(Vector3*)gen->GetAddressOfReturnLocation() = v->get_xzy();
+}
+
+static void Vector3_set_xyz_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	Vector3 *i = *(Vector3**)gen->GetAddressOfArg(0);
+	v->set_xyz(*i);
+}
+
+static void Vector3_set_yzx_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	Vector3 *i = *(Vector3**)gen->GetAddressOfArg(0);
+	v->set_yzx(*i);
+}
+
+static void Vector3_set_zxy_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	Vector3 *i = *(Vector3**)gen->GetAddressOfArg(0);
+	v->set_zxy(*i);
+}
+
+static void Vector3_set_zyx_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	Vector3 *i = *(Vector3**)gen->GetAddressOfArg(0);
+	v->set_zyx(*i);
+}
+
+static void Vector3_set_yxz_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	Vector3 *i = *(Vector3**)gen->GetAddressOfArg(0);
+	v->set_yxz(*i);
+}
+
+static void Vector3_set_xzy_Generic(asIScriptGeneric *gen)
+{
+	Vector3 *v = (Vector3*)gen->GetObject();
+	Vector3 *i = *(Vector3**)gen->GetAddressOfArg(0);
+	v->set_xzy(*i);
+}
+
+//--------------------------------
+// Registration
+//-------------------------------------
+
+void RegisterScriptMath3D_Native(asIScriptEngine *engine)
+{
+	int r;
+
+	// Register the type
+	r = engine->RegisterObjectType("vector3", sizeof(Vector3), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CAK); assert( r >= 0 );
+
+	// Register the object properties
+	r = engine->RegisterObjectProperty("vector3", "float x", asOFFSET(Vector3, x)); assert( r >= 0 );
+	r = engine->RegisterObjectProperty("vector3", "float y", asOFFSET(Vector3, y)); assert( r >= 0 );
+	r = engine->RegisterObjectProperty("vector3", "float z", asOFFSET(Vector3, z)); assert( r >= 0 );
+
+	// Register the constructors
+	r = engine->RegisterObjectBehaviour("vector3", asBEHAVE_CONSTRUCT,  "void f()",                     asFUNCTION(Vector3DefaultConstructor), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+	r = engine->RegisterObjectBehaviour("vector3", asBEHAVE_CONSTRUCT,  "void f(const vector3 &in)",    asFUNCTION(Vector3CopyConstructor), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+	r = engine->RegisterObjectBehaviour("vector3", asBEHAVE_CONSTRUCT,  "void f(float, float y = 0, float z = 0)",  asFUNCTION(Vector3InitConstructor), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+
+	// Register the operator overloads
+	r = engine->RegisterObjectMethod("vector3", "vector3 &opAddAssign(const vector3 &in)", asMETHODPR(Vector3, operator+=, (const Vector3 &), Vector3&), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 &opSubAssign(const vector3 &in)", asMETHODPR(Vector3, operator-=, (const Vector3 &), Vector3&), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 &opMulAssign(float)", asMETHODPR(Vector3, operator*=, (float), Vector3&), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 &opDivAssign(float)", asMETHODPR(Vector3, operator/=, (float), Vector3&), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "bool opEquals(const vector3 &in) const", asFUNCTIONPR(operator==, (const Vector3&, const Vector3&), bool), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opAdd(const vector3 &in) const", asFUNCTIONPR(operator+, (const Vector3&, const Vector3&), Vector3), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opSub(const vector3 &in) const", asFUNCTIONPR(operator-, (const Vector3&, const Vector3&), Vector3), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opMul(float) const", asFUNCTIONPR(operator*, (const Vector3&, float), Vector3), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opMul_r(float) const", asFUNCTIONPR(operator*, (float, const Vector3&), Vector3), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opDiv(float) const", asFUNCTIONPR(operator/, (const Vector3&, float), Vector3), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
+
+	// Register the object methods
+	r = engine->RegisterObjectMethod("vector3", "float length() const", asMETHOD(Vector3,length), asCALL_THISCALL); assert( r >= 0 );
+
+	// Register the swizzle operators
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_xyz() const", asMETHOD(Vector3, get_xyz), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_yzx() const", asMETHOD(Vector3, get_yzx), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_zxy() const", asMETHOD(Vector3, get_zxy), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_zyx() const", asMETHOD(Vector3, get_zyx), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_yxz() const", asMETHOD(Vector3, get_yxz), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_xzy() const", asMETHOD(Vector3, get_xzy), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_xyz(const vector3 &in)", asMETHOD(Vector3, set_xyz), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_yzx(const vector3 &in)", asMETHOD(Vector3, set_yzx), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_zxy(const vector3 &in)", asMETHOD(Vector3, set_zxy), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_zyx(const vector3 &in)", asMETHOD(Vector3, set_zyx), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_yxz(const vector3 &in)", asMETHOD(Vector3, set_yxz), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_xzy(const vector3 &in)", asMETHOD(Vector3, set_xzy), asCALL_THISCALL); assert( r >= 0 );
+}
+
+void RegisterScriptMath3D_Generic(asIScriptEngine *engine)
+{
+	int r;
+
+	// Register the type
+	r = engine->RegisterObjectType("vector3", sizeof(Vector3), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_CAK); assert( r >= 0 );
+
+	// Register the object properties
+	r = engine->RegisterObjectProperty("vector3", "float x", asOFFSET(Vector3, x)); assert( r >= 0 );
+	r = engine->RegisterObjectProperty("vector3", "float y", asOFFSET(Vector3, y)); assert( r >= 0 );
+	r = engine->RegisterObjectProperty("vector3", "float z", asOFFSET(Vector3, z)); assert( r >= 0 );
+
+	// Register the constructors
+	r = engine->RegisterObjectBehaviour("vector3", asBEHAVE_CONSTRUCT, "void f()",                    asFUNCTION(Vector3DefaultConstructor_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectBehaviour("vector3", asBEHAVE_CONSTRUCT, "void f(const vector3 &in)",   asFUNCTION(Vector3CopyConstructor_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectBehaviour("vector3", asBEHAVE_CONSTRUCT, "void f(float, float y = 0, float z = 0)", asFUNCTION(Vector3InitConstructor_Generic), asCALL_GENERIC); assert( r >= 0 );
+
+	// Register the operator overloads
+	r = engine->RegisterObjectMethod("vector3", "vector3 &opAddAssign(const vector3 &in)", asFUNCTION(Vector3AddAssign_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 &opSubAssign(const vector3 &in)", asFUNCTION(Vector3SubAssign_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 &opMulAssign(float)", asFUNCTION(Vector3MulAssign_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 &opDivAssign(float)", asFUNCTION(Vector3DivAssign_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "bool opEquals(const vector3 &in) const", asFUNCTION(Vector3Equal_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opAdd(const vector3 &in) const", asFUNCTION(Vector3Add_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opSub(const vector3 &in) const", asFUNCTION(Vector3Sub_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opMul_r(float) const", asFUNCTION(Vector3FloatMulVector3_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opMul(float) const", asFUNCTION(Vector3Vector3MulFloat_Generic), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 opDiv(float) const", asFUNCTION(Vector3Vector3DivFloat_Generic), asCALL_GENERIC); assert( r >= 0 );
+
+	// Register the object methods
+	r = engine->RegisterObjectMethod("vector3", "float length() const", asFUNCTION(Vector3Length_Generic), asCALL_GENERIC); assert( r >= 0 );
+
+	// Register the swizzle operators
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_xyz() const", asFUNCTION(Vector3_get_xyz_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_yzx() const", asFUNCTION(Vector3_get_yzx_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_zxy() const", asFUNCTION(Vector3_get_zxy_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_zyx() const", asFUNCTION(Vector3_get_zyx_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_yxz() const", asFUNCTION(Vector3_get_yxz_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "vector3 get_xzy() const", asFUNCTION(Vector3_get_xzy_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_xyz(const vector3 &in)", asFUNCTION(Vector3_set_xyz_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_yzx(const vector3 &in)", asFUNCTION(Vector3_set_yzx_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_zxy(const vector3 &in)", asFUNCTION(Vector3_set_zxy_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_zyx(const vector3 &in)", asFUNCTION(Vector3_set_zyx_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_yxz(const vector3 &in)", asFUNCTION(Vector3_set_yxz_Generic), asCALL_THISCALL); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("vector3", "void set_xzy(const vector3 &in)", asFUNCTION(Vector3_set_xzy_Generic), asCALL_THISCALL); assert( r >= 0 );
+}
+
+void RegisterScriptMath3D(asIScriptEngine *engine)
+{
+	if( strstr(asGetLibraryOptions(), "AS_MAX_PORTABILITY") )
+		RegisterScriptMath3D_Generic(engine);
+	else
+		RegisterScriptMath3D_Native(engine);
+}
+
+END_AS_NAMESPACE
+
+

--- a/external/angelscript_addons/scriptmath3d/scriptmath3d.h
+++ b/external/angelscript_addons/scriptmath3d/scriptmath3d.h
@@ -1,0 +1,67 @@
+#ifndef SCRIPTMATH3D_H
+#define SCRIPTMATH3D_H
+
+#include <angelscript.h>
+
+BEGIN_AS_NAMESPACE
+
+// This is not a complete 3D math library. It's only meant as a sample
+// for registering value types. The application developers will most
+// likely want to register their own math library instead.
+
+struct Vector3
+{
+	Vector3();
+	Vector3(const Vector3 &other);
+	Vector3(float x, float y, float z);
+
+	Vector3 &operator=(const Vector3 &other);
+	Vector3 &operator+=(const Vector3 &other);
+	Vector3 &operator-=(const Vector3 &other);
+	Vector3 &operator*=(float scalar);
+	Vector3 &operator/=(float scalar);
+
+	float length() const;
+
+	// Swizzle operators
+	Vector3 get_xyz() const;
+	void    set_xyz(const Vector3 &in);
+	Vector3 get_yzx() const;
+	void    set_yzx(const Vector3 &in);
+	Vector3 get_zxy() const;
+	void    set_zxy(const Vector3 &in);
+	Vector3 get_zyx() const;
+	void    set_zyx(const Vector3 &in);
+	Vector3 get_yxz() const;
+	void    set_yxz(const Vector3 &in);
+	Vector3 get_xzy() const;
+	void    set_xzy(const Vector3 &in);
+
+	friend bool operator==(const Vector3 &a, const Vector3 &b);
+	friend bool operator!=(const Vector3 &a, const Vector3 &b);
+	friend Vector3 operator+(const Vector3 &a, const Vector3 &b);
+	friend Vector3 operator-(const Vector3 &a, const Vector3 &b);
+	friend Vector3 operator*(float s, const Vector3 &v);
+	friend Vector3 operator*(const Vector3 &v, float s);
+	friend Vector3 operator/(const Vector3 &v, float s);
+
+	float x;
+	float y;
+	float z;
+};
+
+// This function will determine the configuration of the engine
+// and use one of the two functions below to register the string type
+void RegisterScriptMath3D(asIScriptEngine *engine);
+
+// Call this function to register the math functions using native calling conventions
+void RegisterScriptMath3D_Native(asIScriptEngine *engine);
+
+// Use this one instead if native calling conventions
+// are not supported on the target platform
+void RegisterScriptMath3D_Generic(asIScriptEngine *engine);
+
+END_AS_NAMESPACE
+
+#endif
+

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -42,6 +42,7 @@
 #include "Network.h"
 #include "ScriptEngine.h"
 #include "ServerScriptEngine.h"
+#include "ServerScriptSequencer.h"
 #include "SoundScriptManager.h"
 #include "Terrain.h"
 #include "ThreadPool.h"
@@ -69,7 +70,7 @@ static MumbleIntegration*   g_mumble = nullptr;
 static OverlayWrapper*      g_overlay_wrapper = nullptr;
 static OutGauge             g_out_gauge;
 static ScriptEngine*        g_script_engine = nullptr;
-static ServerScriptEngine*  g_server_script_engine = nullptr;
+static ServerScriptSequencer*  g_server_script_sequencer = nullptr;
 static SoundScriptManager*  g_sound_script_manager = nullptr;
 static Terrain*             g_sim_terrain = nullptr;
 static ThreadPool*          g_thread_pool = nullptr;
@@ -304,7 +305,7 @@ GfxScene*              GetGfxScene           () { return &g_gfx_scene; }
 SoundScriptManager*    GetSoundScriptManager () { return g_sound_script_manager; }
 LanguageEngine*        GetLanguageEngine     () { return &g_language_engine; }
 ScriptEngine*          GetScriptEngine       () { return g_script_engine; }
-ServerScriptEngine*    GetServerScriptEngine()  { return g_server_script_engine; }
+ServerScriptSequencer* GetServerScript       ()  { return g_server_script_sequencer; }
 GameContext*           GetGameContext        () { return &g_game_context; }
 OutGauge*              GetOutGauge           () { return &g_out_gauge; }
 DiscordRpc*            GetDiscordRpc         () { return &g_discord_rpc; }
@@ -375,11 +376,11 @@ void CreateScriptEngine()
 #endif
 }
 
-void CreateServerScriptEngine()
+void CreateServerScript()
 {
 #if USE_ANGELSCRIPT
     ROR_ASSERT(!g_server_script_engine);
-    g_server_script_engine = new ServerScriptEngine();
+    g_server_script_sequencer = new ServerScriptSequencer();
 #endif
 }
 

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -41,6 +41,7 @@
 #include "MumbleIntegration.h"
 #include "Network.h"
 #include "ScriptEngine.h"
+#include "ServerScriptEngine.h"
 #include "SoundScriptManager.h"
 #include "Terrain.h"
 #include "ThreadPool.h"
@@ -68,6 +69,7 @@ static MumbleIntegration*   g_mumble = nullptr;
 static OverlayWrapper*      g_overlay_wrapper = nullptr;
 static OutGauge             g_out_gauge;
 static ScriptEngine*        g_script_engine = nullptr;
+static ServerScriptEngine*  g_server_script_engine = nullptr;
 static SoundScriptManager*  g_sound_script_manager = nullptr;
 static Terrain*             g_sim_terrain = nullptr;
 static ThreadPool*          g_thread_pool = nullptr;
@@ -174,6 +176,7 @@ CVar* sys_profiler_dir;
 CVar* sys_savegames_dir;
 CVar* sys_screenshot_dir;
 CVar* sys_scripts_dir;
+CVar* sys_server_scripts_dir;
 CVar* sys_projects_dir;
 CVar* sys_repo_attachments_dir;
 
@@ -301,6 +304,7 @@ GfxScene*              GetGfxScene           () { return &g_gfx_scene; }
 SoundScriptManager*    GetSoundScriptManager () { return g_sound_script_manager; }
 LanguageEngine*        GetLanguageEngine     () { return &g_language_engine; }
 ScriptEngine*          GetScriptEngine       () { return g_script_engine; }
+ServerScriptEngine*    GetServerScriptEngine()  { return g_server_script_engine; }
 GameContext*           GetGameContext        () { return &g_game_context; }
 OutGauge*              GetOutGauge           () { return &g_out_gauge; }
 DiscordRpc*            GetDiscordRpc         () { return &g_discord_rpc; }
@@ -368,6 +372,14 @@ void CreateScriptEngine()
 #if USE_ANGELSCRIPT
     ROR_ASSERT(!g_script_engine);
     g_script_engine = new ScriptEngine();
+#endif
+}
+
+void CreateServerScriptEngine()
+{
+#if USE_ANGELSCRIPT
+    ROR_ASSERT(!g_server_script_engine);
+    g_server_script_engine = new ServerScriptEngine();
 #endif
 }
 

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -379,7 +379,7 @@ void CreateScriptEngine()
 void CreateServerScript()
 {
 #if USE_ANGELSCRIPT
-    ROR_ASSERT(!g_server_script_engine);
+    ROR_ASSERT(!g_server_script_sequencer);
     g_server_script_sequencer = new ServerScriptSequencer();
 #endif
 }

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -327,6 +327,7 @@ enum class MpState
     DISABLED,  //!< Not connected for whatever reason.
     CONNECTING,
     CONNECTED,
+    LOCAL_SCRIPT, //!< Not actually connected to network, but running server script locally.
 };
 
 enum class SimState

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -51,6 +51,7 @@
 #define RGN_SAVEGAMES "Savegames"
 #define RGN_MANAGED_MATS "ManagedMaterials"
 #define RGN_SCRIPTS "Scripts"
+#define RGN_SERVER_SCRIPTS "ServerScripts"
 #define RGN_LOGS "Logs"
 
 // Legacy macros
@@ -721,6 +722,7 @@ extern CVar* sys_profiler_dir;
 extern CVar* sys_savegames_dir;
 extern CVar* sys_screenshot_dir;
 extern CVar* sys_scripts_dir;
+extern CVar* sys_server_scripts_dir;
 extern CVar* sys_projects_dir;
 extern CVar* sys_repo_attachments_dir;
 
@@ -852,6 +854,7 @@ GfxScene*            GetGfxScene();
 SoundScriptManager*  GetSoundScriptManager();
 LanguageEngine*      GetLanguageEngine();
 ScriptEngine*        GetScriptEngine();
+ServerScriptEngine* GetServerScriptEngine();
 Network*             GetNetwork();
 GameContext*         GetGameContext();
 OutGauge*            GetOutGauge();
@@ -867,6 +870,7 @@ void CreateCameraManager();
 void CreateGfxScene();
 void CreateSoundScriptManager();
 void CreateScriptEngine();
+void CreateServerScriptEngine();
 
 // Cleanups
 void DestroyOverlayWrapper();

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -855,7 +855,7 @@ GfxScene*            GetGfxScene();
 SoundScriptManager*  GetSoundScriptManager();
 LanguageEngine*      GetLanguageEngine();
 ScriptEngine*        GetScriptEngine();
-ServerScriptEngine* GetServerScriptEngine();
+ServerScriptSequencer* GetServerScript();
 Network*             GetNetwork();
 GameContext*         GetGameContext();
 OutGauge*            GetOutGauge();
@@ -871,7 +871,7 @@ void CreateCameraManager();
 void CreateGfxScene();
 void CreateSoundScriptManager();
 void CreateScriptEngine();
-void CreateServerScriptEngine();
+void CreateServerScript();
 
 // Cleanups
 void DestroyOverlayWrapper();

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -232,7 +232,6 @@ if (ROR_USE_ANGELSCRIPT)
             scripting/GameScript.{h,cpp}
             scripting/LocalStorage.{h,cpp}
             scripting/OgreScriptBuilder.{h,cpp}
-            scripting/ServerScriptEngine.{h,cpp}
             scripting/ScriptEngine.{h,cpp}
             scripting/ScriptUtils.h
             scripting/bindings/AngelScriptBindings.h
@@ -258,6 +257,13 @@ if (ROR_USE_ANGELSCRIPT)
             scripting/bindings/TurbojetAngelscript.cpp
             scripting/bindings/TurbopropAngelscript.cpp
             scripting/bindings/VehicleAiAngelscript.cpp
+            scripting/server/ServerScript.{h,cpp}
+            scripting/server/ServerScriptConfig.h
+            scripting/server/ServerScriptCurlHelpers.{h,cpp}
+            scripting/server/ServerScriptEngine.{h,cpp}
+            scripting/server/ServerScriptFileSafe.{h,cpp}
+            scripting/server/ServerScriptLogger.{h,cpp}
+            scripting/server/ServerScriptSequencer.{h,cpp}
             )
 endif ()
 
@@ -367,6 +373,7 @@ target_include_directories(${BINNAME} PRIVATE
         system
         scripting
         scripting/bindings
+        scripting/server
         terrain
         terrain/map
         threadpool

--- a/source/main/CMakeLists.txt
+++ b/source/main/CMakeLists.txt
@@ -232,6 +232,7 @@ if (ROR_USE_ANGELSCRIPT)
             scripting/GameScript.{h,cpp}
             scripting/LocalStorage.{h,cpp}
             scripting/OgreScriptBuilder.{h,cpp}
+            scripting/ServerScriptEngine.{h,cpp}
             scripting/ScriptEngine.{h,cpp}
             scripting/ScriptUtils.h
             scripting/bindings/AngelScriptBindings.h

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -170,6 +170,7 @@ namespace RoR
     class  RTTLayer;
     class  Screwprop;
     class  ScriptEngine;
+    class  ServerScriptEngine;
     class  ShadowManager;
     class  Skidmark;
     class  SkidmarkConfig;

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -171,6 +171,7 @@ namespace RoR
     class  Screwprop;
     class  ScriptEngine;
     class  ServerScriptEngine;
+    class  ServerScriptSequencer;
     class  ShadowManager;
     class  Skidmark;
     class  SkidmarkConfig;

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -320,6 +320,21 @@ ActorPtr GameContext::SpawnActor(ActorSpawnRequest& rq)
             fresh_actor->ar_engine->setAutoMode(RoR::SimGearboxMode::AUTO);
             fresh_actor->ar_engine->autoShiftSet(Engine::DRIVE);
         }
+
+        if (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT)
+        {
+            fresh_actor->ar_net_source_id = rq.net_source_id;
+            fresh_actor->ar_net_stream_id = rq.net_stream_id;
+
+            if (BITMASK_IS_1(rq.asr_net_peeropts, RoRnet::PEEROPT_MUTE_ACTORS))
+            {
+                this->PushMessage(Message(MSG_SIM_MUTE_NET_ACTOR_REQUESTED, new ActorPtr(fresh_actor)));
+            }
+            if (BITMASK_IS_1(rq.asr_net_peeropts, RoRnet::PEEROPT_HIDE_ACTORS))
+            {
+                this->PushMessage(Message(MSG_SIM_HIDE_NET_ACTOR_REQUESTED, new ActorPtr(fresh_actor)));
+            }
+        }
     }
     else if (rq.asr_origin == ActorSpawnRequest::Origin::NETWORK)
     {

--- a/source/main/gfx/hydrax/CfgFileManager.cpp
+++ b/source/main/gfx/hydrax/CfgFileManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/CfgFileManager.h
+++ b/source/main/gfx/hydrax/CfgFileManager.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/DecalsManager.cpp
+++ b/source/main/gfx/hydrax/DecalsManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/DecalsManager.h
+++ b/source/main/gfx/hydrax/DecalsManager.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Enums.cpp
+++ b/source/main/gfx/hydrax/Enums.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Enums.h
+++ b/source/main/gfx/hydrax/Enums.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/FFT.h
+++ b/source/main/gfx/hydrax/FFT.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/GPUNormalMapManager.cpp
+++ b/source/main/gfx/hydrax/GPUNormalMapManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/GPUNormalMapManager.h
+++ b/source/main/gfx/hydrax/GPUNormalMapManager.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/GodRaysManager.cpp
+++ b/source/main/gfx/hydrax/GodRaysManager.cpp
@@ -1,7 +1,7 @@
 /*
 --------------------------------------------------------------------------------
 This source file is part of sssHydrax.
-sssHydrax is a modified version of Hydrax (Copyright (C) 2008 Xavier VerguÌn Gonz·lez)
+sssHydrax is a modified version of Hydrax (Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez)
 to adapt it to SonSilentSea.
 
 This program is free software; you can redistribute it and/or modify it under
@@ -18,7 +18,7 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place - Suite 330, Boston, MA 02111-1307, USA, or go to
 http://www.gnu.org/copyleft/lesser.txt.
 
-Author: Jose Luis CercÛs Pita
+Author: Jose Luis Cerc√≥s Pita
 --------------------------------------------------------------------------------
 */
 

--- a/source/main/gfx/hydrax/GodRaysManager.h
+++ b/source/main/gfx/hydrax/GodRaysManager.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Help.cpp
+++ b/source/main/gfx/hydrax/Help.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Help.h
+++ b/source/main/gfx/hydrax/Help.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Hydrax.cpp
+++ b/source/main/gfx/hydrax/Hydrax.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
@@ -23,7 +23,7 @@ http://www.gnu.org/copyleft/lesser.txt.
 
 --------------------------------------------------------------------------------
 Contributors:
-    Jose Luis CercÛs Pita <jlcercos@alumnos.upm.es>
+    Jose Luis Cerc√≥s Pita <jlcercos@alumnos.upm.es>
 --------------------------------------------------------------------------------
 */
 

--- a/source/main/gfx/hydrax/Hydrax.h
+++ b/source/main/gfx/hydrax/Hydrax.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Image.cpp
+++ b/source/main/gfx/hydrax/Image.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Image.h
+++ b/source/main/gfx/hydrax/Image.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/MaterialManager.cpp
+++ b/source/main/gfx/hydrax/MaterialManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
@@ -23,7 +23,7 @@ http://www.gnu.org/copyleft/lesser.txt.
 
 --------------------------------------------------------------------------------
 Contributors:
-    Jose Luis CercÛs Pita <jlcercos@alumnos.upm.es>
+    Jose Luis Cerc√≥s Pita <jlcercos@alumnos.upm.es>
 --------------------------------------------------------------------------------
 */
 

--- a/source/main/gfx/hydrax/MaterialManager.h
+++ b/source/main/gfx/hydrax/MaterialManager.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Mesh.h
+++ b/source/main/gfx/hydrax/Mesh.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Module.cpp
+++ b/source/main/gfx/hydrax/Module.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Module.h
+++ b/source/main/gfx/hydrax/Module.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Noise.cpp
+++ b/source/main/gfx/hydrax/Noise.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Noise.h
+++ b/source/main/gfx/hydrax/Noise.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Perlin.h
+++ b/source/main/gfx/hydrax/Perlin.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Prerequisites.cpp
+++ b/source/main/gfx/hydrax/Prerequisites.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/Prerequisites.h
+++ b/source/main/gfx/hydrax/Prerequisites.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/ProjectedGrid.cpp
+++ b/source/main/gfx/hydrax/ProjectedGrid.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/ProjectedGrid.h
+++ b/source/main/gfx/hydrax/ProjectedGrid.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/RadialGrid.cpp
+++ b/source/main/gfx/hydrax/RadialGrid.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/RadialGrid.h
+++ b/source/main/gfx/hydrax/RadialGrid.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/RttManager.cpp
+++ b/source/main/gfx/hydrax/RttManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/RttManager.h
+++ b/source/main/gfx/hydrax/RttManager.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/SimpleGrid.h
+++ b/source/main/gfx/hydrax/SimpleGrid.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/TextureManager.cpp
+++ b/source/main/gfx/hydrax/TextureManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/hydrax/TextureManager.h
+++ b/source/main/gfx/hydrax/TextureManager.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/skyx/AtmosphereManager.cpp
+++ b/source/main/gfx/skyx/AtmosphereManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/AtmosphereManager.h
+++ b/source/main/gfx/skyx/AtmosphereManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/BasicController.cpp
+++ b/source/main/gfx/skyx/BasicController.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/BasicController.h
+++ b/source/main/gfx/skyx/BasicController.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/CloudsManager.cpp
+++ b/source/main/gfx/skyx/CloudsManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/CloudsManager.h
+++ b/source/main/gfx/skyx/CloudsManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/ColorGradient.cpp
+++ b/source/main/gfx/skyx/ColorGradient.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/ColorGradient.h
+++ b/source/main/gfx/skyx/ColorGradient.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/Controller.h
+++ b/source/main/gfx/skyx/Controller.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/GPUManager.cpp
+++ b/source/main/gfx/skyx/GPUManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/GPUManager.h
+++ b/source/main/gfx/skyx/GPUManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/MeshManager.h
+++ b/source/main/gfx/skyx/MeshManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/MoonManager.cpp
+++ b/source/main/gfx/skyx/MoonManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/MoonManager.h
+++ b/source/main/gfx/skyx/MoonManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/Prerequisites.cpp
+++ b/source/main/gfx/skyx/Prerequisites.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/Prerequisites.h
+++ b/source/main/gfx/skyx/Prerequisites.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/SCfgFileManager.cpp
+++ b/source/main/gfx/skyx/SCfgFileManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/skyx/SCfgFileManager.h
+++ b/source/main/gfx/skyx/SCfgFileManager.h
@@ -3,7 +3,7 @@
 This source file is part of Hydrax.
 Visit ---
 
-Copyright (C) 2008 Xavier VerguÌn Gonz·lez <xavierverguin@hotmail.com>
+Copyright (C) 2008 Xavier Vergu√≠n Gonz√°lez <xavierverguin@hotmail.com>
                                            <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/source/main/gfx/skyx/SkyX.cpp
+++ b/source/main/gfx/skyx/SkyX.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/SkyX.h
+++ b/source/main/gfx/skyx/SkyX.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/DataManager.h
+++ b/source/main/gfx/skyx/VClouds/DataManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/Ellipsoid.cpp
+++ b/source/main/gfx/skyx/VClouds/Ellipsoid.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/Ellipsoid.h
+++ b/source/main/gfx/skyx/VClouds/Ellipsoid.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/FastFakeRandom.cpp
+++ b/source/main/gfx/skyx/VClouds/FastFakeRandom.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/FastFakeRandom.h
+++ b/source/main/gfx/skyx/VClouds/FastFakeRandom.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/GeometryBlock.cpp
+++ b/source/main/gfx/skyx/VClouds/GeometryBlock.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/GeometryBlock.h
+++ b/source/main/gfx/skyx/VClouds/GeometryBlock.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/GeometryManager.cpp
+++ b/source/main/gfx/skyx/VClouds/GeometryManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/GeometryManager.h
+++ b/source/main/gfx/skyx/VClouds/GeometryManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/Lightning.cpp
+++ b/source/main/gfx/skyx/VClouds/Lightning.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/Lightning.h
+++ b/source/main/gfx/skyx/VClouds/Lightning.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/LightningManager.h
+++ b/source/main/gfx/skyx/VClouds/LightningManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VClouds/VClouds.h
+++ b/source/main/gfx/skyx/VClouds/VClouds.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VCloudsManager.cpp
+++ b/source/main/gfx/skyx/VCloudsManager.cpp
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gfx/skyx/VCloudsManager.h
+++ b/source/main/gfx/skyx/VCloudsManager.h
@@ -3,7 +3,7 @@
 This source file is part of SkyX.
 Visit http://www.paradise-studios.net/products/skyx/
 
-Copyright (C) 2009-2012 Xavier VerguÌn Gonz·lez <xavyiy@gmail.com>
+Copyright (C) 2009-2012 Xavier Vergu√≠n Gonz√°lez <xavyiy@gmail.com>
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free Software

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -508,7 +508,7 @@ void GUIManager::UpdateInputEvents(float dt)
 
         // EV_COMMON_ENTER_CHATMODE
         if (App::GetInputEngine()->getEventBoolValueBounce(EV_COMMON_ENTER_CHATMODE, 0.5f) &&
-            App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
+            (App::mp_state->getEnum<MpState>() == MpState::CONNECTED || App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT))
         {
             this->ChatBox.SetVisible(!this->ChatBox.IsVisible());
         }

--- a/source/main/gui/GUIManager.cpp
+++ b/source/main/gui/GUIManager.cpp
@@ -400,7 +400,9 @@ void GUIManager::DrawCommonGui()
     // UI usable in both main menu and simulation
     // ------------------------------------------
 
-    if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED && !App::ui_hide_gui->getBool() && !this->SurveyMap.IsVisible())
+    if ((App::mp_state->getEnum<MpState>() == MpState::CONNECTED || App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT)
+        && !App::ui_hide_gui->getBool()
+        && !this->SurveyMap.IsVisible())
     {
         this->MpClientList.Draw();
     }

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -29,6 +29,7 @@
 #include "GUIUtils.h"
 #include "Language.h"
 #include "InputEngine.h"
+#include "ServerScriptEngine.h"
 
 #include <cstring> // strtok, strncmp
 #include <fmt/format.h>
@@ -160,6 +161,10 @@ void GameChatBox::Draw()
             if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
             {
                 this->SubmitMessage();
+            }
+            else if (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT)
+            {
+                App::GetServerScriptEngine()->playerChat(-1, m_msg_buffer.GetBuffer());
             }
             m_msg_buffer.Clear();
             this->SetVisible(false);

--- a/source/main/gui/panels/GUI_GameChatBox.cpp
+++ b/source/main/gui/panels/GUI_GameChatBox.cpp
@@ -164,7 +164,7 @@ void GameChatBox::Draw()
             }
             else if (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT)
             {
-                App::GetServerScriptEngine()->playerChat(-1, m_msg_buffer.GetBuffer());
+                App::GetServerScript()->queueMessagePlayerChat(-1, m_msg_buffer.GetBuffer());
             }
             m_msg_buffer.Clear();
             this->SetVisible(false);

--- a/source/main/gui/panels/GUI_ScriptMonitor.cpp
+++ b/source/main/gui/panels/GUI_ScriptMonitor.cpp
@@ -77,6 +77,15 @@ void ScriptMonitor::Draw()
             ImGui::Text("%s", _LC("ScriptMonitor", "(terrain)"));
             break;
 
+        case ScriptCategory::AI_BOT:
+            ImGui::Text("(%s) [%d]", _LC("ScriptMonitor", "bot"), unit.associatedNetUid);
+            ImGui::SameLine();
+            if (ImGui::Button(_LC("ScriptMonitor", "Kill")))
+            {
+                App::GetGameContext()->PushMessage(Message(MSG_APP_UNLOAD_SCRIPT_REQUESTED, new ScriptUnitID_t(id)));
+            }
+            break;
+
         case ScriptCategory::CUSTOM:
         case ScriptCategory::GADGET:
         {

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -478,7 +478,7 @@ void TopMenubar::Draw(float dt)
         ImGui::SetNextWindowPos(menu_pos);
         if (ImGui::Begin(_LC("TopMenubar", "Actors menu"), nullptr, static_cast<ImGuiWindowFlags_>(flags)))
         {
-            if (App::mp_state->getEnum<MpState>() != MpState::CONNECTED)
+            if (App::mp_state->getEnum<MpState>() == MpState::DISABLED)
             {
                 this->DrawActorListSinglePlayer();
             }
@@ -1182,7 +1182,7 @@ void TopMenubar::Draw(float dt)
 
             if (ImGui::Button(_LC("TopMenubar", "Start"), ImVec2(80, 0)))
             {
-                if (ai_mode == 4) // Chase driving mode
+                if (ai_mode == 4) // Chase driving mode uses special waypoint setup
                 {
                     ai_waypoints.clear();
                     if (App::GetGameContext()->GetPlayerActor()) // We are in vehicle
@@ -1197,20 +1197,20 @@ void TopMenubar::Draw(float dt)
                         waypoint.position = App::GetGameContext()->GetPlayerCharacter()->getPosition() + Ogre::Vector3(20, 0, 0);
                         ai_waypoints.push_back(waypoint);
                     }
-                    App::GetScriptEngine()->loadScript("AI.as", ScriptCategory::CUSTOM);
+                }
+
+                if (ai_waypoints.empty())
+                {
+                    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
+                                                    fmt::format(_LC("TopMenubar", "Select a preset, record or open survey map ({}) to set waypoints."),
+                                                    App::GetInputEngine()->getEventCommandTrimmed(EV_SURVEY_MAP_CYCLE)), "lightbulb.png");
                 }
                 else
                 {
-                    if (ai_waypoints.empty())
-                    {
-                        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
-                                                      fmt::format(_LC("TopMenubar", "Select a preset, record or open survey map ({}) to set waypoints."),
-                                                      App::GetInputEngine()->getEventCommandTrimmed(EV_SURVEY_MAP_CYCLE)), "lightbulb.png");
-                    }
-                    else
-                    {
-                        App::GetScriptEngine()->loadScript("AI.as", ScriptCategory::CUSTOM);
-                    }
+                    LoadScriptRequest* rq = new LoadScriptRequest();
+                    rq->lsr_category = (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT) ? ScriptCategory::AI_BOT : ScriptCategory::CUSTOM;
+                    rq->lsr_filename = "AI.as";
+                    App::GetGameContext()->PushMessage(Message(MSG_APP_LOAD_SCRIPT_REQUESTED, rq));
                 }
             }
 
@@ -1221,18 +1221,31 @@ void TopMenubar::Draw(float dt)
 
             ImGui::SameLine();
 
-            if (ImGui::Button(_LC("TopMenubar", "Stop"), ImVec2(80, 0)))
+            if (ImGui::Button(_LC("TopMenubar", "Stop All"), ImVec2(80, 0)))
             {
                 if (ai_mode == 4) // Chase driving mode
                 {
                     ai_waypoints.clear();
                 }
 
-                for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
+                if (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT)
                 {
-                    if (actor->ar_driveable == AI)
+                    for (const auto& pair: App::GetScriptEngine()->getScriptUnits())
                     {
-                        App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
+                        if (pair.second.scriptCategory == ScriptCategory::AI_BOT)
+                        {
+                            App::GetGameContext()->PushMessage(Message(MSG_APP_UNLOAD_SCRIPT_REQUESTED, new ScriptUnitID_t(pair.first)));
+                        }
+                    }
+                }
+                else
+                {
+                    for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
+                    {
+                        if (actor->ar_driveable == AI)
+                        {
+                            App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
+                        }
                     }
                 }
             }

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -105,6 +105,7 @@ int main(int argc, char *argv[])
         App::sys_savegames_dir ->setStr(PathCombine(App::sys_user_dir->getStr(), "savegames"));
         App::sys_screenshot_dir->setStr(PathCombine(App::sys_user_dir->getStr(), "screenshots"));
         App::sys_scripts_dir   ->setStr(PathCombine(App::sys_user_dir->getStr(), "scripts"));
+        App::sys_server_scripts_dir->setStr(PathCombine(App::sys_user_dir->getStr(), "server_scripts"));
         App::sys_projects_dir  ->setStr(PathCombine(App::sys_user_dir->getStr(), "projects"));
         App::sys_repo_attachments_dir->setStr(PathCombine(App::sys_user_dir->getStr(), "repo_attachments"));
 
@@ -200,8 +201,10 @@ int main(int argc, char *argv[])
         App::GetAppContext()->SetUpInput();
 
 #ifdef USE_ANGELSCRIPT
-        App::CreateScriptEngine();
         CreateFolder(App::sys_scripts_dir->getStr());
+        App::CreateScriptEngine();
+        CreateFolder(App::sys_server_scripts_dir->getStr());
+        App::CreateServerScriptEngine();
         CreateFolder(App::sys_projects_dir->getStr());
 #endif
 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -52,6 +52,7 @@
 #include "PlatformUtils.h"
 #include "RoRVersion.h"
 #include "ScriptEngine.h"
+#include "ServerScriptEngine.h"
 #include "Skidmark.h"
 #include "SoundScriptManager.h"
 #include "Terrain.h"
@@ -547,6 +548,13 @@ int main(int argc, char *argv[])
 #if USE_SOCKETW
                     try
                     {
+                        if (App::GetServerScriptEngine()->GetTimerThreadState() == ServerScriptEngine::ThreadState::RUNNING)
+                        {
+                            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_NOTICE,
+                                _L("Stopping local server script engine before connecting to remote server."));
+                            App::GetServerScriptEngine()->StopTimerThread();
+                            App::mp_state->setVal((int)MpState::DISABLED);
+                        }
                         App::GetNetwork()->StartConnecting();
                     }
                     catch (...) 

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -481,8 +481,35 @@ int main(int argc, char *argv[])
                     try
                     {
                         ActorPtr actor = App::GetGameContext()->GetActorManager()->GetActorById(request->lsr_associated_actor);
+                        int32_t netuid = -1;
+                        if (request->lsr_category == ScriptCategory::AI_BOT)
+                        {
+                            // Network user must be registered before script's `main()` runs.
+                            ROR_ASSERT(App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT && "AI_BOT scripts can only be loaded under 'mp_state = LOCAL_SCRIPT (3)'.");
+                            RoRnet::UserInfo u;
+                            std::memset(&u, 0, sizeof(u));
+                            strcpy(u.username, "Bot");
+                            strcpy(u.language, "cz_CZ");
+                            strcpy(u.sessiontype, "normal");
+                            strcpy(u.clientname, "Script");
+                            strcpy(u.clientversion, "Script");
+                            u.authstatus = RoRnet::AUTH_RANKED;
+                            // Register with server script - fills UID and color
+                            App::GetServerScriptEngine()->playerAdded(u);
+                            netuid = u.uniqueid;
+                            // Register locally
+                            App::GetNetwork()->AddBotUserInfo(u);
+                            App::GetGuiManager()->MpClientList.UpdateClients(); // OK to invoke directly - processing MSG_APP_LOAD_SCRIPT_REQUESTED
+                        }
                         // Notifications for script manipulations are sent by loadScript().
-                        App::GetScriptEngine()->loadScript(request->lsr_filename, request->lsr_category, actor, request->lsr_buffer);
+                        ScriptUnitID_t nid = App::GetScriptEngine()->loadScript(request->lsr_filename, request->lsr_category, actor, netuid, request->lsr_buffer);
+                        if (nid == SCRIPTUNITID_INVALID && request->lsr_category == ScriptCategory::AI_BOT)
+                        {
+                            // AI_BOT failed, clean up network user
+                            App::GetServerScriptEngine()->playerDeleted(netuid);
+                            App::GetNetwork()->RemoveBotUserInfo(netuid);
+                            App::GetGuiManager()->MpClientList.UpdateClients(); // OK to invoke directly - processing MSG_APP_LOAD_SCRIPT_REQUESTED
+                        }
                     }
                     catch (...)
                     {
@@ -497,8 +524,25 @@ int main(int argc, char *argv[])
                     ScriptUnitID_t* id = static_cast<ScriptUnitID_t*>(m.payload);
                     try
                     {
+                        ScriptCategory cat = App::GetScriptEngine()->getScriptUnit(*id).scriptCategory;
+                        int32_t netuid = App::GetScriptEngine()->getScriptUnit(*id).associatedNetUid;
                         // Notifications for script manipulations are sent by unloadScript().
                         App::GetScriptEngine()->unloadScript(*id);
+                        if (cat == ScriptCategory::AI_BOT)
+                        {
+                            // AI_BOT script unloaded, clean up network user
+                            App::GetServerScriptEngine()->playerDeleted(netuid);
+                            App::GetNetwork()->RemoveBotUserInfo(netuid);
+                            App::GetGuiManager()->MpClientList.UpdateClients(); // OK to invoke directly - processing MSG_APP_UNLOAD_SCRIPT_REQUESTED
+                            // Also clean up any actors spawned by the bot
+                            for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
+                            {
+                                if (actor->ar_driveable == AI && actor->ar_net_source_id == netuid)
+                                {
+                                    App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
+                                }
+                            }
+                        }
                     }
                     catch (...)
                     {
@@ -1279,10 +1323,11 @@ int main(int argc, char *argv[])
                     try
                     {
                         ROR_ASSERT(actor_ptr);
-                        if ((App::mp_state->getEnum<MpState>() == MpState::CONNECTED) &&
-                            ((*actor_ptr)->ar_state == ActorState::NETWORKED_OK))
+                        ActorPtr actor = *actor_ptr;
+                        const bool valid_remote_actor = (App::mp_state->getEnum<MpState>() == MpState::CONNECTED) && actor->ar_state == ActorState::NETWORKED_OK;
+                        const bool valid_ai_actor = (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT) && actor->ar_state == ActorState::LOCAL_SIMULATED && actor->ar_driveable == ActorType::AI;
+                        if (valid_remote_actor || valid_ai_actor)
                         {
-                            ActorPtr actor = *actor_ptr;
                             actor->ar_muted_by_peeropt = true;
                             actor->muteAllSounds();
                         }
@@ -1301,10 +1346,11 @@ int main(int argc, char *argv[])
                     try
                     {
                         ROR_ASSERT(actor_ptr);
-                        if ((App::mp_state->getEnum<MpState>() == MpState::CONNECTED) &&
-                            ((*actor_ptr)->ar_state == ActorState::NETWORKED_OK))
+                        ActorPtr actor = *actor_ptr;
+                        const bool valid_remote_actor = (App::mp_state->getEnum<MpState>() == MpState::CONNECTED) && actor->ar_state == ActorState::NETWORKED_OK;
+                        const bool valid_ai_actor = (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT) && actor->ar_state == ActorState::LOCAL_SIMULATED && actor->ar_driveable == ActorType::AI;
+                        if (valid_remote_actor || valid_ai_actor)
                         {
-                            ActorPtr actor = *actor_ptr;
                             actor->ar_muted_by_peeropt = false;
                             actor->unmuteAllSounds();
                         }

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
         CreateFolder(App::sys_scripts_dir->getStr());
         App::CreateScriptEngine();
         CreateFolder(App::sys_server_scripts_dir->getStr());
-        App::CreateServerScriptEngine();
+        App::CreateServerScript();
         CreateFolder(App::sys_projects_dir->getStr());
 #endif
 
@@ -495,7 +495,7 @@ int main(int argc, char *argv[])
                             strcpy(u.clientversion, "Script");
                             u.authstatus = RoRnet::AUTH_RANKED;
                             // Register with server script - fills UID and color
-                            App::GetServerScriptEngine()->playerAdded(u);
+                            App::GetServerScript()->createClient(u);
                             netuid = u.uniqueid;
                             // Register locally
                             App::GetNetwork()->AddBotUserInfo(u);
@@ -506,7 +506,7 @@ int main(int argc, char *argv[])
                         if (nid == SCRIPTUNITID_INVALID && request->lsr_category == ScriptCategory::AI_BOT)
                         {
                             // AI_BOT failed, clean up network user
-                            App::GetServerScriptEngine()->playerDeleted(netuid);
+                            App::GetServerScript()->queueMessageUserLeave(netuid);
                             App::GetNetwork()->RemoveBotUserInfo(netuid);
                             App::GetGuiManager()->MpClientList.UpdateClients(); // OK to invoke directly - processing MSG_APP_LOAD_SCRIPT_REQUESTED
                         }
@@ -530,8 +530,7 @@ int main(int argc, char *argv[])
                         App::GetScriptEngine()->unloadScript(*id);
                         if (cat == ScriptCategory::AI_BOT)
                         {
-                            // AI_BOT script unloaded, clean up network user
-                            App::GetServerScriptEngine()->playerDeleted(netuid);
+                            // AI_BOT script unloaded, clean up local network user
                             App::GetNetwork()->RemoveBotUserInfo(netuid);
                             App::GetGuiManager()->MpClientList.UpdateClients(); // OK to invoke directly - processing MSG_APP_UNLOAD_SCRIPT_REQUESTED
                             // Also clean up any actors spawned by the bot
@@ -592,11 +591,11 @@ int main(int argc, char *argv[])
 #if USE_SOCKETW
                     try
                     {
-                        if (App::GetServerScriptEngine()->GetTimerThreadState() == ServerScriptEngine::ThreadState::RUNNING)
+                        if (App::GetServerScript()->IsRunning())
                         {
                             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_ACTOR, Console::CONSOLE_SYSTEM_NOTICE,
                                 _L("Stopping local server script engine before connecting to remote server."));
-                            App::GetServerScriptEngine()->StopTimerThread();
+                            App::GetServerScript()->Close();
                             App::mp_state->setVal((int)MpState::DISABLED);
                         }
                         App::GetNetwork()->StartConnecting();

--- a/source/main/network/CurlHelpers.cpp
+++ b/source/main/network/CurlHelpers.cpp
@@ -24,6 +24,8 @@
 #include "GameContext.h"
 #include "RoRVersion.h"
 #include "ScriptEvents.h"
+#include "ServerScriptEngine.h"
+#include "ServerScriptCurlHelpers.h"
 
 #include <fmt/format.h>
 

--- a/source/main/network/CurlHelpers.h
+++ b/source/main/network/CurlHelpers.h
@@ -41,6 +41,7 @@ struct CurlTaskContext
     MsgType ctc_msg_failure = MSG_INVALID; //!< Sent on failure; Payload: `RoR::ScriptEventArgs` (see 'gameplay/ScriptEvents.h') with args for `RoR::SE_ANGELSCRIPT_THREAD_STATUS`
     // Status
     double ctc_old_perc = 0; // not threadsafe but whatever
+    ServerScriptEngine* ctc_script_engine = nullptr; // only for rorserver to invoke 'curlStatus' callback.
 };
 
 bool GetUrlAsString(const std::string& url, CURLcode& curl_result, long& response_code, std::string& response_payload);

--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -840,7 +840,7 @@ void Network::BroadcastChatMsg(const char* msg)
 {
     if (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT)
     {
-        App::GetServerScriptEngine()->playerChat(m_uid, msg);
+        App::GetServerScript()->queueMessagePlayerChat(m_uid, msg);
     }
     else
     {

--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -33,6 +33,7 @@
 #include "Language.h"
 #include "RoRVersion.h"
 #include "ScriptEngine.h"
+#include "ServerScriptEngine.h"
 #include "Utils.h"
 
 #include <Ogre.h>
@@ -837,7 +838,14 @@ void Network::RemovePeerOptions(PeerOptionsRequest* rq)
 
 void Network::BroadcastChatMsg(const char* msg)
 {
-    AddPacket(m_stream_id, RoRnet::MSG2_UTF8_CHAT, (int)std::strlen(msg), msg);
+    if (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT)
+    {
+        App::GetServerScriptEngine()->playerChat(m_uid, msg);
+    }
+    else
+    {
+        AddPacket(m_stream_id, RoRnet::MSG2_UTF8_CHAT, (int)std::strlen(msg), msg);
+    }
 }
 
 void Network::WhisperChatMsg(RoRnet::UserInfo const& user, const char* msg)
@@ -886,6 +894,30 @@ void Network::SetLocalUserData(RoRnet::UserInfo const& user)
     ROR_ASSERT(App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT);
     std::lock_guard<std::mutex> lock(m_users_mutex);
     m_userdata = user;
+    m_uid = user.uniqueid;
+}
+
+void Network::AddBotUserInfo(RoRnet::UserInfo const& user)
+{
+    // Lock and update userlist
+    std::lock_guard<std::mutex> lock(m_users_mutex);
+    m_users.push_back(user);
+    m_users_peeropts.push_back(BitMask_t(0));
+}
+
+void Network::RemoveBotUserInfo(int uid)
+{
+    std::lock_guard<std::mutex> lock(m_users_mutex);
+    auto user = std::find_if(m_users.begin(), m_users.end(), [uid](const RoRnet::UserInfo& u) { return static_cast<int>(u.uniqueid) == uid; });
+    if (user != m_users.end())
+    {
+        // Erase matching peer options
+        int peeropt_offset = (int)std::distance(m_users.begin(), user);
+        auto peeropt_itor = m_users_peeropts.begin() + peeropt_offset;
+        m_users_peeropts.erase(peeropt_itor);
+        // omit `m_disconnected_users` for bots.
+        m_users.erase(user);
+    }
 }
 
 #endif // USE_SOCKETW

--- a/source/main/network/Network.cpp
+++ b/source/main/network/Network.cpp
@@ -878,4 +878,14 @@ std::string Network::UserAuthToStringLong(RoRnet::UserInfo const &user)
     else                                      { return _LC("NetUserAuth","Guest");                  }
 }
 
+// ============================================
+// Plumbing for local serverscripts and AI bots
+
+void Network::SetLocalUserData(RoRnet::UserInfo const& user)
+{
+    ROR_ASSERT(App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT);
+    std::lock_guard<std::mutex> lock(m_users_mutex);
+    m_userdata = user;
+}
+
 #endif // USE_SOCKETW

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -147,6 +147,8 @@ public:
     /// @name Plumbing for local serverscripts and AI bots
     /// @{
     void                 SetLocalUserData(RoRnet::UserInfo const& user);
+    void                 AddBotUserInfo(RoRnet::UserInfo const& user);
+    void                 RemoveBotUserInfo(int uid);
     /// @}
 
 private:

--- a/source/main/network/Network.h
+++ b/source/main/network/Network.h
@@ -144,6 +144,11 @@ public:
     std::string          UserAuthToStringShort(RoRnet::UserInfo const &user);
     std::string          UserAuthToStringLong(RoRnet::UserInfo const &user);
 
+    /// @name Plumbing for local serverscripts and AI bots
+    /// @{
+    void                 SetLocalUserData(RoRnet::UserInfo const& user);
+    /// @}
+
 private:
     void                 PushNetMessage(MsgType type, std::string const & message);
     void                 SetNetQuality(int quality);

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -51,6 +51,7 @@
 #include "RigDef_Serializer.h"
 #include "ActorSpawner.h"
 #include "ScriptEngine.h"
+#include "ServerScriptEngine.h"
 #include "SoundScriptManager.h"
 #include "Terrain.h"
 #include "ThreadPool.h"
@@ -610,6 +611,19 @@ void ActorManager::UpdateNetTimeOffset(int sourceid, int offset)
 
 RoRnet::UiStreamsHealth ActorManager::CheckNetworkStreamsOk(int sourceid)
 {
+    // Special case - local serverscript
+    if (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT)
+    {
+        // Mismatches can't happen, just check if any actor is spawned
+        for (ActorPtr& actor: m_actors)
+        {
+            if (actor->ar_driveable == ActorType::AI && actor->ar_net_source_id == sourceid)
+            {
+                return RoRnet::UiStreamsHealth::ALL_OK;
+            }
+        }
+    }
+
     if (!m_stream_mismatches[sourceid].empty())
         return RoRnet::UiStreamsHealth::MISMATCHES;
 

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -154,6 +154,8 @@ void ContentManager::InitContentManager()
     ResourceGroupManager::getSingleton().addResourceLocation(
         App::sys_scripts_dir->getStr(), "FileSystem", RGN_SCRIPTS, /*recursive:*/false, /*readonly:*/false);
     ResourceGroupManager::getSingleton().addResourceLocation(
+        App::sys_server_scripts_dir->getStr(), "FileSystem", RGN_SERVER_SCRIPTS, /*recursive:*/false, /*readonly:*/false);
+    ResourceGroupManager::getSingleton().addResourceLocation(
         App::sys_logs_dir->getStr(), "FileSystem", RGN_LOGS, /*recursive:*/false, /*readonly:*/false);
 
     Ogre::ScriptCompilerManager::getSingleton().setListener(this);

--- a/source/main/resources/ContentManager.cpp
+++ b/source/main/resources/ContentManager.cpp
@@ -154,9 +154,22 @@ void ContentManager::InitContentManager()
     ResourceGroupManager::getSingleton().addResourceLocation(
         App::sys_scripts_dir->getStr(), "FileSystem", RGN_SCRIPTS, /*recursive:*/false, /*readonly:*/false);
     ResourceGroupManager::getSingleton().addResourceLocation(
-        App::sys_server_scripts_dir->getStr(), "FileSystem", RGN_SERVER_SCRIPTS, /*recursive:*/false, /*readonly:*/false);
-    ResourceGroupManager::getSingleton().addResourceLocation(
         App::sys_logs_dir->getStr(), "FileSystem", RGN_LOGS, /*recursive:*/false, /*readonly:*/false);
+
+    // Server scripts must be isolated from any others.
+    ResourceGroupManager::getSingleton().createResourceGroup(RGN_SERVER_SCRIPTS, /* inGlobalPool: */false);
+    ResourceGroupManager::getSingleton().addResourceLocation(
+        App::sys_server_scripts_dir->getStr(), "FileSystem", RGN_SERVER_SCRIPTS, /*recursive:*/false, /*readonly:*/false);
+    // Recurse one level down, that's all the https://github.com/RigsOfRods/RoRServerScripts package needs.
+    // NOTE: We can't use OGRE's 'recursive' mode because it prepends subdir names to the resource name, and we need bare filenames.
+    FileInfoListPtr dirs = ResourceGroupManager::getSingleton().findResourceFileInfo(RGN_SERVER_SCRIPTS, "*", /*dirs:*/true);
+    for (const auto& dir_fileinfo : *dirs)
+    {
+        if (!dir_fileinfo.archive)
+            continue;
+        String fullpath = PathCombine(dir_fileinfo.archive->getName(), dir_fileinfo.filename);
+        ResourceGroupManager::getSingleton().addResourceLocation(fullpath, "FileSystem", RGN_SERVER_SCRIPTS, /*recursive:*/false, /*readonly:*/false);
+    }
 
     Ogre::ScriptCompilerManager::getSingleton().setListener(this);
 
@@ -302,7 +315,7 @@ void ContentManager::InitModCache(CacheValidity validity)
     ResourceGroupManager::getSingleton().addResourceLocation(PathCombine(App::sys_process_dir->getStr(), "content") , "FileSystem", RGN_TEMP, true);
 
     // Traverse RGN_TEMP and add all subdirectories to RGN_CONTENT.
-    // (TBD: why not just make RGN_CONTENT itself recursive? -- ohlidalp, 10/2023)
+    // NOTE we can't use OGRE's 'recursive' mode because it prepends subdir names to the resource name, and we need bare filenames.
 
     FileInfoListPtr dirs = ResourceGroupManager::getSingleton().findResourceFileInfo(RGN_TEMP, "*", /*dirs:*/true);
     for (const auto& dir_fileinfo : *dirs)

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -20,7 +20,6 @@
 */
 
 #include "GameScript.h"
-#include "ScriptUtils.h"
 
 #ifdef USE_CURL
 #   include <curl/curl.h>
@@ -54,6 +53,7 @@
 #include "Network.h"
 #include "RoRVersion.h"
 #include "ScriptEngine.h"
+#include "ServerScriptEngine.h"
 #include "ScriptUtils.h"
 #include "SkyManager.h"
 #include "SoundScriptManager.h"
@@ -1020,6 +1020,11 @@ int GameScript::sendGameCmd(const String& message)
         return 0;
     }
 #endif // USE_SOCKETW
+    if (RoR::App::mp_state->getEnum<MpState>() == RoR::MpState::LOCAL_SCRIPT)
+    {
+        App::GetServerScriptEngine()->gameCmd(-1, message);
+        return 0;
+    }
 
     return -11;
 }

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -1022,7 +1022,7 @@ int GameScript::sendGameCmd(const String& message)
 #endif // USE_SOCKETW
     if (RoR::App::mp_state->getEnum<MpState>() == RoR::MpState::LOCAL_SCRIPT)
     {
-        App::GetServerScriptEngine()->gameCmd(-1, message);
+        App::GetServerScript()->queueMessageGameCmd(-1, message);
         return 0;
     }
 
@@ -1119,7 +1119,7 @@ void spawnTruckAiBotHelper(ActorSpawnRequest& rq, const ScriptUnit& unit)
     {
         strcpy(reg.skin, rq.asr_skin_entry->dname.c_str());
     }
-    App::GetServerScriptEngine()->streamAdded(unit.associatedNetUid, (RoRnet::StreamRegister*)&reg);
+    App::GetServerScript()->queueMessageStreamRegister(unit.associatedNetUid, (RoRnet::StreamRegister*)&reg);
 }
 
 ActorPtr GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x)

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -1097,6 +1097,31 @@ ActorPtr GameScript::spawnTruck(Ogre::String& truckName, Ogre::Vector3& pos, Ogr
     return App::GetGameContext()->SpawnActor(rq);
 }
 
+void spawnTruckAiBotHelper(ActorSpawnRequest& rq, const ScriptUnit& unit)
+{
+    // Fill network info to the spawn request ~ this will not trigger networking because 'origin' remains 'AI'.
+    ROR_ASSERT(unit.associatedNetUid != -1);
+    rq.net_source_id = unit.associatedNetUid;
+    RoRnet::UserInfo user_info;
+    if (App::GetNetwork()->GetAnyUserInfo(unit.associatedNetUid, user_info))
+    {
+        rq.asr_net_color = user_info.colournum;
+        rq.asr_net_username = user_info.username;
+        App::GetNetwork()->GetUserPeerOpts(unit.associatedNetUid, /* [out] */rq.asr_net_peeropts);
+    }
+
+    // Fabricate rornet message and send to serverscript
+    RoRnet::ActorStreamRegister reg;
+    reg.origin_sourceid = unit.associatedNetUid;
+    strcpy(reg.name, rq.asr_filename.c_str());
+    strcpy(reg.sectionconfig, rq.asr_config.c_str());
+    if (rq.asr_skin_entry)
+    {
+        strcpy(reg.skin, rq.asr_skin_entry->dname.c_str());
+    }
+    App::GetServerScriptEngine()->streamAdded(unit.associatedNetUid, (RoRnet::StreamRegister*)&reg);
+}
+
 ActorPtr GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, Ogre::String& truckSectionConfig, std::string& truckSkin, int x)
 {
     try
@@ -1128,11 +1153,21 @@ ActorPtr GameScript::spawnTruckAI(Ogre::String& truckName, Ogre::Vector3& pos, O
         rq.asr_config = truckSectionConfig;
         rq.asr_skin_entry = App::GetCacheSystem()->FetchSkinByName(truckSkin);
         rq.asr_origin = ActorSpawnRequest::Origin::AI;
+
+        // Check if spawned by AI_BOT
+        ScriptUnitID_t nid = App::GetScriptEngine()->getCurrentlyExecutingScriptUnit();
+        ROR_ASSERT(nid != SCRIPTUNITID_INVALID);
+        ScriptUnit& unit = App::GetScriptEngine()->getScriptUnit(nid);
+        if (unit.scriptCategory == ScriptCategory::AI_BOT)
+        {
+            spawnTruckAiBotHelper(rq, unit);
+        }
+
         return App::GetGameContext()->SpawnActor(rq);
     }
     catch (...)
     {
-        App::GetScriptEngine()->forwardExceptionAsScriptEvent("GameScript::setMaterialTextureScale()");
+        App::GetScriptEngine()->forwardExceptionAsScriptEvent("GameScript::spawnTruckAI()");
         return ActorPtr();
     }
 }

--- a/source/main/scripting/OgreScriptBuilder.cpp
+++ b/source/main/scripting/OgreScriptBuilder.cpp
@@ -75,7 +75,7 @@ int OgreScriptBuilder::LoadScriptSection(const char* full_path_cstr)
         {
             ds = Ogre::ResourceGroupManager::getSingleton().openResource(
                 devel_filename,
-                Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME,
+                mResourceGroup,
                 /*resourceBeingLoaded: */nullptr,
                 /*throwOnFailure:*/false);
 
@@ -99,10 +99,7 @@ int OgreScriptBuilder::LoadScriptSection(const char* full_path_cstr)
     {
         try
         {
-            ds = Ogre::ResourceGroupManager::getSingleton().openResource(filename, Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
-
-                     //TODO: do not use `AUTODETECT_RESOURCE_GROUP_NAME`, use specific group, lookups are slow!
-                     //see also https://github.com/OGRECave/ogre/blob/master/Docs/1.10-Notes.md#resourcemanager-strict-mode ~ ohlidalp, 08/2017
+            ds = Ogre::ResourceGroupManager::getSingleton().openResource(filename, mResourceGroup);
         }
         catch (Ogre::Exception& e)
         {

--- a/source/main/scripting/OgreScriptBuilder.h
+++ b/source/main/scripting/OgreScriptBuilder.h
@@ -31,6 +31,8 @@
 
 #include <angelscript.h>
 
+#include <OgreResourceGroupManager.h>
+
 /// @addtogroup Scripting
 /// @{
 
@@ -40,8 +42,10 @@ class OgreScriptBuilder : public AngelScript::CScriptBuilder
 {
 public:
     Ogre::String GetHash() { return hash; };
+    void SetResourceGroup(const Ogre::String& rg) { resourceGroup = rg; }
 protected:
     Ogre::String hash;
+    Ogre::String resourceGroup = Ogre::RGN_AUTODETECT; // Overridable to acommodate server scripts which must load from restricted location to avoid mixups with client scripts.
     int LoadScriptSection(const char* filename);
 };
 

--- a/source/main/scripting/OgreScriptBuilder.h
+++ b/source/main/scripting/OgreScriptBuilder.h
@@ -42,10 +42,10 @@ class OgreScriptBuilder : public AngelScript::CScriptBuilder
 {
 public:
     Ogre::String GetHash() { return hash; };
-    void SetResourceGroup(const Ogre::String& rg) { resourceGroup = rg; }
+    void SetResourceGroup(const Ogre::String& rg) { mResourceGroup = rg; }
 protected:
     Ogre::String hash;
-    Ogre::String resourceGroup = Ogre::RGN_AUTODETECT; // Overridable to acommodate server scripts which must load from restricted location to avoid mixups with client scripts.
+    Ogre::String mResourceGroup = Ogre::RGN_AUTODETECT; // Overridable to acommodate server scripts which must load from restricted location to avoid mixups with client scripts.
     int LoadScriptSection(const char* filename);
 };
 

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -54,6 +54,7 @@
 #include "PlatformUtils.h"
 #include "ScriptEvents.h"
 #include "ScriptUtils.h"
+#include "ServerScriptEngine.h"
 #include "Utils.h"
 #include "VehicleAI.h"
 
@@ -833,7 +834,7 @@ String ScriptEngine::composeModuleName(String const& scriptName, ScriptCategory 
 
 ScriptUnitID_t ScriptEngine::loadScript(
     String scriptOrGadgetFileName, ScriptCategory category/* = ScriptCategory::TERRAIN*/,
-    ActorPtr associatedActor /*= nullptr*/, std::string buffer /* =""*/)
+    ActorPtr associatedActor /*= nullptr*/, int32_t associatedNetUid /* = -1*/, std::string buffer /* =""*/)
 {
     // This function creates a new script unit, tries to set it up and removes it if setup fails.
     // -----------------------------------------------------------------------------------------
@@ -884,6 +885,10 @@ ScriptUnitID_t ScriptEngine::loadScript(
     else if (category == ScriptCategory::ACTOR)
     {
         m_script_units[unit_id].associatedActor = associatedActor;
+    }
+    else if (category == ScriptCategory::AI_BOT)
+    {
+        m_script_units[unit_id].associatedNetUid = associatedNetUid;
     }
 
     // Perform the actual script loading, building and running main().
@@ -1097,6 +1102,23 @@ void ScriptEngine::unloadScript(ScriptUnitID_t nid)
     {
         m_terrain_script_unit = SCRIPTUNITID_INVALID;
     }
+}
+
+void ScriptEngine::kickBotByUid(int32_t bot_net_uid)
+{
+    for (const auto& pair: m_script_units)
+    {
+        const ScriptUnit& unit = pair.second;
+        if (unit.scriptCategory == ScriptCategory::AI_BOT && unit.associatedNetUid == bot_net_uid)
+        {
+            App::GetGameContext()->PushMessage(Message(MSG_APP_UNLOAD_SCRIPT_REQUESTED, new ScriptUnitID_t(pair.first)));
+            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
+                fmt::format("Unloading AI bot script with net UID {} (script unit ID {})", bot_net_uid, pair.first));
+            return;
+        }
+    }
+    App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
+        fmt::format("No AI bot script found with net UID {}", bot_net_uid));
 }
 
 void ScriptEngine::setForwardScriptLogToConsole(bool doForward)

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -1104,7 +1104,7 @@ void ScriptEngine::unloadScript(ScriptUnitID_t nid)
     }
 }
 
-void ScriptEngine::kickBotByUid(int32_t bot_net_uid)
+void ScriptEngine::unloadBotByUid(int32_t bot_net_uid)
 {
     for (const auto& pair: m_script_units)
     {

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -204,7 +204,7 @@ public:
     /**
     * Helper for ServerScriptEngine - requests unloading the AI_BOT script.
     */
-    void kickBotByUid(int32_t bot_net_uid);
+    void unloadBotByUid(int32_t bot_net_uid);
 
     /**
      * Calls the script's framestep function to be able to use timed things inside the script

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -61,6 +61,7 @@ enum class ScriptCategory
     ACTOR,   //!< Defined in truck file under 'scripts', contains global variable `BeamClass@ thisActor`.
     TERRAIN, //!< Defined in terrn2 file under '[Scripts]', receives terrain eventbox notifications.
     GADGET,  //!< Associated with a .gadget mod file, launched via UI or any method given below for CUSTOM scripts (use .gadget suffix - game will fix up category to `GADGET`).
+    AI_BOT,  //!< Only valid under `MpState::LOCAL_SCRIPT`; registers as RoRnet user in the server script (i.e. for competitive racing).
     CUSTOM   //!< Loaded by user via either: A) ingame console 'loadscript'; B) RoR.cfg 'app_custom_scripts'; C) commandline '-runscript'; If used with .gadget file, game will fix up category to `GADGET`.
 };
 
@@ -81,6 +82,7 @@ struct ScriptUnit
     AngelScript::asIScriptFunction* eventCallbackExFunctionPtr = nullptr; //!< script function pointer to the event callback function
     AngelScript::asIScriptFunction* defaultEventCallbackFunctionPtr = nullptr; //!< script function pointer for spawner events
     ActorPtr associatedActor; //!< For ScriptCategory::ACTOR
+    int32_t associatedNetUid = -1; //!< For ScriptCategory::AI_BOT ~ used to identify the bot in the server script.
     CacheEntryPtr originatingGadget; //!< For ScriptCategory::GADGET ~ determines resource group
     Ogre::String scriptName; //!< Name of the '.as' file exclusively.
     Ogre::String scriptHash;
@@ -186,17 +188,23 @@ public:
      * @param filename '.as' file or '.gadget' file to load; if buffer is supplied, this is only a display name.
      * @param category How to treat the script?
      * @param associatedActor Only for category ACTOR
+     * @param associatedNetUid Only for category AI_BOT
      * @param buffer String with full script body; if empty, a file will be loaded as usual.
      * @return Unique ID of the script unit (because one script file can be loaded multiple times).
      */
     ScriptUnitID_t loadScript(Ogre::String filename, ScriptCategory category = ScriptCategory::TERRAIN,
-        ActorPtr associatedActor = nullptr, std::string buffer = "");
+        ActorPtr associatedActor = nullptr, int32_t associatedNetUid = -1, std::string buffer = "");
 
     /**
      * Unloads a script
      * @param unique_id The script unit ID as returned by `loadScript()`
      */
     void unloadScript(ScriptUnitID_t unique_id);
+
+    /**
+    * Helper for ServerScriptEngine - requests unloading the AI_BOT script.
+    */
+    void kickBotByUid(int32_t bot_net_uid);
 
     /**
      * Calls the script's framestep function to be able to use timed things inside the script

--- a/source/main/scripting/ServerScriptEngine.cpp
+++ b/source/main/scripting/ServerScriptEngine.cpp
@@ -614,6 +614,11 @@ int ServerScriptEngine::loadScriptFile(const char *fileName, string &script) {
 }
 
 int ServerScriptEngine::frameStep(float dt) {
+
+    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
+    // All script callbacks must be invoked while clients-mutex is locked
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();
     int r;
@@ -647,6 +652,11 @@ int ServerScriptEngine::frameStep(float dt) {
 }
 
 void ServerScriptEngine::playerDeleted(int uid, int crash, bool doNestedCall /*= false*/) {
+
+    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
+    // All script callbacks must be invoked while clients-mutex is locked
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
     if (!engine) return;
     if (!context) context = engine->CreateContext();
     int r;
@@ -691,6 +701,11 @@ void ServerScriptEngine::playerDeleted(int uid, int crash, bool doNestedCall /*=
 }
 
 void ServerScriptEngine::playerAdded(int uid) {
+
+    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
+    // All script callbacks must be invoked while clients-mutex is locked
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
     if (!engine) return;
     if (!context) context = engine->CreateContext();
     int r;
@@ -720,6 +735,11 @@ void ServerScriptEngine::playerAdded(int uid) {
 }
 
 int ServerScriptEngine::streamAdded(int uid, RoRnet::StreamRegister *reg) {
+
+    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
+    // All script callbacks must be invoked while clients-mutex is locked
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();
     int r;
@@ -759,6 +779,11 @@ int ServerScriptEngine::streamAdded(int uid, RoRnet::StreamRegister *reg) {
 }
 
 int ServerScriptEngine::playerChat(int uid, std::string msg) {
+
+    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
+    // All script callbacks must be invoked while clients-mutex is locked
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();
     int r;
@@ -798,6 +823,11 @@ int ServerScriptEngine::playerChat(int uid, std::string msg) {
 }
 
 void ServerScriptEngine::gameCmd(int uid, const std::string &cmd) {
+
+    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
+    // All script callbacks must be invoked while clients-mutex is locked
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
     if (!engine) return;
     if (!context) context = engine->CreateContext();
     int r;
@@ -834,6 +864,10 @@ void ServerScriptEngine::curlStatus(RoRServerCurlStatusType type, int n1, int n2
     // - for CURL_STATUS_PROGRESS, n1 = bytes downloaded, n2 = total bytes,
     // - otherwise, n1 = CURL return code, n2 = HTTP result code.
     // -------------------------------------------------------------------
+
+    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
+    // All script callbacks must be invoked while clients-mutex is locked
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
 
     if (!engine) return;
     if (!context) context = engine->CreateContext();
@@ -902,7 +936,9 @@ void ServerScriptEngine::StopTimerThread() {
         m_timer_thread_state = ThreadState::STOP_REQUESTED;
     }
 
+    Logger::Log(LOG_DEBUG, "ScriptEngine: stopping framestep thread...");
     m_timer_thread.join();
+    Logger::Log(LOG_DEBUG, "ScriptEngine: stopped framestep thread.");
     
     {
         std::lock_guard<std::mutex> scoped_lock(m_timer_thread_mutex);

--- a/source/main/scripting/ServerScriptEngine.cpp
+++ b/source/main/scripting/ServerScriptEngine.cpp
@@ -223,6 +223,23 @@ int ServerScriptEngine::loadScript(std::string scriptname) {
     return 0;
 }
 
+void ServerScriptEngine::unloadScript() {
+    // Stop thread first
+    this->StopTimerThread();
+    deleteAllCallbacks();
+    context->Unprepare();
+    engine->ReturnContext(context);
+    context = nullptr;
+    if (engine) {
+        asIScriptModule *mod = engine->GetModule("script");
+        if (mod) {
+            engine->DiscardModule("script");
+        }
+    }
+
+
+}
+
 void ServerScriptEngine::ExceptionCallback(asIScriptContext *ctx, void *param) {
     const asIScriptFunction *function = ctx->GetExceptionFunction();
     Logger::Log(LOG_INFO, "--- exception ---");

--- a/source/main/scripting/ServerScriptEngine.cpp
+++ b/source/main/scripting/ServerScriptEngine.cpp
@@ -1,0 +1,1343 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2009   Thomas Fischer
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// created on 22th of June 2009 by Thomas Fischer
+#ifdef USE_ANGELSCRIPT
+
+#include "ServerScriptEngine.h"
+
+#include "scriptstdstring/scriptstdstring.h" // angelscript addon
+#include "scriptmath/scriptmath.h" // angelscript addon
+#include "scriptmath3d/scriptmath3d.h" // angelscript addon
+#include "scriptarray/scriptarray.h" // angelscript addon
+#include "scriptdictionary/scriptdictionary.h" // angelscript addon
+#include "scriptany/scriptany.h" // angelscript addon
+#include "SocketW.h"
+
+#include "CurlHelpers.h" // RIGSOFRODS: This is actually the client's header with same name as server header. Both implement the same functionality but with cosmetic differences.
+#include "OgreScriptBuilder.h" // RIGSOFRODS: Use OGRE to load files.
+#include "PlatformUtils.h" // RIGSOFRODS: For PathCombine
+#include "Application.h" // RIGSOFRODS: For App::sys_logs_dir
+#include "Console.h" // RIGSOFRODS: For putNetMessage()
+
+#include <cstdio>
+#include <stdlib.h>
+
+
+using namespace std;
+using namespace AngelScript; // RIGSOFRODS: Added to match rorserver's style
+using namespace RoR;
+
+#include <assert.h>
+# define assert_net(expr) ROR_ASSERT(expr)
+
+
+#ifdef __GNUC__
+
+#include <string.h>
+
+#endif
+
+#include <thread>
+#include <future>
+
+static Ogre::Log* sServerLog = nullptr;
+
+void Logger::Log(LogLevel level, const char *format, ...)
+{
+    // Format the message
+    const int BUF_LEN = 4000; // hard limit
+    char buffer[BUF_LEN] = {}; // zeroed memory
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buffer, BUF_LEN, format, args);
+    va_end(args);
+    // Log the message
+    sServerLog->logMessage(std::string(buffer));
+}
+
+void Logger::Log(LogLevel level, std::string const& msg)
+{
+    sServerLog->logMessage(msg);
+}
+
+
+// Stream_register_t wrapper
+std::string stream_register_get_name(RoRnet::StreamRegister *reg) {
+    return std::string(reg->name);
+}
+
+
+
+ServerScriptEngine::ServerScriptEngine() :
+                                             engine(0),
+                                             context(0)
+{
+    sServerLog = Ogre::LogManager::getSingleton().createLog(RoR::PathCombine(App::sys_logs_dir->getStr(), "RoRServerScript.log"));
+    init();
+}
+
+ServerScriptEngine::~ServerScriptEngine() {
+    // Stop thread first
+    this->StopTimerThread();
+
+    // Clean up
+    deleteAllCallbacks();
+    if (engine) engine->Release();
+    if (context) context->Release();
+}
+
+void ServerScriptEngine::deleteAllCallbacks() {
+    if (!engine) return;
+
+    for (std::map<std::string, callbackList>::iterator typeit = callbacks.begin();
+         typeit != callbacks.end(); ++typeit) {
+        for (callbackList::iterator it = typeit->second.begin(); it != typeit->second.end(); ++it) {
+            if (it->obj)
+                it->obj->Release();
+        }
+        typeit->second.clear();
+    }
+    callbacks.clear();
+}
+
+int ServerScriptEngine::loadScript(std::string scriptname) {
+    if (scriptname.empty()) return 0;
+
+    int r;
+    OgreScriptBuilder builder;
+    builder.SetResourceGroup(RGN_SERVER_SCRIPTS); // RIGSOFRODS: Server scripts only load from restricted location to avoid mixups with client scripts.
+
+    r = builder.StartNewModule(engine, "script");
+    if (r < 0) {
+        Logger::Log(LOG_ERROR, "ScriptEngine: Unknown error while starting a new script module.");
+        return 1;
+    }
+
+    r = builder.AddSectionFromFile(scriptname.c_str());
+    if (r < 0) {
+        Logger::Log(LOG_ERROR, "ScriptEngine: Unknown error while adding a new section from file.");
+        return 1;
+    }
+
+    r = builder.BuildModule();
+    if (r < 0) {
+        if (r == asINVALID_CONFIGURATION)
+            Logger::Log(LOG_ERROR, "ScriptEngine: The engine configuration is invalid.");
+
+        else if (r == asERROR)
+            Logger::Log(LOG_ERROR, "ScriptEngine: The script failed to build.");
+
+        else if (r == asBUILD_IN_PROGRESS)
+            Logger::Log(LOG_ERROR, "ScriptEngine: Another thread is currently building.");
+
+        else if (r == asINIT_GLOBAL_VARS_FAILED)
+            Logger::Log(LOG_ERROR,
+                        "ScriptEngine: It was not possible to initialize at least one of the global variables.");
+
+        else
+            Logger::Log(LOG_ERROR, "ScriptEngine: Unknown error while building the script.");
+
+        return 1;
+    }
+
+    // Get the newly created module
+    asIScriptModule *mod = builder.GetModule();
+
+    // get some other optional functions
+    asIScriptFunction *func;
+
+    func = mod->GetFunctionByDecl("void frameStep(float)");
+    if (func) addCallback("frameStep", func, NULL);
+
+    func = mod->GetFunctionByDecl("void playerDeleted(int, int)");
+    if (func) addCallback("playerDeleted", func, NULL);
+
+    func = mod->GetFunctionByDecl("void playerAdded(int)");
+    if (func) addCallback("playerAdded", func, NULL);
+
+    func = mod->GetFunctionByDecl("int streamAdded(int, StreamRegister@)");
+    if (func) addCallback("streamAdded", func, NULL);
+
+    func = mod->GetFunctionByDecl("int playerChat(int, string msg)");
+    if (func) addCallback("playerChat", func, NULL);
+
+    func = mod->GetFunctionByDecl("void gameCmd(int, string)");
+    if (func) addCallback("gameCmd", func, NULL);
+
+    func = mod->GetFunctionByDecl("void curlStatus(curlStatusType, int, int, string, string)");
+    if (func) addCallback("curlStatus", func, NULL);
+
+    // Create and configure our context
+    context = engine->CreateContext();
+    //context->SetLineCallback(asMETHOD(ScriptEngine,LineCallback), this, asCALL_THISCALL);
+    context->SetExceptionCallback(asMETHOD(ServerScriptEngine, ExceptionCallback), this, asCALL_THISCALL);
+
+    // Find the function that is to be called.
+    func = mod->GetFunctionByDecl("void main()");
+    if (!func) {
+        // The function couldn't be found. Instruct the script writer to include the
+        // expected function in the script.
+        Logger::Log(LOG_WARN,
+                    "ScriptEngine: The script must have the function 'void main()'. Please add it and try again.");
+        return 1;
+    }
+
+    // prepare and execute the main function
+    context->Prepare(func);
+    Logger::Log(LOG_INFO, "ScriptEngine: Executing main()");
+    r = context->Execute();
+    if (r != asEXECUTION_FINISHED) {
+        // The execution didn't complete as expected. Determine what happened.
+        if (r == asEXECUTION_EXCEPTION) {
+            // An exception occurred, let the script writer know what happened so it can be corrected.
+            Logger::Log(LOG_ERROR,
+                        "ScriptEngine: An exception '%s' occurred. Please correct the code in file '%s' and try again.",
+                        context->GetExceptionString(), scriptname.c_str());
+        }
+    }
+
+    return 0;
+}
+
+void ServerScriptEngine::ExceptionCallback(asIScriptContext *ctx, void *param) {
+    const asIScriptFunction *function = ctx->GetExceptionFunction();
+    Logger::Log(LOG_INFO, "--- exception ---");
+    Logger::Log(LOG_INFO, "desc: %s", ctx->GetExceptionString());
+    Logger::Log(LOG_INFO, "func: %s", function->GetDeclaration());
+    Logger::Log(LOG_INFO, "modl: %s", function->GetModuleName());
+    Logger::Log(LOG_INFO, "sect: %s", function->GetScriptSectionName());
+    int col, line = ctx->GetExceptionLineNumber(&col);
+    Logger::Log(LOG_INFO, "line: %d,%d", line, col);
+
+    // Show the call stack with the variables
+    Logger::Log(LOG_INFO, "--- call stack ---");
+    char tmp[2048] = "";
+    for (asUINT n = 0; n < ctx->GetCallstackSize(); n++) {
+        function = ctx->GetFunction(n);
+        sprintf(tmp, "%s (%d): %s", function->GetScriptSectionName(), ctx->GetLineNumber(n),
+                function->GetDeclaration());
+        Logger::Log(LOG_INFO, tmp);
+        PrintVariables(ctx, n);
+    }
+    Logger::Log(LOG_INFO, "--- end of script exception message ---");
+}
+
+void ServerScriptEngine::LineCallback(asIScriptContext *ctx, void *param) {
+    char tmp[1024] = "";
+    asIScriptEngine *engine = ctx->GetEngine();
+    int col;
+    const char *sectionName;
+    int line = ctx->GetLineNumber(0, &col, &sectionName);
+    int indent = ctx->GetCallstackSize();
+    for (int n = 0; n < indent; n++)
+        sprintf(tmp + n, " ");
+    const asIScriptFunction *function = engine->GetFunctionById(0);
+    sprintf(tmp + indent, "%s:%s:%s:%d,%d", function->GetModuleName(), sectionName,
+            function->GetDeclaration(),
+            line, col);
+
+    strcat(tmp, "");
+    Logger::Log(LOG_INFO, tmp);
+
+//	PrintVariables(ctx, -1);
+}
+
+void ServerScriptEngine::PrintVariables(asIScriptContext *ctx, int stackLevel) {
+    asIScriptEngine *engine = ctx->GetEngine();
+
+    // First print the this pointer if this is a class method
+    int typeId = ctx->GetThisTypeId(stackLevel);
+    void *varPointer = ctx->GetThisPointer(stackLevel);
+    if (typeId) {
+        Logger::Log(LOG_INFO, " this = 0x%x", varPointer);
+    }
+
+    // Print the value of each variable, including parameters
+    int numVars = ctx->GetVarCount(stackLevel);
+    for (int n = 0; n < numVars; n++) {
+        // RIFGSOFRODS: Latest angelscript doesn't have `GetVar()` anymore
+        int typeId = ctx->GetVarTypeId(n, stackLevel);
+        const char* varName = ctx->GetVarName(n, stackLevel);
+        void *varPointer = ctx->GetAddressOfVar(n, stackLevel);
+        if (typeId == asTYPEID_INT32) {
+            Logger::Log(LOG_INFO, " %s = %d", ctx->GetVarDeclaration(n, stackLevel), *(int *) varPointer);
+        } else if (typeId == asTYPEID_FLOAT) {
+            Logger::Log(LOG_INFO, " %s = %f", ctx->GetVarDeclaration(n, stackLevel), *(float *) varPointer);
+        } else if (typeId & asTYPEID_SCRIPTOBJECT) {
+            asIScriptObject *obj = (asIScriptObject *) varPointer;
+            if (obj)
+                Logger::Log(LOG_INFO, " %s = {...}", ctx->GetVarDeclaration(n, stackLevel));
+            else
+                Logger::Log(LOG_INFO, " %s = <null>", ctx->GetVarDeclaration(n, stackLevel));
+        } else if (typeId == engine->GetTypeIdByDecl("string")) {
+            std::string *str = (std::string *) varPointer;
+            if (str)
+                Logger::Log(LOG_INFO, " %s = '%s'", ctx->GetVarDeclaration(n, stackLevel), str->c_str());
+            else
+                Logger::Log(LOG_INFO, " %s = <null>", ctx->GetVarDeclaration(n, stackLevel));
+        } else {
+            Logger::Log(LOG_INFO, " %s = {...}", ctx->GetVarDeclaration(n, stackLevel));
+        }
+    }
+}
+
+// continue with initializing everything
+void ServerScriptEngine::init() {
+    int result;
+
+    // Create the script engine
+    engine = asCreateScriptEngine(ANGELSCRIPT_VERSION);
+
+    // Set the message callback to receive information on errors in human readable form.
+    // It's recommended to do this right after the creation of the engine, because if
+    // some registration fails the engine may send valuable information to the message
+    // stream.
+    result = engine->SetMessageCallback(asMETHOD(ServerScriptEngine, msgCallback), this, asCALL_THISCALL);
+    if (result < 0) {
+        if (result == asINVALID_ARG) {
+            Logger::Log(LOG_ERROR,
+                        "ScriptEngine: One of the arguments is incorrect, e.g. obj is null for a class method.");
+            return;
+        } else if (result == asNOT_SUPPORTED) {
+            Logger::Log(LOG_ERROR, "ScriptEngine: 	The arguments are not supported, e.g. asCALL_GENERIC.");
+            return;
+        }
+        Logger::Log(LOG_ERROR, "ScriptEngine: Unknown error while setting up message callback");
+        return;
+    }
+
+    // AngelScript doesn't have a built-in string type, as there is no definite standard
+    // string type for C++ applications. Every developer is free to register it's own string type.
+    // The SDK do however provide a standard add-on for registering a string type, so it's not
+    // necessary to register your own string type if you don't want to.
+    RegisterStdString(engine);
+    RegisterScriptArray(engine,
+                        true); // true = allow arrays to be registered as type[] (e.g. int[]). Needed for backwards compatibillity.
+    RegisterStdStringUtils(engine); // depends on string and array
+    RegisterScriptMath3D(engine); // depends on string
+    RegisterScriptMath(engine);
+    RegisterScriptDictionary(engine);
+    //RIGSOFRODS: FIXME //RegisterScriptFile(engine);
+    RegisterScriptAny(engine);
+
+    Logger::Log(LOG_INFO, "ScriptEngine: Registration of libs done, now custom things");
+
+    // Register ServerScript class
+    result = engine->RegisterObjectType("ServerScriptClass", sizeof(ServerScript), asOBJ_REF | asOBJ_NOCOUNT);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void Log(const string &in)",
+                                          asMETHOD(ServerScript, log), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void say(const string &in, int uid, int type)",
+                                          asMETHOD(ServerScript, say), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void kick(int kuid, const string &in)",
+                                          asMETHOD(ServerScript, kick), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void ban(int buid, const string &in)",
+                                          asMETHOD(ServerScript, ban), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "bool unban(int buid)", asMETHOD(ServerScript, unban),
+                                          asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "int cmd(int uid, string cmd)",
+                                          asMETHOD(ServerScript, sendGameCommand), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void curlRequestAsync(string url, string displayname)",
+                                          asMETHOD(ServerScript, curlRequestAsync), asCALL_THISCALL);
+
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "int getNumClients()",
+                                          asMETHOD(ServerScript, getNumClients), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string getUserName(int uid)",
+                                          asMETHOD(ServerScript, getUserName), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void setUserName(int uid, const string &in)",
+                                          asMETHOD(ServerScript, setUserName), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string getUserAuth(int uid)",
+                                          asMETHOD(ServerScript, getUserAuth), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "int getUserAuthRaw(int uid)",
+                                          asMETHOD(ServerScript, getUserAuthRaw), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void setUserAuthRaw(int uid, int)",
+                                          asMETHOD(ServerScript, setUserAuthRaw), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "int getUserColourNum(int uid)",
+                                          asMETHOD(ServerScript, getUserColourNum), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void setUserColourNum(int uid, int)",
+                                          asMETHOD(ServerScript, setUserColourNum), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void broadcastUserInfo(int)",
+                                          asMETHOD(ServerScript, broadcastUserInfo), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string getUserToken(int uid)",
+                                          asMETHOD(ServerScript, getUserToken), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string getUserVersion(int uid)",
+                                          asMETHOD(ServerScript, getUserVersion), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string getUserIPAddress(int uid)",
+                                          asMETHOD(ServerScript, getUserIPAddress), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string getServerTerrain()",
+                                          asMETHOD(ServerScript, getServerTerrain), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "int getTime()", asMETHOD(ServerScript, getTime),
+                                          asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "int getStartTime()",
+                                          asMETHOD(ServerScript, getStartTime), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass",
+                                          "void setCallback(const string &in, const string &in, ?&in)",
+                                          asMETHOD(ServerScript, setCallback), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass",
+                                          "void deleteCallback(const string &in, const string &in, ?&in)",
+                                          asMETHOD(ServerScript, deleteCallback), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "void throwException(const string &in)",
+                                          asMETHOD(ServerScript, throwException), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_version()",
+                                          asMETHOD(ServerScript, get_version), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_asVersion()",
+                                          asMETHOD(ServerScript, get_asVersion), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_protocolVersion()",
+                                          asMETHOD(ServerScript, get_protocolVersion), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "uint get_maxClients()",
+                                          asMETHOD(ServerScript, get_maxClients), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_serverName()",
+                                          asMETHOD(ServerScript, get_serverName), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_IPAddr()",
+                                          asMETHOD(ServerScript, get_IPAddr), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "uint get_listenPort()",
+                                          asMETHOD(ServerScript, get_listenPort), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "int get_serverMode()",
+                                          asMETHOD(ServerScript, get_serverMode), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_owner()", asMETHOD(ServerScript, get_owner),
+                                          asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_website()",
+                                          asMETHOD(ServerScript, get_website), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_ircServ()",
+                                          asMETHOD(ServerScript, get_ircServ), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "string get_voipServ()",
+                                          asMETHOD(ServerScript, get_voipServ), asCALL_THISCALL);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("ServerScriptClass", "int rangeRandomInt(int, int)",
+                                          asMETHOD(ServerScript, rangeRandomInt), asCALL_THISCALL);
+    assert_net(result >= 0);
+    ServerScript *serverscript = new ServerScript(this);
+    result = engine->RegisterGlobalProperty("ServerScriptClass server", serverscript);
+    assert_net(result >= 0);
+
+    // Register RoRnet::StreamRegister class
+    result = engine->RegisterObjectType("StreamRegister", sizeof(RoRnet::StreamRegister),
+                                        asOBJ_REF | asOBJ_NOCOUNT);
+    assert_net(result >= 0);
+    result = engine->RegisterObjectMethod("StreamRegister", "string getName()",
+                                          asFUNCTION(stream_register_get_name), asCALL_CDECL_OBJFIRST);
+    assert_net(result >= 0); // (No property accessor on purpose)
+    result = engine->RegisterObjectProperty("StreamRegister", "int type",
+                                            offsetof(RoRnet::StreamRegister, type));
+    assert_net(result >= 0);
+    result = engine->RegisterObjectProperty("StreamRegister", "int status",
+                                            offsetof(RoRnet::StreamRegister, status));
+    assert_net(result >= 0);
+    result = engine->RegisterObjectProperty("StreamRegister", "int origin_sourceid",
+                                            offsetof(RoRnet::StreamRegister, origin_sourceid));
+    assert_net(result >= 0);
+    result = engine->RegisterObjectProperty("StreamRegister", "int origin_streamid",
+                                            offsetof(RoRnet::StreamRegister, origin_streamid));
+    assert_net(result >= 0);
+
+
+    // Register ServerType enum for the server.serverMode attribute
+    result = engine->RegisterEnum("ServerType");
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("ServerType", "SERVER_LAN", SERVER_LAN);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("ServerType", "SERVER_INET", SERVER_INET);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("ServerType", "SERVER_AUTO", SERVER_AUTO);
+    assert_net(result >= 0);
+
+    // Register publish mode enum for the playerChat callback
+    result = engine->RegisterEnum("broadcastType");
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("broadcastType", "BROADCAST_AUTO", BROADCAST_AUTO);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("broadcastType", "BROADCAST_BLOCK", BROADCAST_BLOCK);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("broadcastType", "BROADCAST_NORMAL", BROADCAST_NORMAL);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("broadcastType", "BROADCAST_AUTHED", BROADCAST_AUTHED);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("broadcastType", "BROADCAST_ALL", BROADCAST_ALL);
+    assert_net(result >= 0);
+
+    // Register authorizations
+    result = engine->RegisterEnum("authType");
+    assert_net(result >= 0);
+
+    result = engine->RegisterEnumValue("authType", "AUTH_NONE", RoRnet::AUTH_NONE);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("authType", "AUTH_ADMIN", RoRnet::AUTH_ADMIN);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("authType", "AUTH_RANKED", RoRnet::AUTH_RANKED);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("authType", "AUTH_MOD", RoRnet::AUTH_MOD);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("authType", "AUTH_BOT", RoRnet::AUTH_BOT);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("authType", "AUTH_BANNED", RoRnet::AUTH_BANNED);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("authType", "AUTH_ALL", 0xFFFFFFFF);
+    assert_net(result >= 0);
+
+    // Register serverSayType
+    result = engine->RegisterEnum("serverSayType");
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("serverSayType", "FROM_SERVER", FROM_SERVER);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("serverSayType", "FROM_HOST", FROM_HOST);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("serverSayType", "FROM_MOTD", FROM_MOTD);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("serverSayType", "FROM_RULES", FROM_RULES);
+    assert_net(result >= 0);
+
+    // Register curl update type for `curlStatus` callback
+    result = engine->RegisterEnum("curlStatusType");
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("curlStatusType", "CURL_STATUS_INVALID", CURL_STATUS_INVALID);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("curlStatusType", "CURL_STATUS_START", CURL_STATUS_START);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("curlStatusType", "CURL_STATUS_PROGRESS", CURL_STATUS_PROGRESS);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("curlStatusType", "CURL_STATUS_SUCCESS", CURL_STATUS_SUCCESS);
+    assert_net(result >= 0);
+    result = engine->RegisterEnumValue("curlStatusType", "CURL_STATUS_FAILURE", CURL_STATUS_FAILURE);
+    assert_net(result >= 0);
+
+    // register constants
+    result = engine->RegisterGlobalProperty("const int TO_ALL", (void *) &TO_ALL);
+    assert_net(result >= 0);
+
+
+    Logger::Log(LOG_INFO, "ScriptEngine: Registration done");
+}
+
+void ServerScriptEngine::msgCallback(const asSMessageInfo *msg) {
+    const char *type = "Error";
+    if (msg->type == asMSGTYPE_INFORMATION)
+        type = "Info";
+    else if (msg->type == asMSGTYPE_WARNING)
+        type = "Warning";
+
+    Logger::Log(LOG_INFO, "ScriptEngine: %s (%d, %d): %s = %s", msg->section, msg->row, msg->col, type, msg->message);
+}
+
+// unused method
+int ServerScriptEngine::loadScriptFile(const char *fileName, string &script) {
+    FILE *f = fopen(fileName, "rb");
+    if (!f) return 1;
+
+    // Determine the size of the file
+    fseek(f, 0, SEEK_END);
+    int len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    // Load the entire file in one call
+    script.resize(len);
+    fread(&script[0], len, 1, f);
+
+    fclose(f);
+    return 0;
+}
+
+int ServerScriptEngine::frameStep(float dt) {
+    if (!engine) return 0;
+    if (!context) context = engine->CreateContext();
+    int r;
+
+    // Copy the callback list, because the callback list itself may get changed while executing the script
+    callbackList queue(callbacks["frameStep"]);
+
+    // loop over all callbacks
+    for (unsigned int i = 0; i < queue.size(); ++i) {
+        // prepare the call
+        r = context->Prepare(queue[i].func);
+        if (r < 0) continue;
+
+        // Set the object if present (if we don't set it, then we call a global function)
+        if (queue[i].obj != NULL) {
+            context->SetObject(queue[i].obj);
+            if (r < 0) continue;
+        }
+
+        // Set the arguments
+        context->SetArgFloat(0, dt);
+
+        // Execute it
+        r = context->Execute();
+    }
+
+    // Collect garbage
+    engine->GarbageCollect(asGC_ONE_STEP);
+
+    return 0;
+}
+
+void ServerScriptEngine::playerDeleted(int uid, int crash, bool doNestedCall /*= false*/) {
+    if (!engine) return;
+    if (!context) context = engine->CreateContext();
+    int r;
+
+    // Push the state of the context if this is a nested call
+    if (doNestedCall) {
+        r = context->PushState();
+        if (r < 0) return;
+    }
+
+    // Copy the callback list, because the callback list itself may get changed while executing the script
+    callbackList queue(callbacks["playerDeleted"]);
+
+    // loop over all callbacks
+    for (unsigned int i = 0; i < queue.size(); ++i) {
+        // prepare the call
+        r = context->Prepare(queue[i].func);
+        if (r < 0) continue;
+
+        // Set the object if present (if we don't set it, then we call a global function)
+        if (queue[i].obj != NULL) {
+            context->SetObject(queue[i].obj);
+            if (r < 0) continue;
+        }
+
+        // Set the arguments
+        context->SetArgDWord(0, uid);
+        context->SetArgDWord(1, crash);
+
+        // Execute it
+        r = context->Execute();
+    }
+
+    // Pop the state of the context if this is was a nested call
+    if (doNestedCall) {
+        r = context->PopState();
+        if (r < 0) return;
+    }
+
+
+    return;
+}
+
+void ServerScriptEngine::playerAdded(int uid) {
+    if (!engine) return;
+    if (!context) context = engine->CreateContext();
+    int r;
+
+    // Copy the callback list, because the callback list itself may get changed while executing the script
+    callbackList queue(callbacks["playerAdded"]);
+
+    // loop over all callbacks
+    for (unsigned int i = 0; i < queue.size(); ++i) {
+        // prepare the call
+        r = context->Prepare(queue[i].func);
+        if (r < 0) continue;
+
+        // Set the object if present (if we don't set it, then we call a global function)
+        if (queue[i].obj != NULL) {
+            context->SetObject(queue[i].obj);
+            if (r < 0) continue;
+        }
+
+        // Set the arguments
+        context->SetArgDWord(0, uid);
+
+        // Execute it
+        r = context->Execute();
+    }
+    return;
+}
+
+int ServerScriptEngine::streamAdded(int uid, RoRnet::StreamRegister *reg) {
+    if (!engine) return 0;
+    if (!context) context = engine->CreateContext();
+    int r;
+    int ret = BROADCAST_AUTO;
+
+    // Copy the callback list, because the callback list itself may get changed while executing the script
+    callbackList queue(callbacks["streamAdded"]);
+
+    // loop over all callbacks
+    for (unsigned int i = 0; i < queue.size(); ++i) {
+        // prepare the call
+        r = context->Prepare(queue[i].func);
+        if (r < 0) continue;
+
+        // Set the object if present (if we don't set it, then we call a global function)
+        if (queue[i].obj != NULL) {
+            context->SetObject(queue[i].obj);
+            if (r < 0) continue;
+        }
+
+        // Set the arguments
+        context->SetArgDWord(0, uid);
+        context->SetArgObject(1, (void *) reg);
+
+        // Execute it
+        r = context->Execute();
+        if (r == asEXECUTION_FINISHED) {
+            int newRet = context->GetReturnDWord();
+
+            // Only use the new result if it's more restrictive than what we already had
+            if (newRet > ret)
+                ret = newRet;
+        }
+    }
+
+    return ret;
+}
+
+int ServerScriptEngine::playerChat(int uid, std::string msg) {
+    if (!engine) return 0;
+    if (!context) context = engine->CreateContext();
+    int r;
+    int ret = BROADCAST_AUTO;
+
+    // Copy the callback list, because the callback list itself may get changed while executing the script
+    callbackList queue(callbacks["playerChat"]);
+
+    // loop over all callbacks
+    for (unsigned int i = 0; i < queue.size(); ++i) {
+        // prepare the call
+        r = context->Prepare(queue[i].func);
+        if (r < 0) continue;
+
+        // Set the object if present (if we don't set it, then we call a global function)
+        if (queue[i].obj != NULL) {
+            context->SetObject(queue[i].obj);
+            if (r < 0) continue;
+        }
+
+        // Set the arguments
+        context->SetArgDWord(0, uid);
+        context->SetArgObject(1, (void *) &msg);
+
+        // Execute it
+        r = context->Execute();
+        if (r == asEXECUTION_FINISHED) {
+            int newRet = context->GetReturnDWord();
+
+            // Only use the new result if it's more restrictive than what we already had
+            if (newRet > ret)
+                ret = newRet;
+        }
+    }
+
+    return ret;
+}
+
+void ServerScriptEngine::gameCmd(int uid, const std::string &cmd) {
+    if (!engine) return;
+    if (!context) context = engine->CreateContext();
+    int r;
+
+    // Copy the callback list, because the callback list itself may get changed while executing the script
+    callbackList queue(callbacks["gameCmd"]);
+
+    // loop over all callbacks
+    for (unsigned int i = 0; i < queue.size(); ++i) {
+        // prepare the call
+        r = context->Prepare(queue[i].func);
+        if (r < 0) continue;
+
+        // Set the object if present (if we don't set it, then we call a global function)
+        if (queue[i].obj != NULL) {
+            context->SetObject(queue[i].obj);
+            if (r < 0) continue;
+        }
+
+        // Set the arguments
+        context->SetArgDWord(0, uid);
+        context->SetArgObject(1, (void *) &cmd);
+
+        // Execute it
+        r = context->Execute();
+    }
+
+    return;
+}
+
+void ServerScriptEngine::curlStatus(RoRServerCurlStatusType type, int n1, int n2, string displayname, string message)
+{
+    // Params `n1` and `n2` depend on status type :
+    // - for CURL_STATUS_PROGRESS, n1 = bytes downloaded, n2 = total bytes,
+    // - otherwise, n1 = CURL return code, n2 = HTTP result code.
+    // -------------------------------------------------------------------
+
+    if (!engine) return;
+    if (!context) context = engine->CreateContext();
+    int r;
+
+    // Copy the callback list, because the callback list itself may get changed while executing the script
+    callbackList queue(callbacks["curlStatus"]);
+
+    // loop over all callbacks
+    for (unsigned int i = 0; i < queue.size(); ++i) {
+        // prepare the call
+        r = context->Prepare(queue[i].func);
+        if (r < 0) continue;
+
+        // Set the object if present (if we don't set it, then we call a global function)
+        if (queue[i].obj != NULL) {
+            context->SetObject(queue[i].obj);
+            if (r < 0) continue;
+        }
+
+        // Set the arguments
+        context->SetArgDWord(0, (asDWORD)type);
+        context->SetArgDWord(1, (asDWORD)n1);
+        context->SetArgDWord(2, (asDWORD)n2);
+        context->SetArgObject(3, (void*)&displayname);
+        context->SetArgObject(4, (void*)&message);
+
+        // Execute it
+        r = context->Execute();
+    }
+}
+
+void ServerScriptEngine::TimerThreadMain() {
+    while (this->GetTimerThreadState() == ThreadState::RUNNING) {
+        // sleep 200 miliseconds
+#ifndef _WIN32
+        usleep(200000);
+#else // _WIN32
+        Sleep(200);
+#endif // _WIN32
+
+        // call script
+        this->frameStep(200.f); //RIGSOFRODS //seq->frameStepScripts(200);
+    }
+}
+
+void ServerScriptEngine::EnsureTimerThreadRunning() {
+    std::lock_guard<std::mutex> scoped_lock(m_timer_thread_mutex);
+    if (m_timer_thread_state == ThreadState::NOT_RUNNING) {
+        Logger::Log(LOG_DEBUG, "ScriptEngine: starting framestep thread");
+        m_timer_thread = std::thread(&ServerScriptEngine::TimerThreadMain, this);
+        m_timer_thread_state = ThreadState::RUNNING;
+    }    
+}
+
+ServerScriptEngine::ThreadState ServerScriptEngine::GetTimerThreadState() {
+    std::lock_guard<std::mutex> scoped_lock(m_timer_thread_mutex);
+    return m_timer_thread_state;
+}
+
+void ServerScriptEngine::StopTimerThread() {
+    {
+        std::lock_guard<std::mutex> scoped_lock(m_timer_thread_mutex);
+        if (m_timer_thread_state != ThreadState::RUNNING)
+            return;
+        m_timer_thread_state = ThreadState::STOP_REQUESTED;
+    }
+
+    m_timer_thread.join();
+    
+    {
+        std::lock_guard<std::mutex> scoped_lock(m_timer_thread_mutex);
+        m_timer_thread_state = ThreadState::NOT_RUNNING;
+    }
+}
+
+void ServerScriptEngine::setException(const std::string &message) {
+    if (!engine || !context) {
+        // There's not much we can do, except for logging the message
+        Logger::Log(LOG_INFO, "--- script exception ---");
+        Logger::Log(LOG_INFO, " desc: %s", (message.c_str()));
+        Logger::Log(LOG_INFO, "--- end of script exception message ---");
+    } else
+        context->SetException(message.c_str());
+}
+
+void ServerScriptEngine::addCallbackScript(const std::string &type, const std::string &_func, asIScriptObject *obj) {
+    if (!engine) return;
+
+    // get the function declaration and check the type at the same time
+    std::string funcDecl = "";
+    if (type == "frameStep")
+        funcDecl = "void " + _func + "(float)";
+    else if (type == "playerChat")
+        funcDecl = "int " + _func + "(int, const string &in)";
+    else if (type == "gameCmd")
+        funcDecl = "void " + _func + "(int, const string &in)";
+    else if (type == "playerAdded")
+        funcDecl = "void " + _func + "(int)";
+    else if (type == "playerDeleted")
+        funcDecl = "void " + _func + "(int, int)";
+    else if (type == "streamAdded")
+        funcDecl = "int " + _func + "(int, StreamRegister@)";
+    else if (type == "curlStatus")
+        funcDecl = "void " + _func + "(curlStatusType, int, int, string, string)";
+    else {
+        setException("Type " + type +
+                     " does not exist! Possible type strings: 'frameStep', 'playerChat', 'gameCmd', 'playerAdded', 'playerDeleted', 'streamAdded'.");
+        return;
+    }
+
+    asIScriptFunction *func;
+    if (obj) {
+        // search for a method in the class
+        asITypeInfo *objType = obj->GetObjectType();
+        func = objType->GetMethodByDecl(funcDecl.c_str());
+        if (!func) {
+            // give a nice error message that says that the method was not found.
+            func = objType->GetMethodByName(_func.c_str());
+            if (func)
+                setException("Method '" + std::string(func->GetDeclaration(false)) + "' was found in '" +
+                             objType->GetName() + "' but the correct declaration is: '" + funcDecl + "'.");
+            else
+                setException("Method '" + funcDecl + "' was not found in '" + objType->GetName() + "'.");
+            return;
+        }
+    } else {
+        // search for a global function
+        asIScriptModule *mod = engine->GetModule("script");
+        func = mod->GetFunctionByDecl(funcDecl.c_str());
+        if (!func) {
+            // give a nice error message that says that the function was not found.
+            func = mod->GetFunctionByName(_func.c_str());
+            if (func)
+                setException("Function '" + std::string(func->GetDeclaration(false)) +
+                             "' was found, but the correct declaration is: '" + funcDecl + "'.");
+            else
+                setException("Function '" + funcDecl + "' was not found.");
+            return;
+        }
+    }
+
+    if (callbackExists(type, func, obj))
+        Logger::Log(LOG_INFO, "ScriptEngine: error: Function '" + std::string(func->GetDeclaration(false)) +
+                              "' is already a callback for '" + type + "'.");
+    else
+        addCallback(type, func, obj);
+}
+
+void ServerScriptEngine::addCallback(const std::string &type, asIScriptFunction *func, asIScriptObject *obj) {
+    if (!engine) return;
+
+    if (obj) {
+        // We're about to store a reference to the object, so let's tell the script engine about that
+        // This avoids the object from going out of scope while we're still trying to access it.
+        // BUT: it prevents local objects from being destroyed automatically....
+        engine->AddRefScriptObject(obj, obj->GetObjectType());
+    }
+
+    // Add the function to the list
+    rorserver_callback_t tmp;
+    tmp.obj = obj;
+    tmp.func = func;
+    callbacks[type].push_back(tmp);
+
+    // Do we need to start the frameStep thread?
+    if (type == "frameStep") {
+        this->EnsureTimerThreadRunning();
+    }
+
+    // finished :)
+    Logger::Log(LOG_INFO, "ScriptEngine: success: Added a '" + type + "' callback for: " +
+                          std::string(func->GetDeclaration(true)));
+}
+
+void ServerScriptEngine::deleteCallbackScript(const std::string &type, const std::string &_func, asIScriptObject *obj) {
+    if (!engine) return;
+
+    // get the function declaration and check the type at the same time
+    std::string funcDecl = "";
+    if (type == "frameStep")
+        funcDecl = "void " + _func + "(float)";
+    else if (type == "playerChat")
+        funcDecl = "int " + _func + "(int, const string &in)";
+    else if (type == "gameCmd")
+        funcDecl = "void " + _func + "(int, const string &in)";
+    else if (type == "playerAdded")
+        funcDecl = "void " + _func + "(int)";
+    else if (type == "playerDeleted")
+        funcDecl = "void " + _func + "(int, int)";
+    else if (type == "streamAdded")
+        funcDecl = "int " + _func + "(int, StreamRegister@)";
+    else if (type == "curlStatus")
+        funcDecl = "void " + _func + "(curlStatusType, int, int, string, string)";
+    else {
+        setException("Type " + type +
+                     " does not exist! Possible type strings: 'frameStep', 'playerChat', 'gameCmd', 'playerAdded', 'playerDeleted', 'streamAdded'.");
+        Logger::Log(LOG_INFO, "ScriptEngine: error: Failed to remove callback: " + _func);
+        return;
+    }
+
+    asIScriptFunction *func;
+    if (obj) {
+        // search for a method in the class
+        asITypeInfo *objType = obj->GetObjectType();
+        func = objType->GetMethodByDecl(funcDecl.c_str());
+        if (!func) {
+            // give a nice error message that says that the method was not found.
+            func = objType->GetMethodByName(_func.c_str());
+            if (func)
+                setException("Method '" + std::string(func->GetDeclaration(false)) + "' was found in '" +
+                             objType->GetName() + "' but the correct declaration is: '" + funcDecl + "'.");
+            else
+                setException("Method '" + funcDecl + "' was not found in '" + objType->GetName() + "'.");
+            Logger::Log(LOG_INFO, "ScriptEngine: error: Failed to remove callback: " + funcDecl);
+            return;
+        }
+    } else {
+        // search for a global function
+        asIScriptModule *mod = engine->GetModule("script");
+        func = mod->GetFunctionByDecl(funcDecl.c_str());
+        if (!func) {
+            // give a nice error message that says that the function was not found.
+            func = mod->GetFunctionByName(_func.c_str());
+            if (func)
+                setException("Function '" + std::string(func->GetDeclaration(false)) +
+                             "' was found, but the correct declaration is: '" + funcDecl + "'.");
+            else
+                setException("Function '" + funcDecl + "' was not found.");
+            Logger::Log(LOG_INFO, "ScriptEngine: error: Failed to remove callback: " + funcDecl);
+            return;
+        }
+    }
+    deleteCallback(type, func, obj);
+}
+
+void ServerScriptEngine::deleteCallback(const std::string &type, asIScriptFunction *func, asIScriptObject *obj) {
+    if (!engine) return;
+
+    for (callbackList::iterator it = callbacks[type].begin(); it != callbacks[type].end(); ++it) {
+        if (it->obj == obj && it->func == func) {
+            callbacks[type].erase(it);
+            Logger::Log(LOG_INFO, "ScriptEngine: success: removed a '" + type + "' callback: " +
+                                  std::string(func->GetDeclaration(true)));
+            if (obj)
+                engine->ReleaseScriptObject(obj, obj->GetObjectType());
+            return;
+        }
+    }
+    Logger::Log(LOG_INFO, "ScriptEngine: error: failed to remove callback: " + std::string(func->GetDeclaration(true)));
+}
+
+bool ServerScriptEngine::callbackExists(const std::string &type, asIScriptFunction *func, asIScriptObject *obj) {
+    if (!engine) return false;
+
+    for (callbackList::iterator it = callbacks[type].begin(); it != callbacks[type].end(); ++it) {
+        if (it->obj == obj && it->func == func)
+            return true;
+    }
+    return false;
+}
+
+/* class that implements the interface for the scripts */
+ServerScript::ServerScript(ServerScriptEngine *se) : mse(se) {
+}
+
+ServerScript::~ServerScript() {
+}
+
+void ServerScript::log(std::string &msg) {
+    Logger::Log(LOG_INFO, "SCRIPT|%s", msg.c_str());
+}
+
+void ServerScript::say(std::string &msg, int uid, int type) {
+    // RIGSOFRODS: Do what rorserver's `Sequencer::serverSay()` does.
+    switch (type) {
+        case FROM_SERVER:
+            msg = std::string("SERVER: ") + msg;
+            break;
+
+        case FROM_HOST:
+            if (uid == -1) {
+                msg = std::string("Host(general): ") + msg;
+            } else {
+                msg = std::string("Host(private): ") + msg;
+            }
+            break;
+
+        case FROM_RULES:
+            msg = std::string("Rules: ") + msg;
+            break;
+
+        case FROM_MOTD:
+            msg = std::string("MOTD: ") + msg;
+            break;
+    }
+    // RIGSOFRODS: Post message directly to console (thread safe)
+    App::GetConsole()->putNetMessage(uid, Console::CONSOLE_SYSTEM_NETCHAT, msg.c_str());
+}
+
+void ServerScript::kick(int kuid, std::string &msg) {
+    /* RIGSOFRODS: STUB
+    seq->QueueClientForDisconnect(kuid, msg.c_str(), false, false);
+    mse->playerDeleted(kuid, 0, true);
+    */
+}
+
+void ServerScript::ban(int buid, std::string &msg) {
+    /* RIGSOFRODS: STUB
+    seq->SilentBan(buid, msg.c_str(), false);
+    mse->playerDeleted(buid, 0, true);
+    */
+}
+
+bool ServerScript::unban(int buid) {
+    return true; //RIGSOFRODS STUB // return seq->UnBan(buid);
+}
+
+std::string ServerScript::getUserName(int uid) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return "";
+
+
+    return Str::SanitizeUtf8(c->user.username);
+    */
+    return "";
+}
+
+void ServerScript::setUserName(int uid, const string &username) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return;
+    std::string username_sane = Str::SanitizeUtf8(username.begin(), username.end());
+    strncpy(c->user.username, username_sane.c_str(), RORNET_MAX_USERNAME_LEN);
+    */
+}
+
+std::string ServerScript::getUserAuth(int uid) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return "none";
+    if (c->user.authstatus & RoRnet::AUTH_ADMIN) return "admin";
+    else if (c->user.authstatus & RoRnet::AUTH_MOD) return "moderator";
+    else if (c->user.authstatus & RoRnet::AUTH_RANKED) return "ranked";
+    else if (c->user.authstatus & RoRnet::AUTH_BOT) return "bot";
+    //else if(c->user.authstatus & RoRnet::AUTH_NONE)
+    */
+    return "none";
+}
+
+int ServerScript::getUserAuthRaw(int uid) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return RoRnet::AUTH_NONE;
+    return c->user.authstatus;
+    */
+    return 0;
+}
+
+void ServerScript::setUserAuthRaw(int uid, int authmode) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return;
+    c->user.authstatus = authmode & ~(RoRnet::AUTH_RANKED | RoRnet::AUTH_BANNED);
+    */
+}
+
+int ServerScript::getUserColourNum(int uid) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return 0;
+    return c->user.colournum;
+    */
+    return 0;
+}
+
+void ServerScript::setUserColourNum(int uid, int num) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return;
+    c->user.colournum = num;
+    */
+}
+
+std::string ServerScript::getUserToken(int uid) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return "";
+    return std::string(c->user.usertoken, 40);
+    */
+    return "";
+}
+
+std::string ServerScript::getUserVersion(int uid) {
+    /* RIGSOFRODS: STUB
+    Client *c = seq->getClient(uid);
+    if (!c) return "";
+    return std::string(c->user.clientversion, 25);
+    */
+    return "";
+}
+
+std::string ServerScript::getUserIPAddress(int uid) {
+    /* RIGSOFRODS: STUB
+    Client *client = seq->getClient(uid);
+    if (client != nullptr) {
+        return client->GetIpAddress();
+    }
+    */
+    return "";
+}
+
+std::string ServerScript::getServerTerrain() {
+    return ""; // RIGSOFRODS: STUB // return Config::getTerrainName();
+}
+
+int ServerScript::sendGameCommand(int uid, std::string cmd) {
+    return 0; // RIGSOFRODS: STUB // return seq->sendGameCommand(uid, cmd);
+}
+
+void ServerScript::curlRequestAsync(std::string url, string displayname) {
+#if WITH_CURL
+    CurlTaskContext context;
+    context.ctc_url = url;
+    context.ctc_displayname = displayname;
+    context.ctc_script_engine = this->mse;
+
+    std::packaged_task<void(CurlTaskContext)> pktask(CurlRequestThreadFunc);
+    std::thread(std::move(pktask), context).detach();
+#endif
+}
+
+int ServerScript::getNumClients() {
+    return 0; // RIGSOFRODS: STUB //  seq->getNumClients();
+}
+
+int ServerScript::getStartTime() {
+    return 0; // RIGSOFRODS: STUB //  seq->getStartTime();
+}
+
+int ServerScript::getTime() {
+    return 0; // RIGSOFRODS: STUB //  Messaging::getTime();
+}
+
+void ServerScript::deleteCallback(const std::string &type, const std::string &func, void *obj, int refTypeId) {
+    if (refTypeId & asTYPEID_SCRIPTOBJECT && (refTypeId & asTYPEID_OBJHANDLE)) {
+        mse->deleteCallbackScript(type, func, *(asIScriptObject **) obj);
+    } else if (refTypeId == asTYPEID_VOID) {
+        mse->deleteCallbackScript(type, func, NULL);
+    } else if (refTypeId & asTYPEID_SCRIPTOBJECT) {
+        // We received an object instead of a handle of the object.
+        // We cannot allow this because this will crash if the deleteCallback is called from inside a constructor of a global variable.
+        mse->setException(
+                "server.deleteCallback should be called with a handle of the object! (that is: put an @ sign in front of the object)");
+
+        // uncomment to enable anyway:
+        //mse->deleteCallbackScript(type, func, (asIScriptObject*)obj);
+    } else {
+        mse->setException("The object for the callback has to be a script-class or null!");
+    }
+}
+
+void ServerScript::setCallback(const std::string &type, const std::string &func, void *obj, int refTypeId) {
+    if (refTypeId & asTYPEID_SCRIPTOBJECT && (refTypeId & asTYPEID_OBJHANDLE)) {
+        mse->addCallbackScript(type, func, *(asIScriptObject **) obj);
+    } else if (refTypeId == asTYPEID_VOID) {
+        mse->addCallbackScript(type, func, NULL);
+    } else if (refTypeId & asTYPEID_SCRIPTOBJECT) {
+        // We received an object instead of a handle of the object.
+        // We cannot allow this because this will crash if the setCallback is called from inside a constructor of a global variable.
+        mse->setException(
+                "server.setCallback should be called with a handle of the object! (that is: put an @ sign in front of the object)");
+
+        // uncomment to enable anyway:
+        //mse->addCallbackScript(type, func, (asIScriptObject*)obj);
+    } else {
+        mse->setException("The object for the callback has to be a script-class or null!");
+    }
+}
+
+void ServerScript::throwException(const std::string &message) {
+    mse->setException(message);
+}
+
+std::string ServerScript::get_version() {
+    return "";  // RIGSOFRODS: STUB // std::string(VERSION);
+}
+
+std::string ServerScript::get_asVersion() {
+    return std::string(ANGELSCRIPT_VERSION_STRING);
+}
+
+std::string ServerScript::get_protocolVersion() {
+    return std::string(RORNET_VERSION);
+}
+
+unsigned int ServerScript::get_maxClients() { return 0; } // RIGSOFRODS: STUB // return Config::getMaxClients(); }
+
+std::string ServerScript::get_serverName() { return ""; } // RIGSOFRODS: STUB // Config::getServerName(); }
+
+std::string ServerScript::get_IPAddr() { return ""; } // RIGSOFRODS: STUB // Config::getIPAddr(); }
+
+unsigned int ServerScript::get_listenPort() { return 0u; } // RIGSOFRODS: STUB // return Config::getListenPort(); }
+
+int ServerScript::get_serverMode() { return 0; } // RIGSOFRODS: STUB //  (int)Config::getServerMode(); }
+
+std::string ServerScript::get_owner() { return ""; } // RIGSOFRODS: STUB // Config::getOwner(); }
+
+std::string ServerScript::get_website() { return ""; } // RIGSOFRODS: STUB // Config::getWebsite(); }
+
+std::string ServerScript::get_ircServ() { return ""; } // RIGSOFRODS: STUB // Config::getIRC(); }
+
+std::string ServerScript::get_voipServ() { return ""; } // RIGSOFRODS: STUB // Config::getVoIP(); }
+
+int ServerScript::rangeRandomInt(int from, int to) {
+    return (int) (from + (to - from) * ((float) rand() / (float) RAND_MAX));
+}
+
+void ServerScript::broadcastUserInfo(int uid) {
+    // RIGSOFRODS: STUB // seq->broadcastUserInfo(uid);
+}
+
+#endif //USE_ANGELSCRIPT

--- a/source/main/scripting/ServerScriptEngine.cpp
+++ b/source/main/scripting/ServerScriptEngine.cpp
@@ -700,11 +700,17 @@ void ServerScriptEngine::playerDeleted(int uid, int crash, bool doNestedCall /*=
     return;
 }
 
-void ServerScriptEngine::playerAdded(int uid) {
-
+void ServerScriptEngine::playerAdded(RoRnet::UserInfo& user) // RIGSOFRODS: Assigns the UID
+{
     // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
     // All script callbacks must be invoked while clients-mutex is locked
     std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
+    // RIGSOFRODS: register the new client - in rorserver it's handled by `Sequencer::createClient()`
+    user.uniqueid = m_free_user_id++;
+    ServerScriptClient* client_record = new ServerScriptClient();
+    client_record->user = user;
+    m_clients.push_back(client_record);
 
     if (!engine) return;
     if (!context) context = engine->CreateContext();
@@ -726,7 +732,7 @@ void ServerScriptEngine::playerAdded(int uid) {
         }
 
         // Set the arguments
-        context->SetArgDWord(0, uid);
+        context->SetArgDWord(0, user.uniqueid);
 
         // Execute it
         r = context->Execute();

--- a/source/main/scripting/ServerScriptEngine.cpp
+++ b/source/main/scripting/ServerScriptEngine.cpp
@@ -42,6 +42,8 @@ along with Foobar. If not, see <http://www.gnu.org/licenses/>.
 #include "PlatformUtils.h" // RIGSOFRODS: For PathCombine
 #include "Application.h" // RIGSOFRODS: For App::sys_logs_dir
 #include "Console.h" // RIGSOFRODS: For putNetMessage()
+#include "ScriptEngine.h" // RIGSOFRODS: For ScriptEngine::kickBotByUid()
+#include "Utils.h"
 
 #include <cstdio>
 #include <stdlib.h>
@@ -108,6 +110,27 @@ ServerScriptEngine::~ServerScriptEngine() {
     deleteAllCallbacks();
     if (engine) engine->Release();
     if (context) context->Release();
+}
+
+// RIGSOFRODS: From 'sequencer.cpp' as-is
+int ServerScriptEngine::GetFreePlayerColour() {
+    // WARNING: be sure that this is only called within a clients_mutex lock!
+
+    int col = 0;
+    for (;;) // TODO: How many colors ARE there?
+    {
+        bool collision = false;
+        for (unsigned int i = 0; i < m_clients.size(); i++) {
+            if (m_clients[i]->user.colournum == col) {
+                collision = true;
+                break;
+            }
+        }
+        if (!collision) {
+            return col;
+        }
+        col++;
+    }
 }
 
 void ServerScriptEngine::deleteAllCallbacks() {
@@ -651,7 +674,7 @@ int ServerScriptEngine::frameStep(float dt) {
     return 0;
 }
 
-void ServerScriptEngine::playerDeleted(int uid, int crash, bool doNestedCall /*= false*/) {
+void ServerScriptEngine::playerDeleted(int uid, int crash) {
 
     // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
     // All script callbacks must be invoked while clients-mutex is locked
@@ -660,12 +683,6 @@ void ServerScriptEngine::playerDeleted(int uid, int crash, bool doNestedCall /*=
     if (!engine) return;
     if (!context) context = engine->CreateContext();
     int r;
-
-    // Push the state of the context if this is a nested call
-    if (doNestedCall) {
-        r = context->PushState();
-        if (r < 0) return;
-    }
 
     // Copy the callback list, because the callback list itself may get changed while executing the script
     callbackList queue(callbacks["playerDeleted"]);
@@ -690,17 +707,13 @@ void ServerScriptEngine::playerDeleted(int uid, int crash, bool doNestedCall /*=
         r = context->Execute();
     }
 
-    // Pop the state of the context if this is was a nested call
-    if (doNestedCall) {
-        r = context->PopState();
-        if (r < 0) return;
-    }
-
+    // RIGSOFRODS: Remove the client from the list
+    EraseIf(m_clients, [uid](ServerScriptClient* client) { return client->user.uniqueid == uid; });
 
     return;
 }
 
-void ServerScriptEngine::playerAdded(RoRnet::UserInfo& user) // RIGSOFRODS: Assigns the UID
+void ServerScriptEngine::playerAdded(RoRnet::UserInfo& user) // RIGSOFRODS: Assigns the UID and color
 {
     // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
     // All script callbacks must be invoked while clients-mutex is locked
@@ -708,6 +721,7 @@ void ServerScriptEngine::playerAdded(RoRnet::UserInfo& user) // RIGSOFRODS: Assi
 
     // RIGSOFRODS: register the new client - in rorserver it's handled by `Sequencer::createClient()`
     user.uniqueid = m_free_user_id++;
+    user.colournum = this->GetFreePlayerColour();
     ServerScriptClient* client_record = new ServerScriptClient();
     client_record->user = user;
     m_clients.push_back(client_record);
@@ -789,6 +803,23 @@ int ServerScriptEngine::playerChat(int uid, std::string msg) {
     // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
     // All script callbacks must be invoked while clients-mutex is locked
     std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
+    // Handle server commands
+    if (msg == "!help")
+    {
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NETCHAT, "Server commands: !help, !kick <uid>");
+        return 0;
+    }
+    if (msg.substr(0, 6) == "!kick ") {
+        int kuid = -1;
+        int res = sscanf(msg.substr(6).c_str(), "%d", &kuid);
+        if (res != 1 || kuid == -1) {
+            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NETCHAT, "!kick <uid> ~ kick a bot");
+        } else {
+            App::GetScriptEngine()->kickBotByUid(kuid);
+            return 0;
+        }
+    }
 
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();

--- a/source/main/scripting/ServerScriptEngine.cpp
+++ b/source/main/scripting/ServerScriptEngine.cpp
@@ -381,7 +381,7 @@ void ServerScriptEngine::init() {
     RegisterScriptMath3D(engine); // depends on string
     RegisterScriptMath(engine);
     RegisterScriptDictionary(engine);
-    //RIGSOFRODS: FIXME //RegisterScriptFile(engine);
+    RegisterScriptFile_Native(engine);
     RegisterScriptAny(engine);
 
     Logger::Log(LOG_INFO, "ScriptEngine: Registration of libs done, now custom things");
@@ -1430,4 +1430,361 @@ void ServerScript::broadcastUserInfo(int uid) {
     // RIGSOFRODS: STUB // seq->broadcastUserInfo(uid);
 }
 
+// RIGSOFRODS: from rorserver's 'ScriptFileSafe.cpp'
+
+ScriptFileSafe *ScriptFile_Factory() {
+    return new ScriptFileSafe();
+}
+
+void RoR::RegisterScriptFile_Native(asIScriptEngine *engine) {
+    int r;
+
+    r = engine->RegisterObjectType("file", 0, asOBJ_REF);
+    assert(r >= 0);
+    r = engine->RegisterObjectBehaviour("file", asBEHAVE_FACTORY, "file @f()", asFUNCTION(ScriptFile_Factory),
+                                        asCALL_CDECL);
+    assert(r >= 0);
+    r = engine->RegisterObjectBehaviour("file", asBEHAVE_ADDREF, "void f()", asMETHOD(ScriptFileSafe, AddRef),
+                                        asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectBehaviour("file", asBEHAVE_RELEASE, "void f()", asMETHOD(ScriptFileSafe, Release),
+                                        asCALL_THISCALL);
+    assert(r >= 0);
+
+    r = engine->RegisterObjectMethod("file", "int open(const string &in, const string &in)",
+                                     asMETHOD(ScriptFileSafe, Open), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int close()", asMETHOD(ScriptFileSafe, Close), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int getSize() const", asMETHOD(ScriptFileSafe, GetSize), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "bool isEndOfFile() const", asMETHOD(ScriptFileSafe, IsEOF),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int readString(uint, string &out)", asMETHOD(ScriptFileSafe, ReadString),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int readLine(string &out)", asMETHOD(ScriptFileSafe, ReadLine),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int64 readInt(uint)", asMETHOD(ScriptFileSafe, ReadInt), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "uint64 readUInt(uint)", asMETHOD(ScriptFileSafe, ReadUInt),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "float readFloat()", asMETHOD(ScriptFileSafe, ReadFloat), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "double readDouble()", asMETHOD(ScriptFileSafe, ReadDouble),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+
+    r = engine->RegisterObjectMethod("file", "int writeString(const string &in)", asMETHOD(ScriptFileSafe, WriteString),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int writeInt(int64, uint)", asMETHOD(ScriptFileSafe, WriteInt),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int writeUInt(uint64, uint)", asMETHOD(ScriptFileSafe, WriteUInt),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int writeFloat(float)", asMETHOD(ScriptFileSafe, WriteFloat),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int writeDouble(double)", asMETHOD(ScriptFileSafe, WriteDouble),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+
+    r = engine->RegisterObjectMethod("file", "int getPos() const", asMETHOD(ScriptFileSafe, GetPos), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int setPos(int)", asMETHOD(ScriptFileSafe, SetPos), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int movePos(int)", asMETHOD(ScriptFileSafe, MovePos), asCALL_THISCALL);
+    assert(r >= 0);
+
+    assert(r >= 0);
+}
+
+
+ScriptFileSafe::ScriptFileSafe() {
+    refCount = 1;
+}
+
+ScriptFileSafe::~ScriptFileSafe() {
+    Close();
+}
+
+void ScriptFileSafe::AddRef() const {
+    ++refCount;
+}
+
+void ScriptFileSafe::Release() const {
+    if (--refCount == 0)
+        delete this;
+}
+
+int ScriptFileSafe::Open(const std::string &filename, const std::string &mode) {
+    // Close the previously opened file handle
+    if (m_stream)
+        m_stream->close();
+
+    // Validate the mode
+    string m;
+#if AS_WRITE_OPS == 1
+    if (mode != "r" && mode != "w" && mode != "a")
+#else
+        if( mode != "r" )
+#endif
+        return -2;
+    else
+        m = mode;
+
+    // By default windows translates "\r\n" to "\n", but we want to read the file as-is.
+    m += "b";
+
+    std::string myFilename = filename;
+
+    // Remove the possible .asdata extension
+    if (myFilename.length() > 7 && myFilename.substr(myFilename.length() - 7, 7) == ".asdata")
+        myFilename = myFilename.substr(0, myFilename.length() - 7);
+
+    // Replace all forbidden characters in the filename	
+    std::string allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+    for (std::string::iterator it = myFilename.begin(); it < myFilename.end(); ++it) {
+        if (allowedChars.find(*it) == std::string::npos)
+            *it = '_';
+    }
+
+    // Open the file
+    try
+    {
+        m_stream = Ogre::ResourceGroupManager::getSingleton().openResource(myFilename, RGN_SERVER_SCRIPTS);
+    }
+    catch (...)
+    {
+        HandleGenericException("file.open()");
+        return -3;
+    }
+
+    return 0;
+}
+
+int ScriptFileSafe::Close() {
+    if (!m_stream)
+        return -1;
+
+    m_stream->close();
+    return 0;
+}
+
+int ScriptFileSafe::GetSize() const {
+    if (!m_stream)
+        return -1;
+
+    return m_stream->size();
+}
+
+int ScriptFileSafe::GetPos() const {
+    if (!m_stream)
+        return -1;
+
+    return m_stream->tell();
+}
+
+int ScriptFileSafe::SetPos(int pos) {
+    if (!m_stream)
+        return -1;
+
+    m_stream->seek(pos);
+
+    return 0;
+}
+
+int ScriptFileSafe::MovePos(int delta) {
+    if (!m_stream)
+        return -1;
+
+    m_stream->seek(m_stream->tell() + delta);
+
+    return 0;
+}
+
+int ScriptFileSafe::ReadString(unsigned int length, std::string &str) {
+    if (!m_stream)
+        return 0;
+
+    // Read the string
+    str.resize(length);
+    size_t size = (int)m_stream->read(&str[0], length);
+    str.resize(size);
+
+    return static_cast<int>(size);
+}
+
+int ScriptFileSafe::ReadLine(std::string &str) {
+    if (!m_stream)
+        return 0;
+
+    char buf[2000] = {};
+    size_t count = m_stream->readLine(buf, 2000);
+    str.assign(buf, count);
+
+    return static_cast<int>(count);
+}
+
+asINT64 ScriptFileSafe::ReadInt(asUINT bytes) {
+    if (!m_stream)
+        return 0;
+
+    if (bytes > 8) bytes = 8;
+    if (bytes == 0) return 0;
+
+    unsigned char buf[8];
+    size_t r = m_stream->read(buf, bytes);
+    if (r == 0) return 0;
+
+    asINT64 val = 0;
+
+        unsigned int n = 0;
+        for (; n < bytes; n++)
+            val |= asQWORD(buf[n]) << (n * 8);
+        if (buf[0] & 0x80)
+            for (; n < 8; n++)
+                val |= asQWORD(0xFF) << (n * 8);
+
+
+    return val;
+}
+
+asQWORD ScriptFileSafe::ReadUInt(asUINT bytes) {
+    if (!m_stream)
+        return 0;
+
+    if (bytes > 8) bytes = 8;
+    if (bytes == 0) return 0;
+
+    unsigned char buf[8];
+    size_t r = m_stream->read(buf, bytes);
+    if (r == 0) return 0;
+
+    asQWORD val = 0;
+
+        unsigned int n = 0;
+        for (; n < bytes; n++)
+            val |= asQWORD(buf[n]) << (n * 8);
+
+
+    return val;
+}
+
+float ScriptFileSafe::ReadFloat() {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[4];
+    size_t r = m_stream->read(buf, 4);
+    if (r == 0) return 0;
+
+    asUINT val = 0;
+
+        unsigned int n = 0;
+        for (; n < 4; n++)
+            val |= asUINT(buf[n]) << (n * 8);
+
+
+    return *reinterpret_cast<float *>(&val);
+}
+
+double ScriptFileSafe::ReadDouble() {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[8];
+    size_t r = m_stream->read(buf, 8);
+    if (r == 0) return 0;
+
+    asQWORD val = 0;
+
+        unsigned int n = 0;
+        for (; n < 8; n++)
+            val |= asQWORD(buf[n]) << (n * 8);
+
+
+    return *reinterpret_cast<double *>(&val);
+}
+
+bool ScriptFileSafe::IsEOF() const {
+    if (!m_stream)
+        return true;
+
+    return m_stream->eof();
+}
+
+int ScriptFileSafe::WriteString(const std::string &str) {
+    if (!m_stream)
+        return -1;
+
+    // Write the entire string
+    size_t r = m_stream->write(&str[0], str.length());
+    return int(r);
+}
+
+int ScriptFileSafe::WriteInt(asINT64 val, asUINT bytes) {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[8];
+
+        for (unsigned int n = 0; n < bytes; n++)
+            buf[n] = (val >> (n * 8)) & 0xFF;
+
+
+    size_t r = m_stream->write(&buf, bytes);
+    return int(r);
+}
+
+int ScriptFileSafe::WriteUInt(asQWORD val, asUINT bytes) {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[8];
+
+        for (unsigned int n = 0; n < bytes; n++)
+            buf[n] = (val >> (n * 8)) & 0xFF;
+
+
+    size_t r = m_stream->write(&buf, bytes);
+    return int(r);
+}
+
+int ScriptFileSafe::WriteFloat(float f) {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[4];
+    asUINT val = *reinterpret_cast<asUINT *>(&f);
+
+        for (unsigned int n = 0; n < 4; n++)
+            buf[n] = (val >> (n * 8)) & 0xFF;
+    
+
+    size_t r = m_stream->write(&buf, 4);
+    return int(r);
+}
+
+int ScriptFileSafe::WriteDouble(double d) {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[8];
+    asQWORD val = *reinterpret_cast<asQWORD *>(&d);
+    
+        for (unsigned int n = 0; n < 8; n++)
+            buf[n] = (val >> (n * 8)) & 0xFF;
+    
+
+    size_t r = m_stream->write(&buf, 8);
+    return int(r);
+}
+
 #endif //USE_ANGELSCRIPT
+

--- a/source/main/scripting/ServerScriptEngine.h
+++ b/source/main/scripting/ServerScriptEngine.h
@@ -123,6 +123,8 @@ public:
 
     int loadScript(std::string scriptName);
 
+    void unloadScript(); // RIGSOFRODS: Unload the script (only one can run at a time).
+
     void playerDeleted(int uid, int crash, bool doNestedCall = false);
 
     void playerAdded(int uid);

--- a/source/main/scripting/ServerScriptEngine.h
+++ b/source/main/scripting/ServerScriptEngine.h
@@ -220,6 +220,8 @@ protected:
     ThreadState m_timer_thread_state = ThreadState::NOT_RUNNING;
     std::mutex  m_timer_thread_mutex;
 
+    std::mutex m_clients_mutex;  //!< RIGSOFRODS: from `class Sequencer`, guards (among else) execution of script callbacks.
+
     /**
      * This function initialzies the engine and registeres all types
      */

--- a/source/main/scripting/ServerScriptEngine.h
+++ b/source/main/scripting/ServerScriptEngine.h
@@ -1,0 +1,369 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef USE_ANGELSCRIPT
+
+#include "CurlHelpers.h" // RIGSOFRODS: This is actually the client's header with same name as server header. Both implement the same functionality but with cosmetic differences.
+#include <map>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include "angelscript.h"
+#include "RoRnet.h"
+
+namespace RoR { // RIGSOFRODS
+
+/**
+ * This struct holds the information for a script callback.
+ */
+struct rorserver_callback_t {
+    AngelScript::asIScriptObject *obj{nullptr};  //!< The object instance that will need to be used with the function.
+    AngelScript::asIScriptFunction *func{nullptr}; //!< The function or method pointer that will be called.
+};
+typedef std::vector<rorserver_callback_t> callbackList;
+
+// RIGSOFRODS: Brought from rorserver's 'CurlHelpers.h' (see above)
+enum RoRServerCurlStatusType
+{
+    CURL_STATUS_INVALID,  //!< Should never be reported.
+    CURL_STATUS_START,    //!< New CURL request started, n1/n2 both 0.
+    CURL_STATUS_PROGRESS, //!< Download in progress, n1 = bytes downloaded, n2 = total bytes.
+    CURL_STATUS_SUCCESS,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = received payload.
+    CURL_STATUS_FAILURE,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = CURL error string.
+};
+
+// RIGSOFRODS: Brought from rorserver's 'logger.h'
+enum LogLevel {
+    LOG_STACK = 0,
+    LOG_DEBUG,
+    LOG_VERBOSE,
+    LOG_INFO,
+    LOG_WARN,
+    LOG_ERROR,
+    LOG_NONE
+};
+
+namespace Logger {
+
+    void Log(LogLevel level, const char *format, ...);
+
+    void Log(LogLevel level, std::string const& msg);
+}
+// END 'logger.h'
+
+// RIGSOFRODS: Brought from 'sequencer.h'
+// This is used to define who says it, when the server says something
+enum serverSayType {
+    FROM_SERVER = 0,
+    FROM_HOST,
+    FROM_MOTD,
+    FROM_RULES
+};
+
+enum broadcastType {
+// order: least restrictive to most restrictive!
+            BROADCAST_AUTO = -1,  // Do not edit the publishmode (for scripts only)
+    BROADCAST_ALL,        // broadcast to all clients including sender
+    BROADCAST_NORMAL,     // broadcast to all clients except sender
+    BROADCAST_AUTHED,     // broadcast to authed users (bots)
+    BROADCAST_BLOCK       // no broadcast
+};
+
+// constant for functions that receive an uid for sending something
+static const int TO_ALL = -1;
+// END 'sequencer.h'
+
+// RIGSOFRODS: From 'config.h'
+enum ServerType {
+    SERVER_LAN = 0,
+    SERVER_INET,
+    SERVER_AUTO
+};
+
+class ServerScriptEngine {
+public:
+    enum class ThreadState
+    {
+        NOT_RUNNING,
+        RUNNING,
+        STOP_REQUESTED
+    };
+
+    ServerScriptEngine();
+
+    ~ServerScriptEngine();
+
+    /// @name callbacks
+    /// @{
+
+    int loadScript(std::string scriptName);
+
+    void playerDeleted(int uid, int crash, bool doNestedCall = false);
+
+    void playerAdded(int uid);
+
+    int streamAdded(int uid, RoRnet::StreamRegister *reg);
+
+    int playerChat(int uid, std::string msg);
+
+    void gameCmd(int uid, const std::string &cmd);
+
+    /**
+     * Params `n1`, `n2` and `message` depend on status type :
+     * - CURL_STATUS_PROGRESS: n1 = bytes downloaded, n2 = total bytes, message = empty
+     * - CURL_STATUS_SUCCESS: n1 = CURL return code, n2 = HTTP result code, message = payload as string
+     * - CURL_STATUS_FAILURE: n1 = CURL return code, n2 = HTTP result code, message = CURL error string
+     */
+    void curlStatus(RoRServerCurlStatusType type, int n1, int n2, std::string displayname, std::string message);
+
+    int frameStep(float dt);
+
+    /// @}
+
+    /**
+     * Gets the currently used AngelScript script engine.
+     * @return a pointer to the currently used AngelScript script engine
+     */
+    AngelScript::asIScriptEngine *getEngine() { return engine; };
+
+    /**
+     * Sets an exception that aborts the currently running script and shows the exception in the log file.
+     * @param message A descriptive error message.
+     */
+    void setException(const std::string &message);
+
+    /**
+     * Adds a script callback.
+     * @param type The type of the callback. This can be one of the following: 'frameStep', 'playerChat', 'gameCmd', 'playerAdded', 'playerDeleted'.
+     * @param func A pointer to a script function.
+     * @param obj A pointer to the object of the method or NULL if func is a global function.
+     */
+    void addCallback(const std::string &type, AngelScript::asIScriptFunction *func, AngelScript::asIScriptObject *obj);
+
+    /**
+     * This method checks and converts the parameters and then adds a script callback.
+     * @param type The type of the callback. \see addCallback
+     * @param func The name of a script function.
+     * @param obj A pointer to the object of the method or NULL if func is a global function.
+     */
+    void addCallbackScript(const std::string &type, const std::string &func, AngelScript::asIScriptObject *obj);
+
+    /**
+     * Deletes a script callback.
+     * @param type The type of the callback. \see addCallback
+     * @param func A pointer to a script function.
+     * @param obj A pointer to the object of the method or NULL if func is a global function.
+     */
+    void deleteCallback(const std::string &type, AngelScript::asIScriptFunction *func, AngelScript::asIScriptObject *obj);
+
+    /**
+     * This method checks and converts the parameters and then deletes a script callback.
+     * @param type The type of the callback. \see addCallback
+     * @param func The name of a script function.
+     * @param obj A pointer to the object of the method or NULL if func is a global function.
+     */
+    void deleteCallbackScript(const std::string &type, const std::string &_func, AngelScript::asIScriptObject *obj);
+
+    /**
+     * Deletes all script callbacks.
+     */
+    void deleteAllCallbacks();
+
+    /**
+     * This checks if a script callback exists.
+     * @param type The type of the callback. \see addCallback
+     * @param func A pointer to a script function.
+     * @param obj A pointer to the object of the method or NULL if func is a global function.
+     * @return true if the callback exists
+     */
+    bool callbackExists(const std::string &type, AngelScript::asIScriptFunction *func, AngelScript::asIScriptObject *obj);
+
+    // Timer thread control
+    void        EnsureTimerThreadRunning();
+    void        StopTimerThread();
+    ThreadState GetTimerThreadState();
+
+protected:
+    AngelScript::asIScriptEngine *engine;                //!< instance of the scripting engine
+    AngelScript::asIScriptContext *context;              //!< context in which all scripting happens
+    std::map<std::string, callbackList> callbacks; //!< A map containing the script callbacks by type.
+
+    // Timer thread context
+    std::thread m_timer_thread;
+    ThreadState m_timer_thread_state = ThreadState::NOT_RUNNING;
+    std::mutex  m_timer_thread_mutex;
+
+    /**
+     * This function initialzies the engine and registeres all types
+     */
+    void init();
+
+    /**
+     * This is the callback function that gets called when script error occur.
+     * When the script crashes, this function will provide you with more detail
+     * @param msg arguments that contain details about the crash
+     * @param param unkown?
+     */
+    void msgCallback(const AngelScript::asSMessageInfo *msg);
+
+    /**
+     * This function reads a file into the provided string.
+     * @param filename filename of the file that should be loaded into the script string
+     * @param script reference to a string where the contents of the file is written to
+     * @return 0 on success, everything else on error
+     */
+    int loadScriptFile(const char *fileName, std::string &script);
+
+    /**
+     * This callback gets called when an exception occurs in the script.
+     * It logs the exception message together with the place in the script where the error occurs.
+     * @param ctx The context in which the exception ocurred.
+     * @param param An unused parameter.
+     */
+    void ExceptionCallback(AngelScript::asIScriptContext *ctx, void *param);
+
+    /**
+     * This logs all variables and their values at the specified stack level.
+     * @param ctx The context that should be used.
+     * @param stackLevel A number representing the level in the stack that should be logged.
+     */
+    void PrintVariables(AngelScript::asIScriptContext *ctx, int stackLevel);
+
+    /**
+     * unused
+     */
+    void LineCallback(AngelScript::asIScriptContext *ctx, void *param);
+
+    /**
+     * A loop that periodically the frameStep() script callback.
+     */
+    void TimerThreadMain();
+};
+
+class ServerScript {
+protected:
+    ServerScriptEngine *mse;              //!< local script engine pointer, used as proxy mostly
+
+public:
+    ServerScript(ServerScriptEngine *se);
+
+    ~ServerScript();
+
+    void log(std::string &msg);
+
+    void say(std::string &msg, int uid = -1, int type = 0);
+
+    void kick(int kuid, std::string &msg);
+
+    void ban(int kuid, std::string &msg);
+
+    bool unban(int kuid);
+
+    int playerChat(int uid, char *str);
+
+    std::string getServerTerrain();
+
+    int sendGameCommand(int uid, std::string cmd);
+
+    std::string getUserName(int uid);
+
+    void setUserName(int uid, const std::string &username);
+
+    std::string getUserAuth(int uid);
+
+    int getUserAuthRaw(int uid);
+
+    void setUserAuthRaw(int uid, int authmode);
+
+    int getUserColourNum(int uid);
+
+    void setUserColourNum(int uid, int num);
+
+    std::string getUserToken(int uid);
+
+    std::string getUserVersion(int uid);
+
+    std::string getUserIPAddress(int uid);
+
+    int getUserPosition(int uid, Ogre::Vector3 &v);
+
+    int getNumClients();
+
+    int getStartTime();
+
+    int getTime();
+
+    std::string get_version();
+
+    std::string get_asVersion();
+
+    std::string get_protocolVersion();
+
+    void setCallback(const std::string &type, const std::string &func, void *obj, int refTypeId);
+
+    void deleteCallback(const std::string &type, const std::string &func, void *obj, int refTypeId);
+
+    void throwException(const std::string &message);
+
+    unsigned int get_maxClients();
+
+    std::string get_serverName();
+
+    std::string get_IPAddr();
+
+    unsigned int get_listenPort();
+
+    int get_serverMode();
+
+    std::string get_owner();
+
+    std::string get_website();
+
+    std::string get_ircServ();
+
+    std::string get_voipServ();
+
+    int rangeRandomInt(int from, int to);
+
+    void broadcastUserInfo(int uid);
+
+    /**
+     * Launches a background task, use `curlStatus` callback to monitor progress and receive result.
+     * @param displayname The "correlation ID" - the label passed to the callback to identify the transfer.
+     * @remark Callback signature: `curlStatus(curlStatusType, int n1, int n2, string displayname, string message)`
+     * - CURL_STATUS_PROGRESS: n1 = bytes downloaded, n2 = total bytes, message = empty
+     * - CURL_STATUS_SUCCESS: n1 = CURL return code, n2 = HTTP result code, message = payload as string
+     * - CURL_STATUS_FAILURE: n1 = CURL return code, n2 = HTTP result code, message = CURL error string
+     */
+    void curlRequestAsync(std::string url, std::string displayname);
+};
+
+} // namespace RoR
+
+#endif // USE_ANGELSCRIPT
+

--- a/source/main/scripting/ServerScriptEngine.h
+++ b/source/main/scripting/ServerScriptEngine.h
@@ -123,16 +123,16 @@ public:
 
     ~ServerScriptEngine();
 
-    /// @name callbacks
-    /// @{
-
     int loadScript(std::string scriptName);
 
     void unloadScript(); // RIGSOFRODS: Unload the script (only one can run at a time).
 
-    void playerDeleted(int uid, int crash, bool doNestedCall = false);
+    /// @name callbacks
+    /// @{
 
-    void playerAdded(RoRnet::UserInfo& user); // RIGSOFRODS: Assigns the UID
+    void playerDeleted(int uid, int crash = 0);
+
+    void playerAdded(RoRnet::UserInfo& user); // RIGSOFRODS: Fills UID and color
 
     int streamAdded(int uid, RoRnet::StreamRegister *reg);
 
@@ -214,6 +214,10 @@ public:
     void        EnsureTimerThreadRunning();
     void        StopTimerThread();
     ThreadState GetTimerThreadState();
+
+    // Sequencer context
+    unsigned int GetFreeUserId() { return m_free_user_id++; }
+    int GetFreePlayerColour();
 
 protected:
     AngelScript::asIScriptEngine *engine;                //!< instance of the scripting engine

--- a/source/main/scripting/ServerScriptEngine.h
+++ b/source/main/scripting/ServerScriptEngine.h
@@ -96,6 +96,10 @@ enum broadcastType {
 
 // constant for functions that receive an uid for sending something
 static const int TO_ALL = -1;
+
+struct ServerScriptClient { // Bare minimum from `class Client` in rorserver.
+    RoRnet::UserInfo user;  //!< user information
+};
 // END 'sequencer.h'
 
 // RIGSOFRODS: From 'config.h'
@@ -104,6 +108,7 @@ enum ServerType {
     SERVER_INET,
     SERVER_AUTO
 };
+// END 'config.h'
 
 class ServerScriptEngine {
 public:
@@ -127,7 +132,7 @@ public:
 
     void playerDeleted(int uid, int crash, bool doNestedCall = false);
 
-    void playerAdded(int uid);
+    void playerAdded(RoRnet::UserInfo& user); // RIGSOFRODS: Assigns the UID
 
     int streamAdded(int uid, RoRnet::StreamRegister *reg);
 
@@ -220,7 +225,10 @@ protected:
     ThreadState m_timer_thread_state = ThreadState::NOT_RUNNING;
     std::mutex  m_timer_thread_mutex;
 
-    std::mutex m_clients_mutex;  //!< RIGSOFRODS: from `class Sequencer`, guards (among else) execution of script callbacks.
+    // Sequencer context
+    std::mutex m_clients_mutex;  //!< guards access to `m_clients` and execution of script callbacks.
+    std::vector<ServerScriptClient *> m_clients;
+    unsigned int m_free_user_id = 1;
 
     /**
      * This function initialzies the engine and registeres all types

--- a/source/main/scripting/ServerScriptEngine.h
+++ b/source/main/scripting/ServerScriptEngine.h
@@ -379,6 +379,69 @@ public:
     void curlRequestAsync(std::string url, std::string displayname);
 };
 
+// RIGSOFRODS: from rorserver's 'ScriptFileSafe.h'
+// copied from the angelscript library and edited for use in Rigs of Rods Multiplayer Server ~ 01 Jan 2012
+// Copied from rorserver and modified to use `Ogre::DataStream` instead of `FILE*` ~ ohlidalp, 2026-07-17
+class ScriptFileSafe {
+public:
+    ScriptFileSafe();
+
+    void AddRef() const;
+
+    void Release() const;
+
+    // TODO: Implement the "r+", "w+" and "a+" modes
+    // mode = "r" -> open the file for reading
+    //        "w" -> open the file for writing (overwrites existing file)
+    //        "a" -> open the file for appending
+    int Open(const std::string &filename, const std::string &mode);
+
+    int Close();
+
+    int GetSize() const;
+
+    bool IsEOF() const;
+
+    // Reading
+    int ReadString(unsigned int length, std::string &str);
+
+    int ReadLine(std::string &str);
+
+    AngelScript::asINT64 ReadInt(AngelScript::asUINT bytes);
+
+    AngelScript::asQWORD ReadUInt(AngelScript::asUINT bytes);
+
+    float ReadFloat();
+
+    double ReadDouble();
+
+    // Writing
+    int WriteString(const std::string &str);
+
+    int WriteInt(AngelScript::asINT64 v, AngelScript::asUINT bytes);
+
+    int WriteUInt(AngelScript::asQWORD v, AngelScript::asUINT bytes);
+
+    int WriteFloat(float v);
+
+    int WriteDouble(double v);
+
+    // Cursor
+    int GetPos() const;
+
+    int SetPos(int pos);
+
+    int MovePos(int delta);
+
+protected:
+    ~ScriptFileSafe();
+
+    mutable int refCount;
+    Ogre::DataStreamPtr m_stream;
+};
+
+void RegisterScriptFile_Native(AngelScript::asIScriptEngine *engine);
+
 } // namespace RoR
 
 #endif // USE_ANGELSCRIPT

--- a/source/main/scripting/server/README.txt
+++ b/source/main/scripting/server/README.txt
@@ -1,0 +1,84 @@
+These files are adopted from ror-server.
+See https://github.com/RigsOfRods/ror-server/tree/4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+
+All filenames had "ServerScript*" prepended to them (unless it was there already).
+Changes from the original are marked with "//RIGSOFRODS"
+
+Created by ohlidalp, 2026 (see https://github.com/RigsOfRods/rigs-of-rods/pull/3393)
+
+PURPOSE
+=======
+
+To make gameplay scripts (such as race system) usable both in singleplayer (with AI bots)
+and multiplayer (with actual players under server authority).
+
+USAGE
+=====
+
+Place server scripts to directory indicated by 'sys_server_scripts_dir'
+That's 'Documents\My Games\Rigs of Rods\server_scripts' under MSWindows.
+Tip: use the example script provided with rorserver (also well documented):
+https://github.com/RigsOfRods/ror-server/blob/master/contrib/example-script.as
+
+While in menu or singleplayer, open ingame console and say 'loadserverscript <name>'.
+In case of any error, inspect "RoRServerScript.log" in logs directory.
+The game will show classic Client List UI on top right, with you as server admin.
+To stop the script, say 'unloadserverscript'.
+
+In simulation, the top menubar 'Actors' menu will also behave as in multiplayer,
+showing vehicles sorted by player/bot who spawned them.
+
+To add bots, use the classic 'Vehicle AI' menu in top menubar.
+These will appear as ranked players in the Client List UI.
+To remove all bots, just press [Stop all] in the 'Vehicle AI' menu.
+To remove individual bots, use standard `!kick <uid>` command,
+or alternatively kill the script from Console UI/Script Monitor menu.
+
+SERVER COMMANDS
+===============
+
+!help ~ prints built-in commands.
+!kick <uid> ~ kicks a bot. Unlike in rorserver, kick message isn't supported.
+No other commmads are built-in, but may be provided by the script.
+
+LOCAL PEEROPTIONS
+=================
+
+The 'mute actors' peeropt behaves identically as with rorserver.
+No other peeropts are supported.
+
+SCRIPT CALLBACKS
+================
+
+Supported:
+    void main() ~ required to exist as global function, invoked on startup.
+    void playerAdded(int uid) ~ executed when player or bot joins. Player auto-joins when the server script is started.
+    void playerDeleted(int uid, int crashed) ~ executed when bot leaves by any means. NOTE: RoRserver doesn't seem to invoke 'playerDeleted' on clean disconnect by player, but we do it for consistency
+    int streamAdded(int uid, StreamRegister@ reg) ~ executed when player or bot spawns an actor. Returns `broadcastType` which determines how the message is treated.
+    int playerChat(int uid, const string &in msg) ~ ONLY ONE AT A TIME ~ executed when player sends a chat message. Returns `broadcastType` which determines how the message is treated.
+    void gameCmd(int uid, const string &in cmd) ~ ONLY ONE AT A TIME ~ invoked when a script running on client calls `game.sendGameCmd()`
+    
+To be added:
+    void frameStep(float dt_millis) ~ executed periodically, the parameter is delta time (time since last execution) in milliseconds.
+    void curlStatus(curlStatusType type, int n1, int n2, string displayname, string message) ~ Provides progress and result info, see `server.curlRequestAsync()`; for CURL_STATUS_PROGRESS, n1 = bytes downloaded, n2 = total bytes; otherwise n1 = CURL return code, n2 = HTTP result code.
+
+SCRIPT FUNCTIONS
+================
+
+Most functions work just like they do in rorserver.
+    
+These are stubs, doing nothing and returning 0 or "":
+    game.getServerIpAddress()
+    game.getUserIpAddress(int uid)
+    game.get_version()
+    game.get_maxClients()
+    game.get_serverName()
+    game.get_IPAddr()
+    game.get_listenPort()
+    game.get_serverMode()
+    game.get_owner()
+    game.get_website()
+    game.get_ircServ()
+    game.get_voipServ()
+    game.broadcastUserInfo(int uid)
+    

--- a/source/main/scripting/server/README.txt
+++ b/source/main/scripting/server/README.txt
@@ -38,7 +38,11 @@ SERVER COMMANDS
 ===============
 
 !help ~ prints built-in commands.
-!kick <uid> ~ kicks a bot. Unlike in rorserver, kick message isn't supported.
+!version ~ prints "Local script"
+!list ~ lists connected users.
+!kick <uid> <message> ~ kicks a bot. Unlike in rorserver, kick message isn't supported.
+!say <uid> <message> ~ currently dummy because bots cannot receive chat messages or game commands yet.
+
 No other commmads are built-in, but may be provided by the script.
 
 LOCAL PEEROPTIONS
@@ -50,15 +54,13 @@ No other peeropts are supported.
 SCRIPT CALLBACKS
 ================
 
-Supported:
+All existing callbacks are supported:
     void main() ~ required to exist as global function, invoked on startup.
     void playerAdded(int uid) ~ executed when player or bot joins. Player auto-joins when the server script is started.
     void playerDeleted(int uid, int crashed) ~ executed when bot leaves by any means. NOTE: RoRserver doesn't seem to invoke 'playerDeleted' on clean disconnect by player, but we do it for consistency
     int streamAdded(int uid, StreamRegister@ reg) ~ executed when player or bot spawns an actor. Returns `broadcastType` which determines how the message is treated.
     int playerChat(int uid, const string &in msg) ~ ONLY ONE AT A TIME ~ executed when player sends a chat message. Returns `broadcastType` which determines how the message is treated.
     void gameCmd(int uid, const string &in cmd) ~ ONLY ONE AT A TIME ~ invoked when a script running on client calls `game.sendGameCmd()`
-    
-To be added:
     void frameStep(float dt_millis) ~ executed periodically, the parameter is delta time (time since last execution) in milliseconds.
     void curlStatus(curlStatusType type, int n1, int n2, string displayname, string message) ~ Provides progress and result info, see `server.curlRequestAsync()`; for CURL_STATUS_PROGRESS, n1 = bytes downloaded, n2 = total bytes; otherwise n1 = CURL return code, n2 = HTTP result code.
 
@@ -67,7 +69,7 @@ SCRIPT FUNCTIONS
 
 Most functions work just like they do in rorserver.
     
-These are stubs, doing nothing and returning 0 or "":
+The following are stubs, doing nothing and returning 0 or "":
     game.getServerIpAddress()
     game.getUserIpAddress(int uid)
     game.get_version()

--- a/source/main/scripting/server/ServerScript.cpp
+++ b/source/main/scripting/server/ServerScript.cpp
@@ -1,0 +1,269 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ServerScript.h"
+
+#include "Console.h" // RIGSOFRODS: For putNetMessage()
+#include "ServerScriptEngine.h"
+#include "ServerScriptLogger.h"
+#include "ServerScriptSequencer.h"
+#include "Utils.h" // RIGSOFRODS: For SanitizeUtf8String
+
+using namespace RoR;
+using namespace AngelScript;
+
+/* class that implements the interface for the scripts */
+ServerScript::ServerScript(ServerScriptEngine *se, ServerScriptSequencer* sequencer) : mse(se), seq(sequencer) {
+}
+
+ServerScript::~ServerScript() {
+}
+
+void ServerScript::log(std::string &msg) {
+    Logger::Log(LOG_INFO, "SCRIPT|%s", msg.c_str());
+}
+
+void ServerScript::say(std::string &msg, int uid, int type) {
+    seq->serverSay(msg, uid, type);
+    // RIGSOFRODS: Post message directly to console (thread safe)
+    App::GetConsole()->putNetMessage(uid, Console::CONSOLE_SYSTEM_NETCHAT, msg.c_str());
+}
+
+void ServerScript::kick(int kuid, std::string &msg) {
+
+    seq->QueueClientForDisconnect(kuid);
+    mse->playerDeleted(kuid, 0);
+}
+
+void ServerScript::ban(int buid, std::string &msg) {
+
+    this->kick(buid, msg);
+
+}
+
+bool ServerScript::unban(int buid) {
+    return true; //RIGSOFRODS STUB // return seq->UnBan(buid);
+}
+
+std::string ServerScript::getUserName(int uid) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return "";
+
+    return SanitizeUtf8String(c->user.username);
+}
+
+void ServerScript::setUserName(int uid, const std::string &username) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return;
+    std::string username_sane = SanitizeUtf8String(username);
+    strncpy(c->user.username, username_sane.c_str(), RORNET_MAX_USERNAME_LEN);
+}
+
+std::string ServerScript::getUserAuth(int uid) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return "none";
+    if (c->user.authstatus & RoRnet::AUTH_ADMIN) return "admin";
+    else if (c->user.authstatus & RoRnet::AUTH_MOD) return "moderator";
+    else if (c->user.authstatus & RoRnet::AUTH_RANKED) return "ranked";
+    else if (c->user.authstatus & RoRnet::AUTH_BOT) return "bot";
+
+    return "none";
+}
+
+int ServerScript::getUserAuthRaw(int uid) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return RoRnet::AUTH_NONE;
+    return c->user.authstatus;
+
+    return 0;
+}
+
+void ServerScript::setUserAuthRaw(int uid, int authmode) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return;
+    c->user.authstatus = authmode & ~(RoRnet::AUTH_RANKED | RoRnet::AUTH_BANNED);
+
+}
+
+int ServerScript::getUserColourNum(int uid) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return 0;
+    return c->user.colournum;
+
+    return 0;
+}
+
+void ServerScript::setUserColourNum(int uid, int num) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return;
+    c->user.colournum = num;
+
+}
+
+std::string ServerScript::getUserToken(int uid) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return "";
+    return std::string(c->user.usertoken, 40);
+}
+
+std::string ServerScript::getUserVersion(int uid) {
+
+    ServerScriptClient *c = seq->getClient(uid);
+    if (!c) return "";
+    return std::string(c->user.clientversion, 25);
+
+    return "";
+}
+
+std::string ServerScript::getUserIPAddress(int uid) {
+    /* RIGSOFRODS: STUB
+    ServerScriptClient *client = seq->getClient(uid);
+    if (client != nullptr) {
+        return client->GetIpAddress();
+    }
+    */
+    return "";
+}
+
+std::string ServerScript::getServerTerrain() {
+    return ""; // RIGSOFRODS: STUB // return Config::getTerrainName();
+}
+
+int ServerScript::sendGameCommand(int uid, std::string cmd) {
+    seq->sendGameCommand(uid, cmd);
+    return 0;
+}
+
+void ServerScript::curlRequestAsync(std::string url, std::string displayname) {
+#if USE_CURL
+    CurlTaskContext context;
+    context.ctc_url = url;
+    context.ctc_displayname = displayname;
+    context.ctc_script_engine = this->mse;
+
+    std::packaged_task<void(CurlTaskContext)> pktask(ServerScriptCurlRequestThreadFunc);
+    std::thread(std::move(pktask), context).detach();
+#endif
+}
+
+int ServerScript::getNumClients() {
+    return seq->getNumClients();
+}
+
+int ServerScript::getStartTime() {
+    return seq->getStartTime();
+}
+
+int ServerScript::getTime() {
+    return (int) time(NULL);
+}
+
+void ServerScript::deleteCallback(const std::string &type, const std::string &func, void *obj, int refTypeId) {
+    if (refTypeId & asTYPEID_SCRIPTOBJECT && (refTypeId & asTYPEID_OBJHANDLE)) {
+        mse->deleteCallbackScript(type, func, *(asIScriptObject **) obj);
+    } else if (refTypeId == asTYPEID_VOID) {
+        mse->deleteCallbackScript(type, func, NULL);
+    } else if (refTypeId & asTYPEID_SCRIPTOBJECT) {
+        // We received an object instead of a handle of the object.
+        // We cannot allow this because this will crash if the deleteCallback is called from inside a constructor of a global variable.
+        mse->setException(
+                "server.deleteCallback should be called with a handle of the object! (that is: put an @ sign in front of the object)");
+
+        // uncomment to enable anyway:
+        //mse->deleteCallbackScript(type, func, (asIScriptObject*)obj);
+    } else {
+        mse->setException("The object for the callback has to be a script-class or null!");
+    }
+}
+
+void ServerScript::setCallback(const std::string &type, const std::string &func, void *obj, int refTypeId) {
+    if (refTypeId & asTYPEID_SCRIPTOBJECT && (refTypeId & asTYPEID_OBJHANDLE)) {
+        mse->addCallbackScript(type, func, *(asIScriptObject **) obj);
+    } else if (refTypeId == asTYPEID_VOID) {
+        mse->addCallbackScript(type, func, NULL);
+    } else if (refTypeId & asTYPEID_SCRIPTOBJECT) {
+        // We received an object instead of a handle of the object.
+        // We cannot allow this because this will crash if the setCallback is called from inside a constructor of a global variable.
+        mse->setException(
+                "server.setCallback should be called with a handle of the object! (that is: put an @ sign in front of the object)");
+
+        // uncomment to enable anyway:
+        //mse->addCallbackScript(type, func, (asIScriptObject*)obj);
+    } else {
+        mse->setException("The object for the callback has to be a script-class or null!");
+    }
+}
+
+void ServerScript::throwException(const std::string &message) {
+    mse->setException(message);
+}
+
+std::string ServerScript::get_version() {
+    return "";  // RIGSOFRODS: STUB // std::string(VERSION);
+}
+
+std::string ServerScript::get_asVersion() {
+    return std::string(ANGELSCRIPT_VERSION_STRING);
+}
+
+std::string ServerScript::get_protocolVersion() {
+    return std::string(RORNET_VERSION);
+}
+
+unsigned int ServerScript::get_maxClients() { return 0; } // RIGSOFRODS: STUB // return Config::getMaxClients(); }
+
+std::string ServerScript::get_serverName() { return ""; } // RIGSOFRODS: STUB // Config::getServerName(); }
+
+std::string ServerScript::get_IPAddr() { return ""; } // RIGSOFRODS: STUB // Config::getIPAddr(); }
+
+unsigned int ServerScript::get_listenPort() { return 0u; } // RIGSOFRODS: STUB // return Config::getListenPort(); }
+
+int ServerScript::get_serverMode() { return 0; } // RIGSOFRODS: STUB //  (int)Config::getServerMode(); }
+
+std::string ServerScript::get_owner() { return ""; } // RIGSOFRODS: STUB // Config::getOwner(); }
+
+std::string ServerScript::get_website() { return ""; } // RIGSOFRODS: STUB // Config::getWebsite(); }
+
+std::string ServerScript::get_ircServ() { return ""; } // RIGSOFRODS: STUB // Config::getIRC(); }
+
+std::string ServerScript::get_voipServ() { return ""; } // RIGSOFRODS: STUB // Config::getVoIP(); }
+
+int ServerScript::rangeRandomInt(int from, int to) {
+    return (int) (from + (to - from) * ((float) rand() / (float) RAND_MAX));
+}
+
+void ServerScript::broadcastUserInfo(int uid) {
+    // RIGSOFRODS: STUB // seq->broadcastUserInfo(uid);
+}
+

--- a/source/main/scripting/server/ServerScript.h
+++ b/source/main/scripting/server/ServerScript.h
@@ -1,0 +1,138 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef USE_ANGELSCRIPT
+
+#include "ServerScriptCurlHelpers.h"
+#include "angelscript.h"
+#include "RoRnet.h"
+
+namespace RoR { // RIGSOFRODS
+
+class ServerScript {
+protected:
+    ServerScriptEngine *mse;              //!< local script engine pointer, used as proxy mostly
+    ServerScriptSequencer *seq;
+
+public:
+    ServerScript(ServerScriptEngine *se, ServerScriptSequencer* sequencer);
+
+    ~ServerScript();
+
+    void log(std::string &msg);
+
+    void say(std::string &msg, int uid = -1, int type = 0);
+
+    void kick(int kuid, std::string &msg);
+
+    void ban(int kuid, std::string &msg);
+
+    bool unban(int kuid);
+
+    int playerChat(int uid, char *str);
+
+    std::string getServerTerrain();
+
+    int sendGameCommand(int uid, std::string cmd);
+
+    std::string getUserName(int uid);
+
+    void setUserName(int uid, const std::string &username);
+
+    std::string getUserAuth(int uid);
+
+    int getUserAuthRaw(int uid);
+
+    void setUserAuthRaw(int uid, int authmode);
+
+    int getUserColourNum(int uid);
+
+    void setUserColourNum(int uid, int num);
+
+    std::string getUserToken(int uid);
+
+    std::string getUserVersion(int uid);
+
+    std::string getUserIPAddress(int uid);
+
+    int getUserPosition(int uid, Ogre::Vector3 &v);
+
+    int getNumClients();
+
+    int getStartTime();
+
+    int getTime();
+
+    std::string get_version();
+
+    std::string get_asVersion();
+
+    std::string get_protocolVersion();
+
+    void setCallback(const std::string &type, const std::string &func, void *obj, int refTypeId);
+
+    void deleteCallback(const std::string &type, const std::string &func, void *obj, int refTypeId);
+
+    void throwException(const std::string &message);
+
+    unsigned int get_maxClients();
+
+    std::string get_serverName();
+
+    std::string get_IPAddr();
+
+    unsigned int get_listenPort();
+
+    int get_serverMode();
+
+    std::string get_owner();
+
+    std::string get_website();
+
+    std::string get_ircServ();
+
+    std::string get_voipServ();
+
+    int rangeRandomInt(int from, int to);
+
+    void broadcastUserInfo(int uid);
+
+    /**
+     * Launches a background task, use `curlStatus` callback to monitor progress and receive result.
+     * @param displayname The "correlation ID" - the label passed to the callback to identify the transfer.
+     * @remark Callback signature: `curlStatus(curlStatusType, int n1, int n2, string displayname, string message)`
+     * - CURL_STATUS_PROGRESS: n1 = bytes downloaded, n2 = total bytes, message = empty
+     * - CURL_STATUS_SUCCESS: n1 = CURL return code, n2 = HTTP result code, message = payload as string
+     * - CURL_STATUS_FAILURE: n1 = CURL return code, n2 = HTTP result code, message = CURL error string
+     */
+    void curlRequestAsync(std::string url, std::string displayname);
+};
+
+} // namespace RoR
+
+#endif // USE_ANGELSCRIPT

--- a/source/main/scripting/server/ServerScriptConfig.h
+++ b/source/main/scripting/server/ServerScriptConfig.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// RIGSOFRODS: From 'config.h'
+enum ServerType {
+    SERVER_LAN = 0,
+    SERVER_INET,
+    SERVER_AUTO
+};

--- a/source/main/scripting/server/ServerScriptCurlHelpers.cpp
+++ b/source/main/scripting/server/ServerScriptCurlHelpers.cpp
@@ -1,0 +1,22 @@
+#include "ServerScriptCurlHelpers.h"
+#include "ServerScriptEngine.h"
+
+#ifdef USE_CURL
+
+void RoR::ServerScriptCurlRequestThreadFunc(CurlTaskContext context)
+{
+    context.ctc_script_engine->curlStatus(CURL_STATUS_START, 0, 0, context.ctc_displayname, "");
+    std::string data;
+    CURLcode curl_result = CURLE_OK;
+    long http_response = 0;
+    if (GetUrlAsString(context.ctc_url, /*out:*/curl_result, /*out:*/http_response, /*out:*/data))
+    {
+        context.ctc_script_engine->curlStatus(CURL_STATUS_SUCCESS, (int)curl_result, (int)http_response, context.ctc_displayname, data);
+    }
+    else
+    {
+        context.ctc_script_engine->curlStatus(CURL_STATUS_FAILURE, (int)curl_result, (int)http_response, context.ctc_displayname, curl_easy_strerror(curl_result));
+    }
+}
+
+#endif // USE_CURL

--- a/source/main/scripting/server/ServerScriptCurlHelpers.h
+++ b/source/main/scripting/server/ServerScriptCurlHelpers.h
@@ -1,0 +1,23 @@
+
+#pragma once
+
+#ifdef USE_CURL
+
+#include "CurlHelpers.h" // RIGSOFRODS: This is actually the client's header with same name as original server header. Both implement the same functionality but with cosmetic differences.
+
+namespace RoR { // RIGSOFRODS
+
+enum ServerScriptCurlStatusType
+{
+    CURL_STATUS_INVALID,  //!< Should never be reported.
+    CURL_STATUS_START,    //!< New CURL request started, n1/n2 both 0.
+    CURL_STATUS_PROGRESS, //!< Download in progress, n1 = bytes downloaded, n2 = total bytes.
+    CURL_STATUS_SUCCESS,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = received payload.
+    CURL_STATUS_FAILURE,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = CURL error string.
+};
+
+void ServerScriptCurlRequestThreadFunc(CurlTaskContext context);
+
+} // namespace RoR
+
+#endif // USE_CURL

--- a/source/main/scripting/server/ServerScriptEngine.cpp
+++ b/source/main/scripting/server/ServerScriptEngine.cpp
@@ -87,8 +87,8 @@ ServerScriptEngine::ServerScriptEngine(ServerScriptSequencer* sequencer) :
 }
 
 ServerScriptEngine::~ServerScriptEngine() {
-    // Stop thread first
-    this->StopTimerThread();
+    // thread must be stopped
+    ROR_ASSERT(this->GetTimerThreadState() == ThreadState::NOT_RUNNING);
 
     // Clean up
     deleteAllCallbacks();

--- a/source/main/scripting/server/ServerScriptEngine.cpp
+++ b/source/main/scripting/server/ServerScriptEngine.cpp
@@ -37,12 +37,14 @@ along with Foobar. If not, see <http://www.gnu.org/licenses/>.
 #include "scriptany/scriptany.h" // angelscript addon
 #include "SocketW.h"
 
-#include "CurlHelpers.h" // RIGSOFRODS: This is actually the client's header with same name as server header. Both implement the same functionality but with cosmetic differences.
+#include "ServerScriptCurlHelpers.h"
+#include "ServerScriptConfig.h"
+#include "ServerScriptFileSafe.h"
 #include "OgreScriptBuilder.h" // RIGSOFRODS: Use OGRE to load files.
 #include "PlatformUtils.h" // RIGSOFRODS: For PathCombine
-#include "Application.h" // RIGSOFRODS: For App::sys_logs_dir
+#include "ScriptEngine.h" // RIGSOFRODS: For ScriptEngine::unloadBotByUid()
+
 #include "Console.h" // RIGSOFRODS: For putNetMessage()
-#include "ScriptEngine.h" // RIGSOFRODS: For ScriptEngine::kickBotByUid()
 #include "Utils.h"
 
 #include <cstdio>
@@ -66,25 +68,7 @@ using namespace RoR;
 #include <thread>
 #include <future>
 
-static Ogre::Log* sServerLog = nullptr;
 
-void Logger::Log(LogLevel level, const char *format, ...)
-{
-    // Format the message
-    const int BUF_LEN = 4000; // hard limit
-    char buffer[BUF_LEN] = {}; // zeroed memory
-    va_list args;
-    va_start(args, format);
-    vsnprintf(buffer, BUF_LEN, format, args);
-    va_end(args);
-    // Log the message
-    sServerLog->logMessage(std::string(buffer));
-}
-
-void Logger::Log(LogLevel level, std::string const& msg)
-{
-    sServerLog->logMessage(msg);
-}
 
 
 // Stream_register_t wrapper
@@ -94,11 +78,11 @@ std::string stream_register_get_name(RoRnet::StreamRegister *reg) {
 
 
 
-ServerScriptEngine::ServerScriptEngine() :
+ServerScriptEngine::ServerScriptEngine(ServerScriptSequencer* sequencer) :
+                                             seq(sequencer),
                                              engine(0),
                                              context(0)
 {
-    sServerLog = Ogre::LogManager::getSingleton().createLog(RoR::PathCombine(App::sys_logs_dir->getStr(), "RoRServerScript.log"));
     init();
 }
 
@@ -110,27 +94,6 @@ ServerScriptEngine::~ServerScriptEngine() {
     deleteAllCallbacks();
     if (engine) engine->Release();
     if (context) context->Release();
-}
-
-// RIGSOFRODS: From 'sequencer.cpp' as-is
-int ServerScriptEngine::GetFreePlayerColour() {
-    // WARNING: be sure that this is only called within a clients_mutex lock!
-
-    int col = 0;
-    for (;;) // TODO: How many colors ARE there?
-    {
-        bool collision = false;
-        for (unsigned int i = 0; i < m_clients.size(); i++) {
-            if (m_clients[i]->user.colournum == col) {
-                collision = true;
-                break;
-            }
-        }
-        if (!collision) {
-            return col;
-        }
-        col++;
-    }
 }
 
 void ServerScriptEngine::deleteAllCallbacks() {
@@ -506,7 +469,7 @@ void ServerScriptEngine::init() {
     result = engine->RegisterObjectMethod("ServerScriptClass", "int rangeRandomInt(int, int)",
                                           asMETHOD(ServerScript, rangeRandomInt), asCALL_THISCALL);
     assert_net(result >= 0);
-    ServerScript *serverscript = new ServerScript(this);
+    ServerScript *serverscript = new ServerScript(this, seq);
     result = engine->RegisterGlobalProperty("ServerScriptClass server", serverscript);
     assert_net(result >= 0);
 
@@ -618,29 +581,8 @@ void ServerScriptEngine::msgCallback(const asSMessageInfo *msg) {
     Logger::Log(LOG_INFO, "ScriptEngine: %s (%d, %d): %s = %s", msg->section, msg->row, msg->col, type, msg->message);
 }
 
-// unused method
-int ServerScriptEngine::loadScriptFile(const char *fileName, string &script) {
-    FILE *f = fopen(fileName, "rb");
-    if (!f) return 1;
-
-    // Determine the size of the file
-    fseek(f, 0, SEEK_END);
-    int len = ftell(f);
-    fseek(f, 0, SEEK_SET);
-
-    // Load the entire file in one call
-    script.resize(len);
-    fread(&script[0], len, 1, f);
-
-    fclose(f);
-    return 0;
-}
-
 int ServerScriptEngine::frameStep(float dt) {
 
-    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
-    // All script callbacks must be invoked while clients-mutex is locked
-    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
 
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();
@@ -676,9 +618,6 @@ int ServerScriptEngine::frameStep(float dt) {
 
 void ServerScriptEngine::playerDeleted(int uid, int crash) {
 
-    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
-    // All script callbacks must be invoked while clients-mutex is locked
-    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
 
     if (!engine) return;
     if (!context) context = engine->CreateContext();
@@ -707,24 +646,13 @@ void ServerScriptEngine::playerDeleted(int uid, int crash) {
         r = context->Execute();
     }
 
-    // RIGSOFRODS: Remove the client from the list
-    EraseIf(m_clients, [uid](ServerScriptClient* client) { return client->user.uniqueid == uid; });
+
 
     return;
 }
 
-void ServerScriptEngine::playerAdded(RoRnet::UserInfo& user) // RIGSOFRODS: Assigns the UID and color
+void ServerScriptEngine::playerAdded(RoRnet::UserInfo& user)
 {
-    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
-    // All script callbacks must be invoked while clients-mutex is locked
-    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
-
-    // RIGSOFRODS: register the new client - in rorserver it's handled by `Sequencer::createClient()`
-    user.uniqueid = m_free_user_id++;
-    user.colournum = this->GetFreePlayerColour();
-    ServerScriptClient* client_record = new ServerScriptClient();
-    client_record->user = user;
-    m_clients.push_back(client_record);
 
     if (!engine) return;
     if (!context) context = engine->CreateContext();
@@ -755,10 +683,6 @@ void ServerScriptEngine::playerAdded(RoRnet::UserInfo& user) // RIGSOFRODS: Assi
 }
 
 int ServerScriptEngine::streamAdded(int uid, RoRnet::StreamRegister *reg) {
-
-    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
-    // All script callbacks must be invoked while clients-mutex is locked
-    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
 
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();
@@ -800,27 +724,6 @@ int ServerScriptEngine::streamAdded(int uid, RoRnet::StreamRegister *reg) {
 
 int ServerScriptEngine::playerChat(int uid, std::string msg) {
 
-    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
-    // All script callbacks must be invoked while clients-mutex is locked
-    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
-
-    // Handle server commands
-    if (msg == "!help")
-    {
-        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NETCHAT, "Server commands: !help, !kick <uid>");
-        return 0;
-    }
-    if (msg.substr(0, 6) == "!kick ") {
-        int kuid = -1;
-        int res = sscanf(msg.substr(6).c_str(), "%d", &kuid);
-        if (res != 1 || kuid == -1) {
-            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NETCHAT, "!kick <uid> ~ kick a bot");
-        } else {
-            App::GetScriptEngine()->kickBotByUid(kuid);
-            return 0;
-        }
-    }
-
     if (!engine) return 0;
     if (!context) context = engine->CreateContext();
     int r;
@@ -861,10 +764,6 @@ int ServerScriptEngine::playerChat(int uid, std::string msg) {
 
 void ServerScriptEngine::gameCmd(int uid, const std::string &cmd) {
 
-    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
-    // All script callbacks must be invoked while clients-mutex is locked
-    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
-
     if (!engine) return;
     if (!context) context = engine->CreateContext();
     int r;
@@ -895,16 +794,12 @@ void ServerScriptEngine::gameCmd(int uid, const std::string &cmd) {
     return;
 }
 
-void ServerScriptEngine::curlStatus(RoRServerCurlStatusType type, int n1, int n2, string displayname, string message)
+void ServerScriptEngine::curlStatus(ServerScriptCurlStatusType type, int n1, int n2, string displayname, string message)
 {
     // Params `n1` and `n2` depend on status type :
     // - for CURL_STATUS_PROGRESS, n1 = bytes downloaded, n2 = total bytes,
     // - otherwise, n1 = CURL return code, n2 = HTTP result code.
     // -------------------------------------------------------------------
-
-    // RIGSOFRODS: In RoRServer this mutex is handled by `class Sequencer`, here we must manage it ourselves.
-    // All script callbacks must be invoked while clients-mutex is locked
-    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
 
     if (!engine) return;
     if (!context) context = engine->CreateContext();
@@ -947,7 +842,7 @@ void ServerScriptEngine::TimerThreadMain() {
 #endif // _WIN32
 
         // call script
-        this->frameStep(200.f); //RIGSOFRODS //seq->frameStepScripts(200);
+        seq->frameStepScripts(200);
     }
 }
 
@@ -1168,623 +1063,4 @@ bool ServerScriptEngine::callbackExists(const std::string &type, asIScriptFuncti
     }
     return false;
 }
-
-/* class that implements the interface for the scripts */
-ServerScript::ServerScript(ServerScriptEngine *se) : mse(se) {
-}
-
-ServerScript::~ServerScript() {
-}
-
-void ServerScript::log(std::string &msg) {
-    Logger::Log(LOG_INFO, "SCRIPT|%s", msg.c_str());
-}
-
-void ServerScript::say(std::string &msg, int uid, int type) {
-    // RIGSOFRODS: Do what rorserver's `Sequencer::serverSay()` does.
-    switch (type) {
-        case FROM_SERVER:
-            msg = std::string("SERVER: ") + msg;
-            break;
-
-        case FROM_HOST:
-            if (uid == -1) {
-                msg = std::string("Host(general): ") + msg;
-            } else {
-                msg = std::string("Host(private): ") + msg;
-            }
-            break;
-
-        case FROM_RULES:
-            msg = std::string("Rules: ") + msg;
-            break;
-
-        case FROM_MOTD:
-            msg = std::string("MOTD: ") + msg;
-            break;
-    }
-    // RIGSOFRODS: Post message directly to console (thread safe)
-    App::GetConsole()->putNetMessage(uid, Console::CONSOLE_SYSTEM_NETCHAT, msg.c_str());
-}
-
-void ServerScript::kick(int kuid, std::string &msg) {
-    /* RIGSOFRODS: STUB
-    seq->QueueClientForDisconnect(kuid, msg.c_str(), false, false);
-    mse->playerDeleted(kuid, 0, true);
-    */
-}
-
-void ServerScript::ban(int buid, std::string &msg) {
-    /* RIGSOFRODS: STUB
-    seq->SilentBan(buid, msg.c_str(), false);
-    mse->playerDeleted(buid, 0, true);
-    */
-}
-
-bool ServerScript::unban(int buid) {
-    return true; //RIGSOFRODS STUB // return seq->UnBan(buid);
-}
-
-std::string ServerScript::getUserName(int uid) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return "";
-
-
-    return Str::SanitizeUtf8(c->user.username);
-    */
-    return "";
-}
-
-void ServerScript::setUserName(int uid, const string &username) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return;
-    std::string username_sane = Str::SanitizeUtf8(username.begin(), username.end());
-    strncpy(c->user.username, username_sane.c_str(), RORNET_MAX_USERNAME_LEN);
-    */
-}
-
-std::string ServerScript::getUserAuth(int uid) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return "none";
-    if (c->user.authstatus & RoRnet::AUTH_ADMIN) return "admin";
-    else if (c->user.authstatus & RoRnet::AUTH_MOD) return "moderator";
-    else if (c->user.authstatus & RoRnet::AUTH_RANKED) return "ranked";
-    else if (c->user.authstatus & RoRnet::AUTH_BOT) return "bot";
-    //else if(c->user.authstatus & RoRnet::AUTH_NONE)
-    */
-    return "none";
-}
-
-int ServerScript::getUserAuthRaw(int uid) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return RoRnet::AUTH_NONE;
-    return c->user.authstatus;
-    */
-    return 0;
-}
-
-void ServerScript::setUserAuthRaw(int uid, int authmode) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return;
-    c->user.authstatus = authmode & ~(RoRnet::AUTH_RANKED | RoRnet::AUTH_BANNED);
-    */
-}
-
-int ServerScript::getUserColourNum(int uid) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return 0;
-    return c->user.colournum;
-    */
-    return 0;
-}
-
-void ServerScript::setUserColourNum(int uid, int num) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return;
-    c->user.colournum = num;
-    */
-}
-
-std::string ServerScript::getUserToken(int uid) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return "";
-    return std::string(c->user.usertoken, 40);
-    */
-    return "";
-}
-
-std::string ServerScript::getUserVersion(int uid) {
-    /* RIGSOFRODS: STUB
-    Client *c = seq->getClient(uid);
-    if (!c) return "";
-    return std::string(c->user.clientversion, 25);
-    */
-    return "";
-}
-
-std::string ServerScript::getUserIPAddress(int uid) {
-    /* RIGSOFRODS: STUB
-    Client *client = seq->getClient(uid);
-    if (client != nullptr) {
-        return client->GetIpAddress();
-    }
-    */
-    return "";
-}
-
-std::string ServerScript::getServerTerrain() {
-    return ""; // RIGSOFRODS: STUB // return Config::getTerrainName();
-}
-
-int ServerScript::sendGameCommand(int uid, std::string cmd) {
-    return 0; // RIGSOFRODS: STUB // return seq->sendGameCommand(uid, cmd);
-}
-
-void ServerScript::curlRequestAsync(std::string url, string displayname) {
-#if WITH_CURL
-    CurlTaskContext context;
-    context.ctc_url = url;
-    context.ctc_displayname = displayname;
-    context.ctc_script_engine = this->mse;
-
-    std::packaged_task<void(CurlTaskContext)> pktask(CurlRequestThreadFunc);
-    std::thread(std::move(pktask), context).detach();
-#endif
-}
-
-int ServerScript::getNumClients() {
-    return 0; // RIGSOFRODS: STUB //  seq->getNumClients();
-}
-
-int ServerScript::getStartTime() {
-    return 0; // RIGSOFRODS: STUB //  seq->getStartTime();
-}
-
-int ServerScript::getTime() {
-    return 0; // RIGSOFRODS: STUB //  Messaging::getTime();
-}
-
-void ServerScript::deleteCallback(const std::string &type, const std::string &func, void *obj, int refTypeId) {
-    if (refTypeId & asTYPEID_SCRIPTOBJECT && (refTypeId & asTYPEID_OBJHANDLE)) {
-        mse->deleteCallbackScript(type, func, *(asIScriptObject **) obj);
-    } else if (refTypeId == asTYPEID_VOID) {
-        mse->deleteCallbackScript(type, func, NULL);
-    } else if (refTypeId & asTYPEID_SCRIPTOBJECT) {
-        // We received an object instead of a handle of the object.
-        // We cannot allow this because this will crash if the deleteCallback is called from inside a constructor of a global variable.
-        mse->setException(
-                "server.deleteCallback should be called with a handle of the object! (that is: put an @ sign in front of the object)");
-
-        // uncomment to enable anyway:
-        //mse->deleteCallbackScript(type, func, (asIScriptObject*)obj);
-    } else {
-        mse->setException("The object for the callback has to be a script-class or null!");
-    }
-}
-
-void ServerScript::setCallback(const std::string &type, const std::string &func, void *obj, int refTypeId) {
-    if (refTypeId & asTYPEID_SCRIPTOBJECT && (refTypeId & asTYPEID_OBJHANDLE)) {
-        mse->addCallbackScript(type, func, *(asIScriptObject **) obj);
-    } else if (refTypeId == asTYPEID_VOID) {
-        mse->addCallbackScript(type, func, NULL);
-    } else if (refTypeId & asTYPEID_SCRIPTOBJECT) {
-        // We received an object instead of a handle of the object.
-        // We cannot allow this because this will crash if the setCallback is called from inside a constructor of a global variable.
-        mse->setException(
-                "server.setCallback should be called with a handle of the object! (that is: put an @ sign in front of the object)");
-
-        // uncomment to enable anyway:
-        //mse->addCallbackScript(type, func, (asIScriptObject*)obj);
-    } else {
-        mse->setException("The object for the callback has to be a script-class or null!");
-    }
-}
-
-void ServerScript::throwException(const std::string &message) {
-    mse->setException(message);
-}
-
-std::string ServerScript::get_version() {
-    return "";  // RIGSOFRODS: STUB // std::string(VERSION);
-}
-
-std::string ServerScript::get_asVersion() {
-    return std::string(ANGELSCRIPT_VERSION_STRING);
-}
-
-std::string ServerScript::get_protocolVersion() {
-    return std::string(RORNET_VERSION);
-}
-
-unsigned int ServerScript::get_maxClients() { return 0; } // RIGSOFRODS: STUB // return Config::getMaxClients(); }
-
-std::string ServerScript::get_serverName() { return ""; } // RIGSOFRODS: STUB // Config::getServerName(); }
-
-std::string ServerScript::get_IPAddr() { return ""; } // RIGSOFRODS: STUB // Config::getIPAddr(); }
-
-unsigned int ServerScript::get_listenPort() { return 0u; } // RIGSOFRODS: STUB // return Config::getListenPort(); }
-
-int ServerScript::get_serverMode() { return 0; } // RIGSOFRODS: STUB //  (int)Config::getServerMode(); }
-
-std::string ServerScript::get_owner() { return ""; } // RIGSOFRODS: STUB // Config::getOwner(); }
-
-std::string ServerScript::get_website() { return ""; } // RIGSOFRODS: STUB // Config::getWebsite(); }
-
-std::string ServerScript::get_ircServ() { return ""; } // RIGSOFRODS: STUB // Config::getIRC(); }
-
-std::string ServerScript::get_voipServ() { return ""; } // RIGSOFRODS: STUB // Config::getVoIP(); }
-
-int ServerScript::rangeRandomInt(int from, int to) {
-    return (int) (from + (to - from) * ((float) rand() / (float) RAND_MAX));
-}
-
-void ServerScript::broadcastUserInfo(int uid) {
-    // RIGSOFRODS: STUB // seq->broadcastUserInfo(uid);
-}
-
-// RIGSOFRODS: from rorserver's 'ScriptFileSafe.cpp'
-
-ScriptFileSafe *ScriptFile_Factory() {
-    return new ScriptFileSafe();
-}
-
-void RoR::RegisterScriptFile_Native(asIScriptEngine *engine) {
-    int r;
-
-    r = engine->RegisterObjectType("file", 0, asOBJ_REF);
-    assert(r >= 0);
-    r = engine->RegisterObjectBehaviour("file", asBEHAVE_FACTORY, "file @f()", asFUNCTION(ScriptFile_Factory),
-                                        asCALL_CDECL);
-    assert(r >= 0);
-    r = engine->RegisterObjectBehaviour("file", asBEHAVE_ADDREF, "void f()", asMETHOD(ScriptFileSafe, AddRef),
-                                        asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectBehaviour("file", asBEHAVE_RELEASE, "void f()", asMETHOD(ScriptFileSafe, Release),
-                                        asCALL_THISCALL);
-    assert(r >= 0);
-
-    r = engine->RegisterObjectMethod("file", "int open(const string &in, const string &in)",
-                                     asMETHOD(ScriptFileSafe, Open), asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int close()", asMETHOD(ScriptFileSafe, Close), asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int getSize() const", asMETHOD(ScriptFileSafe, GetSize), asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "bool isEndOfFile() const", asMETHOD(ScriptFileSafe, IsEOF),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int readString(uint, string &out)", asMETHOD(ScriptFileSafe, ReadString),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int readLine(string &out)", asMETHOD(ScriptFileSafe, ReadLine),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int64 readInt(uint)", asMETHOD(ScriptFileSafe, ReadInt), asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "uint64 readUInt(uint)", asMETHOD(ScriptFileSafe, ReadUInt),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "float readFloat()", asMETHOD(ScriptFileSafe, ReadFloat), asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "double readDouble()", asMETHOD(ScriptFileSafe, ReadDouble),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-
-    r = engine->RegisterObjectMethod("file", "int writeString(const string &in)", asMETHOD(ScriptFileSafe, WriteString),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int writeInt(int64, uint)", asMETHOD(ScriptFileSafe, WriteInt),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int writeUInt(uint64, uint)", asMETHOD(ScriptFileSafe, WriteUInt),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int writeFloat(float)", asMETHOD(ScriptFileSafe, WriteFloat),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int writeDouble(double)", asMETHOD(ScriptFileSafe, WriteDouble),
-                                     asCALL_THISCALL);
-    assert(r >= 0);
-
-    r = engine->RegisterObjectMethod("file", "int getPos() const", asMETHOD(ScriptFileSafe, GetPos), asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int setPos(int)", asMETHOD(ScriptFileSafe, SetPos), asCALL_THISCALL);
-    assert(r >= 0);
-    r = engine->RegisterObjectMethod("file", "int movePos(int)", asMETHOD(ScriptFileSafe, MovePos), asCALL_THISCALL);
-    assert(r >= 0);
-
-    assert(r >= 0);
-}
-
-
-ScriptFileSafe::ScriptFileSafe() {
-    refCount = 1;
-}
-
-ScriptFileSafe::~ScriptFileSafe() {
-    Close();
-}
-
-void ScriptFileSafe::AddRef() const {
-    ++refCount;
-}
-
-void ScriptFileSafe::Release() const {
-    if (--refCount == 0)
-        delete this;
-}
-
-int ScriptFileSafe::Open(const std::string &filename, const std::string &mode) {
-    // Close the previously opened file handle
-    if (m_stream)
-        m_stream->close();
-
-    // Validate the mode
-    string m;
-#if AS_WRITE_OPS == 1
-    if (mode != "r" && mode != "w" && mode != "a")
-#else
-        if( mode != "r" )
-#endif
-        return -2;
-    else
-        m = mode;
-
-    // By default windows translates "\r\n" to "\n", but we want to read the file as-is.
-    m += "b";
-
-    std::string myFilename = filename;
-
-    // Remove the possible .asdata extension
-    if (myFilename.length() > 7 && myFilename.substr(myFilename.length() - 7, 7) == ".asdata")
-        myFilename = myFilename.substr(0, myFilename.length() - 7);
-
-    // Replace all forbidden characters in the filename	
-    std::string allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
-    for (std::string::iterator it = myFilename.begin(); it < myFilename.end(); ++it) {
-        if (allowedChars.find(*it) == std::string::npos)
-            *it = '_';
-    }
-
-    // Open the file
-    try
-    {
-        m_stream = Ogre::ResourceGroupManager::getSingleton().openResource(myFilename, RGN_SERVER_SCRIPTS);
-    }
-    catch (...)
-    {
-        HandleGenericException("file.open()");
-        return -3;
-    }
-
-    return 0;
-}
-
-int ScriptFileSafe::Close() {
-    if (!m_stream)
-        return -1;
-
-    m_stream->close();
-    return 0;
-}
-
-int ScriptFileSafe::GetSize() const {
-    if (!m_stream)
-        return -1;
-
-    return m_stream->size();
-}
-
-int ScriptFileSafe::GetPos() const {
-    if (!m_stream)
-        return -1;
-
-    return m_stream->tell();
-}
-
-int ScriptFileSafe::SetPos(int pos) {
-    if (!m_stream)
-        return -1;
-
-    m_stream->seek(pos);
-
-    return 0;
-}
-
-int ScriptFileSafe::MovePos(int delta) {
-    if (!m_stream)
-        return -1;
-
-    m_stream->seek(m_stream->tell() + delta);
-
-    return 0;
-}
-
-int ScriptFileSafe::ReadString(unsigned int length, std::string &str) {
-    if (!m_stream)
-        return 0;
-
-    // Read the string
-    str.resize(length);
-    size_t size = (int)m_stream->read(&str[0], length);
-    str.resize(size);
-
-    return static_cast<int>(size);
-}
-
-int ScriptFileSafe::ReadLine(std::string &str) {
-    if (!m_stream)
-        return 0;
-
-    char buf[2000] = {};
-    size_t count = m_stream->readLine(buf, 2000);
-    str.assign(buf, count);
-
-    return static_cast<int>(count);
-}
-
-asINT64 ScriptFileSafe::ReadInt(asUINT bytes) {
-    if (!m_stream)
-        return 0;
-
-    if (bytes > 8) bytes = 8;
-    if (bytes == 0) return 0;
-
-    unsigned char buf[8];
-    size_t r = m_stream->read(buf, bytes);
-    if (r == 0) return 0;
-
-    asINT64 val = 0;
-
-        unsigned int n = 0;
-        for (; n < bytes; n++)
-            val |= asQWORD(buf[n]) << (n * 8);
-        if (buf[0] & 0x80)
-            for (; n < 8; n++)
-                val |= asQWORD(0xFF) << (n * 8);
-
-
-    return val;
-}
-
-asQWORD ScriptFileSafe::ReadUInt(asUINT bytes) {
-    if (!m_stream)
-        return 0;
-
-    if (bytes > 8) bytes = 8;
-    if (bytes == 0) return 0;
-
-    unsigned char buf[8];
-    size_t r = m_stream->read(buf, bytes);
-    if (r == 0) return 0;
-
-    asQWORD val = 0;
-
-        unsigned int n = 0;
-        for (; n < bytes; n++)
-            val |= asQWORD(buf[n]) << (n * 8);
-
-
-    return val;
-}
-
-float ScriptFileSafe::ReadFloat() {
-    if (!m_stream)
-        return 0;
-
-    unsigned char buf[4];
-    size_t r = m_stream->read(buf, 4);
-    if (r == 0) return 0;
-
-    asUINT val = 0;
-
-        unsigned int n = 0;
-        for (; n < 4; n++)
-            val |= asUINT(buf[n]) << (n * 8);
-
-
-    return *reinterpret_cast<float *>(&val);
-}
-
-double ScriptFileSafe::ReadDouble() {
-    if (!m_stream)
-        return 0;
-
-    unsigned char buf[8];
-    size_t r = m_stream->read(buf, 8);
-    if (r == 0) return 0;
-
-    asQWORD val = 0;
-
-        unsigned int n = 0;
-        for (; n < 8; n++)
-            val |= asQWORD(buf[n]) << (n * 8);
-
-
-    return *reinterpret_cast<double *>(&val);
-}
-
-bool ScriptFileSafe::IsEOF() const {
-    if (!m_stream)
-        return true;
-
-    return m_stream->eof();
-}
-
-int ScriptFileSafe::WriteString(const std::string &str) {
-    if (!m_stream)
-        return -1;
-
-    // Write the entire string
-    size_t r = m_stream->write(&str[0], str.length());
-    return int(r);
-}
-
-int ScriptFileSafe::WriteInt(asINT64 val, asUINT bytes) {
-    if (!m_stream)
-        return 0;
-
-    unsigned char buf[8];
-
-        for (unsigned int n = 0; n < bytes; n++)
-            buf[n] = (val >> (n * 8)) & 0xFF;
-
-
-    size_t r = m_stream->write(&buf, bytes);
-    return int(r);
-}
-
-int ScriptFileSafe::WriteUInt(asQWORD val, asUINT bytes) {
-    if (!m_stream)
-        return 0;
-
-    unsigned char buf[8];
-
-        for (unsigned int n = 0; n < bytes; n++)
-            buf[n] = (val >> (n * 8)) & 0xFF;
-
-
-    size_t r = m_stream->write(&buf, bytes);
-    return int(r);
-}
-
-int ScriptFileSafe::WriteFloat(float f) {
-    if (!m_stream)
-        return 0;
-
-    unsigned char buf[4];
-    asUINT val = *reinterpret_cast<asUINT *>(&f);
-
-        for (unsigned int n = 0; n < 4; n++)
-            buf[n] = (val >> (n * 8)) & 0xFF;
-    
-
-    size_t r = m_stream->write(&buf, 4);
-    return int(r);
-}
-
-int ScriptFileSafe::WriteDouble(double d) {
-    if (!m_stream)
-        return 0;
-
-    unsigned char buf[8];
-    asQWORD val = *reinterpret_cast<asQWORD *>(&d);
-    
-        for (unsigned int n = 0; n < 8; n++)
-            buf[n] = (val >> (n * 8)) & 0xFF;
-    
-
-    size_t r = m_stream->write(&buf, 8);
-    return int(r);
-}
-
-#endif //USE_ANGELSCRIPT
-
+#endif // USE_ANGELSCRIPT

--- a/source/main/scripting/server/ServerScriptEngine.h
+++ b/source/main/scripting/server/ServerScriptEngine.h
@@ -28,7 +28,10 @@ along with Foobar. If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef USE_ANGELSCRIPT
 
-#include "CurlHelpers.h" // RIGSOFRODS: This is actually the client's header with same name as server header. Both implement the same functionality but with cosmetic differences.
+#include "ServerScriptCurlHelpers.h"
+#include "ServerScriptLogger.h"
+#include "ServerScriptSequencer.h"
+#include "ServerScript.h"
 #include <map>
 #include <mutex>
 #include <thread>
@@ -47,68 +50,6 @@ struct rorserver_callback_t {
 };
 typedef std::vector<rorserver_callback_t> callbackList;
 
-// RIGSOFRODS: Brought from rorserver's 'CurlHelpers.h' (see above)
-enum RoRServerCurlStatusType
-{
-    CURL_STATUS_INVALID,  //!< Should never be reported.
-    CURL_STATUS_START,    //!< New CURL request started, n1/n2 both 0.
-    CURL_STATUS_PROGRESS, //!< Download in progress, n1 = bytes downloaded, n2 = total bytes.
-    CURL_STATUS_SUCCESS,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = received payload.
-    CURL_STATUS_FAILURE,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = CURL error string.
-};
-
-// RIGSOFRODS: Brought from rorserver's 'logger.h'
-enum LogLevel {
-    LOG_STACK = 0,
-    LOG_DEBUG,
-    LOG_VERBOSE,
-    LOG_INFO,
-    LOG_WARN,
-    LOG_ERROR,
-    LOG_NONE
-};
-
-namespace Logger {
-
-    void Log(LogLevel level, const char *format, ...);
-
-    void Log(LogLevel level, std::string const& msg);
-}
-// END 'logger.h'
-
-// RIGSOFRODS: Brought from 'sequencer.h'
-// This is used to define who says it, when the server says something
-enum serverSayType {
-    FROM_SERVER = 0,
-    FROM_HOST,
-    FROM_MOTD,
-    FROM_RULES
-};
-
-enum broadcastType {
-// order: least restrictive to most restrictive!
-            BROADCAST_AUTO = -1,  // Do not edit the publishmode (for scripts only)
-    BROADCAST_ALL,        // broadcast to all clients including sender
-    BROADCAST_NORMAL,     // broadcast to all clients except sender
-    BROADCAST_AUTHED,     // broadcast to authed users (bots)
-    BROADCAST_BLOCK       // no broadcast
-};
-
-// constant for functions that receive an uid for sending something
-static const int TO_ALL = -1;
-
-struct ServerScriptClient { // Bare minimum from `class Client` in rorserver.
-    RoRnet::UserInfo user;  //!< user information
-};
-// END 'sequencer.h'
-
-// RIGSOFRODS: From 'config.h'
-enum ServerType {
-    SERVER_LAN = 0,
-    SERVER_INET,
-    SERVER_AUTO
-};
-// END 'config.h'
 
 class ServerScriptEngine {
 public:
@@ -119,7 +60,7 @@ public:
         STOP_REQUESTED
     };
 
-    ServerScriptEngine();
+    ServerScriptEngine(ServerScriptSequencer* sequencer);
 
     ~ServerScriptEngine();
 
@@ -132,7 +73,7 @@ public:
 
     void playerDeleted(int uid, int crash = 0);
 
-    void playerAdded(RoRnet::UserInfo& user); // RIGSOFRODS: Fills UID and color
+    void playerAdded(RoRnet::UserInfo& user);
 
     int streamAdded(int uid, RoRnet::StreamRegister *reg);
 
@@ -146,7 +87,7 @@ public:
      * - CURL_STATUS_SUCCESS: n1 = CURL return code, n2 = HTTP result code, message = payload as string
      * - CURL_STATUS_FAILURE: n1 = CURL return code, n2 = HTTP result code, message = CURL error string
      */
-    void curlStatus(RoRServerCurlStatusType type, int n1, int n2, std::string displayname, std::string message);
+    void curlStatus(ServerScriptCurlStatusType type, int n1, int n2, std::string displayname, std::string message);
 
     int frameStep(float dt);
 
@@ -215,11 +156,8 @@ public:
     void        StopTimerThread();
     ThreadState GetTimerThreadState();
 
-    // Sequencer context
-    unsigned int GetFreeUserId() { return m_free_user_id++; }
-    int GetFreePlayerColour();
-
 protected:
+    ServerScriptSequencer* seq;
     AngelScript::asIScriptEngine *engine;                //!< instance of the scripting engine
     AngelScript::asIScriptContext *context;              //!< context in which all scripting happens
     std::map<std::string, callbackList> callbacks; //!< A map containing the script callbacks by type.
@@ -228,11 +166,6 @@ protected:
     std::thread m_timer_thread;
     ThreadState m_timer_thread_state = ThreadState::NOT_RUNNING;
     std::mutex  m_timer_thread_mutex;
-
-    // Sequencer context
-    std::mutex m_clients_mutex;  //!< guards access to `m_clients` and execution of script callbacks.
-    std::vector<ServerScriptClient *> m_clients;
-    unsigned int m_free_user_id = 1;
 
     /**
      * This function initialzies the engine and registeres all types
@@ -246,14 +179,6 @@ protected:
      * @param param unkown?
      */
     void msgCallback(const AngelScript::asSMessageInfo *msg);
-
-    /**
-     * This function reads a file into the provided string.
-     * @param filename filename of the file that should be loaded into the script string
-     * @param script reference to a string where the contents of the file is written to
-     * @return 0 on success, everything else on error
-     */
-    int loadScriptFile(const char *fileName, std::string &script);
 
     /**
      * This callback gets called when an exception occurs in the script.
@@ -280,167 +205,6 @@ protected:
      */
     void TimerThreadMain();
 };
-
-class ServerScript {
-protected:
-    ServerScriptEngine *mse;              //!< local script engine pointer, used as proxy mostly
-
-public:
-    ServerScript(ServerScriptEngine *se);
-
-    ~ServerScript();
-
-    void log(std::string &msg);
-
-    void say(std::string &msg, int uid = -1, int type = 0);
-
-    void kick(int kuid, std::string &msg);
-
-    void ban(int kuid, std::string &msg);
-
-    bool unban(int kuid);
-
-    int playerChat(int uid, char *str);
-
-    std::string getServerTerrain();
-
-    int sendGameCommand(int uid, std::string cmd);
-
-    std::string getUserName(int uid);
-
-    void setUserName(int uid, const std::string &username);
-
-    std::string getUserAuth(int uid);
-
-    int getUserAuthRaw(int uid);
-
-    void setUserAuthRaw(int uid, int authmode);
-
-    int getUserColourNum(int uid);
-
-    void setUserColourNum(int uid, int num);
-
-    std::string getUserToken(int uid);
-
-    std::string getUserVersion(int uid);
-
-    std::string getUserIPAddress(int uid);
-
-    int getUserPosition(int uid, Ogre::Vector3 &v);
-
-    int getNumClients();
-
-    int getStartTime();
-
-    int getTime();
-
-    std::string get_version();
-
-    std::string get_asVersion();
-
-    std::string get_protocolVersion();
-
-    void setCallback(const std::string &type, const std::string &func, void *obj, int refTypeId);
-
-    void deleteCallback(const std::string &type, const std::string &func, void *obj, int refTypeId);
-
-    void throwException(const std::string &message);
-
-    unsigned int get_maxClients();
-
-    std::string get_serverName();
-
-    std::string get_IPAddr();
-
-    unsigned int get_listenPort();
-
-    int get_serverMode();
-
-    std::string get_owner();
-
-    std::string get_website();
-
-    std::string get_ircServ();
-
-    std::string get_voipServ();
-
-    int rangeRandomInt(int from, int to);
-
-    void broadcastUserInfo(int uid);
-
-    /**
-     * Launches a background task, use `curlStatus` callback to monitor progress and receive result.
-     * @param displayname The "correlation ID" - the label passed to the callback to identify the transfer.
-     * @remark Callback signature: `curlStatus(curlStatusType, int n1, int n2, string displayname, string message)`
-     * - CURL_STATUS_PROGRESS: n1 = bytes downloaded, n2 = total bytes, message = empty
-     * - CURL_STATUS_SUCCESS: n1 = CURL return code, n2 = HTTP result code, message = payload as string
-     * - CURL_STATUS_FAILURE: n1 = CURL return code, n2 = HTTP result code, message = CURL error string
-     */
-    void curlRequestAsync(std::string url, std::string displayname);
-};
-
-// RIGSOFRODS: from rorserver's 'ScriptFileSafe.h'
-// copied from the angelscript library and edited for use in Rigs of Rods Multiplayer Server ~ 01 Jan 2012
-// Copied from rorserver and modified to use `Ogre::DataStream` instead of `FILE*` ~ ohlidalp, 2026-07-17
-class ScriptFileSafe {
-public:
-    ScriptFileSafe();
-
-    void AddRef() const;
-
-    void Release() const;
-
-    // TODO: Implement the "r+", "w+" and "a+" modes
-    // mode = "r" -> open the file for reading
-    //        "w" -> open the file for writing (overwrites existing file)
-    //        "a" -> open the file for appending
-    int Open(const std::string &filename, const std::string &mode);
-
-    int Close();
-
-    int GetSize() const;
-
-    bool IsEOF() const;
-
-    // Reading
-    int ReadString(unsigned int length, std::string &str);
-
-    int ReadLine(std::string &str);
-
-    AngelScript::asINT64 ReadInt(AngelScript::asUINT bytes);
-
-    AngelScript::asQWORD ReadUInt(AngelScript::asUINT bytes);
-
-    float ReadFloat();
-
-    double ReadDouble();
-
-    // Writing
-    int WriteString(const std::string &str);
-
-    int WriteInt(AngelScript::asINT64 v, AngelScript::asUINT bytes);
-
-    int WriteUInt(AngelScript::asQWORD v, AngelScript::asUINT bytes);
-
-    int WriteFloat(float v);
-
-    int WriteDouble(double v);
-
-    // Cursor
-    int GetPos() const;
-
-    int SetPos(int pos);
-
-    int MovePos(int delta);
-
-protected:
-    ~ScriptFileSafe();
-
-    mutable int refCount;
-    Ogre::DataStreamPtr m_stream;
-};
-
-void RegisterScriptFile_Native(AngelScript::asIScriptEngine *engine);
 
 } // namespace RoR
 

--- a/source/main/scripting/server/ServerScriptFileSafe.cpp
+++ b/source/main/scripting/server/ServerScriptFileSafe.cpp
@@ -1,0 +1,390 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ServerScriptFileSafe.h"
+
+// RIGSOFRODS: from rorserver's 'ScriptFileSafe.cpp'
+
+#ifdef USE_ANGELSCRIPT
+
+using namespace RoR; // RIGSOFRODS
+using namespace AngelScript;
+
+ScriptFileSafe *ScriptFile_Factory() {
+    return new ScriptFileSafe();
+}
+
+void RoR::RegisterScriptFile_Native(asIScriptEngine *engine) {
+    int r;
+
+    r = engine->RegisterObjectType("file", 0, asOBJ_REF);
+    assert(r >= 0);
+    r = engine->RegisterObjectBehaviour("file", asBEHAVE_FACTORY, "file @f()", asFUNCTION(ScriptFile_Factory),
+                                        asCALL_CDECL);
+    assert(r >= 0);
+    r = engine->RegisterObjectBehaviour("file", asBEHAVE_ADDREF, "void f()", asMETHOD(ScriptFileSafe, AddRef),
+                                        asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectBehaviour("file", asBEHAVE_RELEASE, "void f()", asMETHOD(ScriptFileSafe, Release),
+                                        asCALL_THISCALL);
+    assert(r >= 0);
+
+    r = engine->RegisterObjectMethod("file", "int open(const string &in, const string &in)",
+                                     asMETHOD(ScriptFileSafe, Open), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int close()", asMETHOD(ScriptFileSafe, Close), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int getSize() const", asMETHOD(ScriptFileSafe, GetSize), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "bool isEndOfFile() const", asMETHOD(ScriptFileSafe, IsEOF),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int readString(uint, string &out)", asMETHOD(ScriptFileSafe, ReadString),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int readLine(string &out)", asMETHOD(ScriptFileSafe, ReadLine),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int64 readInt(uint)", asMETHOD(ScriptFileSafe, ReadInt), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "uint64 readUInt(uint)", asMETHOD(ScriptFileSafe, ReadUInt),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "float readFloat()", asMETHOD(ScriptFileSafe, ReadFloat), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "double readDouble()", asMETHOD(ScriptFileSafe, ReadDouble),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+
+    r = engine->RegisterObjectMethod("file", "int writeString(const string &in)", asMETHOD(ScriptFileSafe, WriteString),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int writeInt(int64, uint)", asMETHOD(ScriptFileSafe, WriteInt),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int writeUInt(uint64, uint)", asMETHOD(ScriptFileSafe, WriteUInt),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int writeFloat(float)", asMETHOD(ScriptFileSafe, WriteFloat),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int writeDouble(double)", asMETHOD(ScriptFileSafe, WriteDouble),
+                                     asCALL_THISCALL);
+    assert(r >= 0);
+
+    r = engine->RegisterObjectMethod("file", "int getPos() const", asMETHOD(ScriptFileSafe, GetPos), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int setPos(int)", asMETHOD(ScriptFileSafe, SetPos), asCALL_THISCALL);
+    assert(r >= 0);
+    r = engine->RegisterObjectMethod("file", "int movePos(int)", asMETHOD(ScriptFileSafe, MovePos), asCALL_THISCALL);
+    assert(r >= 0);
+
+    assert(r >= 0);
+}
+
+
+ScriptFileSafe::ScriptFileSafe() {
+    refCount = 1;
+}
+
+ScriptFileSafe::~ScriptFileSafe() {
+    Close();
+}
+
+void ScriptFileSafe::AddRef() const {
+    ++refCount;
+}
+
+void ScriptFileSafe::Release() const {
+    if (--refCount == 0)
+        delete this;
+}
+
+int ScriptFileSafe::Open(const std::string &filename, const std::string &mode) {
+    // Close the previously opened file handle
+    if (m_stream)
+        m_stream->close();
+
+    // Validate the mode
+    std::string m;
+#if AS_WRITE_OPS == 1
+    if (mode != "r" && mode != "w" && mode != "a")
+#else
+        if( mode != "r" )
+#endif
+        return -2;
+    else
+        m = mode;
+
+    // By default windows translates "\r\n" to "\n", but we want to read the file as-is.
+    m += "b";
+
+    std::string myFilename = filename;
+
+    // Remove the possible .asdata extension
+    if (myFilename.length() > 7 && myFilename.substr(myFilename.length() - 7, 7) == ".asdata")
+        myFilename = myFilename.substr(0, myFilename.length() - 7);
+
+    // Replace all forbidden characters in the filename	
+    std::string allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+    for (std::string::iterator it = myFilename.begin(); it < myFilename.end(); ++it) {
+        if (allowedChars.find(*it) == std::string::npos)
+            *it = '_';
+    }
+
+    // Open the file
+    try
+    {
+        m_stream = Ogre::ResourceGroupManager::getSingleton().openResource(myFilename, RGN_SERVER_SCRIPTS);
+    }
+    catch (...)
+    {
+        HandleGenericException("file.open()");
+        return -3;
+    }
+
+    return 0;
+}
+
+int ScriptFileSafe::Close() {
+    if (!m_stream)
+        return -1;
+
+    m_stream->close();
+    return 0;
+}
+
+int ScriptFileSafe::GetSize() const {
+    if (!m_stream)
+        return -1;
+
+    return m_stream->size();
+}
+
+int ScriptFileSafe::GetPos() const {
+    if (!m_stream)
+        return -1;
+
+    return m_stream->tell();
+}
+
+int ScriptFileSafe::SetPos(int pos) {
+    if (!m_stream)
+        return -1;
+
+    m_stream->seek(pos);
+
+    return 0;
+}
+
+int ScriptFileSafe::MovePos(int delta) {
+    if (!m_stream)
+        return -1;
+
+    m_stream->seek(m_stream->tell() + delta);
+
+    return 0;
+}
+
+int ScriptFileSafe::ReadString(unsigned int length, std::string &str) {
+    if (!m_stream)
+        return 0;
+
+    // Read the string
+    str.resize(length);
+    size_t size = (int)m_stream->read(&str[0], length);
+    str.resize(size);
+
+    return static_cast<int>(size);
+}
+
+int ScriptFileSafe::ReadLine(std::string &str) {
+    if (!m_stream)
+        return 0;
+
+    char buf[2000] = {};
+    size_t count = m_stream->readLine(buf, 2000);
+    str.assign(buf, count);
+
+    return static_cast<int>(count);
+}
+
+asINT64 ScriptFileSafe::ReadInt(asUINT bytes) {
+    if (!m_stream)
+        return 0;
+
+    if (bytes > 8) bytes = 8;
+    if (bytes == 0) return 0;
+
+    unsigned char buf[8];
+    size_t r = m_stream->read(buf, bytes);
+    if (r == 0) return 0;
+
+    asINT64 val = 0;
+
+        unsigned int n = 0;
+        for (; n < bytes; n++)
+            val |= asQWORD(buf[n]) << (n * 8);
+        if (buf[0] & 0x80)
+            for (; n < 8; n++)
+                val |= asQWORD(0xFF) << (n * 8);
+
+
+    return val;
+}
+
+asQWORD ScriptFileSafe::ReadUInt(asUINT bytes) {
+    if (!m_stream)
+        return 0;
+
+    if (bytes > 8) bytes = 8;
+    if (bytes == 0) return 0;
+
+    unsigned char buf[8];
+    size_t r = m_stream->read(buf, bytes);
+    if (r == 0) return 0;
+
+    asQWORD val = 0;
+
+        unsigned int n = 0;
+        for (; n < bytes; n++)
+            val |= asQWORD(buf[n]) << (n * 8);
+
+
+    return val;
+}
+
+float ScriptFileSafe::ReadFloat() {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[4];
+    size_t r = m_stream->read(buf, 4);
+    if (r == 0) return 0;
+
+    asUINT val = 0;
+
+        unsigned int n = 0;
+        for (; n < 4; n++)
+            val |= asUINT(buf[n]) << (n * 8);
+
+
+    return *reinterpret_cast<float *>(&val);
+}
+
+double ScriptFileSafe::ReadDouble() {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[8];
+    size_t r = m_stream->read(buf, 8);
+    if (r == 0) return 0;
+
+    asQWORD val = 0;
+
+        unsigned int n = 0;
+        for (; n < 8; n++)
+            val |= asQWORD(buf[n]) << (n * 8);
+
+
+    return *reinterpret_cast<double *>(&val);
+}
+
+bool ScriptFileSafe::IsEOF() const {
+    if (!m_stream)
+        return true;
+
+    return m_stream->eof();
+}
+
+int ScriptFileSafe::WriteString(const std::string &str) {
+    if (!m_stream)
+        return -1;
+
+    // Write the entire string
+    size_t r = m_stream->write(&str[0], str.length());
+    return int(r);
+}
+
+int ScriptFileSafe::WriteInt(asINT64 val, asUINT bytes) {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[8];
+
+        for (unsigned int n = 0; n < bytes; n++)
+            buf[n] = (val >> (n * 8)) & 0xFF;
+
+
+    size_t r = m_stream->write(&buf, bytes);
+    return int(r);
+}
+
+int ScriptFileSafe::WriteUInt(asQWORD val, asUINT bytes) {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[8];
+
+        for (unsigned int n = 0; n < bytes; n++)
+            buf[n] = (val >> (n * 8)) & 0xFF;
+
+
+    size_t r = m_stream->write(&buf, bytes);
+    return int(r);
+}
+
+int ScriptFileSafe::WriteFloat(float f) {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[4];
+    asUINT val = *reinterpret_cast<asUINT *>(&f);
+
+        for (unsigned int n = 0; n < 4; n++)
+            buf[n] = (val >> (n * 8)) & 0xFF;
+    
+
+    size_t r = m_stream->write(&buf, 4);
+    return int(r);
+}
+
+int ScriptFileSafe::WriteDouble(double d) {
+    if (!m_stream)
+        return 0;
+
+    unsigned char buf[8];
+    asQWORD val = *reinterpret_cast<asQWORD *>(&d);
+    
+        for (unsigned int n = 0; n < 8; n++)
+            buf[n] = (val >> (n * 8)) & 0xFF;
+    
+
+    size_t r = m_stream->write(&buf, 8);
+    return int(r);
+}
+
+#endif //USE_ANGELSCRIPT

--- a/source/main/scripting/server/ServerScriptFileSafe.h
+++ b/source/main/scripting/server/ServerScriptFileSafe.h
@@ -1,0 +1,97 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef USE_ANGELSCRIPT
+
+namespace RoR { // RIGSOFRODS
+
+// copied from the angelscript library and edited for use in Rigs of Rods Multiplayer Server ~ 01 Jan 2012
+// Copied from rorserver and modified to use `Ogre::DataStream` instead of `FILE*` ~ ohlidalp, 2026-07-17
+class ScriptFileSafe {
+public:
+    ScriptFileSafe();
+
+    void AddRef() const;
+
+    void Release() const;
+
+    // TODO: Implement the "r+", "w+" and "a+" modes
+    // mode = "r" -> open the file for reading
+    //        "w" -> open the file for writing (overwrites existing file)
+    //        "a" -> open the file for appending
+    int Open(const std::string &filename, const std::string &mode);
+
+    int Close();
+
+    int GetSize() const;
+
+    bool IsEOF() const;
+
+    // Reading
+    int ReadString(unsigned int length, std::string &str);
+
+    int ReadLine(std::string &str);
+
+    AngelScript::asINT64 ReadInt(AngelScript::asUINT bytes);
+
+    AngelScript::asQWORD ReadUInt(AngelScript::asUINT bytes);
+
+    float ReadFloat();
+
+    double ReadDouble();
+
+    // Writing
+    int WriteString(const std::string &str);
+
+    int WriteInt(AngelScript::asINT64 v, AngelScript::asUINT bytes);
+
+    int WriteUInt(AngelScript::asQWORD v, AngelScript::asUINT bytes);
+
+    int WriteFloat(float v);
+
+    int WriteDouble(double v);
+
+    // Cursor
+    int GetPos() const;
+
+    int SetPos(int pos);
+
+    int MovePos(int delta);
+
+protected:
+    ~ScriptFileSafe();
+
+    mutable int refCount;
+    Ogre::DataStreamPtr m_stream;
+};
+
+void RegisterScriptFile_Native(AngelScript::asIScriptEngine *engine);
+
+} // namespace RoR
+
+#endif // USE_ANGELSCRIPT

--- a/source/main/scripting/server/ServerScriptLogger.cpp
+++ b/source/main/scripting/server/ServerScriptLogger.cpp
@@ -1,0 +1,66 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_ANGELSCRIPT
+
+#include "ServerScriptLogger.h"
+
+#include "Application.h" // RIGSOFRODS: For App::sys_logs_dir
+#include "PlatformUtils.h" // RIGSOFRODS: For RoR::PathCombine
+
+using namespace RoR;
+
+static Ogre::Log* sServerLog = nullptr;
+
+void Init()
+{
+    if (!sServerLog)
+        sServerLog = Ogre::LogManager::getSingleton().createLog(RoR::PathCombine(App::sys_logs_dir->getStr(), "RoRServerScript.log"));
+}
+
+void Logger::Log(ServerLogLevel level, const char *format, ...)
+{
+    Init();
+    
+    // Format the message
+    const int BUF_LEN = 4000; // hard limit
+    char buffer[BUF_LEN] = {}; // zeroed memory
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buffer, BUF_LEN, format, args);
+    va_end(args);
+    // Log the message
+    sServerLog->logMessage(std::string(buffer));
+}
+
+void Logger::Log(ServerLogLevel level, std::string const& msg)
+{
+    Init();
+    
+    sServerLog->logMessage(msg);
+}
+
+#endif // USE_ANGELSCRIPT

--- a/source/main/scripting/server/ServerScriptLogger.h
+++ b/source/main/scripting/server/ServerScriptLogger.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// RIGSOFRODS: Brought from rorserver's 'logger.h'
+
+enum ServerLogLevel {
+    LOG_STACK = 0,
+    LOG_DEBUG,
+    LOG_VERBOSE,
+    LOG_INFO,
+    LOG_WARN,
+    LOG_ERROR,
+    LOG_NONE
+};
+
+namespace Logger {
+
+    void Log(ServerLogLevel level, const char *format, ...);
+
+    void Log(ServerLogLevel level, std::string const& msg);
+}
+

--- a/source/main/scripting/server/ServerScriptSequencer.cpp
+++ b/source/main/scripting/server/ServerScriptSequencer.cpp
@@ -59,6 +59,7 @@ int ServerScriptSequencer::Initialize(const std::string& script_filename) {
 
 void ServerScriptSequencer::Close() {
     // stop the script engine
+    m_script_engine->StopTimerThread();
     m_script_engine.reset();
     // delete all clients
     for (unsigned int i = 0; i < m_clients.size(); i++) {

--- a/source/main/scripting/server/ServerScriptSequencer.cpp
+++ b/source/main/scripting/server/ServerScriptSequencer.cpp
@@ -130,20 +130,16 @@ void ServerScriptSequencer::createClient(RoRnet::UserInfo& user) {
         }
     }
 
-    //okay, create the client slot
-    ServerScriptClient *to_add = new ServerScriptClient();
-    user.colournum = ServerScriptSequencer::GetFreePlayerColour();
-    user.authstatus = user.authstatus;
-    to_add->user = user;
-
     // assign unique userid
-    unsigned int client_id = m_free_user_id;
-    to_add->user.uniqueid = client_id;
-
-    // count up unique id
+    user.uniqueid = m_free_user_id;
     m_free_user_id++;
 
-    // add the client to the vector
+    // assign color
+    user.colournum = ServerScriptSequencer::GetFreePlayerColour();
+
+    //okay, create the client slot
+    ServerScriptClient *to_add = new ServerScriptClient();
+    to_add->user = user;
     m_clients.push_back(to_add);
 
     // Do script callback

--- a/source/main/scripting/server/ServerScriptSequencer.cpp
+++ b/source/main/scripting/server/ServerScriptSequencer.cpp
@@ -344,7 +344,7 @@ void ServerScriptSequencer::queueMessagePlayerChat(int uid, const std::string & 
 
     if (str == "!help") {
         serverSay(std::string("builtin commands:"), uid);
-        serverSay(std::string("!version, !list, !say, !kick"), uid);
+        serverSay(std::string("!help !version, !list, !say, !kick"), uid);
     }
 
     if (str == "!version") {; 

--- a/source/main/scripting/server/ServerScriptSequencer.cpp
+++ b/source/main/scripting/server/ServerScriptSequencer.cpp
@@ -1,0 +1,464 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ServerScriptSequencer.h"
+
+#include "ServerScriptLogger.h"
+#include "ServerScriptConfig.h"
+#include "ServerScriptEngine.h"
+#include "ScriptEngine.h" // RIGSOFRODS: for QueueStringForExecution()
+#include "Utils.h"
+
+#include <stdio.h>
+#include <time.h>
+#include <chrono>
+#include <string>
+#include <iostream>
+#include <stdexcept>
+#include <sstream>
+#include <memory>
+
+using namespace RoR;
+
+
+ServerScriptSequencer::ServerScriptSequencer() {
+    m_start_time = static_cast<int>(time(nullptr));
+}
+
+ServerScriptSequencer::~ServerScriptSequencer() {
+    this->Close();
+}
+
+int ServerScriptSequencer::Initialize(const std::string& script_filename) {
+    m_script_engine = std::unique_ptr<ServerScriptEngine>(new ServerScriptEngine(this));
+    return m_script_engine->loadScript(script_filename);
+}
+
+void ServerScriptSequencer::Close() {
+    // stop the script engine
+    m_script_engine.reset();
+    // delete all clients
+    for (unsigned int i = 0; i < m_clients.size(); i++) {
+        delete m_clients[i];
+    }
+    m_clients.clear();
+}
+
+bool ServerScriptSequencer::CheckNickIsUnique(std::string &nick) {
+    // WARNING: be sure that this is only called within a clients_mutex lock!
+
+    // check for duplicate names
+    for (unsigned int i = 0; i < m_clients.size(); i++) {
+        if (nick == SanitizeUtf8String(m_clients[i]->user.username)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+int ServerScriptSequencer::GetFreePlayerColour() {
+    // WARNING: be sure that this is only called within a clients_mutex lock!
+
+    int col = 0;
+    for (;;) // TODO: How many colors ARE there?
+    {
+        bool collision = false;
+        for (unsigned int i = 0; i < m_clients.size(); i++) {
+            if (m_clients[i]->user.colournum == col) {
+                collision = true;
+                break;
+            }
+        }
+        if (!collision) {
+            return col;
+        }
+        col++;
+    }
+}
+
+void ServerScriptSequencer::createClient(RoRnet::UserInfo& user) {
+    //we have a confirmed client that wants to play
+    //try to find a place for him
+    Logger::Log(LOG_DEBUG, "got instance in createClient()");
+
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
+	std::string nick = SanitizeUtf8String(user.username);
+
+    if (nick.empty())
+    {
+        nick = "Anonymous";
+        strncpy(user.username, nick.c_str(), RORNET_MAX_USERNAME_LEN - 1);
+    }
+    if (ServerScriptSequencer::CheckNickIsUnique(nick)) {
+        Logger::Log(LOG_WARN, std::string("found duplicate nick, getting new one: ") + nick);
+
+        // shorten username so the number will fit (only if its too long already)
+        std::string new_nick_base = nick.substr(0, RORNET_MAX_USERNAME_LEN - 4) + "-";
+
+        for (int i = 2; i < 99; i++) {
+            nick = new_nick_base + std::to_string(i);
+            if (!ServerScriptSequencer::CheckNickIsUnique(nick)) {
+                Logger::Log(LOG_WARN, std::string("New username was composed: ") + nick);
+                strncpy(user.username, nick.c_str(), RORNET_MAX_USERNAME_LEN - 1);
+                break;
+            }
+        }
+    }
+
+    //okay, create the client slot
+    ServerScriptClient *to_add = new ServerScriptClient();
+    user.colournum = ServerScriptSequencer::GetFreePlayerColour();
+    user.authstatus = user.authstatus;
+    to_add->user = user;
+
+    // assign unique userid
+    unsigned int client_id = m_free_user_id;
+    to_add->user.uniqueid = client_id;
+
+    // count up unique id
+    m_free_user_id++;
+
+    // add the client to the vector
+    m_clients.push_back(to_add);
+
+    // Do script callback
+#ifdef WITH_ANGELSCRIPT
+    if (m_script_engine != nullptr) {
+        m_script_engine->playerAdded(client_id);
+    }
+#endif //WITH_ANGELSCRIPT
+
+    // done!
+    Logger::Log(LOG_VERBOSE, "ServerScriptSequencer: New client added");
+}
+
+int ServerScriptSequencer::getNumClients() {
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+    return (int) m_clients.size();
+}
+
+void ServerScriptSequencer::QueueClientForDisconnect(int uid) {
+
+    ServerScriptClient *client = this->FindClientById(static_cast<unsigned int>(uid));
+    if (client == nullptr) {
+        Logger::Log(LOG_DEBUG,
+            "ServerScriptSequencer::QueueClientForDisconnect() Internal error, got non-existent user ID: %d", uid);
+        return;
+    }
+
+    // RIGSOFRODS: We always call 'playerDeleted' callback externally - even rorserver does it mostly so.
+
+    EraseIf(m_clients, [uid](ServerScriptClient* client) { return client->user.uniqueid == uid; });
+}
+
+void ServerScriptSequencer::sendGameCommand(int uid, std::string cmd) {
+    const char *data = cmd.c_str();
+    int size = cmd.size();
+
+    // RIGSOFRODS: only forward commands for the player, bots currently don't have any means to deal with them.
+
+    if (uid == TO_ALL || uid == App::GetNetwork()->GetLocalUserData().uniqueid)
+    {
+        App::GetScriptEngine()->queueStringForExecution(cmd);
+    }
+}
+
+// this does not lock the clients_mutex, make sure it is locked before hand
+// note: uid==-1==TO_ALL = broadcast your message to all players
+void ServerScriptSequencer::serverSay(std::string msg, int uid, int type) {
+    switch (type) {
+        case FROM_SERVER:
+            msg = std::string("SERVER: ") + msg;
+            break;
+
+        case FROM_HOST:
+            if (uid == -1) {
+                msg = std::string("Host(general): ") + msg;
+            } else {
+                msg = std::string("Host(private): ") + msg;
+            }
+            break;
+
+        case FROM_RULES:
+            msg = std::string("Rules: ") + msg;
+            break;
+
+        case FROM_MOTD:
+            msg = std::string("MOTD: ") + msg;
+            break;
+    }
+
+    std::string msg_valid = SanitizeUtf8String(msg);
+    auto itor = m_clients.begin();
+    auto endi = m_clients.end();
+    for (; itor != endi; ++itor) {
+        ServerScriptClient *client = *itor;
+        if ((uid == TO_ALL || ((int) client->user.uniqueid) == uid)) {
+            // RIGSOFRODS: for the local player (AUTH_ADMIN), just
+        }
+    }
+}
+
+bool ServerScriptSequencer::Kick(int kuid) {
+    ServerScriptClient *kicked_client = this->FindClientById(static_cast<unsigned int>(kuid));
+    if (kicked_client == nullptr) {
+        return false;
+    }
+
+    this->QueueClientForDisconnect(kicked_client->user.uniqueid);
+    return true;
+}
+
+// RIGSOFRODS: chops of `queueMessage()` in rorserver.
+
+void ServerScriptSequencer::queueMessageStreamRegister(int uid, RoRnet::StreamRegister *reg)
+{
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+    ServerScriptClient *client = this->FindClientById(static_cast<unsigned int>(uid));
+    if (client == nullptr) {
+        return;
+    }    
+    
+    int publishMode = BROADCAST_NORMAL;
+
+    // Do a script callback
+    if (m_script_engine) {
+        int scriptpub = m_script_engine->streamAdded(client->user.uniqueid, reg);
+
+        // We only support blocking and normal at the moment. Other modes are not supported.
+        switch (scriptpub) {
+            case BROADCAST_AUTO:
+                break;
+
+            case BROADCAST_BLOCK:
+                publishMode = BROADCAST_BLOCK;
+                break;
+
+            case BROADCAST_NORMAL:
+                publishMode = BROADCAST_NORMAL;
+                break;
+
+            default:
+                Logger::Log(LOG_ERROR, "Stream broadcasting mode not supported.");
+                break;
+        }
+    }
+
+    int streamid = reg->origin_streamid;
+    if (publishMode != BROADCAST_BLOCK) {
+        // Add the stream
+        reg->name[127] = 0;
+        Logger::Log(LOG_VERBOSE, " * new stream registered: %d:%d, type: %d, name: '%s', status: %d",
+                    client->user.uniqueid, streamid, reg->type, reg->name, reg->status);
+        client->streams[streamid] = *reg;
+    }
+    else
+    {
+        Logger::Log(LOG_INFO, " * stream reg blocked: %d:%d, type: %d, name: '%s', status: %d",
+                    client->user.uniqueid, streamid, reg->type, reg->name, reg->status);
+    }
+}
+
+void ServerScriptSequencer::queueMessageStreamUnregister(int uid, unsigned int streamid) {
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
+    ServerScriptClient *client = this->FindClientById(static_cast<unsigned int>(uid));
+    if (client == nullptr) {
+        return;
+    }
+    
+    int publishMode = BROADCAST_NORMAL;
+    
+    // Remove the stream
+    if (client->streams.erase(streamid) > 0) {
+        Logger::Log(LOG_VERBOSE, " * stream deregistered: %d:%d", client->user.uniqueid, streamid);
+        publishMode = BROADCAST_ALL;
+    }
+}
+
+void ServerScriptSequencer::queueMessageUserLeave(int uid) {
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
+    ServerScriptClient *client = this->FindClientById(static_cast<unsigned int>(uid));
+    if (client == nullptr) {
+        return;
+    }
+
+    int publishMode = BROADCAST_NORMAL;
+
+    // from client
+    Logger::Log(LOG_INFO, "User disconnects on request: " + SanitizeUtf8String(client->user.username));
+    QueueClientForDisconnect(client->user.uniqueid);
+    // RIGSOFRODS: RoRserver doesn't seem to invoke 'playerDeleted' on clean disconnect by player, but we do it for consistency.
+    m_script_engine->playerDeleted(client->user.uniqueid, 0);
+}
+
+void ServerScriptSequencer::queueMessagePlayerChat(int uid, const std::string & data) {
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
+    ServerScriptClient *client = this->FindClientById(static_cast<unsigned int>(uid));
+    if (client == nullptr) {
+        return;
+    }
+
+    int publishMode = BROADCAST_NORMAL;
+
+    std::string str = SanitizeUtf8String(data);
+    Logger::Log(LOG_INFO, "CHAT| %s: %s", SanitizeUtf8String(client->user.username).c_str(), str.c_str());
+
+    publishMode = BROADCAST_ALL;
+    if (str[0] == '!') {
+        publishMode = BROADCAST_BLOCK; // no broadcast of server commands!
+    }
+
+    // Script callback
+    if (m_script_engine) {
+        int scriptpub = m_script_engine->playerChat(client->user.uniqueid, str);
+        if (scriptpub != BROADCAST_AUTO) publishMode = scriptpub;
+    }
+
+    if (str == "!help") {
+        serverSay(std::string("builtin commands:"), uid);
+        serverSay(std::string("!version, !list, !say, !kick"), uid);
+    }
+
+    if (str == "!version") {; 
+        serverSay("Local script", uid);
+    } else if (str == "!list") {
+        if (client->user.authstatus & RoRnet::AUTH_MOD || client->user.authstatus & RoRnet::AUTH_ADMIN)
+        {
+            serverSay(std::string(" uid | auth   | nick   | ip"), uid);
+        }
+        else
+        {
+            serverSay(std::string(" uid | auth   | nick"), uid);
+        }
+
+        for (unsigned int i = 0; i < m_clients.size(); i++) {
+            if (i >= m_clients.size())
+                break;
+            char authst[10] = "";
+            if (m_clients[i]->user.authstatus & RoRnet::AUTH_ADMIN) strcat(authst, "A");
+            if (m_clients[i]->user.authstatus & RoRnet::AUTH_MOD) strcat(authst, "M");
+            if (m_clients[i]->user.authstatus & RoRnet::AUTH_RANKED) strcat(authst, "R");
+            if (m_clients[i]->user.authstatus & RoRnet::AUTH_BOT) strcat(authst, "B");
+            if (m_clients[i]->user.authstatus & RoRnet::AUTH_BANNED) strcat(authst, "X");\
+
+            char tmp2[256] = "";
+
+            sprintf(tmp2, "% 3d | %-6s | %-20s", m_clients[i]->user.uniqueid, authst,
+                    SanitizeUtf8String(m_clients[i]->user.username).c_str());
+            
+            serverSay(std::string(tmp2), uid);
+        }
+ 
+    } else if (str.substr(0, 6) == "!kick ") {
+        if (client->user.authstatus & RoRnet::AUTH_MOD || client->user.authstatus & RoRnet::AUTH_ADMIN) {
+            int kuid = -1;
+            char kickmsg_tmp[256] = "";
+            int res = sscanf(str.substr(6).c_str(), "%d %s", &kuid, kickmsg_tmp);
+            std::string kickMsg = std::string(kickmsg_tmp);
+            Ogre::StringUtil::trim(kickMsg);
+            if (res != 2 || kuid == -1 || !kickMsg.size()) {
+                serverSay(std::string("usage: !kick <uid> <message>"), uid);
+                serverSay(std::string("example: !kick 3 bye!"), uid);
+            } else {
+                bool kicked = Kick(kuid);
+                if (!kicked)
+                    serverSay(std::string("kick not successful: uid not found!"), uid);
+            }
+        } else {
+            // not allowed
+            serverSay(std::string("You are not authorized to kick people!"), uid);
+        }
+
+    } else if (str.substr(0, 5) == "!say ") {
+        if (client->user.authstatus & RoRnet::AUTH_MOD || client->user.authstatus & RoRnet::AUTH_ADMIN) {
+            int kuid = -2;
+            char saymsg_tmp[256] = "";
+            int res = sscanf(str.substr(5).c_str(), "%d %s", &kuid, saymsg_tmp);
+            std::string sayMsg = std::string(saymsg_tmp);
+            Ogre::StringUtil::trim(sayMsg);
+            if (res != 2 || kuid < -1 || !sayMsg.size()) {
+                serverSay(std::string("usage: !say <uid> <message> (use uid -1 for general broadcast)"), uid);
+                serverSay(std::string("example: !say 3 Wecome to this server!"), uid);
+            } else {
+                serverSay(sayMsg, kuid, FROM_HOST);
+            }
+
+        } else {
+            // not allowed
+            serverSay(std::string("You are not authorized to use this command!"), uid);
+        }
+    }
+}
+
+void ServerScriptSequencer::queueMessageGameCmd(int uid, const std::string & data) {
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+
+    ServerScriptClient *client = this->FindClientById(static_cast<unsigned int>(uid));
+    if (client == nullptr) {
+        return;
+    }
+
+    // script message
+    if (m_script_engine) m_script_engine->gameCmd(client->user.uniqueid, std::string(data));
+}
+
+int ServerScriptSequencer::getStartTime() {
+    return m_start_time;
+}
+
+ServerScriptClient *ServerScriptSequencer::getClient(int uid) {
+    return this->FindClientById(static_cast<unsigned int>(uid));
+}
+
+
+void ServerScriptSequencer::frameStepScripts(float dt)
+{
+
+    // All script callbacks must be invoked while clients-mutex is locked
+    std::lock_guard<std::mutex> scoped_lock(m_clients_mutex);
+    m_script_engine->frameStep(dt);
+
+}
+
+// clients_mutex needs to be locked wen calling this method
+// Invoked either from ServerScriptSequencer or ServerScript
+ServerScriptClient *ServerScriptSequencer::FindClientById(unsigned int client_id) {
+    auto itor = m_clients.begin();
+    auto endi = m_clients.end();
+    for (; itor != endi; ++itor) {
+        ServerScriptClient *client = *itor;
+        if (client->user.uniqueid == client_id) {
+            return client;
+        }
+    }
+    return nullptr;
+}
+

--- a/source/main/scripting/server/ServerScriptSequencer.h
+++ b/source/main/scripting/server/ServerScriptSequencer.h
@@ -1,0 +1,112 @@
+
+// =============================================================================
+// This file is adopted from rorserver at commit 4a7109ae2d9a081ccfdad8cc696dc54efe49acb3
+// Changes from the original are marked with "//RIGSOFRODS"
+// =============================================================================
+
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef USE_ANGELSCRIPT
+
+#include "ForwardDeclarations.h"
+
+#include <map>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include "angelscript.h"
+#include "RoRnet.h"
+
+namespace RoR { // RIGSOFRODS
+
+// This is used to define who says it, when the server says something
+enum serverSayType {
+    FROM_SERVER = 0,
+    FROM_HOST,
+    FROM_MOTD,
+    FROM_RULES
+};
+
+enum broadcastType {
+// order: least restrictive to most restrictive!
+    BROADCAST_AUTO = -1,  // Do not edit the publishmode (for scripts only)
+    BROADCAST_ALL,        // broadcast to all clients including sender
+    BROADCAST_NORMAL,     // broadcast to all clients except sender
+    BROADCAST_AUTHED,     // broadcast to authed users (bots)
+    BROADCAST_BLOCK       // no broadcast
+};
+
+// constant for functions that receive an uid for sending something
+static const int TO_ALL = -1;
+
+struct ServerScriptClient { // RIGSOFRODS: Bare minimum from `class Client` in rorserver.
+    RoRnet::UserInfo user;  //!< user information
+    std::map<unsigned int, RoRnet::StreamRegister> streams;
+};
+
+class ServerScriptSequencer // RIGSOFRODS: Bare minimum from `class Sequencer` in rorserver.
+{
+    friend class ServerScript;
+public:
+    ServerScriptSequencer();
+    ~ServerScriptSequencer();
+
+    int Initialize(const std::string& script_filename); // Creates scripting engine and loads the server script. Returns 0 on success.
+    bool IsRunning() { return m_script_engine != nullptr; }
+    void Close();
+
+    // Synchronized public interface
+    void createClient(RoRnet::UserInfo& user); // Performs the 'playerAdded' callback.
+    int getNumClients();
+    void frameStepScripts(float dt);
+    int getStartTime();
+
+    // RIGSOFRODS: chops of `queueMessage()` in rorserver.
+    void queueMessageStreamRegister(int uid, RoRnet::StreamRegister *reg);
+    void queueMessageStreamUnregister(int uid, unsigned int streamid);
+    void queueMessageUserLeave(int uid);
+    void queueMessagePlayerChat(int uid, const std::string & data);
+    void queueMessageGameCmd(int uid, const std::string & data);
+    
+private:
+    // Helpers (not thread safe - only call when clients-mutex is locked!)
+    ServerScriptClient*      FindClientById(unsigned int client_id);
+    ServerScriptClient*      getClient(int uid);
+    void                     QueueClientForDisconnect(int client_id); // RIGSOFRODS: We always call 'playerDeleted' callback externally - even rorserver does it mostly so.
+    void                     serverSay(std::string msg, int uid = -1, int type = 0);
+    void                     sendGameCommand(int uid, std::string cmd);
+    bool                     CheckNickIsUnique(std::string &nick);
+    int                      GetFreePlayerColour();
+    bool                     Kick(int to_kick_uid);
+
+    std::unique_ptr<ServerScriptEngine> m_script_engine;
+
+    std::mutex m_clients_mutex;  //!< guards access to `m_clients` and execution of script callbacks.
+    std::vector<ServerScriptClient *> m_clients;
+    unsigned int m_free_user_id = 1;
+    int m_start_time = 0;
+};
+
+} // namespace RoR
+
+#endif //USE_ANGELSCRIPT

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -120,6 +120,7 @@ void Console::cVarSetupBuiltins()
     App::sys_savegames_dir       = this->cVarCreate("sys_savegames_dir",       "",                           0);
     App::sys_screenshot_dir      = this->cVarCreate("sys_screenshot_dir",      "",                           0);
     App::sys_scripts_dir         = this->cVarCreate("sys_scripts_dir",         "",                           0);
+    App::sys_server_scripts_dir  = this->cVarCreate("sys_server_scripts_dir",  "",                           0);
     App::sys_projects_dir        = this->cVarCreate("sys_projects_dir",        "",                           0);
     App::sys_repo_attachments_dir= this->cVarCreate("sys_repo_attachments_dir","",                           0);
 

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -501,6 +501,39 @@ public:
     }
 };
 
+class UnloadServerScriptCmd : public ConsoleCmd
+{
+public:
+    UnloadServerScriptCmd() : ConsoleCmd("unloadserverscript", "", _L("Stops a running RoRServer script")) {}
+
+    void Run(Ogre::StringVector const& args) override
+    {
+        Str<200> reply;
+        reply << m_name << ": ";
+        Console::MessageType reply_type;
+
+#ifdef USE_ANGELSCRIPT
+        ServerScriptEngine::ThreadState thread_state = App::GetServerScriptEngine()->GetTimerThreadState();
+        if (thread_state != ServerScriptEngine::ThreadState::RUNNING)
+        {
+            reply_type = Console::CONSOLE_SYSTEM_ERROR;
+            reply << _L("Server script was not running.");
+        }
+        else
+        {
+            App::GetServerScriptEngine()->unloadScript();
+            reply_type = Console::CONSOLE_SYSTEM_REPLY;
+            reply << _L("Server script stopped.");
+        }
+#else
+        reply_type = Console::CONSOLE_SYSTEM_ERROR;
+        reply << _L("Scripting disabled in this build");
+#endif
+        
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, reply_type, reply.ToCStr());
+    }
+};
+
 // -------------------------------------------------------------------------------------
 // CVar (builtin) console commmands
 
@@ -735,6 +768,7 @@ void Console::regBuiltinCommands()
     cmd = new ClearCmd();                 m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new LoadScriptCmd();            m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new LoadServerScriptCmd();      m_commands.insert(std::make_pair(cmd->getName(), cmd));
+    cmd = new UnloadServerScriptCmd();    m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new SpeedOfSoundCmd();          m_commands.insert(std::make_pair(cmd->getName(), cmd));
     // CVars
     cmd = new SetCmd();                   m_commands.insert(std::make_pair(cmd->getName(), cmd));

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -478,6 +478,16 @@ public:
             reply_type = Console::CONSOLE_SYSTEM_ERROR;
             reply << _L("Missing parameter: ") << m_usage;
         }
+        else if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
+        {
+            reply_type = Console::CONSOLE_SYSTEM_ERROR;
+            reply << _L("Not allowed while connected to network.");
+        }
+        else if (App::GetServerScriptEngine()->GetTimerThreadState() == ServerScriptEngine::ThreadState::RUNNING)
+        {
+            reply_type = Console::CONSOLE_SYSTEM_ERROR;
+            reply << _L("Server script is already running.");
+        }
         else
         {
             int result = App::GetServerScriptEngine()->loadScript(args[1]);
@@ -488,6 +498,7 @@ public:
             }
             else
             {
+                App::mp_state->setVal(MpState::LOCAL_SCRIPT);
                 reply_type = Console::CONSOLE_SYSTEM_REPLY;
                 reply << fmt::format(_L("Server script '{}' started"), args[1]);
             }
@@ -513,8 +524,7 @@ public:
         Console::MessageType reply_type;
 
 #ifdef USE_ANGELSCRIPT
-        ServerScriptEngine::ThreadState thread_state = App::GetServerScriptEngine()->GetTimerThreadState();
-        if (thread_state != ServerScriptEngine::ThreadState::RUNNING)
+        if (App::GetServerScriptEngine()->GetTimerThreadState() != ServerScriptEngine::ThreadState::RUNNING)
         {
             reply_type = Console::CONSOLE_SYSTEM_ERROR;
             reply << _L("Server script was not running.");
@@ -522,6 +532,7 @@ public:
         else
         {
             App::GetServerScriptEngine()->unloadScript();
+            App::mp_state->setVal(MpState::DISABLED);
             reply_type = Console::CONSOLE_SYSTEM_REPLY;
             reply << _L("Server script stopped.");
         }

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -35,6 +35,7 @@
 #include "RoRnet.h"
 #include "RoRVersion.h"
 #include "ScriptEngine.h"
+#include "ServerScriptEngine.h"
 #include "Terrain.h"
 #include "TerrainObjectManager.h"
 #include "Utils.h"
@@ -460,6 +461,46 @@ public:
     }
 };
 
+class LoadServerScriptCmd : public ConsoleCmd
+{
+public:
+    LoadServerScriptCmd() : ConsoleCmd("loadserverscript", "[filename]", _L("Runs a RoRServer AngelScript file")) {}
+
+    void Run(Ogre::StringVector const& args) override
+    {
+        Str<200> reply;
+        reply << m_name << ": ";
+        Console::MessageType reply_type;
+
+#ifdef USE_ANGELSCRIPT
+        if (args.size() == 1)
+        {
+            reply_type = Console::CONSOLE_SYSTEM_ERROR;
+            reply << _L("Missing parameter: ") << m_usage;
+        }
+        else
+        {
+            int result = App::GetServerScriptEngine()->loadScript(args[1]);
+            if (result != 0)
+            {
+                reply_type = Console::CONSOLE_SYSTEM_ERROR;
+                reply << _L("Failed to load server script. See 'RoRServerScript.log'.");
+            }
+            else
+            {
+                reply_type = Console::CONSOLE_SYSTEM_REPLY;
+                reply << fmt::format(_L("Server script '{}' started"), args[1]);
+            }
+        }
+#else
+        reply_type = Console::CONSOLE_SYSTEM_ERROR;
+        reply << _L("Scripting disabled in this build");
+#endif
+        
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, reply_type, reply.ToCStr());
+    }
+};
+
 // -------------------------------------------------------------------------------------
 // CVar (builtin) console commmands
 
@@ -693,6 +734,7 @@ void Console::regBuiltinCommands()
     // Additions
     cmd = new ClearCmd();                 m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new LoadScriptCmd();            m_commands.insert(std::make_pair(cmd->getName(), cmd));
+    cmd = new LoadServerScriptCmd();      m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new SpeedOfSoundCmd();          m_commands.insert(std::make_pair(cmd->getName(), cmd));
     // CVars
     cmd = new SetCmd();                   m_commands.insert(std::make_pair(cmd->getName(), cmd));

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -483,14 +483,14 @@ public:
             reply_type = Console::CONSOLE_SYSTEM_ERROR;
             reply << _L("Not allowed while connected to network.");
         }
-        else if (App::GetServerScriptEngine()->GetTimerThreadState() == ServerScriptEngine::ThreadState::RUNNING)
+        else if (App::GetServerScript()->IsRunning())
         {
             reply_type = Console::CONSOLE_SYSTEM_ERROR;
             reply << _L("Server script is already running.");
         }
         else
         {
-            int result = App::GetServerScriptEngine()->loadScript(args[1]);
+            int result = App::GetServerScript()->Initialize(args[1]);
             if (result != 0)
             {
                 reply_type = Console::CONSOLE_SYSTEM_ERROR;
@@ -512,7 +512,7 @@ public:
                 strcpy(c.sessiontype, "normal");
                 c.authstatus = RoRnet::AUTH_ADMIN; // Register player as admin - serverscript engine assigns UID but doesn't do auth.
                 // Notify serverscript engine that player is added (assigns UID)
-                App::GetServerScriptEngine()->playerAdded(c);
+                App::GetServerScript()->createClient(c);
                 // Save user data locally to display in Player List UI.
                 App::GetNetwork()->SetLocalUserData(c);
                 // Refresh PlayerList UI to show local player.
@@ -543,14 +543,14 @@ public:
         Console::MessageType reply_type;
 
 #ifdef USE_ANGELSCRIPT
-        if (App::GetServerScriptEngine()->GetTimerThreadState() != ServerScriptEngine::ThreadState::RUNNING)
+        if (!App::GetServerScript()->IsRunning())
         {
             reply_type = Console::CONSOLE_SYSTEM_ERROR;
             reply << _L("Server script was not running.");
         }
         else
         {
-            App::GetServerScriptEngine()->unloadScript();
+            App::GetServerScript()->Close();
             App::mp_state->setVal(MpState::DISABLED);
             reply_type = Console::CONSOLE_SYSTEM_REPLY;
             reply << _L("Server script stopped.");

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -499,6 +499,25 @@ public:
             else
             {
                 App::mp_state->setVal(MpState::LOCAL_SCRIPT);
+
+                // Construct user credentials
+                RoRnet::UserInfo c;
+                memset(&c, 0, sizeof(RoRnet::UserInfo));
+                strncpy(c.username, App::mp_player_name->getStr().substr(0, RORNET_MAX_USERNAME_LEN).c_str(), RORNET_MAX_USERNAME_LEN);
+                strncpy(c.clientversion, ROR_VERSION_STRING, strnlen(ROR_VERSION_STRING, 25));
+                strncpy(c.clientname, "LocalPlayer", 10);
+                std::string language = App::app_language->getStr().substr(0, 2);
+                std::string country = App::app_country->getStr().substr(0, 2);
+                strncpy(c.language, (language + std::string("_") + country).c_str(), 5);
+                strcpy(c.sessiontype, "normal");
+                c.authstatus = RoRnet::AUTH_ADMIN; // Register player as admin - serverscript engine assigns UID but doesn't do auth.
+                // Notify serverscript engine that player is added (assigns UID)
+                App::GetServerScriptEngine()->playerAdded(c);
+                // Save user data locally to display in Player List UI.
+                App::GetNetwork()->SetLocalUserData(c);
+                // Refresh PlayerList UI to show local player.
+                App::GetGameContext()->PushMessage(Message(MSG_GUI_MP_CLIENTS_REFRESH));
+
                 reply_type = Console::CONSOLE_SYSTEM_REPLY;
                 reply << fmt::format(_L("Server script '{}' started"), args[1]);
             }


### PR DESCRIPTION
It's now possible to run server-side scripts (like https://github.com/RigsOfRods/RoRServerScripts) inside the client (without any modifications!). These scripts run in complete isolation from the game (no access to `game` global etc...). The server api (global object `server` and callbacks) is fully supported, except some things that aren't relevant here like `game.getServerIpAddress()`.

**No modifications to rorserver or rornet are needed.**

### Usage
Open ingame console and type `loadserverscript [filename]`. Server scripts only load from dedicated directory 'Documents\My Games\Rigs of Rods\server_scripts' to avoid any mixups with client scripts. Only one can run at a time. Logging is directed to separate file 'logs\RoRServerScript.log'.

### Motivation
I want to extend our race system to support racing against other players (when online) or bots (singleplayer), and, I want one generic code to handle both cases. I figured I can port the rorserver's script subsystem to the client and then create a server-only race supervisor script to cover both scenarios.

### Status
This code was tested to run the rorserver's example script, see https://github.com/RigsOfRods/ror-server/blob/master/contrib/example-script.as - It's richly commented to guide new users through the API.
I was also able to successfully load https://github.com/RigsOfRods/RoRServerScripts - Except for one complaint about `#include "utils"` instead of `#include "utils.as"` in gameScriptWrapper.as
Full documentation of the server API: https://developer.rigsofrods.org/d0/d8c/namespace_script2_server.html
Server callbacks docs: https://developer.rigsofrods.org/df/d6c/group___server2_script.html

Screenshot showing the rorserver example script running in main menu.
<img width="1215" height="481" alt="image" src="https://github.com/user-attachments/assets/7ab0f784-faa0-4efc-bb12-0cff9fa15551" />
