### PR TITLE
:dash: Made particles freeze when actor physics are paused (hidden mode '2')

### DIFF
--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -419,6 +419,13 @@ enum class GfxSkyMode
 };
 std::string ToLocalizedString(GfxSkyMode e);
 
+enum class GfxParticlesMode
+{
+    OFF = 0,
+    GLOBAL_POOL = 1,
+    PER_ACTOR_POOLS = 2, // Experimental, not in GUI yet, may cause performance issues with many actors emitting particles
+};
+
 enum class EfxReverbEngine
 {
     NONE,

--- a/source/main/gfx/DustPool.cpp
+++ b/source/main/gfx/DustPool.cpp
@@ -36,19 +36,18 @@ using namespace RoR;
   const int DustPool::MAX_DUSTS;
 #endif // !_WIN32
 
-DustPool::DustPool(Ogre::SceneManager* sm, const char* dname, int dsize):
+DustPool::DustPool(Ogre::SceneManager* sm, const char* dname, int dsize, const std::string& custom_name /* = "" */):
 	allocated(0),
 	size(std::min(dsize, static_cast<int>(MAX_DUSTS))),
 	m_is_discarded(false)
 {
-    parent_snode = sm->getRootSceneNode()->createChildSceneNode(fmt::format("DustPools/{}", dname));
+    std::string poolname = fmt::format("DustPools/{}", custom_name.empty() ? dname : custom_name);
+    parent_snode = sm->getRootSceneNode()->createChildSceneNode(poolname);
 
     for (int i = 0; i < size; i++)
     {
-        char dename[256];
-        sprintf(dename, "Dust %s %i", dname, i);
         sns[i] = parent_snode->createChildSceneNode();
-        pss[i] = sm->createParticleSystem(dename, dname);
+        pss[i] = sm->createParticleSystem(fmt::format("{}_{}", poolname, i), dname);
         if (pss[i])
         {
             sns[i]->attachObject(pss[i]);
@@ -192,11 +191,19 @@ void DustPool::allocRipple(Vector3 pos, Vector3 vel)
     }
 }
 
+void DustPool::AdjustDustPoolSpeedFactor(GfxActor* gfx_actor /* = nullptr */)
+{
+    // This must be done over all particle system, even those not allocated at the moment
+    for (int i = 0; i < size; i++)
+    {
+        App::GetGfxScene()->AdjustParticleSystemTimeFactor(pss[i], gfx_actor);
+    }
+}
+
 void DustPool::update()
 {
     for (int i = 0; i < allocated; i++)
     {
-        App::GetGfxScene()->AdjustParticleSystemTimeFactor(pss[i]);
         ParticleEmitter* emit = pss[i]->getEmitter(0);
         Vector3 ndir = velocities[i];
         Real vel = ndir.length();

--- a/source/main/gfx/DustPool.h
+++ b/source/main/gfx/DustPool.h
@@ -34,10 +34,12 @@ class DustPool
 {
 public:
 
-    DustPool(Ogre::SceneManager* sm, const char* dname, int dsize);
+    DustPool(Ogre::SceneManager* sm, const char* dname, int dsize, const std::string& custom_name = "");
     ~DustPool();
 
     void Discard(Ogre::SceneManager* sm);
+
+    void AdjustDustPoolSpeedFactor(GfxActor* gfx_actor = nullptr);
 
     void setVisible(bool s);
     //Dust

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -66,12 +66,26 @@ RoR::GfxActor::GfxActor(ActorPtr actor, ActorSpawner* spawner, std::string ogre_
     m_renderdash(renderdash)
 {
     // Setup particles
-    m_particles_drip   = App::GetGfxScene()->GetDustPool("drip");
-    m_particles_dust   = App::GetGfxScene()->GetDustPool("dust"); // Dust, water vapour, tyre smoke
-    m_particles_splash = App::GetGfxScene()->GetDustPool("splash");
-    m_particles_ripple = App::GetGfxScene()->GetDustPool("ripple");
-    m_particles_sparks = App::GetGfxScene()->GetDustPool("sparks");
-    m_particles_clump  = App::GetGfxScene()->GetDustPool("clump");
+    switch (m_actor->m_particles_mode)
+    {
+    case GfxParticlesMode::PER_ACTOR_POOLS:
+        m_particles_drip   = new DustPool(App::GetGfxScene()->GetSceneManager(), "tracks/Drip",   50, spawner->ComposeName("Drip"));
+        m_particles_dust   = new DustPool(App::GetGfxScene()->GetSceneManager(), "tracks/Dust",   20, spawner->ComposeName("Dust"));
+        m_particles_splash = new DustPool(App::GetGfxScene()->GetSceneManager(), "tracks/Splash", 20, spawner->ComposeName("Splash"));
+        m_particles_ripple = new DustPool(App::GetGfxScene()->GetSceneManager(), "tracks/Ripple", 20, spawner->ComposeName("Ripple"));
+        m_particles_sparks = new DustPool(App::GetGfxScene()->GetSceneManager(), "tracks/Sparks", 10, spawner->ComposeName("Sparks"));
+        m_particles_clump  = new DustPool(App::GetGfxScene()->GetSceneManager(), "tracks/Clump",  20, spawner->ComposeName("Clump"));
+        break;
+
+    default:
+        m_particles_drip   = App::GetGfxScene()->GetDustPool("drip");
+        m_particles_dust   = App::GetGfxScene()->GetDustPool("dust"); // Dust, water vapour, tyre smoke
+        m_particles_splash = App::GetGfxScene()->GetDustPool("splash");
+        m_particles_ripple = App::GetGfxScene()->GetDustPool("ripple");
+        m_particles_sparks = App::GetGfxScene()->GetDustPool("sparks");
+        m_particles_clump  = App::GetGfxScene()->GetDustPool("clump");
+        break;
+    }
 }
 
 std::string WhereFrom(GfxActor* gfx_actor, const std::string& doing_what)
@@ -330,6 +344,24 @@ RoR::GfxActor::~GfxActor()
         {
             HandleGenericException(fmt::format("Actor::dispose(); instanceID:{}, streamID:{}, filename:{}; deleting custom particle {}/{}.",
                 m_actor->ar_instance_id, m_actor->ar_net_stream_id, m_actor->ar_filename, i, m_cparticles.size()), HANDLEGENERICEXCEPTION_LOGFILE);
+        }
+    }
+
+    // delete default particles, if owned by this actor
+    if (m_actor->m_particles_mode == GfxParticlesMode::PER_ACTOR_POOLS)
+    {
+        try
+        {
+            m_particles_drip->Discard(App::GetGfxScene()->GetSceneManager()); delete m_particles_drip;
+            m_particles_dust->Discard(App::GetGfxScene()->GetSceneManager()); delete m_particles_dust;
+            m_particles_splash->Discard(App::GetGfxScene()->GetSceneManager()); delete m_particles_splash;
+            m_particles_ripple->Discard(App::GetGfxScene()->GetSceneManager()); delete m_particles_ripple;
+            m_particles_sparks->Discard(App::GetGfxScene()->GetSceneManager()); delete m_particles_sparks;
+            m_particles_clump->Discard(App::GetGfxScene()->GetSceneManager()); delete m_particles_clump;
+        }
+        catch (...)
+        {
+            HandleGenericException(WhereFrom(this, "deleting per-actor particle pools (spawned with 'gfx_particles_mode=2')"), HANDLEGENERICEXCEPTION_LOGFILE);
         }
     }
 }
@@ -701,6 +733,23 @@ void RoR::GfxActor::UpdateParticles(float dt)
         }
 
         nfx.nx_under_water_prev = n.nd_under_water;
+    }
+
+    if (m_actor->m_particles_mode == GfxParticlesMode::PER_ACTOR_POOLS)
+    {
+        m_particles_drip->AdjustDustPoolSpeedFactor(this);
+        m_particles_dust->AdjustDustPoolSpeedFactor(this);
+        m_particles_splash->AdjustDustPoolSpeedFactor(this);
+        m_particles_ripple->AdjustDustPoolSpeedFactor(this);
+        m_particles_sparks->AdjustDustPoolSpeedFactor(this);
+        m_particles_clump->AdjustDustPoolSpeedFactor(this);
+
+        m_particles_drip->update();
+        m_particles_dust->update();
+        m_particles_splash->update();
+        m_particles_ripple->update();
+        m_particles_sparks->update();
+        m_particles_clump->update();
     }
 }
 
@@ -2026,7 +2075,7 @@ void RoR::GfxActor::UpdateCParticles()
 {
     for (CParticle& cparticle: m_cparticles)
     {
-        App::GetGfxScene()->AdjustParticleSystemTimeFactor(cparticle.psys);
+        App::GetGfxScene()->AdjustParticleSystemTimeFactor(cparticle.psys, this);
         const Ogre::Vector3 pos = m_simbuf.simbuf_nodes[cparticle.emitterNode].AbsPosition;
         const Ogre::Vector3 dir = fast_normalise(pos - m_simbuf.simbuf_nodes[cparticle.directionNode].AbsPosition);
         cparticle.snode->setPosition(pos);
@@ -2049,7 +2098,7 @@ void RoR::GfxActor::UpdateExhausts()
         if (!exhaust.smoker) // This remains `nullptr` if removed via `addonpart_unwanted_exhaust` or Tuning UI.
             continue;
 
-        App::GetGfxScene()->AdjustParticleSystemTimeFactor(exhaust.smoker);
+        App::GetGfxScene()->AdjustParticleSystemTimeFactor(exhaust.smoker, this);
         const Ogre::Vector3 pos = m_simbuf.simbuf_nodes[exhaust.emitterNode].AbsPosition;
         const Ogre::Vector3 dir = pos - m_simbuf.simbuf_nodes[exhaust.directionNode].AbsPosition;
         exhaust.smokeNode->setPosition(pos);

--- a/source/main/gfx/GfxScene.cpp
+++ b/source/main/gfx/GfxScene.cpp
@@ -119,7 +119,7 @@ void GfxScene::UpdateScene(float dt)
     }
 
     // Particles
-    if (App::gfx_particles_mode->getInt() == 1)
+    if (App::gfx_particles_mode->getEnum<GfxParticlesMode>() != GfxParticlesMode::OFF)
     {
         // Generate particles as needed
         for (GfxActor* gfx_actor: m_all_gfx_actors)
@@ -131,6 +131,7 @@ void GfxScene::UpdateScene(float dt)
         // Update particle movement
         for (auto itor : m_dustpools)
         {
+            itor.second->AdjustDustPoolSpeedFactor();
             itor.second->update();
         }
     }
@@ -432,12 +433,17 @@ void GfxScene::DrawNetLabel(Ogre::Vector3 scene_pos, float cam_dist, std::string
 #endif // USE_SOCKETW
 }
 
-void GfxScene::AdjustParticleSystemTimeFactor(Ogre::ParticleSystem* psys)
+void GfxScene::AdjustParticleSystemTimeFactor(Ogre::ParticleSystem* psys, GfxActor* gfx_actor /* = nullptr */)
 {
     float speed_factor = 0.f;
     if (App::sim_state->getEnum<SimState>() == SimState::RUNNING && !App::GetGameContext()->GetActorManager()->IsSimulationPaused())
     {
         speed_factor = m_simbuf.simbuf_sim_speed;
+    }
+
+    if (gfx_actor && gfx_actor->GetSimDataBuffer().simbuf_physics_paused)
+    {
+        speed_factor = 0.f;
     }
 
     psys->setSpeedFactor(speed_factor);

--- a/source/main/gfx/GfxScene.h
+++ b/source/main/gfx/GfxScene.h
@@ -53,7 +53,7 @@ public:
     /// @{
     void           CreateDustPools();
     DustPool*      GetDustPool(const char* name);
-    void           AdjustParticleSystemTimeFactor(Ogre::ParticleSystem* psys);
+    void           AdjustParticleSystemTimeFactor(Ogre::ParticleSystem* psys, GfxActor* gfx_actor = nullptr);
     void           SetParticlesVisible(bool visible);
     /// @}
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4494,7 +4494,6 @@ Actor::Actor(
     , m_beam_deform_debug_enabled(false)
     , m_trigger_debug_enabled(false)
     , m_disable_default_sounds(false)
-    , m_disable_smoke(false)
 {
 }
 

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -669,6 +669,7 @@ private:
     CacheEntryPtr     m_used_skin_entry;               //!< Optional, only graphics.
     CacheEntryPtrVec  m_used_addonpart_entries;        //!< Optional, assigned by player via Tuning menu (.tuneup files).
     CacheEntryPtrVec  m_used_assetpack_entries;        //!< Optional, specified by mod author in truck file via 'assetpacks' section.
+    /// @}
 
     /// @name Networking
     /// @{
@@ -693,6 +694,12 @@ private:
     bool              m_blinker_right_lit = false;               //!< Blinking state of right turn signal
     /// @}
 
+    /// @name Built-in particles
+    /// @{
+    GfxParticlesMode  m_particles_mode = GfxParticlesMode::OFF; //!< Snapshot of cvar 'gfx_particles_mode' on spawn.
+    bool              m_disable_smoke = false;                  //!< Stops/starts smoke particles (i.e. exhausts, turbojets).
+    /// @}
+
     bool m_hud_features_ok:1;      //!< Gfx state; Are HUD features matching actor's capabilities?
     bool m_slidenodes_locked:1;    //!< Physics state; Are SlideNodes locked?
     bool m_net_initialized:1;
@@ -704,7 +711,6 @@ private:
     bool m_beam_deform_debug_enabled:1; //!< Logging state
     bool m_trigger_debug_enabled:1;     //!< Logging state
     bool m_disable_default_sounds:1;    //!< Spawner context; TODO: remove
-    bool m_disable_smoke:1;             //!< Stops/starts smoke particles (i.e. exhausts, turbojets).
 
     struct VehicleForceSensors
     {

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -310,7 +310,8 @@ void ActorSpawner::InitializeRig()
     m_actor->m_odometer_user  = 0;
 
     m_actor->ar_masscount=0;
-    m_actor->m_disable_smoke = App::gfx_particles_mode->getInt() == 0;
+    m_actor->m_particles_mode =  App::gfx_particles_mode->getEnum<GfxParticlesMode>();
+    m_actor->m_disable_smoke = App::gfx_particles_mode->getEnum<GfxParticlesMode>() == GfxParticlesMode::OFF;
     m_actor->m_beam_break_debug_enabled  = App::diag_log_beam_break->getBool();
     m_actor->m_beam_deform_debug_enabled = App::diag_log_beam_deform->getBool();
     m_actor->m_trigger_debug_enabled    = App::diag_log_beam_trigger->getBool();
@@ -2948,7 +2949,7 @@ void ActorSpawner::ProcessTorqueCurve(RigDef::TorqueCurve & def)
 
 void ActorSpawner::ProcessParticle(RigDef::Particle & def)
 {
-    if (App::gfx_particles_mode->getInt() != 1)
+    if (App::gfx_particles_mode->getEnum<GfxParticlesMode>() == GfxParticlesMode::OFF)
     {
         return;
     }

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -70,6 +70,7 @@ namespace RoR {
 class ActorSpawner
 {
     friend class RoR::FlexFactory; // Needs to use `ComposeName()` and `SetupNewEntity()`
+    friend class RoR::GfxActor; // Needs to use `ComposeName()`
 
 public:
 

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -183,7 +183,7 @@ void TurbojetVisual::UpdateVisuals(RoR::GfxActor* gfx_actor)
     if (m_smoke_particle &&
         gfx_actor->GetSimDataBuffer().simbuf_smoke_enabled)
     {
-        App::GetGfxScene()->AdjustParticleSystemTimeFactor(m_smoke_particle);
+        App::GetGfxScene()->AdjustParticleSystemTimeFactor(m_smoke_particle, gfx_actor);
         m_smoke_scenenode->setPosition(node_buf[m_node_back].AbsPosition);
         ParticleEmitter* emit = m_smoke_particle->getEmitter(0);
         emit->setDirection(-laxis);

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -168,14 +168,14 @@ Turboprop::~Turboprop()
     }
 }
 
-void Turboprop::updateVisuals(RoR::GfxActor* gfx_m_actor)
+void Turboprop::updateVisuals(RoR::GfxActor* gfx_actor)
 {
-    RoR::NodeSB* node_buf = gfx_m_actor->GetSimNodeBuffer();
+    RoR::NodeSB* node_buf = gfx_actor->GetSimNodeBuffer();
 
     //smoke
     if (smokeNode)
     {
-        App::GetGfxScene()->AdjustParticleSystemTimeFactor(smokePS);
+        App::GetGfxScene()->AdjustParticleSystemTimeFactor(smokePS, gfx_actor);
         smokeNode->setPosition(node_buf[nodeback].AbsPosition);
         ParticleEmitter* emit = smokePS->getEmitter(0);
         Vector3 dir = node_buf[nodeback].AbsPosition - node_buf[noderef].AbsPosition;


### PR DESCRIPTION
I've added a hidden option `gfx_particles_mode = 2` which gives every actor it's own particle pools that freeze when the actor physics are paused.

This option isn't shown in the Settings UI yet since it's experimental. It might negatively impact FPS and terrain loading times (for example Auriga because of the traffic cones).

The best way to use it is to open ingame console and type `set gfx_particles_mode 2`. Any actor (re)spawned afterwards will have it's own particle pools that pause when it's paused. To just view the current value, type `vars gfx_particles`.

Note that custom particles and legacy systems (like x/y exhausts or turbojets) will pause regardless because these were always per-actor.

Codechanges:
* Application.h: added `enum GfxParticlesMode`
* DustPool.h/cpp: added function `AdjustDustPoolSpeedFactor()` because doing it inside `update()` isn't reliable.
* GfxActor.cpp: Added creating/updating/deleting the per-actor particle pools.
* GfxScene.h/cpp: Extended helper `AdjustParticleSystemTimeFactor()` to respect paused actors.
* the rest is minor adjustments to fit the new feature

Fixes #3412