### PR TITLE
⏱️ Integrated OGRE profiler

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,6 +6,10 @@ from conan.tools.files import copy
 class RoR(ConanFile):
     name = "Rigs of Rods"
     settings = "os", "compiler", "build_type", "arch"
+    default_options = {
+        "ogre3d*:resourcemanager_strict": "off",
+        "ogre3d*:profiling": "True"
+    }
 
     def layout(self):
         self.folders.generators = os.path.join(self.folders.build, "generators")

--- a/resources/fonts/SdkTraysRedirect.fontdef
+++ b/resources/fonts/SdkTraysRedirect.fontdef
@@ -1,0 +1,11 @@
+// OGRE script, see https://ogrecave.github.io/ogre/api/latest/_font-_definition-_scripts.html
+
+// This font name is hardcoded in OGRE profiler, see 'OgreOverlayProfileSessionListener.cpp' func `createTextArea()`
+font SdkTrays/Value
+{
+	type 		truetype
+	source 		Roboto-Medium.ttf
+    // see '/Media/packs/SdkTrays.zip' in OGRE repo.
+	size 		20
+    resolution  96
+}

--- a/source/main/AppContext.cpp
+++ b/source/main/AppContext.cpp
@@ -463,6 +463,31 @@ void AppContext::ActivateFullscreen(bool val)
 }
 
 // --------------------------
+// Profiling
+
+void AppContext::PrepareProfiler()
+{
+#if OGRE_PROFILING == 1 // Singleton is null otherwise
+
+    // WORKAROUND for OGRE v14.5.2 bug - repeated `setEnabled()` true causes shutdown-reinit cycle.
+    // See https://github.com/OGRECave/ogre/commit/05dd52dc7c9abfc3a15734dab59deede7288404a
+    if (App::diag_profiler_enabled->getBool() != m_profiler_enabled)
+    {
+        m_profiler_enabled = App::diag_profiler_enabled->getBool();
+        Ogre::Profiler::getSingleton().setEnabled(m_profiler_enabled);
+    }
+
+    if (App::diag_profiler_rate->getInt() < 1) // Check valid uint & Avoid division by zero in OGRE
+    {
+        App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
+            fmt::format(_L("Invalid profiler update rate ({}), resetting to default"), App::diag_profiler_rate->getInt()));
+        App::diag_profiler_rate->setVal(10); // Default in OGRE
+    }
+    Ogre::Profiler::getSingleton().setUpdateDisplayFrequency((Ogre::uint)App::diag_profiler_rate->getInt());
+#endif
+}
+
+// --------------------------
 // Program paths and logging
 
 bool AppContext::SetUpProgramPaths()

--- a/source/main/AppContext.h
+++ b/source/main/AppContext.h
@@ -61,6 +61,9 @@ public:
     void                 CaptureScreenshot();
     void                 ActivateFullscreen(bool val);
 
+    // Profiling
+    void                 PrepareProfiler();
+
     // Getters
     Ogre::Root*          GetOgreRoot() { return m_ogre_root; }
     Ogre::Viewport*      GetViewport() { return m_viewport; }
@@ -98,6 +101,7 @@ private:
     Ogre::RenderWindow*  m_render_window = nullptr;
     Ogre::Viewport*      m_viewport      = nullptr;
     bool                 m_windowed_fix = false; //!< Workaround OGRE glitch when switching from fullscreen.
+    bool                 m_profiler_enabled = false; //!< Last known state, to workaround OGRE v14.5.2 bug
 
     std::time_t          m_prev_screenshot_time;
     int                  m_prev_screenshot_index = 1;

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -159,6 +159,8 @@ CVar* diag_actor_dump;
 CVar* diag_allow_window_resize;
 CVar* diag_use_mygui_logfile;
 CVar* diag_load_devel_scripts;
+CVar* diag_profiler_enabled;
+CVar* diag_profiler_rate;
 
 // System
 CVar* sys_process_dir;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -705,6 +705,8 @@ extern CVar* diag_actor_dump;
 extern CVar* diag_allow_window_resize;
 extern CVar* diag_use_mygui_logfile;
 extern CVar* diag_load_devel_scripts;
+extern CVar* diag_profiler_enabled;
+extern CVar* diag_profiler_rate;
 
 // System
 extern CVar* sys_process_dir;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -706,6 +706,8 @@ extern CVar* diag_actor_dump;
 extern CVar* diag_allow_window_resize;
 extern CVar* diag_use_mygui_logfile;
 extern CVar* diag_load_devel_scripts;
+extern CVar* diag_profiler_enabled;
+extern CVar* diag_profiler_rate;
 
 // System
 extern CVar* sys_process_dir;

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -327,6 +327,7 @@ int main(int argc, char *argv[])
 
         while (App::app_state->getEnum<AppState>() != AppState::SHUTDOWN)
         {
+            App::GetAppContext()->PrepareProfiler();
             OgreBites::WindowEventUtilities::messagePump();
 
             // Halt physics (wait for async tasks to finish)
@@ -336,8 +337,10 @@ int main(int argc, char *argv[])
             }
 
             // Game events
+            OgreProfileBegin("RoR message queue");
             while (App::GetGameContext()->HasMessages())
             {
+                OgreProfile("RoR Message Handling");
                 Message m = App::GetGameContext()->PopMessage();
                 bool failed_m = false;
                 switch (m.type)
@@ -1969,10 +1972,12 @@ int main(int argc, char *argv[])
                 }
 
             } // Game events block
+            OgreProfileEnd("RoR message queue");
 
             // Check FPS limit
             if (App::gfx_fps_limit->getInt() > 0)
             {
+                OgreProfile("RoR FPS limiter");
                 const float min_frame_time = 1.0f / Ogre::Math::Clamp(App::gfx_fps_limit->getInt(), 5, 240);
                 float dt = std::chrono::duration<float>(std::chrono::high_resolution_clock::now() - start_time).count();
                 while (dt < min_frame_time)
@@ -1981,6 +1986,7 @@ int main(int argc, char *argv[])
                 }
             } // Check FPS limit block
 
+            OgreProfileBegin("RoR Main Loop");
             // Calculate delta time
             const auto now = std::chrono::high_resolution_clock::now();
             const float dt = std::chrono::duration<float>(now - start_time).count();
@@ -2004,6 +2010,7 @@ int main(int argc, char *argv[])
 #endif // USE_SOCKETW
 
             // Process input events
+            OgreProfileBegin("RoR Input processing");
             if (dt != 0.f)
             {
                 App::GetInputEngine()->Capture();
@@ -2075,14 +2082,17 @@ int main(int argc, char *argv[])
                     } // app state SIMULATION
                 } // interactive key binding mode
             } // dt != 0
+            OgreProfileEnd("RoR Input processing");
 
             // Update OutGauge device
             if (App::io_outgauge_mode->getInt() > 0)
             {
+                OgreProfile("OutGauge");
                 App::GetOutGauge()->Update(dt, App::GetGameContext()->GetPlayerActor());
             }
 
             // Early GUI updates which require halted physics
+            OgreProfileBegin("Early GUI");
             App::GetGuiManager()->NewImGuiFrame(dt);
             if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
             {
@@ -2100,28 +2110,36 @@ int main(int argc, char *argv[])
                     }
                 }
             }
+            OgreProfileEnd("Early GUI");
 
 #ifdef USE_MUMBLE
             if (App::GetMumble())
             {
+                OgreProfile("Mumble");
                 App::GetMumble()->Update(); // 3d voice over network
             }
 #endif // USE_MUMBLE
 
 #ifdef USE_OPENAL
+            OgreProfileBegin("3D audio");
             App::GetSoundScriptManager()->update(dt); // update 3d audio listener position
+            OgreProfileEnd("3D audio");
 #endif // USE_OPENAL
 
 #ifdef USE_ANGELSCRIPT
+            OgreProfileBegin("Scripting");
             App::GetScriptEngine()->framestep(dt);
+            OgreProfileEnd("Scripting");
 #endif // USE_ANGELSCRIPT
 
             if (App::io_ffb_enabled->getBool() &&
                 App::sim_state->getEnum<SimState>() == SimState::RUNNING)
             {
+                OgreProfile("Force Feedback");
                 App::GetAppContext()->GetForceFeedback().Update();
             }
 
+            OgreProfileBegin("Simulation");
             if (App::sim_state->getEnum<SimState>() == SimState::RUNNING)
             {
                 App::GetGameContext()->GetSceneMouse().UpdateSimulation();
@@ -2151,8 +2169,10 @@ int main(int argc, char *argv[])
                 }
                 App::GetGameContext()->UpdateActors(); // *** Start new physics tasks. No reading from Actor N/B beyond this point.
             }
+            OgreProfileEnd("Simulation");
 
             // Scene and GUI updates
+            OgreProfileBegin("Scene and GUI");
             if (App::app_state->getEnum<AppState>() == AppState::MAIN_MENU)
             {
                 App::GetGuiManager()->DrawMainMenuGui();
@@ -2161,8 +2181,10 @@ int main(int argc, char *argv[])
             {
                 App::GetGfxScene()->UpdateScene(dt_sim); // Draws GUI as well
             }
+            OgreProfileEnd("Scene and GUI");
 
             // Render!
+            OgreProfileEnd("RoR Main Loop"); // Must stay alive until rendering ends.
             Ogre::RenderWindow* render_window = RoR::App::GetAppContext()->GetRenderWindow();
             if (render_window->isClosed())
             {

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -327,6 +327,7 @@ int main(int argc, char *argv[])
 
         while (App::app_state->getEnum<AppState>() != AppState::SHUTDOWN)
         {
+            App::GetAppContext()->PrepareProfiler();
             OgreBites::WindowEventUtilities::messagePump();
 
             // Halt physics (wait for async tasks to finish)
@@ -336,6 +337,7 @@ int main(int argc, char *argv[])
             }
 
             // Game events
+            OgreProfileBegin("RoR message queue");
             while (App::GetGameContext()->HasMessages())
             {
                 Message m = App::GetGameContext()->PopMessage();
@@ -1969,10 +1971,12 @@ int main(int argc, char *argv[])
                 }
 
             } // Game events block
+            OgreProfileEnd("RoR message queue");
 
             // Check FPS limit
             if (App::gfx_fps_limit->getInt() > 0)
             {
+                OgreProfile("RoR FPS limiter");
                 const float min_frame_time = 1.0f / Ogre::Math::Clamp(App::gfx_fps_limit->getInt(), 5, 240);
                 float dt = std::chrono::duration<float>(std::chrono::high_resolution_clock::now() - start_time).count();
                 while (dt < min_frame_time)
@@ -1981,6 +1985,7 @@ int main(int argc, char *argv[])
                 }
             } // Check FPS limit block
 
+            OgreProfileBegin("RoR Main Loop");
             // Calculate delta time
             const auto now = std::chrono::high_resolution_clock::now();
             const float dt = std::chrono::duration<float>(now - start_time).count();
@@ -2004,6 +2009,7 @@ int main(int argc, char *argv[])
 #endif // USE_SOCKETW
 
             // Process input events
+            OgreProfileBegin("Input processing");
             if (dt != 0.f)
             {
                 App::GetInputEngine()->Capture();
@@ -2075,10 +2081,12 @@ int main(int argc, char *argv[])
                     } // app state SIMULATION
                 } // interactive key binding mode
             } // dt != 0
+            OgreProfileEnd("Input processing");
 
             // Update OutGauge device
             if (App::io_outgauge_mode->getInt() > 0)
             {
+                OgreProfile("OutGauge");
                 App::GetOutGauge()->Update(dt, App::GetGameContext()->GetPlayerActor());
             }
 
@@ -2086,6 +2094,7 @@ int main(int argc, char *argv[])
             App::GetGuiManager()->NewImGuiFrame(dt);
             if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
             {
+                OgreProfile("Scene and GUI");
                 App::GetGuiManager()->DrawSimulationGui(dt);
                 for (ActorPtr& actor : App::GetGameContext()->GetActorManager()->GetActors())
                 {
@@ -2104,24 +2113,31 @@ int main(int argc, char *argv[])
 #ifdef USE_MUMBLE
             if (App::GetMumble())
             {
+                OgreProfile("Mumble");
                 App::GetMumble()->Update(); // 3d voice over network
             }
 #endif // USE_MUMBLE
 
 #ifdef USE_OPENAL
+            OgreProfileBegin("3D audio");
             App::GetSoundScriptManager()->update(dt); // update 3d audio listener position
+            OgreProfileEnd("3D audio");
 #endif // USE_OPENAL
 
 #ifdef USE_ANGELSCRIPT
+            OgreProfileBegin("Scripting");
             App::GetScriptEngine()->framestep(dt);
+            OgreProfileEnd("Scripting");
 #endif // USE_ANGELSCRIPT
 
             if (App::io_ffb_enabled->getBool() &&
                 App::sim_state->getEnum<SimState>() == SimState::RUNNING)
             {
+                OgreProfile("Force Feedback");
                 App::GetAppContext()->GetForceFeedback().Update();
             }
 
+            OgreProfileBegin("Simulation");
             if (App::sim_state->getEnum<SimState>() == SimState::RUNNING)
             {
                 App::GetGameContext()->GetSceneMouse().UpdateSimulation();
@@ -2151,8 +2167,10 @@ int main(int argc, char *argv[])
                 }
                 App::GetGameContext()->UpdateActors(); // *** Start new physics tasks. No reading from Actor N/B beyond this point.
             }
+            OgreProfileEnd("Simulation");
 
             // Scene and GUI updates
+            OgreProfileBegin("Scene and GUI"); // Adds up to existing profile
             if (App::app_state->getEnum<AppState>() == AppState::MAIN_MENU)
             {
                 App::GetGuiManager()->DrawMainMenuGui();
@@ -2161,6 +2179,9 @@ int main(int argc, char *argv[])
             {
                 App::GetGfxScene()->UpdateScene(dt_sim); // Draws GUI as well
             }
+            OgreProfileEnd("Scene and GUI");
+
+            OgreProfileEnd("RoR Main Loop");
 
             // Render!
             Ogre::RenderWindow* render_window = RoR::App::GetAppContext()->GetRenderWindow();

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -106,6 +106,8 @@ void Console::cVarSetupBuiltins()
     App::diag_allow_window_resize= this->cVarCreate("diag_allow_window_resize","",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::diag_use_mygui_logfile  = this->cVarCreate("diag_use_mygui_logfile",  "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
     App::diag_load_devel_scripts = this->cVarCreate("diag_load_devel_scripts", "",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
+    App::diag_profiler_enabled   = this->cVarCreate("diag_profiler_enabled",   "",                           CVAR_TYPE_BOOL,                   "false");
+    App::diag_profiler_rate      = this->cVarCreate("diag_profiler_rate",      "",                           CVAR_ARCHIVE | CVAR_TYPE_INT,     "10");
 
     App::sys_process_dir         = this->cVarCreate("sys_process_dir",         "",                           0);
     App::sys_user_dir            = this->cVarCreate("sys_user_dir",            "",                           0);


### PR DESCRIPTION
User-facing features:
- new cvar `diag_profiler_enabled` (bool) - always false on startup, can be activated via console `set diag_profiler_enabled 1`
- new cvar `diag_profiler_rate` (int) - sampling rate of the profiler, defaults to 10 frames. Stored in RoR.cfg.

<img width="1520" height="785" alt="screenshot_2026-04-27_08-53-50_1" src="https://github.com/user-attachments/assets/79f4d698-11ad-4fd1-8755-45b73b8704fd" />
