### PR TITLE
:angel:Script :bug:: Updated scriptstdstring addon to 2.37.0

### DIFF
--- a/external/angelscript_addons/scriptstdstring/scriptstdstring.cpp
+++ b/external/angelscript_addons/scriptstdstring/scriptstdstring.cpp
@@ -2,7 +2,7 @@
 #include <assert.h> // assert()
 #include <sstream>  // std::stringstream
 #include <string.h> // strstr()
-#include <stdio.h>	// sprintf()
+#include <stdio.h>	// snprintf()
 #include <stdlib.h> // strtod()
 #ifndef __psp2__
 	#include <locale.h> // setlocale()
@@ -29,18 +29,23 @@ END_AS_NAMESPACE
 #endif
 
 BEGIN_AS_NAMESPACE
-
 class CStdStringFactory : public asIStringFactory
 {
 public:
 	CStdStringFactory() {}
 	~CStdStringFactory() 
 	{
-
+		// The script engine must release each string 
+		// constant that it has requested
+		assert(stringCache.size() == 0);
 	}
 
 	const void *GetStringConstant(const char *data, asUINT length)
 	{
+		// The string factory might be modified from multiple 
+		// threads, so it is necessary to use a mutex.
+		asAcquireExclusiveLock();
+		
 		string str(data, length);
 		map_t::iterator it = stringCache.find(str);
 		if (it != stringCache.end())
@@ -48,6 +53,8 @@ public:
 		else
 			it = stringCache.insert(map_t::value_type(str, 1)).first;
 
+		asReleaseExclusiveLock();
+		
 		return reinterpret_cast<const void*>(&it->first);
 	}
 
@@ -56,14 +63,25 @@ public:
 		if (str == 0)
 			return asERROR;
 
+		int ret = asSUCCESS;
+		
+		// The string factory might be modified from multiple 
+		// threads, so it is necessary to use a mutex.
+		asAcquireExclusiveLock();
+		
 		map_t::iterator it = stringCache.find(*reinterpret_cast<const string*>(str));
 		if (it == stringCache.end())
-			return asERROR;
-
-		it->second--;
-		if (it->second == 0)
-			stringCache.erase(it);
-		return asSUCCESS;
+			ret = asERROR;
+		else
+		{
+			it->second--;
+			if (it->second == 0)
+				stringCache.erase(it);
+		}
+		
+		asReleaseExclusiveLock();
+		
+		return ret;
 	}
 
 	int  GetRawStringData(const void *str, char *data, asUINT *length) const
@@ -80,11 +98,55 @@ public:
 		return asSUCCESS;
 	}
 
-	// TODO: Make sure the access to the string cache is thread safe
+	// THe access to the string cache is protected with the common mutex provided by AngelScript
 	map_t stringCache;
 };
 
-static CStdStringFactory stringFactory;
+static CStdStringFactory *stringFactory = 0;
+
+// TODO: Make this public so the application can also use the string 
+//       factory and share the string constants if so desired, or to
+//       monitor the size of the string factory cache.
+CStdStringFactory *GetStdStringFactorySingleton()
+{
+	if( stringFactory == 0 )
+	{
+		// Make sure no other thread is creating the string factory at the same time
+		asAcquireExclusiveLock();
+		if (stringFactory == 0)
+		{
+			// The following instance will be destroyed by the global 
+			// CStdStringFactoryCleaner instance upon application shutdown
+			stringFactory = new CStdStringFactory();
+		}
+		asReleaseExclusiveLock();
+	}
+	return stringFactory;
+}
+
+class CStdStringFactoryCleaner
+{
+public:
+	~CStdStringFactoryCleaner()
+	{
+		if (stringFactory)
+		{
+			// Only delete the string factory if the stringCache is empty
+			// If it is not empty, it means that someone might still attempt
+			// to release string constants, so if we delete the string factory
+			// the application might crash. Not deleting the cache would
+			// lead to a memory leak, but since this is only happens when the
+			// application is shutting down anyway, it is not important.
+			if (stringFactory->stringCache.empty())
+			{
+				delete stringFactory;
+				stringFactory = 0;
+			}
+		}
+	}
+};
+
+static CStdStringFactoryCleaner cleaner;
 
 
 static void ConstructString(string *thisPointer)
@@ -123,6 +185,7 @@ static bool StringIsEmpty(const string &str)
 	return str.empty();
 }
 
+#if AS_NO_IMPL_OPS_WITH_STRING_AND_PRIMITIVE == 0
 static string &AssignUInt64ToString(asQWORD i, string &dest)
 {
 	ostringstream stream;
@@ -272,6 +335,7 @@ static string AddBoolString(bool b, const string &str)
 	stream << (b ? "true" : "false");
 	return stream.str() + str;
 }
+#endif
 
 static char *StringCharAt(unsigned int i, string &str)
 {
@@ -353,7 +417,7 @@ static int StringFindFirstNotOf(const string &sub, asUINT start, const string &s
 static int StringFindLastNotOf(const string &sub, asUINT start, const string &str)
 {
 	// We don't register the method directly because the argument types change between 32bit and 64bit platforms
-	return (int)str.find_last_of(sub, (size_t)(start < 0 ? string::npos : start));
+	return (int)str.find_last_not_of(sub, (size_t)(start < 0 ? string::npos : start));
 }
 
 // This function returns the index of the last position where the substring
@@ -439,7 +503,7 @@ static string formatInt(asINT64 value, const string &options, asUINT width)
 	// MSVC 8.0 / 2005 or newer
 	sprintf_s(&buf[0], buf.size(), fmt.c_str(), width, value);
 #else
-	sprintf(&buf[0], fmt.c_str(), width, value);
+	snprintf(&buf[0], buf.size(), fmt.c_str(), width, value);
 #endif
 	buf.resize(strlen(&buf[0]));
 
@@ -483,7 +547,7 @@ static string formatUInt(asQWORD value, const string &options, asUINT width)
 	// MSVC 8.0 / 2005 or newer
 	sprintf_s(&buf[0], buf.size(), fmt.c_str(), width, value);
 #else
-	sprintf(&buf[0], fmt.c_str(), width, value);
+	snprintf(&buf[0], buf.size(), fmt.c_str(), width, value);
 #endif
 	buf.resize(strlen(&buf[0]));
 
@@ -519,7 +583,7 @@ static string formatFloat(double value, const string &options, asUINT width, asU
 	// MSVC 8.0 / 2005 or newer
 	sprintf_s(&buf[0], buf.size(), fmt.c_str(), width, precision, value);
 #else
-	sprintf(&buf[0], fmt.c_str(), width, precision, value);
+	snprintf(&buf[0], buf.size(), fmt.c_str(), width, precision, value);
 #endif
 	buf.resize(strlen(&buf[0]));
 
@@ -638,7 +702,8 @@ double parseFloat(const string &val, asUINT *byteCount)
 	// locale is ",".
 #if !defined(_WIN32_WCE) && !defined(ANDROID) && !defined(__psp2__)
 	// Set the locale to C so that we are guaranteed to parse the float value correctly
-	char *orig = setlocale(LC_NUMERIC, 0);
+	char *tmp = setlocale(LC_NUMERIC, 0);
+	string orig = tmp ? tmp : "C";
 	setlocale(LC_NUMERIC, "C");
 #endif
 
@@ -646,7 +711,7 @@ double parseFloat(const string &val, asUINT *byteCount)
 
 #if !defined(_WIN32_WCE) && !defined(ANDROID) && !defined(__psp2__)
 	// Restore the locale
-	setlocale(LC_NUMERIC, orig);
+	setlocale(LC_NUMERIC, orig.c_str());
 #endif
 
 	if( byteCount )
@@ -694,7 +759,7 @@ void RegisterStdString_Native(asIScriptEngine *engine)
 	r = engine->RegisterObjectType("string", sizeof(string), asOBJ_VALUE | asOBJ_APP_CLASS_CDAK); assert( r >= 0 );
 #endif
 
-	r = engine->RegisterStringFactory("string", &stringFactory);
+	r = engine->RegisterStringFactory("string", GetStdStringFactorySingleton());
 
 	// Register the object operator overloads
 	r = engine->RegisterObjectBehaviour("string", asBEHAVE_CONSTRUCT,  "void f()",                    asFUNCTION(ConstructString), asCALL_CDECL_OBJLAST); assert( r >= 0 );
@@ -711,10 +776,16 @@ void RegisterStdString_Native(asIScriptEngine *engine)
 	r = engine->RegisterObjectMethod("string", "string opAdd(const string &in) const", asFUNCTIONPR(operator +, (const string &, const string &), string), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
 
 	// The string length can be accessed through methods or through virtual property
+	// TODO: Register as size() for consistency with other types
+#if AS_USE_ACCESSORS != 1
 	r = engine->RegisterObjectMethod("string", "uint length() const", asFUNCTION(StringLength), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+#endif
 	r = engine->RegisterObjectMethod("string", "void resize(uint)", asFUNCTION(StringResize), asCALL_CDECL_OBJLAST); assert( r >= 0 );
-	r = engine->RegisterObjectMethod("string", "uint get_length() const", asFUNCTION(StringLength), asCALL_CDECL_OBJLAST); assert( r >= 0 );
-	r = engine->RegisterObjectMethod("string", "void set_length(uint)", asFUNCTION(StringResize), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+#if AS_USE_STLNAMES != 1 && AS_USE_ACCESSORS == 1
+	// Don't register these if STL names is used, as they conflict with the method size()
+	r = engine->RegisterObjectMethod("string", "uint get_length() const property", asFUNCTION(StringLength), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("string", "void set_length(uint) property", asFUNCTION(StringResize), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+#endif
 	// Need to use a wrapper on Mac OS X 10.7/XCode 4.3 and CLang/LLVM, otherwise the linker fails
 //	r = engine->RegisterObjectMethod("string", "bool isEmpty() const", asMETHOD(string, empty), asCALL_THISCALL); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "bool isEmpty() const", asFUNCTION(StringIsEmpty), asCALL_CDECL_OBJLAST); assert( r >= 0 );
@@ -724,6 +795,7 @@ void RegisterStdString_Native(asIScriptEngine *engine)
 	r = engine->RegisterObjectMethod("string", "uint8 &opIndex(uint)", asFUNCTION(StringCharAt), asCALL_CDECL_OBJLAST); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "const uint8 &opIndex(uint) const", asFUNCTION(StringCharAt), asCALL_CDECL_OBJLAST); assert( r >= 0 );
 
+#if AS_NO_IMPL_OPS_WITH_STRING_AND_PRIMITIVE == 0
 	// Automatic conversion from values
 	r = engine->RegisterObjectMethod("string", "string &opAssign(double)", asFUNCTION(AssignDoubleToString), asCALL_CDECL_OBJLAST); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "string &opAddAssign(double)", asFUNCTION(AddAssignDoubleToString), asCALL_CDECL_OBJLAST); assert( r >= 0 );
@@ -749,6 +821,7 @@ void RegisterStdString_Native(asIScriptEngine *engine)
 	r = engine->RegisterObjectMethod("string", "string &opAddAssign(bool)", asFUNCTION(AddAssignBoolToString), asCALL_CDECL_OBJLAST); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "string opAdd(bool) const", asFUNCTION(AddStringBool), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "string opAdd_r(bool) const", asFUNCTION(AddBoolString), asCALL_CDECL_OBJLAST); assert( r >= 0 );
+#endif
 
 	// Utilities
 	r = engine->RegisterObjectMethod("string", "string substr(uint start = 0, int count = -1) const", asFUNCTION(StringSubString), asCALL_CDECL_OBJLAST); assert( r >= 0 );
@@ -995,6 +1068,7 @@ static void StringCharAtGeneric(asIScriptGeneric * gen)
 	}
 }
 
+#if AS_NO_IMPL_OPS_WITH_STRING_AND_PRIMITIVE == 0
 static void AssignInt2StringGeneric(asIScriptGeneric *gen)
 {
 	asINT64 *a = static_cast<asINT64*>(gen->GetAddressOfArg(0));
@@ -1194,6 +1268,7 @@ static void AddBool2StringGeneric(asIScriptGeneric * gen)
 	std::string ret_val = sstr.str();
 	gen->SetReturnObject(&ret_val);
 }
+#endif
 
 static void StringSubString_Generic(asIScriptGeneric *gen)
 {
@@ -1214,7 +1289,7 @@ void RegisterStdString_Generic(asIScriptEngine *engine)
 	// Register the string type
 	r = engine->RegisterObjectType("string", sizeof(string), asOBJ_VALUE | asOBJ_APP_CLASS_CDAK); assert( r >= 0 );
 
-	r = engine->RegisterStringFactory("string", &stringFactory);
+	r = engine->RegisterStringFactory("string", GetStdStringFactorySingleton());
 
 	// Register the object operator overloads
 	r = engine->RegisterObjectBehaviour("string", asBEHAVE_CONSTRUCT,  "void f()",                    asFUNCTION(ConstructStringGeneric), asCALL_GENERIC); assert( r >= 0 );
@@ -1228,16 +1303,21 @@ void RegisterStdString_Generic(asIScriptEngine *engine)
 	r = engine->RegisterObjectMethod("string", "string opAdd(const string &in) const", asFUNCTION(StringAddGeneric), asCALL_GENERIC); assert( r >= 0 );
 
 	// Register the object methods
+#if AS_USE_ACCESSORS != 1
 	r = engine->RegisterObjectMethod("string", "uint length() const", asFUNCTION(StringLengthGeneric), asCALL_GENERIC); assert( r >= 0 );
+#endif
 	r = engine->RegisterObjectMethod("string", "void resize(uint)",   asFUNCTION(StringResizeGeneric), asCALL_GENERIC); assert( r >= 0 );
-	r = engine->RegisterObjectMethod("string", "uint get_length() const", asFUNCTION(StringLengthGeneric), asCALL_GENERIC); assert( r >= 0 );
-	r = engine->RegisterObjectMethod("string", "void set_length(uint)", asFUNCTION(StringResizeGeneric), asCALL_GENERIC); assert( r >= 0 );
+#if AS_USE_STLNAMES != 1 && AS_USE_ACCESSORS == 1
+	r = engine->RegisterObjectMethod("string", "uint get_length() const property", asFUNCTION(StringLengthGeneric), asCALL_GENERIC); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("string", "void set_length(uint) property", asFUNCTION(StringResizeGeneric), asCALL_GENERIC); assert( r >= 0 );
+#endif
 	r = engine->RegisterObjectMethod("string", "bool isEmpty() const", asFUNCTION(StringIsEmptyGeneric), asCALL_GENERIC); assert( r >= 0 );
 
 	// Register the index operator, both as a mutator and as an inspector
 	r = engine->RegisterObjectMethod("string", "uint8 &opIndex(uint)", asFUNCTION(StringCharAtGeneric), asCALL_GENERIC); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "const uint8 &opIndex(uint) const", asFUNCTION(StringCharAtGeneric), asCALL_GENERIC); assert( r >= 0 );
 
+#if AS_NO_IMPL_OPS_WITH_STRING_AND_PRIMITIVE == 0
 	// Automatic conversion from values
 	r = engine->RegisterObjectMethod("string", "string &opAssign(double)", asFUNCTION(AssignDouble2StringGeneric), asCALL_GENERIC); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "string &opAddAssign(double)", asFUNCTION(AddAssignDouble2StringGeneric), asCALL_GENERIC); assert( r >= 0 );
@@ -1263,6 +1343,7 @@ void RegisterStdString_Generic(asIScriptEngine *engine)
 	r = engine->RegisterObjectMethod("string", "string &opAddAssign(bool)", asFUNCTION(AddAssignBool2StringGeneric), asCALL_GENERIC); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "string opAdd(bool) const", asFUNCTION(AddString2BoolGeneric), asCALL_GENERIC); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "string opAdd_r(bool) const", asFUNCTION(AddBool2StringGeneric), asCALL_GENERIC); assert( r >= 0 );
+#endif
 
 	r = engine->RegisterObjectMethod("string", "string substr(uint start = 0, int count = -1) const", asFUNCTION(StringSubString_Generic), asCALL_GENERIC); assert(r >= 0);
 	r = engine->RegisterObjectMethod("string", "int findFirst(const string &in, uint start = 0) const", asFUNCTION(StringFindFirst_Generic), asCALL_GENERIC); assert(r >= 0);

--- a/external/angelscript_addons/scriptstdstring/scriptstdstring.cpp
+++ b/external/angelscript_addons/scriptstdstring/scriptstdstring.cpp
@@ -35,9 +35,6 @@ public:
 	CStdStringFactory() {}
 	~CStdStringFactory() 
 	{
-		// The script engine must release each string 
-		// constant that it has requested
-		assert(stringCache.size() == 0);
 	}
 
 	const void *GetStringConstant(const char *data, asUINT length)

--- a/external/angelscript_addons/scriptstdstring/scriptstdstring.h
+++ b/external/angelscript_addons/scriptstdstring/scriptstdstring.h
@@ -28,9 +28,19 @@
 //
 //  0 = off
 //  1 = on
-
 #ifndef AS_USE_STLNAMES
 #define AS_USE_STLNAMES 0
+#endif
+
+// Some prefer to use property accessors to get/set the length of the string
+// This option registers the accessors instead of the method length()
+#ifndef AS_USE_ACCESSORS
+#define AS_USE_ACCESSORS 0
+#endif
+
+// This option disables the implicit operators with primitives
+#ifndef AS_NO_IMPL_OPS_WITH_STRING_AND_PRIMITIVE
+#define AS_NO_IMPL_OPS_WITH_STRING_AND_PRIMITIVE 0
 #endif
 
 BEGIN_AS_NAMESPACE

--- a/external/angelscript_addons/scriptstdstring/scriptstdstring_utils.cpp
+++ b/external/angelscript_addons/scriptstdstring/scriptstdstring_utils.cpp
@@ -34,8 +34,9 @@ static CScriptArray *StringSplit(const string &delim, const string &str)
 	CScriptArray *array = CScriptArray::Create(arrayType);
 
 	// Find the existence of the delimiter in the input string
-	int pos = 0, prev = 0, count = 0;
-	while( (pos = (int)str.find(delim, prev)) != (int)string::npos )
+	size_t pos = 0, prev = 0;
+	asUINT count = 0;
+	while( (pos = str.find(delim, prev)) != string::npos )
 	{
 		// Add the part to the array
 		array->Resize(array->GetSize()+1);
@@ -43,7 +44,7 @@ static CScriptArray *StringSplit(const string &delim, const string &str)
 
 		// Find the next part
 		count++;
-		prev = pos + (int)delim.length();
+		prev = pos + delim.length();
 	}
 
 	// Add the remaining part
@@ -87,12 +88,12 @@ static string StringJoin(const CScriptArray &array, const string &delim)
 		int n;
 		for( n = 0; n < (int)array.GetSize() - 1; n++ )
 		{
-			str += *(string*)array.At(n);
+			str += *(const string*)array.At(n);
 			str += delim;
 		}
 
 		// Add the last part
-		str += *(string*)array.At(n);
+		str += *(const string*)array.At(n);
 	}
 
 	return str;


### PR DESCRIPTION
This fixes a series of problems that happened just after calling `parseFloat()` in a script, mainly:

- Terrain objects weren't loaded.
- Loss of control for aircraft caused by invalid simulation of airfoils.

`parseFloat()` needs to temporarily change the numeric locale to "C" to ensure decimal strings like "3.14" are always parsed properly. The previous version of `parseFloat()` used the `setlocale()` C function incorrectly (see [commit](https://github.com/anjo76/angelscript/commit/c7c880dbb8c889863af6ea7f5c7eb95cf6aabce0)), causing the locale to be changed to the system locale. This affects the reading of .tobj (terrain objects) and .afl (X-Plane airfoil definition) files if the new locale uses the comma as the decimal separator, since both file formats contain comma-separated values that are read using the locale-sensitive `sscanf()` C function.

The issue of terrain objects not loading was initially reported in [this forum thread](https://forum.rigsofrods.org/threads/problem-with-auriga-proving-grounds.4893/).