### PR TITLE
:angel:Script: Load "foo_DEVEL.as" instead of "foo.as" if found (opt-in).

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -158,6 +158,7 @@ CVar* diag_terrn_log_roads;
 CVar* diag_actor_dump;
 CVar* diag_allow_window_resize;
 CVar* diag_use_mygui_logfile;
+CVar* diag_load_devel_scripts;
 
 // System
 CVar* sys_process_dir;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -704,6 +704,7 @@ extern CVar* diag_terrn_log_roads;
 extern CVar* diag_actor_dump;
 extern CVar* diag_allow_window_resize;
 extern CVar* diag_use_mygui_logfile;
+extern CVar* diag_load_devel_scripts;
 
 // System
 extern CVar* sys_process_dir;

--- a/source/main/scripting/OgreScriptBuilder.cpp
+++ b/source/main/scripting/OgreScriptBuilder.cpp
@@ -2,7 +2,7 @@
     This source file is part of Rigs of Rods
     Copyright 2005-2012 Pierre-Michel Ricordel
     Copyright 2007-2012 Thomas Fischer
-    Copyright 2013-2020 Petr Ohlidal
+    Copyright 2013-2026 Petr Ohlidal
 
     For more information, see http://www.rigsofrods.org/
 
@@ -41,7 +41,7 @@ int OgreScriptBuilder::LoadScriptSection(const char* full_path_cstr)
     //  This function received filename in older AngelScript versions, but now receives full path
     //      (reconstructed wrong by CScriptBuilder because it doesn't know about OGRE's ZIP files).
     //  TODO: Refactor the entire script building logic 
-    //      - create fully RoR-custom builder instead of hacked stock CScriptBuilder + our overload. ~ only_a_ptr, 08/2017
+    //      - create fully RoR-custom builder instead of hacked stock CScriptBuilder + our overload. ~ ohlidalp, 08/2017
 
     std::string full_path(full_path_cstr);
     std::string filename;
@@ -55,19 +55,63 @@ int OgreScriptBuilder::LoadScriptSection(const char* full_path_cstr)
         filename = full_path;
     }
 
+    // Check for _DEVEL.as version first if the CVar is enabled
+    std::string devel_filename;
+    std::string basename, ext;
+    Ogre::StringUtil::splitBaseFilename(filename, basename, ext);
+    if (ext == "as" && App::diag_load_devel_scripts->getBool())
+    {
+        devel_filename = basename + "_DEVEL.as";
+    }
+
     Ogre::DataStreamPtr ds;
-    try
+    std::string actual_filename = filename;
+    
+    // Try to load _DEVEL version first if applicable
+    // Note we use 'throwOnFailure=false' to avoid spamming the log with 'Not found' errors. ~ ohlidalp, 01/2026
+    if (!devel_filename.empty())
     {
-        ds = Ogre::ResourceGroupManager::getSingleton().openResource(filename, Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
-                 //TODO: do not use `AUTODETECT_RESOURCE_GROUP_NAME`, use specific group, lookups are slow!
-                 //see also https://github.com/OGRECave/ogre/blob/master/Docs/1.10-Notes.md#resourcemanager-strict-mode ~ only_a_ptr, 08/2017
+        try
+        {
+            ds = Ogre::ResourceGroupManager::getSingleton().openResource(
+                devel_filename,
+                Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME,
+                /*resourceBeingLoaded: */nullptr,
+                /*throwOnFailure:*/false);
+
+            if (ds)
+            {
+                actual_filename = devel_filename;
+                App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE,
+                    fmt::format("Using development version of script: '{}'", devel_filename));
+            }
+        }
+        catch (Ogre::Exception&)
+        {
+            // _DEVEL version not found, fall back to regular version
+            ds.reset();
+        }
     }
-    catch (Ogre::Exception& e)
+
+    // If _DEVEL version wasn't found or not applicable, load the regular version
+    
+    if (!ds)
     {
-        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_ERROR, e.getDescription());
-        return -2;
+        try
+        {
+            ds = Ogre::ResourceGroupManager::getSingleton().openResource(filename, Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
+
+                     //TODO: do not use `AUTODETECT_RESOURCE_GROUP_NAME`, use specific group, lookups are slow!
+                     //see also https://github.com/OGRECave/ogre/blob/master/Docs/1.10-Notes.md#resourcemanager-strict-mode ~ ohlidalp, 08/2017
+        }
+        catch (Ogre::Exception& e)
+        {
+            App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_ERROR, e.getDescription());
+            return -2;
+        }
     }
-    // In some cases (i.e. when fed a full path with '/'-s on Windows), `openResource()` will silently return NULL for datastream. ~ only_a_ptr, 08/2017
+    
+    // In some cases (i.e. when fed a full path with '/'-s on Windows), `openResource()` will silently return NULL for datastream. ~ ohlidalp, 08/2017
     if (!ds)
     {
         LOG("[RoR|Scripting] Failed to load file '"+filename+"', reason unknown.");
@@ -77,5 +121,5 @@ int OgreScriptBuilder::LoadScriptSection(const char* full_path_cstr)
     const std::string& code = ds->getAsString();
     hash = RoR::Sha1Hash(code);
 
-    return ProcessScriptSection(code.c_str(), static_cast<unsigned int>(code.length()), filename.c_str(), 0);
+    return ProcessScriptSection(code.c_str(), static_cast<unsigned int>(code.length()), actual_filename.c_str(), 0);
 }

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -105,6 +105,7 @@ void Console::cVarSetupBuiltins()
     App::diag_actor_dump         = this->cVarCreate("diag_actor_dump",         "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::diag_allow_window_resize= this->cVarCreate("diag_allow_window_resize","",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::diag_use_mygui_logfile  = this->cVarCreate("diag_use_mygui_logfile",  "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
+    App::diag_load_devel_scripts = this->cVarCreate("diag_load_devel_scripts", "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
 
     App::sys_process_dir         = this->cVarCreate("sys_process_dir",         "",                           0);
     App::sys_user_dir            = this->cVarCreate("sys_user_dir",            "",                           0);


### PR DESCRIPTION
When enabled and _DEVEL file is found, logs "Using development version of script: 'foo_DEVEL.as'" to console and RoR.log.
This applies to scripts loaded by any means (RoR.cfg, commandline, console, gadgets ... even include scripts are checked).

Configurable via cvar (RoR.cfg entry) `diag_load_devel_scripts` (bool, default false).

I've had the habit of naming my dev versions _DEVEL before, but I only loaded them manually. To test things like the race system, I needed to hack around. With this feature, I can just have dev variants in 'Documents\My Games\Rigs of Rods\scripts' all the time and enable their loading when I need.