### PR TITLE
:bug: Script Monitor GUI: Fixed crash caused by bad string formatting.

### DIFF
--- a/source/main/gui/panels/GUI_ScriptMonitor.cpp
+++ b/source/main/gui/panels/GUI_ScriptMonitor.cpp
@@ -70,7 +70,7 @@ void ScriptMonitor::Draw()
         switch (unit.scriptCategory)
         {
         case ScriptCategory::ACTOR:
-            ImGui::Text("({} [%u] '%s')", _LC("ScriptMonitor", "actor"), unit.associatedActor->ar_vector_index, unit.associatedActor->getTruckName().c_str());
+            ImGui::Text("(%s) [%u] '%s'", _LC("ScriptMonitor", "actor"), unit.associatedActor->ar_vector_index, unit.associatedActor->getTruckName().c_str());
             break;
 
         case ScriptCategory::TERRAIN:


### PR DESCRIPTION
I was able to replicate the crash by spawning two vehicles that loaded dashboards with scripts.