### PR TITLE
Race system rework: '.racetrack' files are now a standalone mod.

### DIFF
--- a/doc/angelscript/Script2Game/GameScriptClass.h
+++ b/doc/angelscript/Script2Game/GameScriptClass.h
@@ -441,7 +441,7 @@ public:
 	 * @param instanceName A unique name for this object (you can choose one, but make sure that you don't use the same name twice)
 	 * @param pos The position where the object should be spawned
 	 * @param rot The rotation in which the object should be spawned
-	 * @param eventhandler (Optional, default empty string) A name of a function that should be called when an eventbox is triggered (see .ODEF file format). <br> If empty, a function `defaultEventHandler()` is executed instead, see /resources/scripts/base.as. <br>OBSOLETE - Use `SE_EVENTBOX_ENTER` instead - it provides the same info plus ActorID.
+	 * @param eventhandler (Optional, default empty string) A name of a function that should be called when an eventbox is triggered (see .ODEF file format). <br> If empty, a function `defaultEventHandler()` is executed instead, see /resources/scripts/base.as. <br>A special value "!supress" prevents running the fallback handler ~ recommended if you rely on `SE_EVENTBOX_ENTER/EXIT` <br>THIS IS DEPRECATED - Use `SE_EVENTBOX_ENTER` instead - it provides the same info plus ActorID.
 	 * @param uniquifyMaterials (Optional, default false) Set this to true if you need to uniquify the materials
 	 */
 	void spawnObject(const string objectName, const string instanceName, vector3 pos, vector3 rot, const string &in eventhandler = "", bool uniquifyMaterials = false);

--- a/doc/angelscript/Script2Game/GameScriptClass.h
+++ b/doc/angelscript/Script2Game/GameScriptClass.h
@@ -441,10 +441,10 @@ public:
 	 * @param instanceName A unique name for this object (you can choose one, but make sure that you don't use the same name twice)
 	 * @param pos The position where the object should be spawned
 	 * @param rot The rotation in which the object should be spawned
-	 * @param eventhandler A name of a function that should be called when an event happens (events, as defined in the object definition file). Enter empty string to ignore events.
-	 * @param uniquifyMaterials Set this to true if you need to uniquify the materials
+	 * @param eventhandler (Optional, default empty string) A name of a function that should be called when an eventbox is triggered (see .ODEF file format). <br> If empty, a function `defaultEventHandler()` is executed instead, see /resources/scripts/base.as. <br>OBSOLETE - Use `SE_EVENTBOX_ENTER` instead - it provides the same info plus ActorID.
+	 * @param uniquifyMaterials (Optional, default false) Set this to true if you need to uniquify the materials
 	 */
-	void spawnObject(const string objectName, const string instanceName, vector3 pos, vector3 rot, const string eventhandler, bool uniquifyMaterials);
+	void spawnObject(const string objectName, const string instanceName, vector3 pos, vector3 rot, const string &in eventhandler = "", bool uniquifyMaterials = false);
     
 	/**
 	 * This moves an object to a new position

--- a/doc/angelscript/Script2Game/enums/TokenType.h
+++ b/doc/angelscript/Script2Game/enums/TokenType.h
@@ -19,13 +19,13 @@ namespace Script2Game {
 enum TokenType
 {
     TOKEN_TYPE_NONE,
-    TOKEN_TYPE_LINEBREAK,
-    TOKEN_TYPE_COMMENT,
-    TOKEN_TYPE_STRING,
-    TOKEN_TYPE_FLOAT,
-	TOKEN_TYPE_INT,
-    TOKEN_TYPE_BOOL,
-    TOKEN_TYPE_KEYWORD
+    TOKEN_TYPE_LINEBREAK,    //!< Input: LF (CR is ignored); Output: platform-specific.
+    TOKEN_TYPE_COMMENT,      //!< Line starting with ; (skipping whitespace).
+    TOKEN_TYPE_STRING,       //!< Quoted string.
+    TOKEN_TYPE_FLOAT,        //!< Numbers with or without a decimal point.
+    TOKEN_TYPE_INT,          //!< Only numbers without decimal point.
+    TOKEN_TYPE_BOOL,         //!< Lowercase 'true'/'false'.
+    TOKEN_TYPE_KEYWORD,      //!< Unquoted string at start of line (skipping whitespace).
 };
 
 } // namespace Script2Game

--- a/doc/angelscript/Script2Game/enums/genericGamestateNotificationType.h
+++ b/doc/angelscript/Script2Game/enums/genericGamestateNotificationType.h
@@ -1,0 +1,27 @@
+
+  // =================================================== //
+  // THIS IS NOT A C++ HEADER! Only a dummy for Doxygen. //
+  // =================================================== //
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Game
+ *  @{
+ */   
+
+namespace Script2Game {
+
+/// Argument $1 of script event `RoR::SE_GENERIC_GAMESTATE_NOTIFICATION`
+enum genericGamestateNotificationType
+{
+    GAMESTATE_NOTIFICATION_NONE = 0,
+    GAMESTATE_RACETRACK_LOAD_REQUESTED,       //!< Instructs race manager (TERRAIN script) to load a '.racetrack' mod; args: $5 mission filename, $6 mission rg name
+    GAMESTATE_RACETRACK_UNLOAD_REQUESTED,     //!< Instructs race manager to unload race; args: $2 raceID
+};
+
+} // namespace Script2Game
+
+/// @}    //addtogroup Script2Game
+/// @}    //addtogroup ScriptSideAPIs

--- a/doc/angelscript/Script2Game/enums/scriptEvents.h
+++ b/doc/angelscript/Script2Game/enums/scriptEvents.h
@@ -51,6 +51,8 @@ namespace Script2Game {
     SE_GENERIC_MODCACHE_ACTIVITY,       //!< Triggered when status of modcache changes,<br> args:<br> #1 type,<br> #2 entry number,<br> for other args see `RoR::modCacheActivityType`  
 
     SE_GENERIC_TRUCK_LINKING_CHANGED,   //!< Triggered when 2 actors become linked or unlinked via ties/hooks/ropes/slidenodes;<br> args:<br> #1 state (1=linked, 0=unlinked),<br> #2 action `ActorLinkingRequestType`<br> #3 master ActorInstanceID_t,<br> #4 slave ActorInstanceID_t
+    SE_GENERIC_FREEFORCES_ACTIVITY,     //!< Triggered on freeforce add/update/delete or breaking; args: #1 `freeForcesActivityType`, #2 freeforce ID
+    SE_GENERIC_GAMESTATE_NOTIFICATION,  //!< Triggered by various game state changes; args: #1 `RoR::genericGamestateNotificationType`
 
  	SE_ALL_EVENTS                      = 0xffffffff,
     SE_NO_EVENTS                       = 0

--- a/doc/angelscript/Script2Game/enums/truckTypes.h
+++ b/doc/angelscript/Script2Game/enums/truckTypes.h
@@ -23,7 +23,7 @@ enum truckTypes
     TT_AIRPLANE,
     TT_BOAT,
     TT_MACHINE,
-    TT_AI,
+    // TT_AI ~ replaced by checking if `BeamClass::getVehicleAI()` returns a valid object.
 }
 
 } // namespace Script2Game

--- a/doc/angelscript/Script2Server/GenericDocContextClass.h
+++ b/doc/angelscript/Script2Server/GenericDocContextClass.h
@@ -1,0 +1,68 @@
+namespace Script2Server {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Server
+ *  @{
+ */
+
+/**
+ * @brief Binding of RoR::GenericDocContext; Traverses document tokens; See 'demo_script.as' for an example.
+ */
+class GenericDocContextClass
+{
+    // PLEASE maintain the same order as in 'GenericFileFormat.h' and 'GenericFileFormatAngelscript.cpp'
+    
+    GenericDocContext(GenericDocument@ d);
+
+    bool moveNext();
+    uint getPos();
+    bool seekNextLine();
+    int countLineArgs();
+    bool endOfFile(int offset = 0);
+    TokenType tokenType(int offset = 0);
+
+    string getTokString(int offset = 0);
+    float getTokFloat(int offset = 0);
+    float getTokInt(int offset = 0);
+    bool gettokBool(int offset = 0);
+    string getTokKeyword(int offset = 0);
+    string getTokComment(int offset = 0);
+
+    bool isTokString(int offset = 0);
+    bool isTokFloat(int offset = 0);
+    bool isTokInt(int offset = 0);
+    bool isTokBool(int offset = 0);
+    bool isTokKeyword(int offset = 0);
+    bool isTokComment(int offset = 0);
+    bool isTokLineBreak(int offset = 0);
+    
+    // Editing functions:
+
+    void appendTokens(int count); //!< Appends a series of `TokenType::NONE` and sets Pos at the first one added; use `setTok*` functions to fill them.
+    bool insertToken(int offset = 0); //!< Inserts `TokenType::NONE`; @return false if offset is beyond EOF
+    bool eraseToken(int offset = 0); //!< @return false if offset is beyond EOF
+    
+    void appendTokString(const string&in str);
+    void appendTokFloat(float val);
+    void appendTokInt(float val);
+    void appendTokBool(bool val);
+    void appendTokKeyword(const string&in str);
+    void appendTokComment(const string&in str);
+    void appendTokLineBreak();    
+
+    bool setTokString(int offset, const string&in str);
+    bool setTokFloat(int offset, float val);
+    bool setTokInt(int offset, int val);
+    bool setTokBool(int offset, bool val);
+    bool setTokKeyword(int offset, const string&in str);
+    bool setTokComment(int offset, const string&in str);
+    bool setTokLineBreak(int offset);
+};
+
+/// @}    //addtogroup Script2Server
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Server

--- a/doc/angelscript/Script2Server/GenericDocContextClass.h
+++ b/doc/angelscript/Script2Server/GenericDocContextClass.h
@@ -9,7 +9,7 @@ namespace Script2Server {
  */
 
 /**
- * @brief Binding of RoR::GenericDocContext; Traverses document tokens; See 'demo_script.as' for an example.
+ * @brief Binding of GenericDocContext; Traverses document tokens; See rorserver's 'example-script.as' for an example.
  */
 class GenericDocContextClass
 {

--- a/doc/angelscript/Script2Server/GenericDocumentClass.h
+++ b/doc/angelscript/Script2Server/GenericDocumentClass.h
@@ -1,0 +1,30 @@
+namespace Script2Server {
+
+/** \addtogroup ScriptSideAPIs
+ *  @{
+ */    
+
+/** \addtogroup Script2Server
+ *  @{
+ */   
+
+/**
+ * @brief Binding of RoR::GenericDocument; Parses TRUCK/TOBJ/ODEF/CHARACTER file formats.
+ */
+class GenericDocumentClass
+{
+    /**
+    * Loads and parses a document from dedicated server script directory.
+    */
+    bool loadFromFile(string filename, int options = 0);
+    
+    /**
+    * Saves the document to dedicated server script directory.
+    */
+    bool saveToFile(string filename);
+};
+
+/// @}    //addtogroup Script2Server
+/// @}    //addtogroup ScriptSideAPIs
+
+} //namespace Script2Server

--- a/doc/angelscript/Script2Server/globals.h
+++ b/doc/angelscript/Script2Server/globals.h
@@ -61,6 +61,33 @@ namespace Script2Server
         CURL_STATUS_SUCCESS,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = received payload.
         CURL_STATUS_FAILURE,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = CURL error string.
     };
+    
+    /**
+    * For use with Script2Server::GenericDocContextClass
+    */
+    enum TokenType
+    {
+        TOKEN_TYPE_NONE,
+        TOKEN_TYPE_LINEBREAK,    //!< Input: LF (CR is ignored); Output: platform-specific.
+        TOKEN_TYPE_COMMENT,      //!< Line starting with ; (skipping whitespace).
+        TOKEN_TYPE_STRING,       //!< Quoted string.
+        TOKEN_TYPE_FLOAT,        //!< Numbers with or without a decimal point.
+        TOKEN_TYPE_INT,          //!< Only numbers without decimal point.
+        TOKEN_TYPE_BOOL,         //!< Lowercase 'true'/'false'.
+        TOKEN_TYPE_KEYWORD,      //!< Unquoted string at start of line (skipping whitespace).
+    };
+    
+    enum GenericDocumentOptions
+    {
+        GENERIC_DOCUMENT_OPTION_ALLOW_NAKED_STRINGS, //!< Allow strings without quotes, for backwards compatibility.
+        GENERIC_DOCUMENT_OPTION_ALLOW_SLASH_COMMENTS, //!< Allow comments starting with `//`. 
+        GENERIC_DOCUMENT_OPTION_FIRST_LINE_IS_TITLE, //!< First non-empty & non-comment line is a naked string with spaces. 
+        GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_COLON, //!< Allow ':' as separator between tokens.
+        GENERIC_DOCUMENT_OPTION_PARENTHESES_CAPTURE_SPACES, //!< If non-empty NAKED string encounters '(', following spaces will be captured until matching ')' is found.    
+        GENERIC_DOCUMENT_OPTION_ALLOW_BRACED_KEYWORDS, //!< Allow INI-like '[keyword]' tokens.
+        GENERIC_DOCUMENT_OPTION_ALLOW_SEPARATOR_EQUALS, //!< Allow '=' as separator between tokens.
+        GENERIC_DOCUMENT_OPTION_ALLOW_HASH_COMMENTS //!< Allow comments starting with `#`.     
+    };
 
 } // namespace Script2Server
 

--- a/resources/scripts/races.as
+++ b/resources/scripts/races.as
@@ -165,7 +165,7 @@ shared class racesManager {
 		game.registerForEvent(SE_TRUCK_EXIT);
 		game.registerForEvent(SE_TRUCK_RESET);
 		game.registerForEvent(SE_TRUCK_TELEPORT);
-        game.registerForEvent(SE_TRUCK_MOUSE_GRAB);
+		game.registerForEvent(SE_TRUCK_MOUSE_GRAB);
 		game.registerForEvent(SE_GENERIC_DELETED_TRUCK);
 		game.registerForEvent(SE_ANGELSCRIPT_MANIPULATIONS);
 
@@ -177,7 +177,11 @@ shared class racesManager {
 		{
 			if( game.scriptFunctionExists("void eventCallback(int, int)")<0)
 			{
-				game.addScriptFunction("void eventCallback(int key, int value) { races.eventCallback(key, value); }");
+				int res = game.addScriptFunction("void eventCallback(int key, int value) { races.eventCallback(key, value); }");
+				if (res < 0)
+				{
+					game.log("Error in racesManager: could not set up `eventCallback(int, int)` (error code:"+res+"), races will not work.");
+				}
 			}
 		}
 

--- a/resources/scripts/races.as
+++ b/resources/scripts/races.as
@@ -1115,8 +1115,8 @@ shared class racesManager {
 		// dict.set("rotation", vector3(rot));
 		dict.set("callback", @callback);
 		this.callbacks.set("race_cancel_"+cancelPointCount, dict);
-		// Note: Param 'event handler' intentionally omitted - we now use `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
-		game.spawnObject(objName, "race_cancel_"+cancelPointCount, pos, rot);
+		// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
+		game.spawnObject(objName, "race_cancel_"+cancelPointCount, pos, rot, "!supress");
 	}
 	void addCancelPoint(int raceID, const string &in objName, const double[] &in v, RACE_EVENT_CALLBACK @callback)
 	{
@@ -1131,8 +1131,8 @@ shared class racesManager {
 		// dict.set("rotation", vector3(rot));
 		dict.set("callback", null);
 		this.callbacks.set("race_cancel_"+cancelPointCount, dict);
-		// Note: Param 'event handler' intentionally omitted - we now use `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
-		game.spawnObject(objName, "race_cancel_"+cancelPointCount, pos, rot);
+		// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
+		game.spawnObject(objName, "race_cancel_"+cancelPointCount, pos, rot, "!supress");
 	}
 	void addCancelPoint(int raceID, const string &in objName, const double[] &in v)
 	{
@@ -1464,8 +1464,8 @@ shared class raceBuilder {
 		this.objNames[number][this.chpInstances[number]] = objName;
 		if( not this.hidden )
 		{
-			// Note: Param 'event handler' intentionally omitted - we now use `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
-			game.spawnObject(objName, "checkpoint|"+this.id+"|"+number+"|"+this.chpInstances[number]++, vector3(v[0], v[1], v[2]), vector3(v[3], v[4], v[5]));
+			// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
+			game.spawnObject(objName, "checkpoint|"+this.id+"|"+number+"|"+this.chpInstances[number]++, vector3(v[0], v[1], v[2]), vector3(v[3], v[4], v[5]), "!supress");
 		}
 	}
 
@@ -1593,8 +1593,9 @@ shared class raceBuilder {
 		{
 			for( int k = 0; k < this.chpInstances[i]; k++ )
 			{
-				// Note: Param 'event handler' intentionally omitted - we now use `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
-				game.spawnObject(objNames[i][k], "checkpoint|"+this.id+"|"+i+"|"+k, vector3(this.checkpoints[i][k][0], this.checkpoints[i][k][1], this.checkpoints[i][k][2]), vector3(this.checkpoints[i][k][3], this.checkpoints[i][k][4], this.checkpoints[i][k][5]));
+				array<double>@ v = this.checkpoints[i][k];
+				// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
+				game.spawnObject(objNames[i][k], "checkpoint|"+this.id+"|"+i+"|"+k, vector3(v[0], v[1], v[2]), vector3(v[3], v[4], v[5]), "!supress");
 			}
 		}
 	}

--- a/resources/scripts/races.as
+++ b/resources/scripts/races.as
@@ -34,6 +34,22 @@ raceBuilder::raceBuilderVersion)
 
 #include "genericdoc_utils.as"
 
+/*
+Following are dev notes from 2023's mission system project.
+This involved thorough study of the existing logic, as original devs are no longer on the project.
+
+Terminology:
+- Instance name = unique label assigned to whole object in .TOBJ file or `game.spawnObject()` call.
+- Box name = desired operation type specified as `event <boxname> [<filter>]` for each box in .ODEF file.
+
+Instance name schemes = their meaning:
+- "checkpoint|$RaceID|$ChpNumber|$SplitTrailNumber"   = Start/Checkpoint/Finish. Use `races.addCheckpoint()` to create.
+- "race_abort|$RaceID(-1 = any race)|$ChpNumber(??)"  = Abort point (box name must be 'race_abort'). Cannot be added via `races` :(
+- "race_cancel|$RaceID(-1 = any race)|$UniqueNum"     = Abort point (box name doesn't matter). Use `races.addCancelPoint()` to create.
+- "race_penalty|$RaceID(-1 = any race)|$ChpNumber(??) = Time penalization. Cannot be added via `races` :(
+
+*/
+
 // Define a function signature for the callback pointers
 funcdef void RACE_EVENT_CALLBACK(dictionary@);
 
@@ -112,7 +128,7 @@ shared class racesManager {
 
 		// we initialize the callbacks dictionary
 		this.callbacks.set("RaceFinish", null); // when a race was finished
-		this.callbacks.set("RaceCancel", null); // when a race was canceled
+		this.callbacks.set("RaceCancel", null); // when a race was canceled by any means (race_abort box or forbidden user action)
 		this.callbacks.set("RaceStart",  null); // when a race starts
 		this.callbacks.set("AdvanceLap", null); // when a lap is done, but not when the race is done
 		this.callbacks.set("Checkpoint", null); // when a checkpoint is taken (excluding start and finish)
@@ -902,8 +918,8 @@ shared class racesManager {
 			newBestRace = false;
 	}
 
-    // Backwards compatible with former `eventCallback(int eventnum, int value)`
-    // see docs at https://developer.rigsofrods.org/d3/d68/namespace_script2_game.html#a366408518753189dc7895f392b6ce8e6 ~ ohlidalp, 01/2016
+	// Backwards compatible with former `eventCallback(int eventnum, int value)`
+	// see docs at https://developer.rigsofrods.org/d3/d68/namespace_script2_game.html#a366408518753189dc7895f392b6ce8e6 ~ ohlidalp, 01/2016
 	void eventCallback(int eventnum,  int value,int arg2=0,int arg3=0,int arg4=0,  string arg5="",string arg6="",string arg7="",string arg8="")
 	{
 		//debug: game.log("raceManager::eventCallback("+eventnum+",   "+value+", "+arg2+", "+arg3+", "+arg4+",   "+arg5+", "+arg6+", "+arg7+", "+arg8+") called");
@@ -965,7 +981,11 @@ shared class racesManager {
 			}
 			else if (instName.findFirst('race_cancel_') == 0)
 			{
-				this.raceCancelPointHandler(trigger_type, instName, boxName, nodeID);
+				// We've hit an event box added via `races.addCancelPoint()`.
+				// It works exactly like a "race_abort" event box, except the box name (specified as `event` in .ODEF file) can be anything.
+				// This is required for backwards compatibility with older terrains.
+				// (For example: Auriga Proving Grounds uses event box named "checkpoint", see '31-trigger10x10.odef').
+				this.raceCancelPointHandler(trigger_type, instName, "race_abort", nodeID);
 			}
 		}
 	}
@@ -1103,71 +1123,34 @@ shared class racesManager {
 		this.raceList[raceID].deleteCheckpoint(number, instance);
 	}
 
-	// if the user comes in this event box, the current race will be cancelled
-	// example usage: if the users drives off the track
-	// (race will be stopped)
-	void addCancelPoint(int raceID, const string &in objName, const vector3 &in pos, const vector3 &in rot, RACE_EVENT_CALLBACK @callback)
+	// if the user comes in this event box, the current race will be cancelled.
+	// The `raceID` parameter can be -1 to abort any race or an existing raceID to abort only that.
+	// The optional callback parameter will be set as "AbortEvent" callback.
+	void addCancelPoint(int raceID, const string &in objName, const vector3 &in pos, const vector3 &in rot, RACE_EVENT_CALLBACK @callback = null)
 	{
-		dictionary dict;
-		dict.set("raceID", raceID);
-		dict.set("oname", ""+objName);
-		// dict.set("position", vector3(pos));
-		// dict.set("rotation", vector3(rot));
-		dict.set("callback", @callback);
-		this.callbacks.set("race_cancel_"+cancelPointCount, dict);
-		// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
-		game.spawnObject(objName, "race_cancel_"+cancelPointCount, pos, rot, "!supress");
+		if (@callback != null)
+			this.setCallback("AbortEvent", callback);
+
+		// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2026
+		game.spawnObject(objName, "race_cancel|"+raceID+"|-1|"+cancelPointCount++, pos, rot, "!supress");
+
 	}
-	void addCancelPoint(int raceID, const string &in objName, const double[] &in v, RACE_EVENT_CALLBACK @callback)
+
+	// Convenience overload with pos+rot specified as double[]
+	void addCancelPoint(int raceID, const string &in objName, const double[] &in v, RACE_EVENT_CALLBACK @callback = null)
 	{
 		addCancelPoint(raceID, objName, vector3(v[0], v[1], v[2]), vector3(v[3], v[4], v[5]), @callback);
 	}
-	void addCancelPoint(int raceID, const string &in objName, const vector3 &in pos, const vector3 &in rot)
-	{
-		dictionary dict;
-		dict.set("raceID", raceID);
-		dict.set("oname", ""+objName);
-		// dict.set("position", vector3(pos));
-		// dict.set("rotation", vector3(rot));
-		dict.set("callback", null);
-		this.callbacks.set("race_cancel_"+cancelPointCount, dict);
-		// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
-		game.spawnObject(objName, "race_cancel_"+cancelPointCount, pos, rot, "!supress");
-	}
-	void addCancelPoint(int raceID, const string &in objName, const double[] &in v)
-	{
-		addCancelPoint(raceID, objName, vector3(v[0], v[1], v[2]), vector3(v[3], v[4], v[5]));
-	}
 
+
+	// Special callback, invoked from event boxes added via `races.addCancelPoint()`.
+	// It works exactly like a "race_abort" event box, except the box name (specified as `event` in .ODEF file) can be anything.
+	// This is required for backwards compatibility with older terrains.
+	// (For example: Auriga Proving Grounds uses event box named "checkpoint", see '31-trigger10x10.odef').
 	void raceCancelPointHandler(int trigger_type, const string &in inst, const string &in box, int nodeid)
 	{
-		if( this.state == this.STATE_NotInRace )
-			return;
-
-		dictionary dict;
-		if( not this.callbacks.get(inst, dict) )
-			return;
-
-		int raceID;
-		dict.get("raceID", raceID);
-		if( raceID != -1 and this.currentRace != raceID )
-			return;
-
-		this.cancelCurrentRace();
-
-		// call the callback function
-		RACE_EVENT_CALLBACK @handle;
-		if( dict.get("callback", @handle) and not (handle is null) )
-		{
-			dictionary args;
-			args.set("event", "cancel_point");
-			args.set("raceID", this.currentRace);
-			args.set("inst", ""+inst);
-			args.set("trigger_type", trigger_type);
-			args.set("box", ""+box);
-			args.set("nodeid", nodeid);
-			handle(args);
-		}
+		game.log("DBG raceManager.raceCancelPointHandler() called; trigger:"+trigger_type+", inst:"+inst+", box:"+box+", nodeid:"+nodeid);
+		this.raceEvent(trigger_type, inst, "race_abort", nodeid);
 	}
 
 	void recalcArrow()

--- a/resources/scripts/races.as
+++ b/resources/scripts/races.as
@@ -942,7 +942,7 @@ shared class racesManager {
 	}
 
 	// Backwards compatible with former `eventCallback(int eventnum, int value)`
-	// see docs at https://developer.rigsofrods.org/d3/d68/namespace_script2_game.html#a366408518753189dc7895f392b6ce8e6 ~ ohlidalp, 01/2016
+	// see docs at https://developer.rigsofrods.org/d3/d68/namespace_script2_game.html#a366408518753189dc7895f392b6ce8e6 ~ ohlidalp, 01/2026
 	void eventCallback(int eventnum,  int value,int arg2=0,int arg3=0,int arg4=0,  string arg5="",string arg6="",string arg7="",string arg8="")
 	{
 		//debug: game.log("raceManager::eventCallback("+eventnum+",   "+value+", "+arg2+", "+arg3+", "+arg4+",   "+arg5+", "+arg6+", "+arg7+", "+arg8+") called");
@@ -1480,7 +1480,7 @@ shared class raceBuilder {
 		this.objNames[number][this.chpInstances[number]] = objName;
 		if( not this.hidden )
 		{
-			// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
+			// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2026
 			game.spawnObject(objName, "checkpoint|"+this.id+"|"+number+"|"+this.chpInstances[number]++, vector3(v[0], v[1], v[2]), vector3(v[3], v[4], v[5]), "!supress");
 		}
 	}
@@ -1610,7 +1610,7 @@ shared class raceBuilder {
 			for( int k = 0; k < this.chpInstances[i]; k++ )
 			{
 				array<double>@ v = this.checkpoints[i][k];
-				// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2016
+				// Note: The '!supress' constant prevents invoking default handler ~ we rely exclusively on `SE_EVENTBOX_ENTER` ~ ohlidalp, 01/2026
 				game.spawnObject(objNames[i][k], "checkpoint|"+this.id+"|"+i+"|"+k, vector3(v[0], v[1], v[2]), vector3(v[3], v[4], v[5]), "!supress");
 			}
 		}

--- a/resources/scripts/races.as
+++ b/resources/scripts/races.as
@@ -33,6 +33,7 @@ raceBuilder::raceBuilderVersion)
 */
 
 #include "genericdoc_utils.as"
+#include "road_utils.as"
 
 /*
 Following are dev notes from 2023's mission system project.
@@ -75,7 +76,7 @@ shared class racesManager {
 	bool showTimeDiff      = true;  // if true: Show + or - <best time minus current time> when passing a checkpoint.
 	bool showBestLap       = true;  // if true: If a race is started or a new best lap is set, the best lap will be shown
 	bool showBestRace      = true;  // if true: If a race is started or a new best race is set, the best race will be shown
-	bool submitScore       = true; // if true: If the user has a new best lap or new best race, this is submitted to the master server.
+	bool submitScore       = true;  // if true: If the user has a new best lap or new best race, this is submitted to the master server.
 	bool silentMode        = false; // if true: No messages will be shown
 	bool allowVehicleChanging = false; // if false: if the user changes vehicle, the race will be aborted.
 	bool abortOnVehicleExit = false;  // if true: if the user exits his vehicle, the race will be aborted
@@ -119,7 +120,7 @@ shared class racesManager {
 	array<raceBuilder@> raceList;
 	dictionary callbacks;
 	LocalStorageClass@ raceDataFile;
-	array<int> penaltyTime;	
+	array<int> penaltyTime;
 
 // public functions
 
@@ -148,6 +149,7 @@ shared class racesManager {
 		game.registerForEvent(SE_TRUCK_MOUSE_GRAB);
 		game.registerForEvent(SE_GENERIC_DELETED_TRUCK);
 		game.registerForEvent(SE_ANGELSCRIPT_MANIPULATIONS);
+		game.registerForEvent(SE_GENERIC_GAMESTATE_NOTIFICATION);
 
 		// add the eventcallback method if it doesn't exist
 		// ^ but only if loaded from terrain script, not i.e. terrain_project_importer
@@ -189,6 +191,7 @@ shared class racesManager {
 
 		GenericDocContextClass@ ctx = GenericDocContextClass(doc);
 		bool inCheckpoints = false;
+		bool inProceduralRoad = false;
 		array<uint> checkpointTokPositions; // We must pre-count checkpoints to pick finish-obj correctly.
 		int highestCheckpointNum = 0; // Multiple finish lines are supported!
 		while (!ctx.endOfFile())
@@ -224,6 +227,22 @@ shared class racesManager {
 				else if (ctx.getTokKeyword() == "end_checkpoints")
 				{
 					inCheckpoints = false;
+				}
+				else if (ctx.getTokKeyword() == "begin_procedural_roads")
+				{
+					inProceduralRoad = true;
+				}
+				else if (ctx.getTokKeyword() == "end_procedural_roads")
+				{
+					inProceduralRoad = false;
+				}
+			}
+			else if (inProceduralRoad)
+			{
+				ProceduralObjectClass@ road = road_utils::ParseProceduralRoadFromFile(ctx);
+				if (@road != null) // Errors already logged
+				{
+					this.raceList[raceID].proceduralRoads.insertLast(road);
 				}
 			}
 			else if (inCheckpoints)
@@ -281,6 +300,9 @@ shared class racesManager {
 			const double[] v = { ctx.getTokFloat(2), ctx.getTokFloat(3), ctx.getTokFloat(4), ctx.getTokFloat(5), ctx.getTokFloat(6), ctx.getTokFloat(7) };
 			this.raceList[raceID].addCheckpoint(ctx.getTokInt(0)-1, objName, v);
 		}
+
+		// Build procedural roads
+		this.raceList[raceID].buildProceduralRoads();
 
 		return highestCheckpointNum;
 	}
@@ -839,6 +861,7 @@ shared class racesManager {
 	{
 		this.raceList[raceID].bestLapTime = time;
 	}
+
 	void setBestRaceTime(int raceID, double time)
 	{
 		this.raceList[raceID].bestRaceTime = time;
@@ -923,11 +946,20 @@ shared class racesManager {
 	void eventCallback(int eventnum,  int value,int arg2=0,int arg3=0,int arg4=0,  string arg5="",string arg6="",string arg7="",string arg8="")
 	{
 		//debug: game.log("raceManager::eventCallback("+eventnum+",   "+value+", "+arg2+", "+arg3+", "+arg4+",   "+arg5+", "+arg6+", "+arg7+", "+arg8+") called");
-
 		if( eventnum != SE_EVENTBOX_ENTER && this.state != this.STATE_Racing )
+		{
+			if( eventnum == SE_GENERIC_GAMESTATE_NOTIFICATION && value == GAMESTATE_RACETRACK_LOAD_REQUESTED )
+			{
+				game.log("[Race system] Loading racetrack '" + arg5 + "'");
+				this.addRaceFromDefinitionFile(arg5, arg6);
+			}
+			else if( eventnum == SE_GENERIC_GAMESTATE_NOTIFICATION && value == GAMESTATE_RACETRACK_UNLOAD_REQUESTED )
+			{
+				this.deleteRace(arg2);
+			}
 			return;
+		}
 
-		// this never gets called
 		if( eventnum == SE_TRUCK_EXIT )
 		{
 			if( this.abortOnVehicleExit )
@@ -1286,6 +1318,7 @@ shared class raceBuilder {
 	string raceName;
 	double[][][] checkpoints;
 	array<array<string>> objNames;
+	array<ProceduralObjectClass@> proceduralRoads;
 	int checkPointsCount;
 	int id;
 	double bestLapTime;
@@ -1661,6 +1694,16 @@ shared class raceBuilder {
 			p2 = tmp.findFirst(";", p1+1);
 			bestTimeTillPoint[i] = parseFloat(tmp.substr(p1+1, p2-p1-1));
 			p1 = p2;
+		}
+	}
+	
+	void buildProceduralRoads()
+	{
+		TerrainClass@ terrain = game.getTerrain();
+		ProceduralManagerClass@ roadManager = terrain.getProceduralManager();
+		for (uint i = 0; i < this.proceduralRoads.length(); i++)
+		{
+			roadManager.addObject(this.proceduralRoads[i]);
 		}
 	}
 }

--- a/resources/scripts/races.as
+++ b/resources/scripts/races.as
@@ -200,23 +200,23 @@ shared class racesManager {
 
 			if (ctx.isTokKeyword(0))
 			{
-				if (ctx.isTokString(1) && ctx.getTokKeyword() == "race_name")
+				if (ctx.isTokString(1) && ctx.getTokKeyword() == "racetrack_name")
 				{
 					this.raceList[raceID].raceName = ctx.getTokString(1);
 				}
-				if (ctx.isTokInt(1) && ctx.getTokKeyword() == "race_laps")
+				if (ctx.isTokInt(1) && ctx.getTokKeyword() == "racetrack_laps")
 				{
 					this.raceList[raceID].setLaps(ctx.getTokInt(1));
 				}
-				else if (ctx.isTokString(1) && ctx.getTokKeyword() == "race_checkpoint_object")
+				else if (ctx.isTokString(1) && ctx.getTokKeyword() == "racetrack_checkpoint_object")
 				{
 					this.raceList[raceID].objNameCheckpoint = ctx.getTokString(1);
 				}
-				else if (ctx.isTokString(1) && ctx.getTokKeyword() == "race_start_object")
+				else if (ctx.isTokString(1) && ctx.getTokKeyword() == "racetrack_start_object")
 				{
 					this.raceList[raceID].objNameStart = ctx.getTokString(1);
 				}
-				else if (ctx.isTokString(1) && ctx.getTokKeyword() == "race_finish_object")
+				else if (ctx.isTokString(1) && ctx.getTokKeyword() == "racetrack_finish_object")
 				{
 					this.raceList[raceID].objNameFinish = ctx.getTokString(1);
 				}

--- a/resources/scripts/road_utils.as
+++ b/resources/scripts/road_utils.as
@@ -1,0 +1,124 @@
+/*
+* Helpers for working with procedural roads
+* See https://docs.rigsofrods.org/terrain-creation/terrn2-subsystem/#procedural-roads
+* The objects used are defined by the game API:
+* - `ProceduralObjectClass` - https://developer.rigsofrods.org/df/d88/class_script2_game_1_1_procedural_object_class.html
+* - `ProceduralPointClass` - https://developer.rigsofrods.org/df/d16/struct_script2_game_1_1_procedural_point_class.html
+*/
+
+// By convention, all includes have filename '*_utils' and namespace matching filename.
+namespace road_utils
+{
+    /**
+    * Parses a procedural road from TOBJ or MISSION file.
+    * @param reader Must be positioned on the 'begin_procedural_roads' keyword, otherwise function returns null and leaves reader unchanged.
+    * @return on success, returns the road and leaves reader on 'end_procedural_road'. On unexpected end-of-file, returns null and leaves reader at the end-of-file.
+    */
+    shared ProceduralObjectClass@ ParseProceduralRoadFromFile(GenericDocContextClass@ reader)
+    {
+        if (reader.isTokKeyword() && reader.getTokKeyword() == "begin_procedural_roads")
+        {
+            ProceduralObjectClass@ road = ProceduralObjectClass();
+            reader.seekNextLine();
+            while (!reader.endOfFile() && (reader.tokenType() != TOKEN_TYPE_KEYWORD || reader.getTokKeyword() != "end_procedural_roads"))
+            {
+                if ((reader.tokenType() == TOKEN_TYPE_KEYWORD) 
+                    && (reader.getTokKeyword() == "smoothing_num_splits"))
+                {
+                    road.smoothing_num_splits = reader.getTokInt(1);
+                }
+                else
+                {
+                    ProceduralPointClass@ point = ParseProceduralPointLine(reader);
+                    if (@point != null)
+                    {
+                        road.addPoint(point);
+                    }
+                    else
+                    {
+                        game.log("ParseProceduralRoadFromFile(): Warning - skipping bad procedural point line");
+                    }
+                }
+                
+                reader.seekNextLine();
+            }
+            
+            // Finalize
+            if (!reader.endOfFile())
+            {
+                return road;
+            }
+            else
+            {
+                game.log("ParseProceduralRoadFromFile(): Fatal error - unexpected end of file");
+            }
+        }
+        else
+        {
+            game.log("ParseProceduralRoadFromFile(): Fatal error - no 'begin_procedural_roads'");
+        }
+        return null;
+    }
+
+    /**
+    * Parses one line from procedural road definition in TOBJ/MISSION file.
+    * @param reader Must be positioned at the start of the line.
+    * @return null if the line could not be parsed (bad syntax or unexpected end-of-file).
+    */
+    shared ProceduralPointClass@ ParseProceduralPointLine(GenericDocContextClass@ reader)
+    {
+        if ( //Syntax: 'position x,y,z rotation rx,ry,rz, width, border width, border height, type'
+               (reader.tokenType(0) == TOKEN_TYPE_FLOAT)  // x
+            && (reader.tokenType(1) == TOKEN_TYPE_FLOAT)  // y
+            && (reader.tokenType(2) == TOKEN_TYPE_FLOAT)  // z
+            && (reader.tokenType(3) == TOKEN_TYPE_FLOAT)  // rx
+            && (reader.tokenType(4) == TOKEN_TYPE_FLOAT)  // ry
+            && (reader.tokenType(5) == TOKEN_TYPE_FLOAT)  // rz
+            && (reader.tokenType(6) == TOKEN_TYPE_FLOAT)  // width
+            && (reader.tokenType(7) == TOKEN_TYPE_FLOAT)  // border width
+            && (reader.tokenType(8) == TOKEN_TYPE_FLOAT)  // border height
+            && (reader.tokenType(9) == TOKEN_TYPE_STRING) // type
+            )
+        {
+            ProceduralPointClass@ point = ProceduralPointClass();
+            
+            point.position.x = reader.getTokFloat(0);
+            point.position.y = reader.getTokFloat(1);
+            point.position.z = reader.getTokFloat(2);
+            
+            vector3 rot;
+            rot.x = reader.getTokFloat(3);
+            rot.y = reader.getTokFloat(4);
+            rot.z = reader.getTokFloat(5);
+            point.rotation = CalcProceduralPointRotation(rot);        
+            
+            point.width = reader.getTokFloat(6);
+            point.border_width = reader.getTokFloat(7);
+            point.border_height = reader.getTokFloat(8);
+            
+            // See `TObjParser::ProcessProceduralLine()` - https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/resources/tobj_fileformat/TObjFileFormat.cpp#L201-L224
+            string typeStr = reader.getTokString(9);
+                 if (typeStr == "flat"             ) { point.type = ROAD_FLAT;  }
+            else if (typeStr == "left"             ) { point.type = ROAD_LEFT;  }
+            else if (typeStr == "right"            ) { point.type = ROAD_RIGHT; }
+            else if (typeStr == "both"             ) { point.type = ROAD_BOTH;  }
+            else if (typeStr == "bridge"           ) { point.type = ROAD_BRIDGE;    point.pillar_type = 1; }
+            else if (typeStr == "monorail"         ) { point.type = ROAD_MONORAIL;  point.pillar_type = 2; }
+            else if (typeStr == "monorail2"        ) { point.type = ROAD_MONORAIL;  point.pillar_type = 0; }
+            else if (typeStr == "bridge_no_pillars") { point.type = ROAD_BRIDGE;    point.pillar_type = 0; }
+            else                                     { point.type = ROAD_AUTOMATIC; point.pillar_type = 0; }
+            
+            return point;
+        }
+        return null;
+    }
+
+    shared quaternion CalcProceduralPointRotation(vector3 rot)
+    {
+        // See `TOBjParser::CalcRotation` - https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/resources/tobj_fileformat/TObjFileFormat.cpp#L344-L349
+        return quaternion(degree(rot.x).valueRadians(), vector3(1,0,0))
+             * quaternion(degree(rot.y).valueRadians(), vector3(0,1,0))
+             * quaternion(degree(rot.z).valueRadians(), vector3(0,0,1));    
+    }
+
+} // namespace road_utils

--- a/resources/scripts/terrain_project_importer.as
+++ b/resources/scripts/terrain_project_importer.as
@@ -1,7 +1,7 @@
 /// \title terrn2 project importer & race converter
-/// \brief imports races from scripts and generates race-def files.
+/// \brief imports races from scripts and generates '.racetrack' files.
 /// uses new section in terrn2 format: [Races]
-/// ^ each line is a tobj-like file with any extension (i.e. *.race) which is loaded by the race system.
+/// ^ each line is a tobj-like file with any extension (i.e. *.racetrack) which is loaded by the race system.
 ///
 /// The program flow of this script got a little crazy, see `enum Stage`
 /// ^ I wanted a fluidly updating UI, performing just one step (1 doc conversion / 1 file write) per frame.
@@ -320,7 +320,7 @@ bool convertNextRace()
         if (@convertedRaces[i] == null)
         {
             @convertedRaces[i] = convertSingleRace(races.raceList[i]);
-            convertedRaceFileNames[i] = generateSafeFileName(races.raceList[i].raceName + ".race");
+            convertedRaceFileNames[i] = generateSafeFileName(races.raceList[i].raceName + ".racetrack");
             return true;
         }
     }
@@ -347,8 +347,8 @@ GenericDocumentClass@ convertSingleRace(raceBuilder@ race)
     GenericDocumentClass doc;
     GenericDocContextClass ctx(doc);
 
-    ctx.appendTokComment( " ~~ New 'race-def' format (file extension: .race). ~~");ctx.appendTokLineBreak();
-    ctx.appendTokComment( " Each race file specifies a single race");ctx.appendTokLineBreak();
+    ctx.appendTokComment( " ~~ New '.racetrack' format (file extension: .racetrack). ~~");ctx.appendTokLineBreak();
+    ctx.appendTokComment( " Each file specifies a single race track.");ctx.appendTokLineBreak();
     ctx.appendTokComment( " In .terrn2 file, list the race files under new section [Races]");ctx.appendTokLineBreak();
     ctx.appendTokComment( " Filenames must include extension and end with = (like scripts do)");ctx.appendTokLineBreak();
     ctx.appendTokComment( " Race system supports branching/joining paths!");ctx.appendTokLineBreak();
@@ -356,11 +356,11 @@ GenericDocumentClass@ convertSingleRace(raceBuilder@ race)
     ctx.appendTokComment( " By convention, the checkpoint meshes are oriented sideways (facing X axis)");ctx.appendTokLineBreak();
     ctx.appendTokLineBreak();
 
-    appendKeyValuePair(ctx, "race_name", race.raceName);
-    appendKeyValuePair(ctx, "race_laps", race.laps);
-    appendKeyValuePair(ctx, "race_checkpoint_object", race.objNameCheckpoint);
-    appendKeyValuePair(ctx, "race_start_object", race.objNameStart);
-    appendKeyValuePair(ctx, "race_finish_object", race.objNameFinish);
+    appendKeyValuePair(ctx, "racetrack_name", race.raceName);
+    appendKeyValuePair(ctx, "racetrack_laps", race.laps);
+    appendKeyValuePair(ctx, "racetrack_checkpoint_object", race.objNameCheckpoint);
+    appendKeyValuePair(ctx, "racetrack_start_object", race.objNameStart);
+    appendKeyValuePair(ctx, "racetrack_finish_object", race.objNameFinish);
 
     ctx.appendTokLineBreak();
 

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -477,12 +477,13 @@ enum LoaderType //!< Search mode for `ModCache::Query()` & Operation mode for `G
     LT_Load,      // Script "load",      ext: load
     LT_Extension, // Script "extension", ext: trailer load
     LT_Skin,      // No script alias, invoked automatically
-    LT_AllBeam,   // Invocable from GUI; Script "all",  ext: truck car boat airplane train load
+    LT_AllBeam,   // Invocable from GUI; Script "all",  ext: truck car boat airplane train load trailer
     LT_AddonPart, // No script alias, invoked manually, ext: addonpart
     LT_Tuneup,    // No script alias, invoked manually, ext: tuneup
     LT_AssetPack, // No script alias, invoked manually, ext: assetpack
     LT_DashBoard, // No script alias, invoked manually, ext: dashboard
     LT_Gadget,    // No script alias, invoked manually, ext: gadget
+    LT_RaceTrack, // No script alias, invoked manually, ext: racetrack
 };
 
 enum CacheCategoryId

--- a/source/main/ForwardDeclarations.h
+++ b/source/main/ForwardDeclarations.h
@@ -99,6 +99,10 @@ namespace RoR
     typedef int RepoFileInstallRequestID_t; //!< Unique sequentially generated ID of a repository item installation request; use `GUI::RepositorySelector::GetNextInstallRequestId()`.
     static const RepoFileInstallRequestID_t REPOFILEINSTALLREQUESTID_INVALID = -1; //!< Invalid ID for repository item installation request.
 
+    typedef int EvHandlerFuncID_t; //!< AngelScript function ID (positive) a constant below.
+    static const EvHandlerFuncID_t EVHANDLERFUNCID_INVALID = -1; //!< Invalid ID, a fallback `defaultEventHandler()` will be used (backwards compatibility).
+    static const EvHandlerFuncID_t EVHANDLERFUNCID_SUPRESS = -2; //!< Invalid ID, no event handler will be invoked (standard scriptEvent `SE_EVENTBOX_ENTER/EXIT` can be used instead).
+
     class  Actor;
     class  ActorManager;
     class  ActorSpawner;

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -187,6 +187,26 @@ void GameContext::UnloadTerrain()
     }
 }
 
+bool GameContext::LoadRaceTrack(std::string const& filename_part)
+{
+    // Find terrain in modcache
+    CacheEntryPtr race_entry = App::GetCacheSystem()->FindEntryByFilename(LT_RaceTrack, /*partial=*/true, filename_part);
+    if (!race_entry)
+    {
+        Str<200> msg; msg << _L("Race track not found: ") << filename_part;
+        RoR::Log(msg.ToCStr());
+        return false;
+    }
+
+    // Init resources
+    App::GetCacheSystem()->LoadResource(race_entry);
+
+    // Request race system to load the race
+    TRIGGER_EVENT_ASYNC(SE_GENERIC_GAMESTATE_NOTIFICATION,
+        GAMESTATE_RACETRACK_LOAD_REQUESTED, 0, 0, 0, race_entry->fname, race_entry->resource_group);
+    return true;
+}
+
 // --------------------------------
 // Actors (physics and netcode)
 

--- a/source/main/GameContext.cpp
+++ b/source/main/GameContext.cpp
@@ -332,7 +332,9 @@ ActorPtr GameContext::SpawnActor(ActorSpawnRequest& rq)
     }
     else if (rq.asr_origin == ActorSpawnRequest::Origin::AI)
     {
-        fresh_actor->ar_driveable = AI;
+#ifdef USE_ANGELSCRIPT
+        fresh_actor->ar_vehicle_ai = new VehicleAI(fresh_actor);
+#endif // USE_ANGELSCRIPT
         fresh_actor->ar_state = ActorState::LOCAL_SIMULATED;
 
         if (fresh_actor->ar_engine)
@@ -1134,7 +1136,7 @@ void GameContext::UpdateSimInputEvents(float dt)
         {
             if (this->GetPlayerActor()->ar_nodes[0].Velocity.squaredLength() < 1.0f ||
                 this->GetPlayerActor()->ar_state == ActorState::NETWORKED_OK || this->GetPlayerActor()->ar_state == ActorState::NETWORKED_HIDDEN ||
-                this->GetPlayerActor()->ar_driveable == AI)
+                this->GetPlayerActor()->ar_vehicle_ai)
             {
                 this->PushMessage(Message(MSG_SIM_SEAT_PLAYER_REQUESTED, static_cast<void*>(new ActorPtr())));
             }
@@ -1541,7 +1543,7 @@ void GameContext::UpdateCommonInputEvents(float dt, ActorPtr actor)
     // enter/exit truck - Without a delay: the vehicle must brake like braking normally
     if (actor->getEventBoolValue(EV_COMMON_ENTER_OR_EXIT_TRUCK))
     {
-        if (actor->ar_driveable != AI)
+        if (!actor->ar_vehicle_ai)
         {
             actor->ar_brake = 0.66f;
         }

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -168,6 +168,7 @@ public:
     /// @{
 
     RaceSystem&         GetRaceSystem() { return m_race_system; }
+    void                ResetRaceSystem() { m_race_system = RaceSystem(); }
     RepairMode&         GetRepairMode() { return m_recovery_mode; }
     SceneMouse&         GetSceneMouse() { return m_scene_mouse; }
     void                TeleportPlayer(float x, float z);

--- a/source/main/GameContext.h
+++ b/source/main/GameContext.h
@@ -115,6 +115,7 @@ public:
     bool                LoadTerrain(std::string const& filename_part);
     void                UnloadTerrain();
     const TerrainPtr&   GetTerrain() { return m_terrain; }
+    bool                LoadRaceTrack(std::string const& filename_part);
 
     /// @}
     /// @name Actors

--- a/source/main/gameplay/RaceSystem.cpp
+++ b/source/main/gameplay/RaceSystem.cpp
@@ -60,9 +60,3 @@ float RaceSystem::GetRaceTime() const
 {
     return App::GetGameContext()->GetActorManager()->GetTotalTime() - m_race_start_time;
 }
-
-void RaceSystem::ResetRaceUI()
-{
-    this->StopRaceTimer();
-    this->UpdateDirectionArrow(nullptr, Ogre::Vector3::ZERO); // hide arrow
-}

--- a/source/main/gameplay/RaceSystem.h
+++ b/source/main/gameplay/RaceSystem.h
@@ -36,7 +36,6 @@ public:
     bool                IsRaceInProgress() const { return m_race_id != -1; }
     int                 GetRaceId() const { return m_race_id; }
     float               GetRaceTime() const;
-    void                ResetRaceUI();
 
     void                SetRaceTimeDiff(float diff) { m_race_time_diff = diff; };
     float               GetRaceTimeDiff() const { return m_race_time_diff; };

--- a/source/main/gameplay/ScriptEvents.h
+++ b/source/main/gameplay/ScriptEvents.h
@@ -62,6 +62,7 @@ enum scriptEvents
     SE_GENERIC_MODCACHE_ACTIVITY       = BITMASK(25), //!< Triggered when status of modcache changes, args: #1 type, #2 entry number, for other args see `RoR::modCacheActivityType`
     SE_GENERIC_TRUCK_LINKING_CHANGED   = BITMASK(26), //!< Triggered when 2 actors become linked or unlinked via ties/hooks/ropes/slidenodes; args: #1 state (1=linked, 0=unlinked), #2 action `ActorLinkingRequestType` #3 master ActorInstanceID_t, #4 slave ActorInstanceID_t
     SE_GENERIC_FREEFORCES_ACTIVITY     = BITMASK(27), //!< Triggered on freeforce add/update/delete or breaking; args: #1 `freeForcesActivityType`, #2 freeforce ID
+    SE_GENERIC_GAMESTATE_NOTIFICATION  = BITMASK(28), //!< Triggered by various game state changes; args: #1 `RoR::genericGamestateNotificationType`
 
     SE_ALL_EVENTS                      = 0xffffffff,
     SE_NO_EVENTS                       = 0
@@ -76,6 +77,14 @@ enum angelScriptManipulationType
     ASMANIP_SCRIPT_LOAD_FAILED,           //!< Triggered if the script fails to start at all. Args: #2 unused, #3 RoR::ScriptCategory, #4 unused, #5 filename.
     ASMANIP_SCRIPT_UNLOADING,             //!< Triggered before unloading the script to let it clean up. Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
     ASMANIP_ACTORSIMATTR_SET              //!< Triggered when `setSimAttribute()` or `setIndexedSimAttribute()` is called; additional args: #2 `RoR::ActorSimAttr`, #3 index (-1 if not set), #4 ---, #5 attr name, #6 value converted to string.
+};
+
+/// Argument #1 of script event `RoR::SE_GENERIC_GAMESTATE_NOTIFICATION`
+enum genericGamestateNotificationType
+{
+    GAMESTATE_NOTIFICATION_NONE = 0,
+    GAMESTATE_RACETRACK_LOAD_REQUESTED,       //!< Instructs race manager (TERRAIN script) to load a '*.racetrack' file; args: $5 filename, $6 resource group
+    GAMESTATE_RACETRACK_UNLOAD_REQUESTED,     //!< Instructs race manager to unload race; args: $2 raceID
 };
 
 enum angelScriptThreadStatus

--- a/source/main/gui/panels/GUI_SurveyMap.cpp
+++ b/source/main/gui/panels/GUI_SurveyMap.cpp
@@ -508,29 +508,9 @@ const char* SurveyMap::getTypeByDriveable(const ActorPtr& actor)
         return "boat";
     case MACHINE:
         return "machine";
-    case AI:
-        return this->getAIType(actor);
     default:
         return "unknown";
     }
-}
-
-const char* SurveyMap::getAIType(const ActorPtr& actor)
-{
-    if (actor->ar_engine)
-    {
-        return "truck";
-    }
-    else if (actor->ar_num_aeroengines > 0)
-    {
-        return "airplane";
-    }
-    else if (actor->ar_num_screwprops > 0)
-    {
-        return "boat";
-    }
-
-    return "unknown";
 }
 
 void SurveyMap::CycleMode()

--- a/source/main/gui/panels/GUI_SurveyMap.h
+++ b/source/main/gui/panels/GUI_SurveyMap.h
@@ -71,7 +71,6 @@ protected:
     void setMapZoom(float zoom);
     void setMapZoomRelative(float dt);
     const char* getTypeByDriveable(const ActorPtr& actor);
-    const char* getAIType(const ActorPtr& actor);
 
     void CacheMapIcon(SurveyMapEntity& e);
 

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -2326,40 +2326,46 @@ void TopMenubar::DrawSpecialStateBox(float top_offset)
         special_color = ORANGE_TEXT;
         special_text_centering_weight = 0.7f;
     }
-    else if (App::GetGfxScene()->GetSimDataBuffer().simbuf_dir_arrow_visible)
+    else if (App::GetGameContext()->GetRaceSystem().IsDirArrowVisible())
     {
         m_state_box = StateBox::STATEBOX_RACE;
+        // Race system data ~ we cannot use SimBuffer here because TopMenubar draws before buffering.
+        float data_race_time = App::GetGameContext()->GetRaceSystem().GetRaceTime();
+        float data_race_best_time = App::GetGameContext()->GetRaceSystem().GetRaceBestTime();
+        float data_race_time_diff = App::GetGameContext()->GetRaceSystem().GetRaceTimeDiff();
+        bool data_race_in_progress = App::GetGameContext()->GetRaceSystem().IsRaceInProgress();
+        Ogre::Vector3 data_dir_arrow_target = App::GetGameContext()->GetRaceSystem().GetDirArrowTarget();
+        std::string data_dir_arrow_text = App::GetGameContext()->GetRaceSystem().GetDirArrowText();
+        bool data_dir_arrow_visible = App::GetGameContext()->GetRaceSystem().IsDirArrowVisible();
 
         // Calculate distance
-        GameContextSB& data = App::GetGfxScene()->GetSimDataBuffer();
         GUIManager::GuiTheme const& theme = App::GetGuiManager()->GetTheme();
         float distance = 0.0f;
-        ActorPtr player_actor = App::GetGfxScene()->GetSimDataBuffer().simbuf_player_actor;
-        if (player_actor != nullptr && App::GetGameContext()->GetPlayerActor() &&
-            player_actor->GetGfxActor()->GetSimDataBuffer().simbuf_actor_state == ActorState::LOCAL_SIMULATED)
+        ActorPtr player_actor = App::GetGameContext()->GetPlayerActor();
+        if (player_actor != nullptr && player_actor->ar_state == ActorState::LOCAL_SIMULATED)
         {
-            distance = player_actor->GetGfxActor()->GetSimDataBuffer().simbuf_pos.distance(data.simbuf_dir_arrow_target);
+            distance = player_actor->GetGfxActor()->GetSimDataBuffer().simbuf_pos.distance(data_dir_arrow_target);
         }
         else
         {
-            distance = data.simbuf_character_pos.distance(data.simbuf_dir_arrow_target);
+            distance = App::GetGameContext()->GetPlayerCharacter()->getPosition().distance(data_dir_arrow_target);
         }
 
         // format text
-        special_text = App::GetGfxScene()->GetSimDataBuffer().simbuf_dir_arrow_text;
+        special_text = data_dir_arrow_text;
         special_text_b = fmt::format("{:.1f} {}", distance, _LC("DirectionArrow", "meter"));
         content_width = ImGui::CalcTextSize(special_text.c_str()).x + ImGui::CalcTextSize(special_text_b.c_str()).x;
 
-        float time = App::GetGfxScene()->GetSimDataBuffer().simbuf_race_time;
+        float time = data_race_time;
         special_text_c = fmt::format("{:02d}.{:02d}.{:02d}", (int)(time) / 60, (int)(time) % 60, (int)(time * 100.0) % 100);
-        float time_diff = App::GetGfxScene()->GetSimDataBuffer().simbuf_race_time_diff;
+        float time_diff = data_race_time_diff;
         special_color_c = (time_diff > 0.0f)
                           ? theme.value_red_text_color
                           : ((time_diff < 0.0f) ? theme.success_text_color : theme.value_blue_text_color);
 
-        if (App::GetGfxScene()->GetSimDataBuffer().simbuf_race_best_time > 0.0f)
+        if (data_race_best_time > 0.0f)
         {
-            float best_time = App::GetGfxScene()->GetSimDataBuffer().simbuf_race_best_time;
+            float best_time = data_race_best_time;
             special_text_d = fmt::format("{:02d}.{:02d}.{:02d}", (int)(best_time) / 60, (int)(best_time) % 60, (int)(best_time * 100.0) % 100);
         }
     }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -1001,7 +1001,7 @@ void TopMenubar::Draw(float dt)
 
             for (auto actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
             {
-                if (actor->ar_driveable == AI)
+                if (actor->ar_vehicle_ai)
                 {
                     ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
                     ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
@@ -1100,7 +1100,7 @@ void TopMenubar::Draw(float dt)
 
             for (auto actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
             {
-                if (actor->ar_driveable == AI)
+                if (actor->ar_vehicle_ai)
                 {
                     ImGui::PopItemFlag();
                     ImGui::PopStyleVar();
@@ -1242,7 +1242,7 @@ void TopMenubar::Draw(float dt)
                 {
                     for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
                     {
-                        if (actor->ar_driveable == AI)
+                        if (actor->ar_vehicle_ai)
                         {
                             App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                         }

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -1118,7 +1118,7 @@ int main(int argc, char *argv[])
                         App::GetOutGauge()->Close();
                         App::GetSoundScriptManager()->SetListener(/*position:*/Ogre::Vector3::ZERO, /*direction:*/Ogre::Vector3::ZERO, /*up:*/Ogre::Vector3::UNIT_Y, /*velocity:*/Ogre::Vector3::ZERO);
                         App::GetSoundScriptManager()->getSoundManager()->CleanUp();
-                        App::GetGameContext()->GetRaceSystem().ResetRaceUI();
+                        App::GetGameContext()->ResetRaceSystem();
                     }
                     catch (...)
                     {

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -536,7 +536,7 @@ int main(int argc, char *argv[])
                             // Also clean up any actors spawned by the bot
                             for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetLocalActors())
                             {
-                                if (actor->ar_driveable == AI && actor->ar_net_source_id == netuid)
+                                if (actor->ar_vehicle_ai && actor->ar_net_source_id == netuid)
                                 {
                                     App::GetGameContext()->PushMessage(Message(MSG_SIM_DELETE_ACTOR_REQUESTED, static_cast<void*>(new ActorPtr(actor))));
                                 }
@@ -1324,7 +1324,7 @@ int main(int argc, char *argv[])
                         ROR_ASSERT(actor_ptr);
                         ActorPtr actor = *actor_ptr;
                         const bool valid_remote_actor = (App::mp_state->getEnum<MpState>() == MpState::CONNECTED) && actor->ar_state == ActorState::NETWORKED_OK;
-                        const bool valid_ai_actor = (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT) && actor->ar_state == ActorState::LOCAL_SIMULATED && actor->ar_driveable == ActorType::AI;
+                        const bool valid_ai_actor = (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT) && actor->ar_state == ActorState::LOCAL_SIMULATED && actor->ar_vehicle_ai;
                         if (valid_remote_actor || valid_ai_actor)
                         {
                             actor->ar_muted_by_peeropt = true;
@@ -1347,7 +1347,7 @@ int main(int argc, char *argv[])
                         ROR_ASSERT(actor_ptr);
                         ActorPtr actor = *actor_ptr;
                         const bool valid_remote_actor = (App::mp_state->getEnum<MpState>() == MpState::CONNECTED) && actor->ar_state == ActorState::NETWORKED_OK;
-                        const bool valid_ai_actor = (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT) && actor->ar_state == ActorState::LOCAL_SIMULATED && actor->ar_driveable == ActorType::AI;
+                        const bool valid_ai_actor = (App::mp_state->getEnum<MpState>() == MpState::LOCAL_SCRIPT) && actor->ar_state == ActorState::LOCAL_SIMULATED && actor->ar_vehicle_ai;
                         if (valid_remote_actor || valid_ai_actor)
                         {
                             actor->ar_muted_by_peeropt = false;

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -482,7 +482,7 @@ public:
     bool              ar_camera_node_roll_inv[MAX_CAMERAS] = {false};              //!< Physics attr; 'camera' = frame of reference; indicates roll node is right instead of left
     
     float             ar_posnode_spawn_height = 0.f;
-    VehicleAIPtr      ar_vehicle_ai;
+    VehicleAIPtr      ar_vehicle_ai; //!< Indicates an A.I. controlled actor (bot).
 
     // Overrides the input event values from InputEngine with custom values
     // for this actor.

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -617,7 +617,7 @@ RoRnet::UiStreamsHealth ActorManager::CheckNetworkStreamsOk(int sourceid)
         // Mismatches can't happen, just check if any actor is spawned
         for (ActorPtr& actor: m_actors)
         {
-            if (actor->ar_driveable == ActorType::AI && actor->ar_net_source_id == sourceid)
+            if (actor->ar_vehicle_ai && actor->ar_net_source_id == sourceid)
             {
                 return RoRnet::UiStreamsHealth::ALL_OK;
             }
@@ -849,7 +849,7 @@ void ActorManager::UpdateSleepingState(ActorPtr player_actor, float dt)
         {
             if (actor->ar_state != ActorState::LOCAL_SIMULATED)
                 continue;
-            if (actor->ar_driveable == AI)
+            if (actor->ar_vehicle_ai)
                 continue;
             if (actor->getVelocity().squaredLength() > 0.01f)
             {

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -339,10 +339,6 @@ void ActorSpawner::InitializeRig()
         m_actor->ar_camera_node_roll[i] = NODENUM_INVALID;
     }
 
-#ifdef USE_ANGELSCRIPT
-    m_actor->ar_vehicle_ai = new VehicleAI(m_actor);
-#endif // USE_ANGELSCRIPT
-
     m_actor->ar_airbrake_intensity = 0;
     m_actor->alb_minspeed = 0.0f;
     m_actor->alb_mode = false;

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -86,7 +86,7 @@ enum ActorType //!< Aka 'Driveable'
     AIRPLANE       = 2,   //!< its an airplane
     BOAT           = 3,   //!< its a boat
     MACHINE        = 4,   //!< its a machine
-    AI             = 5,   //!< machine controlled by an Artificial Intelligence
+    // TT_AI ~ replaced by checking if `RoR::Actor::getVehicleAI()` returns a valid object.
 };
 
 /// @}

--- a/source/main/physics/collision/Collisions.cpp
+++ b/source/main/physics/collision/Collisions.cpp
@@ -398,7 +398,7 @@ int Collisions::hash_find(int cell_x, int cell_z)
     return static_cast<int>(pos);
 }
 
-int Collisions::addCollisionBox(bool rotating, bool virt, Vector3 pos, Ogre::Vector3 rot, Ogre::Vector3 l, Ogre::Vector3 h, Ogre::Vector3 sr, const Ogre::String &eventname, const Ogre::String &instancename, const Ogre::String& reverb_preset_name, bool forcecam, Ogre::Vector3 campos, Ogre::Vector3 sc /* = Vector3::UNIT_SCALE */, Ogre::Vector3 dr /* = Vector3::ZERO */, CollisionEventFilter event_filter /* = EVENT_ALL */, int scripthandler /* = -1 */)
+int Collisions::addCollisionBox(bool rotating, bool virt, Vector3 pos, Ogre::Vector3 rot, Ogre::Vector3 l, Ogre::Vector3 h, Ogre::Vector3 sr, const Ogre::String &eventname, const Ogre::String &instancename, const Ogre::String& reverb_preset_name, bool forcecam, Ogre::Vector3 campos, Ogre::Vector3 sc /* = Vector3::UNIT_SCALE */, Ogre::Vector3 dr /* = Vector3::ZERO */, CollisionEventFilter event_filter /* = EVENT_ALL */, EvHandlerFuncID_t scripthandler /* = EVHANDLERFUNCID_INVALID */)
 {
     Quaternion rotation  = Quaternion(Degree(rot.x), Vector3::UNIT_X) * Quaternion(Degree(rot.y), Vector3::UNIT_Y) * Quaternion(Degree(rot.z), Vector3::UNIT_Z);
     Quaternion direction = Quaternion(Degree(dr.x), Vector3::UNIT_X) * Quaternion(Degree(dr.y), Vector3::UNIT_Y) * Quaternion(Degree(dr.z), Vector3::UNIT_Z);
@@ -611,7 +611,7 @@ void Collisions::envokeScriptCallback(collision_box_t *cbox, node_t *node)
     // check if this box is active anymore
     if (!eventsources[cbox->eventsourcenum].es_enabled)
         return;
-    
+
     if (node)
     {
         // An actor is activating the eventbox

--- a/source/main/physics/collision/Collisions.h
+++ b/source/main/physics/collision/Collisions.h
@@ -42,7 +42,7 @@ struct eventsource_t //!< Scripting
     std::string       es_instance_name;  //!< Specified by user when calling "GameScript::spawnObject()"
     std::string       es_box_name;       //!< Specified in ODEF file as "event"
     Ogre::Quaternion  es_direction;
-    int               es_script_handler; //!< AngelScript function ID
+    EvHandlerFuncID_t es_script_handler = EVHANDLERFUNCID_INVALID; //!< AngelScript function ID
     int               es_cbox;           //!< Collision box ID
     bool              es_enabled;
 };
@@ -199,7 +199,7 @@ public:
 
     void finishLoadingTerrain();
 
-    int addCollisionBox(bool rotating, bool virt, Ogre::Vector3 pos, Ogre::Vector3 rot, Ogre::Vector3 l, Ogre::Vector3 h, Ogre::Vector3 sr, const Ogre::String& eventname, const Ogre::String& instancename, const Ogre::String& reverb_preset_name, bool forcecam, Ogre::Vector3 campos, Ogre::Vector3 sc = Ogre::Vector3::UNIT_SCALE, Ogre::Vector3 dr = Ogre::Vector3::ZERO, CollisionEventFilter event_filter = EVENT_ALL, int scripthandler = -1);
+    int addCollisionBox(bool rotating, bool virt, Ogre::Vector3 pos, Ogre::Vector3 rot, Ogre::Vector3 l, Ogre::Vector3 h, Ogre::Vector3 sr, const Ogre::String& eventname, const Ogre::String& instancename, const Ogre::String& reverb_preset_name, bool forcecam, Ogre::Vector3 campos, Ogre::Vector3 sc = Ogre::Vector3::UNIT_SCALE, Ogre::Vector3 dr = Ogre::Vector3::ZERO, CollisionEventFilter event_filter = EVENT_ALL, EvHandlerFuncID_t scripthandler = EVHANDLERFUNCID_INVALID);
     void addCollisionMesh(Ogre::String const& srcname, Ogre::String const& meshname, Ogre::Vector3 const& pos, Ogre::Quaternion const& q, Ogre::Vector3 const& scale, ground_model_t* gm = 0, std::vector<int>* collTris = 0); //!< generate collision tris from existing mesh resource
     void registerCollisionMesh(Ogre::String const& srcname, Ogre::String const& meshname, Ogre::Vector3 const& pos, Ogre::AxisAlignedBox bounding_box, ground_model_t* gm, int ctri_start, int ctri_count); //!< Mark already generated collision tris as belonging to (virtual) mesh.
     int addCollisionTri(Ogre::Vector3 p1, Ogre::Vector3 p2, Ogre::Vector3 p3, ground_model_t* gm);

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -1235,11 +1235,11 @@ void CacheSystem::FillRaceTrackDetailInfo(CacheEntryPtr& entry, Ogre::DataStream
         {
             std::string keyword = reader->getTokKeyword();
 
-            if (keyword == "race_name")
+            if (keyword == "racetrack_name")
                 entry->dname = reader->getTokString(1);
-            else if (keyword == "race_description")
+            else if (keyword == "racetrack_description")
                 entry->description = reader->getTokString(1);
-            else if (keyword == "race_terrain_guid")
+            else if (keyword == "racetrack_terrain_guid")
                 entry->guid = reader->getTokString(1);
         }
 

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -136,6 +136,7 @@ CacheSystem::CacheSystem()
     m_known_extensions.push_back("load");
     m_known_extensions.push_back("train");
     m_known_extensions.push_back("skin");
+    m_known_extensions.push_back("racetrack");
     m_known_extensions.push_back("addonpart");
     m_known_extensions.push_back("tuneup");
     m_known_extensions.push_back("assetpack");
@@ -310,6 +311,7 @@ void CacheSystem::ImportEntryFromJson(rapidjson::Value& j_entry, CacheEntryPtr &
     out_entry->uniqueid =               j_entry["uniqueid"].GetString();
     out_entry->version =                j_entry["version"].GetInt();
     out_entry->filecachename =          j_entry["filecachename"].GetString();
+    out_entry->description =            j_entry["description"].GetString();
 
     out_entry->guid = j_entry["guid"].GetString();
     Ogre::StringUtil::trim(out_entry->guid);
@@ -338,7 +340,6 @@ void CacheSystem::ImportEntryFromJson(rapidjson::Value& j_entry, CacheEntryPtr &
     }
 
     // Vehicle details
-    out_entry->description =       j_entry["description"].GetString();
     out_entry->tags =              j_entry["tags"].GetString();
     out_entry->default_skin =      j_entry["default_skin"].GetString();
     out_entry->fileformatversion = j_entry["fileformatversion"].GetInt();
@@ -600,6 +601,7 @@ void CacheSystem::ExportEntryToJson(rapidjson::Value& j_entries, rapidjson::Docu
     j_entry.AddMember("guid",                 rapidjson::StringRef(entry->guid.c_str()),                    j_doc.GetAllocator());
     j_entry.AddMember("version",              entry->version,                                               j_doc.GetAllocator());
     j_entry.AddMember("filecachename",        rapidjson::StringRef(entry->filecachename.c_str()),           j_doc.GetAllocator());
+    j_entry.AddMember("description",          rapidjson::StringRef(entry->description.c_str()),             j_doc.GetAllocator());
 
     // Common - Authors
     rapidjson::Value j_authors(rapidjson::kArrayType);
@@ -617,7 +619,6 @@ void CacheSystem::ExportEntryToJson(rapidjson::Value& j_entries, rapidjson::Docu
     j_entry.AddMember("authors", j_authors, j_doc.GetAllocator());
 
     // Vehicle details
-    j_entry.AddMember("description",         rapidjson::StringRef(entry->description.c_str()),       j_doc.GetAllocator());
     j_entry.AddMember("tags",                rapidjson::StringRef(entry->tags.c_str()),              j_doc.GetAllocator());
     j_entry.AddMember("default_skin",        rapidjson::StringRef(entry->default_skin.c_str()),      j_doc.GetAllocator());
     j_entry.AddMember("fileformatversion",   entry->fileformatversion, j_doc.GetAllocator());
@@ -806,6 +807,12 @@ void CacheSystem::AddFile(String group, Ogre::FileInfo f, String ext)
         {
             CacheEntryPtr entry = new CacheEntry();
             FillGadgetDetailInfo(entry, ds);
+            new_entries.push_back(entry);
+        }
+        else if (ext == "racetrack")
+        {
+            CacheEntryPtr entry = new CacheEntry();
+            FillRaceTrackDetailInfo(entry, ds);
             new_entries.push_back(entry);
         }
         else
@@ -1217,6 +1224,31 @@ void CacheSystem::FillTerrainDetailInfo(CacheEntryPtr& entry, Ogre::DataStreamPt
     entry->version    = def->version;
 }
 
+void CacheSystem::FillRaceTrackDetailInfo(CacheEntryPtr& entry, Ogre::DataStreamPtr ds)
+{
+    GenericDocumentPtr doc = new GenericDocument();
+    doc->loadFromDataStream(ds, GenericDocument::OPTION_ALLOW_NAKED_STRINGS);
+    GenericDocContextPtr reader = new GenericDocContext(doc);
+    while (!reader->endOfFile())
+    {
+        if (reader->tokenType() == TokenType::KEYWORD)
+        {
+            std::string keyword = reader->getTokKeyword();
+
+            if (keyword == "race_name")
+                entry->dname = reader->getTokString(1);
+            else if (keyword == "race_description")
+                entry->description = reader->getTokString(1);
+            else if (keyword == "race_terrain_guid")
+                entry->guid = reader->getTokString(1);
+        }
+
+        reader->seekNextLine();
+    }
+    entry->fname = ds->getName();
+    entry->fext = "racetrack";
+}
+
 void CacheSystem::FillSkinDetailInfo(CacheEntryPtr &entry, std::shared_ptr<SkinDocument>& skin_def)
 {
     if (!skin_def->author_name.empty())
@@ -1562,6 +1594,13 @@ void CacheSystem::LoadResource(CacheEntryPtr& entry)
         if (entry->fext == "terrn2")
         {
             // PagedGeometry is hardcoded to use `Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME`
+            ResourceGroupManager::getSingleton().createResourceGroup(group, /*inGlobalPool=*/true);
+            ResourceGroupManager::getSingleton().addResourceLocation(
+                entry->resource_bundle_path, entry->resource_bundle_type, group, recursive, readonly);
+        }
+        else if (entry->fext == "race")
+        {
+            // This is a race bundle - use `inGlobalPool=true` to allow terrain script (race handler) to access it.
             ResourceGroupManager::getSingleton().createResourceGroup(group, /*inGlobalPool=*/true);
             ResourceGroupManager::getSingleton().addResourceLocation(
                 entry->resource_bundle_path, entry->resource_bundle_type, group, recursive, readonly);
@@ -2333,6 +2372,8 @@ size_t CacheSystem::Query(CacheQuery& query)
         bool add = false;
         if (entry->fext == "terrn2")
             add = (query.cqy_filter_type == LT_Terrain);
+        if (entry->fext == "racetrack")
+            add = (query.cqy_filter_type == LT_RaceTrack);
         if (entry->fext == "skin")
             add = (query.cqy_filter_type == LT_Skin);
         else if (entry->fext == "addonpart")

--- a/source/main/resources/CacheSystem.cpp
+++ b/source/main/resources/CacheSystem.cpp
@@ -576,7 +576,6 @@ std::string CacheSystem::ActorTypeToName(ActorType driveable)
     case ActorType::AIRPLANE:      return _LC("MainSelector", "Airplane");
     case ActorType::BOAT:          return _LC("MainSelector", "Boat");
     case ActorType::MACHINE:       return _LC("MainSelector", "Machine");
-    case ActorType::AI:            return _LC("MainSelector", "A.I.");
     default:                       return "";
     };
 }

--- a/source/main/resources/CacheSystem.h
+++ b/source/main/resources/CacheSystem.h
@@ -39,7 +39,7 @@
 #include <set>
 
 #define CACHE_FILE "mods.cache"
-#define CACHE_FILE_FORMAT 14
+#define CACHE_FILE_FORMAT 15
 #define CACHE_FILE_FRESHNESS 86400 // 60*60*24 = one day
 
 namespace RoR {
@@ -74,7 +74,7 @@ public:
 
     std::time_t addtimestamp;           //!< timestamp when this file was added to the cache
     Ogre::String uniqueid;              //!< file's unique id
-    Ogre::String guid;                  //!< global unique id; Type "addonpart" leaves this empty and uses `addonpart_guids`; Always lowercase.
+    Ogre::String guid;                  //!< global unique id (NOTE: Only vehicles and terrains have their own GUIDs; For skins and races, this is the GUID of associated vehicle or terrain); Type "addonpart" leaves this empty and uses `addonpart_guids`; Always lowercase.
     int version;                        //!< file's version
     
     std::string resource_bundle_type;   //!< Archive type recognized by OGRE resource system: 'FileSystem' or 'Zip'
@@ -85,6 +85,7 @@ public:
     int usagecounter;                   //!< how much it was used already
     std::vector<AuthorInfo> authors;    //!< authors
     Ogre::String filecachename;         //!< preview image filename
+    Ogre::String description;
 
     Ogre::String resource_group;        //!< Resource group of the loaded bundle. Empty if not loaded yet.
 
@@ -102,7 +103,6 @@ public:
     std::string tuneup_associated_filename; //!< Value of 'filename' field in the tuneup file; always lowercase.
 
     // following all TRUCK detail information:
-    Ogre::String description;
     Ogre::String tags;
     std::string default_skin;
     int fileformatversion;
@@ -371,6 +371,7 @@ private:
     void FillAssetPackDetailInfo(CacheEntryPtr &entry, Ogre::DataStreamPtr ds);
     void FillDashboardDetailInfo(CacheEntryPtr& entry, Ogre::DataStreamPtr ds);
     void FillGadgetDetailInfo(CacheEntryPtr& entry, Ogre::DataStreamPtr ds);
+    void FillRaceTrackDetailInfo(CacheEntryPtr& entry, Ogre::DataStreamPtr ds);
     /// @}
 
     void GenerateHashFromFilenames();         //!< For quick detection of added/removed content

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -471,8 +471,12 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
             return;
         }
 
-        int handler_func_id = -1; // no function
-        if (eventhandler != "")
+        EvHandlerFuncID_t handler_func_id = EVHANDLERFUNCID_INVALID;
+        if (eventhandler == "!supress")
+        {
+            handler_func_id = EVHANDLERFUNCID_SUPRESS;
+        }
+        else if (eventhandler != "")
         {
             // Let script author know (via Angelscript.log) there's a better alternative.
             App::GetScriptEngine()->setForwardScriptLogToConsole(false);

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -445,7 +445,7 @@ void GameScript::moveObjectVisuals(const String& instanceName, const Vector3& po
     }
 }
 
-void GameScript::spawnObject(const String& objectName, const String& instanceName, const Vector3& pos, const Vector3& rot, const String& eventhandler, bool uniquifyMaterials)
+void GameScript::spawnObject(const String& objectName, const String& instanceName, const Vector3& pos, const Vector3& rot, const String& eventhandler /* = "" */, bool uniquifyMaterials /* = false */)
 {
     if (!this->HaveSimTerrain(__FUNCTION__))
         return;
@@ -472,7 +472,7 @@ void GameScript::spawnObject(const String& objectName, const String& instanceNam
         }
 
         int handler_func_id = -1; // no function
-        if (!eventhandler.empty())
+        if (eventhandler != "")
         {
             // Let script author know (via Angelscript.log) there's a better alternative.
             App::GetScriptEngine()->setForwardScriptLogToConsole(false);

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -355,7 +355,7 @@ public:
     * @param eventhandler A name of a function that should be called when an event happens (events, as defined in the object definition file)
     * @param uniquifyMaterials Set this to true if you need to uniquify the materials
     */
-    void spawnObject(const Ogre::String& objectName, const Ogre::String& instanceName, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& eventhandler, bool uniquifyMaterials);
+    void spawnObject(const Ogre::String& objectName, const Ogre::String& instanceName, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& eventhandler = "", bool uniquifyMaterials = false);
 
     /**
     * This moves an object to a new position

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -391,6 +391,11 @@ bool ScriptEngine::prepareContextAndHandleErrors(ScriptUnitID_t nid, int asFunct
 
 ScriptRetCode_t ScriptEngine::validateScriptModule(ScriptUnitID_t nid, asIScriptModule*& out_mod)
 {
+    if (nid == SCRIPTUNITID_DEFAULT)
+    {
+        nid = m_terrain_script_unit;
+    }
+
     if (!engine)
         return SCRIPTRETCODE_ENGINE_NOT_CREATED;
 

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -954,7 +954,7 @@ int ScriptEngine::setupScriptUnit(int unit_id)
             fmt::format("Could not load script '{}' - failed to create module.", moduleName));
         return result;
     }
-    m_script_units[unit_id].scriptModule = engine->GetModule(moduleName.c_str(), AngelScript::asGM_ONLY_IF_EXISTS);
+    m_script_units[unit_id].scriptModule = builder.GetModule();
 
     // For actor scripts, add global var `thisActor` to the module
     if (m_script_units[unit_id].scriptCategory == ScriptCategory::ACTOR)

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -471,19 +471,21 @@ int ScriptEngine::fireEvent(std::string instanceName, float intensity)
     return 0;
 }
 
-void ScriptEngine::envokeCallback(int _functionId, eventsource_t *source, NodeNum_t nodenum, int type)
+void ScriptEngine::envokeCallback(EvHandlerFuncID_t functionId, eventsource_t *source, NodeNum_t nodenum, int type)
 {
-    // THIS IS OBSOLETE - Use `eventCallbackEx()` and `SE_EVENTBOX_ENTER` instead.
-    // ################
+    // THIS IS DEPRECATED - Use `eventCallbackEx()` and `SE_EVENTBOX_ENTER` instead.
+    // ##################
     // Legacy eventbox handler, specified by name in .TOBJ file or in call to `game.spawnObject()`
     // ===========================================================================================
     if (!engine || !context)
         return;
 
+    if (functionId == EVHANDLERFUNCID_SUPRESS)
+        return;
+
     for (auto& pair: m_script_units)
     {
         ScriptUnitID_t id = pair.first;
-        int functionId = _functionId;
         if (functionId <= 0 && (m_script_units[id].defaultEventCallbackFunctionPtr != nullptr))
         {
             // use the default event handler instead then

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -584,7 +584,7 @@ ScriptRetCode_t ScriptEngine::functionExists(const String& arg, const ScriptUnit
     result = this->validateScriptModule(nid, /*[out]*/ mod);
     if (result == 0)
     {
-        if (mod->GetFunctionByDecl(arg.c_str()) != nullptr)
+        if (mod->GetFunctionByDecl(arg.c_str()) == nullptr)
             result = SCRIPTRETCODE_FUNCTION_NOT_EXISTS;
     }
     return result;

--- a/source/main/scripting/ScriptEngine.h
+++ b/source/main/scripting/ScriptEngine.h
@@ -286,7 +286,7 @@ public:
 
     int fireEvent(std::string instanceName, float intensity);
 
-    void envokeCallback(int functionId, eventsource_t* source, NodeNum_t nodenum = NODENUM_INVALID, int type = 0);
+    void envokeCallback(EvHandlerFuncID_t functionId, eventsource_t* source, NodeNum_t nodenum = NODENUM_INVALID, int type = 0);
 
     /**
     * Forwards useful info from C++ `try{}catch{}` exceptions to script in the form of game event.

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -45,7 +45,6 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("truckTypes", "TT_AIRPLANE", AIRPLANE); ROR_ASSERT(result>=0);
     result = engine->RegisterEnumValue("truckTypes", "TT_BOAT", BOAT); ROR_ASSERT(result>=0);
     result = engine->RegisterEnumValue("truckTypes", "TT_MACHINE", MACHINE); ROR_ASSERT(result>=0);
-    result = engine->RegisterEnumValue("truckTypes", "TT_AI", AI); ROR_ASSERT(result>=0);
 
     // enum FlareType
     result = engine->RegisterEnum("FlareType"); ROR_ASSERT(result >= 0);

--- a/source/main/scripting/bindings/GameScriptAngelscript.cpp
+++ b/source/main/scripting/bindings/GameScriptAngelscript.cpp
@@ -144,7 +144,7 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("GameScriptClass", "float getGroundHeight(vector3 &in)", asMETHOD(GameScript, getGroundHeight), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "float getWaterHeight()", asMETHOD(GameScript, getWaterHeight), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void setWaterHeight(float)", asMETHOD(GameScript, setWaterHeight), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("GameScriptClass", "void spawnObject(const string &in, const string &in, vector3 &in, vector3 &in, const string &in, bool)", asMETHOD(GameScript, spawnObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "void spawnObject(const string &in, const string &in, vector3 &in, vector3 &in, const string &in evHandler = string(), bool uniqMat = false)", asMETHOD(GameScript, spawnObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void moveObjectVisuals(const string &in, vector3 &in)", asMETHOD(GameScript, moveObjectVisuals), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void destroyObject(const string &in)", asMETHOD(GameScript, destroyObject), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "array<TerrainEditorObjectClassPtr@>@ getEditorObjects()", asMETHOD(GameScript, getEditorObjects), asCALL_THISCALL); ROR_ASSERT(result >= 0);

--- a/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
+++ b/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
@@ -76,8 +76,8 @@ void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
     // SPECIAL CONDITION - pick API based on which script engine we're registering to.
     if (App::GetServerScript() && App::GetServerScript()->GetScriptEngine() && engine == App::GetServerScript()->GetScriptEngine()->getEngine())
     {
-        engine->RegisterObjectMethod("GenericDocumentClass", "bool loadFromFile(string const&in,int)", asMETHOD(GenericDocument, loadFromFile), asCALL_THISCALL);
-        engine->RegisterObjectMethod("GenericDocumentClass", "bool saveToFile(string const&in)", asMETHOD(GenericDocument, saveToFile), asCALL_THISCALL);
+        engine->RegisterObjectMethod("GenericDocumentClass", "bool loadFromFile(const string &in,int)", asMETHOD(GenericDocument, loadFromFile), asCALL_THISCALL);
+        engine->RegisterObjectMethod("GenericDocumentClass", "bool saveToFile(const string &in)", asMETHOD(GenericDocument, saveToFile), asCALL_THISCALL);
     }
     else
     {

--- a/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
+++ b/source/main/scripting/bindings/GenericFileFormatAngelscript.cpp
@@ -25,6 +25,8 @@
 
 #include "AngelScriptBindings.h"
 #include "GenericFileFormat.h"
+#include "ServerScriptSequencer.h"
+#include "ServerScriptEngine.h"
 
 using namespace RoR;
 using namespace AngelScript;
@@ -71,8 +73,17 @@ void RoR::RegisterGenericFileFormat(asIScriptEngine* engine)
     GenericDocumentPtr::RegisterRefCountingObjectPtr(engine, "GenericDocumentClassPtr", "GenericDocumentClass");
     engine->RegisterObjectBehaviour("GenericDocumentClass", asBEHAVE_FACTORY, "GenericDocumentClass@+ f()", asFUNCTION(GenericDocumentFactory), asCALL_CDECL);
 
-    engine->RegisterObjectMethod("GenericDocumentClass", "bool loadFromResource(string,string,int)", asMETHOD(GenericDocument, loadFromResource), asCALL_THISCALL);
-    engine->RegisterObjectMethod("GenericDocumentClass", "bool saveToResource(string,string)", asMETHOD(GenericDocument, saveToResource), asCALL_THISCALL);
+    // SPECIAL CONDITION - pick API based on which script engine we're registering to.
+    if (App::GetServerScript() && App::GetServerScript()->GetScriptEngine() && engine == App::GetServerScript()->GetScriptEngine()->getEngine())
+    {
+        engine->RegisterObjectMethod("GenericDocumentClass", "bool loadFromFile(string const&in,int)", asMETHOD(GenericDocument, loadFromFile), asCALL_THISCALL);
+        engine->RegisterObjectMethod("GenericDocumentClass", "bool saveToFile(string const&in)", asMETHOD(GenericDocument, saveToFile), asCALL_THISCALL);
+    }
+    else
+    {
+        engine->RegisterObjectMethod("GenericDocumentClass", "bool loadFromResource(string,string,int)", asMETHOD(GenericDocument, loadFromResource), asCALL_THISCALL);
+        engine->RegisterObjectMethod("GenericDocumentClass", "bool saveToResource(string,string)", asMETHOD(GenericDocument, saveToResource), asCALL_THISCALL);
+    }
 
 
     // class GenericDocContext

--- a/source/main/scripting/bindings/ScriptEventsAngelscript.cpp
+++ b/source/main/scripting/bindings/ScriptEventsAngelscript.cpp
@@ -66,6 +66,7 @@ void RoR::RegisterScriptEvents(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("scriptEvents", "SE_GENERIC_MODCACHE_ACTIVITY", SE_GENERIC_MODCACHE_ACTIVITY); ROR_ASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_GENERIC_TRUCK_LINKING_CHANGED", SE_GENERIC_TRUCK_LINKING_CHANGED); ROR_ASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_GENERIC_FREEFORCES_ACTIVITY", SE_GENERIC_FREEFORCES_ACTIVITY); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("scriptEvents", "SE_GENERIC_GAMESTATE_NOTIFICATION", SE_GENERIC_GAMESTATE_NOTIFICATION); ROR_ASSERT(result >= 0);
 
     result = engine->RegisterEnumValue("scriptEvents", "SE_ALL_EVENTS", SE_ALL_EVENTS); ROR_ASSERT(result>=0);
     result = engine->RegisterEnumValue("scriptEvents", "SE_NO_EVENTS", SE_NO_EVENTS); ROR_ASSERT(result>=0);
@@ -78,6 +79,13 @@ void RoR::RegisterScriptEvents(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("angelScriptManipulationType", "ASMANIP_SCRIPT_LOAD_FAILED", ASMANIP_SCRIPT_LOAD_FAILED); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("angelScriptManipulationType", "ASMANIP_SCRIPT_UNLOADING", ASMANIP_SCRIPT_UNLOADING); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("angelScriptManipulationType", "ASMANIP_ACTORSIMATTR_SET", ASMANIP_ACTORSIMATTR_SET); ROR_ASSERT(result >= 0);
+
+    // enum genericGamestateNotificationType
+    result = engine->RegisterEnum("genericGamestateNotificationType"); ROR_ASSERT(result >= 0);
+
+    result = engine->RegisterEnumValue("genericGamestateNotificationType", "GAMESTATE_NOTIFICATION_NONE", GAMESTATE_NOTIFICATION_NONE); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("genericGamestateNotificationType", "GAMESTATE_RACETRACK_LOAD_REQUESTED", GAMESTATE_RACETRACK_LOAD_REQUESTED); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("genericGamestateNotificationType", "GAMESTATE_RACETRACK_UNLOAD_REQUESTED", GAMESTATE_RACETRACK_UNLOAD_REQUESTED); ROR_ASSERT(result >= 0);
 
     // enum angelScriptThreadStatus
     result = engine->RegisterEnum("angelScriptThreadStatus"); ROR_ASSERT(result>=0);

--- a/source/main/scripting/server/ServerScriptEngine.cpp
+++ b/source/main/scripting/server/ServerScriptEngine.cpp
@@ -567,6 +567,9 @@ void ServerScriptEngine::init() {
     result = engine->RegisterGlobalProperty("const int TO_ALL", (void *) &TO_ALL);
     assert_net(result >= 0);
 
+    Logger::Log(LOG_INFO, "ScriptEngine: Registering the generic document parser...");
+
+    RegisterGenericFileFormat(engine); // Defined in 'GenericFileFormatAngelscript.cpp'
 
     Logger::Log(LOG_INFO, "ScriptEngine: Registration done");
 }

--- a/source/main/scripting/server/ServerScriptEngine.cpp
+++ b/source/main/scripting/server/ServerScriptEngine.cpp
@@ -83,7 +83,7 @@ ServerScriptEngine::ServerScriptEngine(ServerScriptSequencer* sequencer) :
                                              engine(0),
                                              context(0)
 {
-    init();
+    // NOTE: we cannot call `init()` from here because `RegisterGenericDocument()` needs the ServerScriptEngine instance available already.
 }
 
 ServerScriptEngine::~ServerScriptEngine() {

--- a/source/main/scripting/server/ServerScriptEngine.h
+++ b/source/main/scripting/server/ServerScriptEngine.h
@@ -64,6 +64,11 @@ public:
 
     ~ServerScriptEngine();
 
+    /**
+     * This function initialzies the engine and registeres all types
+     */
+    void init();
+
     int loadScript(std::string scriptName);
 
     void unloadScript(); // RIGSOFRODS: Unload the script (only one can run at a time).
@@ -166,11 +171,6 @@ protected:
     std::thread m_timer_thread;
     ThreadState m_timer_thread_state = ThreadState::NOT_RUNNING;
     std::mutex  m_timer_thread_mutex;
-
-    /**
-     * This function initialzies the engine and registeres all types
-     */
-    void init();
 
     /**
      * This is the callback function that gets called when script error occur.

--- a/source/main/scripting/server/ServerScriptSequencer.cpp
+++ b/source/main/scripting/server/ServerScriptSequencer.cpp
@@ -54,6 +54,7 @@ ServerScriptSequencer::~ServerScriptSequencer() {
 
 int ServerScriptSequencer::Initialize(const std::string& script_filename) {
     m_script_engine = std::unique_ptr<ServerScriptEngine>(new ServerScriptEngine(this));
+    m_script_engine->init();
     return m_script_engine->loadScript(script_filename);
 }
 

--- a/source/main/scripting/server/ServerScriptSequencer.h
+++ b/source/main/scripting/server/ServerScriptSequencer.h
@@ -74,6 +74,7 @@ public:
     int Initialize(const std::string& script_filename); // Creates scripting engine and loads the server script. Returns 0 on success.
     bool IsRunning() { return m_script_engine != nullptr; }
     void Close();
+    ServerScriptEngine* GetScriptEngine() { return m_script_engine.get(); }
 
     // Synchronized public interface
     void createClient(RoRnet::UserInfo& user); // Performs the 'playerAdded' callback.

--- a/source/main/system/ConsoleCmd.cpp
+++ b/source/main/system/ConsoleCmd.cpp
@@ -461,6 +461,48 @@ public:
     }
 };
 
+class LoadRaceTrackCmd : public ConsoleCmd
+{
+public:
+    LoadRaceTrackCmd() : ConsoleCmd("loadracetrack", "[filename]", _L("Loads a *.racetrack file")) {}
+
+    void Run(Ogre::StringVector const& args) override
+    {
+        if (!this->CheckAppState(AppState::SIMULATION))
+            return;
+
+        Str<200> reply;
+        reply << m_name << ": ";
+        Console::MessageType reply_type;
+
+#ifdef USE_ANGELSCRIPT
+        if (args.size() == 1)
+        {
+            reply_type = Console::CONSOLE_SYSTEM_ERROR;
+            reply << _L("Missing parameter: ") << m_usage;
+        }
+        else
+        {
+            if (!App::GetGameContext()->LoadRaceTrack(args[1]))
+            {
+                reply_type = Console::CONSOLE_SYSTEM_ERROR;
+                reply << _L("The race could not be loaded");
+            }
+            else
+            {
+                reply_type = Console::CONSOLE_SYSTEM_REPLY;
+                reply << _L("The race was loaded successfully");
+            }
+        }
+#else
+        reply_type = Console::CONSOLE_SYSTEM_ERROR;
+        reply << _L("Scripting disabled in this build");
+#endif
+
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, reply_type, reply.ToCStr());
+    }
+};
+
 class LoadServerScriptCmd : public ConsoleCmd
 {
 public:
@@ -797,6 +839,7 @@ void Console::regBuiltinCommands()
     // Additions
     cmd = new ClearCmd();                 m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new LoadScriptCmd();            m_commands.insert(std::make_pair(cmd->getName(), cmd));
+    cmd = new LoadRaceTrackCmd();         m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new LoadServerScriptCmd();      m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new UnloadServerScriptCmd();    m_commands.insert(std::make_pair(cmd->getName(), cmd));
     cmd = new SpeedOfSoundCmd();          m_commands.insert(std::make_pair(cmd->getName(), cmd));

--- a/source/main/terrain/TerrainEditor.h
+++ b/source/main/terrain/TerrainEditor.h
@@ -50,7 +50,7 @@ public:
     std::vector<int> static_collision_boxes;
     std::vector<int> static_collision_tris;
     bool enable_collisions = true;
-    int script_handler = -1;
+    EvHandlerFuncID_t script_handler = EVHANDLERFUNCID_INVALID;
     // ~ only for preloaded actors:
     TObjSpecialObject special_object_type = TObjSpecialObject::NONE;
     ActorInstanceID_t actor_instance_id = ACTORINSTANCEID_INVALID;

--- a/source/main/terrain/TerrainObjectManager.cpp
+++ b/source/main/terrain/TerrainObjectManager.cpp
@@ -597,7 +597,7 @@ ODefDocument* TerrainObjectManager::FetchODef(std::string const & odef_name)
     }
 }
 
-bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, float rendering_distance /* = 0 */, bool enable_collisions /* = true */, int scripthandler /* = -1 */, bool uniquifyMaterial /* = false */)
+bool TerrainObjectManager::LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, float rendering_distance /* = 0 */, bool enable_collisions /* = true */, EvHandlerFuncID_t scripthandler /* = EVHANDLERFUNCID_INVALID */, bool uniquifyMaterial /* = false */)
 {
     if (type == "grid")
     {

--- a/source/main/terrain/TerrainObjectManager.h
+++ b/source/main/terrain/TerrainObjectManager.h
@@ -66,7 +66,7 @@ public:
     TerrainEditorObjectPtrVec& GetEditorObjects() { return m_editor_objects; }
     std::vector<TObjDocumentPtr>& GetTobjCache() { return m_tobj_cache; }
     void           LoadTObjFile(Ogre::String filename);
-    bool           LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, float rendering_distance = 0, bool enable_collisions = true, int scripthandler = -1, bool uniquifyMaterial = false);
+    bool           LoadTerrainObject(const Ogre::String& name, const Ogre::Vector3& pos, const Ogre::Vector3& rot, const Ogre::String& instancename, const Ogre::String& type, float rendering_distance = 0, bool enable_collisions = true, EvHandlerFuncID_t scripthandler = EVHANDLERFUNCID_INVALID, bool uniquifyMaterial = false);
     bool           LoadTerrainScript(const Ogre::String& filename);
     void           moveObjectVisuals(const Ogre::String& instancename, const Ogre::Vector3& pos);
     void           destroyObject(const Ogre::String& instancename);

--- a/source/main/utils/GenericFileFormat.cpp
+++ b/source/main/utils/GenericFileFormat.cpp
@@ -1126,6 +1126,16 @@ bool GenericDocument::saveToResource(std::string resource_name, std::string reso
     }
 }
 
+bool GenericDocument::loadFromFile(const std::string& filename, BitMask_t options /* = 0 */)
+{
+    return this->loadFromResource(filename, RGN_SERVER_SCRIPTS, options);
+}
+
+bool GenericDocument::saveToFile(const std::string& filename)
+{
+    return this->saveToResource(filename, RGN_SERVER_SCRIPTS);
+}
+
 bool GenericDocContext::seekNextLine()
 {
     // Skip current line

--- a/source/main/utils/GenericFileFormat.h
+++ b/source/main/utils/GenericFileFormat.h
@@ -51,8 +51,8 @@ enum class TokenType
     LINEBREAK,    // Input: LF (CR is ignored); Output: platform-specific.
     COMMENT,      // Line starting with ; (skipping whitespace). Data: offset in string pool.
     STRING,       // Quoted string. Data: offset in string pool.
-    FLOAT,
-    INT,
+    FLOAT,        // Numbers with or without a decimal point.
+    INT,          // Only numbers without decimal point.
     BOOL,         // Lowercase 'true'/'false'. Data: 1.0 for true, 0.0 for false.
     KEYWORD,      // Unquoted string at start of line (skipping whitespace). Data: offset in string pool.
 };
@@ -119,7 +119,7 @@ struct GenericDocContext: public RefCountingObject<GenericDocContext>
     std::string getTokComment(int offset = 0) const { ROR_ASSERT(isTokComment(offset)); return getStringData(offset); }
 
     bool isTokString(int offset = 0) const { return tokenType(offset) == TokenType::STRING; }
-    bool isTokFloat(int offset = 0) const { return tokenType(offset) == TokenType::FLOAT; }
+    bool isTokFloat(int offset = 0) const { return tokenType(offset) == TokenType::FLOAT || tokenType(offset) == TokenType::INT; }
     bool isTokInt(int offset = 0) const { return tokenType(offset) == TokenType::INT; }
     bool isTokBool(int offset = 0) const { return tokenType(offset) == TokenType::BOOL; }
     bool isTokKeyword(int offset = 0) const { return tokenType(offset) == TokenType::KEYWORD; }

--- a/source/main/utils/GenericFileFormat.h
+++ b/source/main/utils/GenericFileFormat.h
@@ -84,6 +84,12 @@ struct GenericDocument: public RefCountingObject<GenericDocument>
 
     virtual bool loadFromResource(std::string resource_name, std::string resource_group_name, BitMask_t options = 0);
     virtual bool saveToResource(std::string resource_name, std::string resource_group_name);
+
+    /// @name Server script interface (not available for game scripts)
+    /// @{
+    virtual bool loadFromFile(const std::string& filename, BitMask_t options = 0);
+    virtual bool saveToFile(const std::string& filename);
+    /// @}
 };
 
 struct GenericDocContext: public RefCountingObject<GenericDocContext>


### PR DESCRIPTION
## The new '.racetrack' mod

'.race' files were introduced in 2025: https://github.com/RigsOfRods/rigs-of-rods/commit/0d43021523e61a75c0e9b70354fff21e8f68f35f
After it became clear races should be multiplayer, the name was changed to 'racetrack' because "race" should refer to a single organized event (as in "hey player, want to join this race?").
Otherwise nothing changed - you can still convert existing terrain races using the converter.
Browsing racetracks via Selector UI is currently only possible via script. This will be expanded after integrating https://github.com/RigsOfRods/rigs-of-rods/pull/3389

## races internal reworks (simplified eventboxes)

This is a follow-up to #3081 which declared the 'eventhandler' arg of `game.spawnObject()` deprecated.

The reason to touch on this is preparation for race system extension in #3389 - it requires eventboxes to provide ActorID and `SE_EVENTBOX_ENTER` already does it.

@CuriousMike56 @danmackey @cosmic-vole Please skim through the code and tell me if it makes sense to you. Ofc also test if I didn't break anything please.

To avoid confusion: The script callback `eventCallbackEx(ev, int,int,int,int,  string,string,string,string)` has precedence over the original `eventCallback(ev, int)` so even if the terrain script contains explicit `eventCallback()` (like Auriga does), the `eventCallbackEx()` added dynamically by race system overrides it. This _might_ break some terrains if there's custom stuff in their `eventCallback()` but I think the risk is minor.