### PR TITLE
✨ Added `engine_running` input source

### DIFF
--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -49,6 +49,7 @@ DashBoardManager::DashBoardManager(ActorPtr actor) : visible(true), m_actor(acto
     INITDATA(DD_ENGINE_SPEEDO_MPH       , DC_FLOAT, "speedo_mph");
     INITDATA(DD_ENGINE_TURBO            , DC_FLOAT, "engine_turbo");
     INITDATA(DD_ENGINE_IGNITION         , DC_BOOL , "engine_ignition");
+    INITDATA(DD_ENGINE_RUNNING          , DC_BOOL , "engine_running");
     INITDATA(DD_ENGINE_BATTERY          , DC_BOOL , "engine_battery");
     INITDATA(DD_ENGINE_CLUTCH_WARNING   , DC_BOOL , "engine_clutch_warning");
     INITDATA(DD_ENGINE_GEAR             , DC_INT  , "engine_gear");

--- a/source/main/gui/DashBoardManager.h
+++ b/source/main/gui/DashBoardManager.h
@@ -94,6 +94,7 @@ enum DashData
     DD_ENGINE_SPEEDO_MPH,      /// speedo in miles per hour
     DD_ENGINE_TURBO,           /// turbo gauge
     DD_ENGINE_IGNITION,
+    DD_ENGINE_RUNNING,
     DD_ENGINE_BATTERY,         /// battery lamp
     DD_ENGINE_CLUTCH_WARNING,  /// clutch warning lamp
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -3999,6 +3999,10 @@ void Actor::updateDashBoards(float dt)
         float rpm = ar_engine->getRPM();
         ar_dashboard->setFloat(DD_ENGINE_RPM, rpm);
 
+        // engine running
+        bool engRun = ar_engine->isRunning();
+        ar_dashboard->setBool(DD_ENGINE_RUNNING, engRun);
+
         // turbo
         float turbo = ar_engine->getTurboPSI() * 3.34f; // MAGIC :/
         ar_dashboard->setFloat(DD_ENGINE_TURBO, turbo);


### PR DESCRIPTION
Adds a simple `engine_running` dashboard input source:

`add_animation 180, 0, 0, source: dashboard,  mode: x-rotation, link:engine_running`

https://github.com/user-attachments/assets/196bf27a-3eb4-41d1-929c-fe58e083e6cf

