### PR TITLE
:bug: Restored option to hide commands from T-screen.

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -3769,28 +3769,31 @@ void ActorSpawner::ProcessCommand(RigDef::Command2 & def)
     m_actor->m_has_command_beams = true;
 
     // Update the unique pair list
-    bool must_insert_qpair = true;
-    for (UniqueCommandKeyPair& qpair: m_actor->ar_unique_commandkey_pairs)
+    if (def.description != "hide")
     {
-        // seek match on both keys (in any order)
-        if ((def.contract_key == qpair.uckp_key1 && def.extend_key == qpair.uckp_key2)
-            || (def.contract_key == qpair.uckp_key2 && def.extend_key == qpair.uckp_key1))
+        bool must_insert_qpair = true;
+        for (UniqueCommandKeyPair& qpair: m_actor->ar_unique_commandkey_pairs)
         {
-            must_insert_qpair = false;
-            if (def.description != "")
+            // seek match on both keys (in any order)
+            if ((def.contract_key == qpair.uckp_key1 && def.extend_key == qpair.uckp_key2)
+                || (def.contract_key == qpair.uckp_key2 && def.extend_key == qpair.uckp_key1))
             {
-                qpair.uckp_description = def.description; // Last description always wins
+                must_insert_qpair = false;
+                if (def.description != "")
+                {
+                    qpair.uckp_description = def.description; // Last description always wins
+                }
+                break;
             }
-            break;
         }
-    }
-    if (must_insert_qpair)
-    {
-        UniqueCommandKeyPair qpair;
-        qpair.uckp_key1 = def.contract_key;
-        qpair.uckp_key2 = def.extend_key;
-        qpair.uckp_description = def.description;
-        m_actor->ar_unique_commandkey_pairs.push_back(qpair);
+        if (must_insert_qpair)
+        {
+            UniqueCommandKeyPair qpair;
+            qpair.uckp_key1 = def.contract_key;
+            qpair.uckp_key2 = def.extend_key;
+            qpair.uckp_description = def.description;
+            m_actor->ar_unique_commandkey_pairs.push_back(qpair);
+        }
     }
 }
 


### PR DESCRIPTION
The feature is described in docs: `Writing "hide" will hide the command from the "t-screen": https://docs.rigsofrods.org/vehicle-creation/fileformat-truck/#commands

Pointed out by Zephyr on Discord: https://discord.com/channels/136544456244461568/409871728597139457/1492057910975660044

This was probably broken around 2010 with MyGUI migration when commands were moved out from T-window to Ctrl+T-window.