### PR TITLE
:bug: Bugfix: Last hovered button in the aircraft overlay can be pressed without hovering on it

### DIFF
--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -1277,6 +1277,7 @@ void AeroDashOverlay::SetupMouseHovers()
 
 void AeroDashOverlay::UpdateMouseHovers()
 {
+    hovered_widget = nullptr;
     for (auto elem : aero_widgets)
     {
         if (elem->UpdateMouseHover())
@@ -1285,4 +1286,5 @@ void AeroDashOverlay::UpdateMouseHovers()
         }
     }
 }
+
 


### PR DESCRIPTION
Fixed it by setting hovered_widget to `nullptr` before looking for hovered buttons (in OverlayWrapper.cpp).