### PR TITLE
:wrench::bug: Fixed crashes when spawning scripted actors using `game.spawnTruck()` or `game.spawnTruckAI()`

### DIFF
--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -509,10 +509,6 @@ DashBoard* DashBoardManager::loadDashBoard(std::string const& filename, BitMask_
         // GameContext.ChangePlayerActor() will change the visibility
         // when needed.
         d->setVisible(false);
-        if (scriptfilename != "")
-        {
-            d->loadScript(scriptfilename, m_actor);
-        }
         m_dashboards.push_back(d);
 
         if (BITMASK_IS_0(flags, LOADDASHBOARD_STACKABLE))
@@ -526,10 +522,6 @@ DashBoard* DashBoardManager::loadDashBoard(std::string const& filename, BitMask_
         d = new DashBoard(this, layoutfname, rttLayer);
         loadedRTTDashboards++;
         d->setVisible(true);
-        if (scriptfilename != "")
-        {
-            d->loadScript(scriptfilename, m_actor);
-        }
         m_dashboards.push_back(d);
         // NOTE: Renderdash RTTs are never stackable
     }
@@ -538,16 +530,31 @@ DashBoard* DashBoardManager::loadDashBoard(std::string const& filename, BitMask_
     {
         d = new DashBoard(this, layoutfname, rttLayer);
         d->setVisible(true);
-        if (scriptfilename != "")
-        {
-            d->loadScript(scriptfilename, m_actor);
-        }
         m_dashboards.push_back(d);
 
         if (BITMASK_IS_0(flags, LOADDASHBOARD_STACKABLE))
         {
             m_hud_loaded = true;
         }
+    }
+
+    // Load dashboard script
+    // We have to push messages to load dashboard scripts because
+    // this code can be called from a script execution context
+    // (e.g. using game.spawnTruck()).
+    // If we are in a script context, calling loadScript() directly
+    // will crash the game immediately, since AngelScript doesn't
+    // allow scripts to load other scripts.
+    if (scriptfilename != "")
+    {
+        LoadScriptRequest* req = new LoadScriptRequest();
+        req->lsr_category = ScriptCategory::ACTOR;
+        req->lsr_filename = scriptfilename;
+        req->lsr_associated_actor = m_actor->getInstanceId();
+        App::GetGameContext()->PushMessage(Message(MSG_APP_LOAD_SCRIPT_REQUESTED, req));
+        // We don't need to worry about unloading the script later because
+        // it has an actor associated to it. Actor scripts are unloaded
+        // already when calling ActorManager::DeleteActorInternal().
     }
 
     // Apply textures from 'guisettings' in truck file.
@@ -693,11 +700,6 @@ DashBoard::DashBoard(DashBoardManager* manager, Ogre::String filename, RTTLayer*
 
 DashBoard::~DashBoard()
 {
-    // Unload dashboard script
-    if (scriptUnitID != SCRIPTUNITID_INVALID)
-    {
-        App::GetScriptEngine()->unloadScript(scriptUnitID);
-    }
     // Clear the GUI widgets
     MyGUI::LayoutManager::getInstance().unloadLayout(widgets);
     // Force unloading the '.layout' file from memory
@@ -708,14 +710,6 @@ DashBoard::~DashBoard()
         rttLayer->destroyRttTexture();
         App::GetGuiManager()->GetRttLayerManager().RecycleRttLayer(rttLayer);
     }
-}
-
-void DashBoard::loadScript(std::string scriptFilename, ActorPtr associatedActor)
-{
-    if (scriptUnitID != SCRIPTUNITID_INVALID)
-        return;
-
-    scriptUnitID = App::GetScriptEngine()->loadScript(scriptFilename, ScriptCategory::ACTOR, associatedActor);
 }
 
 void DashBoard::updateFeatures()

--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -480,11 +480,17 @@ DashBoard* DashBoardManager::loadDashBoard(std::string const& filename, BitMask_
         }
 
         // Load dashboard script
-        Ogre::FileInfoListPtr scriptFile
-            = Ogre::ResourceGroupManager::getSingleton().findResourceFileInfo(entry->resource_group, fmt::format("{}.as", basename));
-        if (scriptFile->size() > 0)
+        // First, we check if the script file actually exists.
+        std::string expected_script_name = fmt::format("{}.as", basename);
+        Ogre::FileInfoListPtr scriptFiles
+            = Ogre::ResourceGroupManager::getSingleton().findResourceFileInfo(entry->resource_group, fmt::format("{}*.as", basename));
+        for (Ogre::FileInfo& fileinfo : *scriptFiles)
         {
-            scriptfilename = scriptFile->front().filename;
+            if (fileinfo.filename == expected_script_name)
+            {
+                scriptfilename = fileinfo.filename;
+                break;
+            }
         }
     }
     else

--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -482,16 +482,10 @@ DashBoard* DashBoardManager::loadDashBoard(std::string const& filename, BitMask_
         // Load dashboard script
         // First, we check if the script file actually exists.
         std::string expected_script_name = fmt::format("{}.as", basename);
-        Ogre::FileInfoListPtr scriptFiles
-            = Ogre::ResourceGroupManager::getSingleton().findResourceFileInfo(entry->resource_group, fmt::format("{}*.as", basename));
-        for (Ogre::FileInfo& fileinfo : *scriptFiles)
-        {
-            if (fileinfo.filename == expected_script_name)
-            {
-                scriptfilename = fileinfo.filename;
-                break;
-            }
-        }
+        bool script_exists =
+            Ogre::ResourceGroupManager::getSingleton().resourceExists(entry->resource_group, expected_script_name);
+        if (script_exists)
+            scriptfilename = expected_script_name;
     }
     else
     {

--- a/source/main/gui/DashBoardManager.h
+++ b/source/main/gui/DashBoardManager.h
@@ -285,8 +285,6 @@ public:
     DashBoard(DashBoardManager* manager, Ogre::String filename, RTTLayer* _rttLayer);
     ~DashBoard();
 
-    void loadScript(std::string scriptFilename, ActorPtr associatedActor);
-
     void setVisible(bool visible, bool smooth = true);
     bool getVisible() { return visible; };
 
@@ -302,7 +300,6 @@ public:
 protected:
     DashBoardManager* manager{nullptr};
     Ogre::String filename;
-    ScriptUnitID_t scriptUnitID = SCRIPTUNITID_INVALID;
     MyGUI::VectorWidgetPtr widgets;
     MyGUI::WindowPtr mainWidget;
     bool visible;

--- a/source/main/physics/ActorManager.cpp
+++ b/source/main/physics/ActorManager.cpp
@@ -336,12 +336,6 @@ ActorPtr ActorManager::CreateNewActor(ActorSpawnRequest rq, RigDef::DocumentPtr 
         actor->m_buoyance->buoy_projected_nodes = actor->m_buoyance->buoy_cached_nodes;
     }
 
-    // Launch scripts (FIXME: ignores sectionconfig)
-    for (RigDef::Script const& script_def : def->root_module->scripts)
-    {
-        App::GetScriptEngine()->loadScript(script_def.filename, ScriptCategory::ACTOR, actor);
-    }
-
     LOG(" ===== DONE LOADING VEHICLE");
 
     if (App::diag_actor_dump->getBool())

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -30,9 +30,9 @@
 
 #include "AddonPartFileFormat.h"
 #include "AppContext.h"
+#include "Application.h"
 #include "AirBrake.h"
 #include "Airfoil.h"
-#include "Application.h"
 #include "ApproxMath.h"
 #include "AutoPilot.h"
 #include "Actor.h"
@@ -61,6 +61,7 @@
 #include "MeshObject.h"
 #include "PointColDetector.h"
 #include "ScrewProp.h"
+#include "ScriptEngine.h"
 #include "Skidmark.h"
 #include "SkinFileFormat.h"
 #include "SlideNode.h"
@@ -740,6 +741,23 @@ void ActorSpawner::ProcessScrewprop(RigDef::Screwprop & def)
     );
     m_actor->ar_driveable=BOAT;
     m_actor->ar_num_screwprops++;
+}
+
+void ActorSpawner::ProcessScript(RigDef::Script& def)
+{
+    // Load actor script
+    // We have to push messages to load actor scripts because
+    // this code can be called from a script execution context
+    // (e.g. using game.spawnTruck()).
+    // If we are in a script context, calling loadScript() directly
+    // will crash the game immediately, since AngelScript doesn't
+    // allow scripts to load other scripts.
+    LoadScriptRequest* req = new LoadScriptRequest();
+    req->lsr_category = ScriptCategory::ACTOR;
+    req->lsr_filename = def.filename;
+    req->lsr_associated_actor = m_actor->getInstanceId();
+    App::GetGameContext()->PushMessage(RoR::Message(MSG_APP_LOAD_SCRIPT_REQUESTED, req));
+    // ActorManager::DeleteActorInternal() will unload scripts later.
 }
 
 void ActorSpawner::ProcessFusedrag(RigDef::Fusedrag & def)

--- a/source/main/physics/ActorSpawner.h
+++ b/source/main/physics/ActorSpawner.h
@@ -199,7 +199,8 @@ private:
     void ProcessRope(RigDef::Rope & def);
     void ProcessRotator(RigDef::Rotator & def);
     void ProcessRotator2(RigDef::Rotator2 & def);
-    void ProcessScrewprop(RigDef::Screwprop & def);
+    void ProcessScrewprop(RigDef::Screwprop& def);
+    void ProcessScript(RigDef::Script& def);
     void ProcessShock(RigDef::Shock & def);
     void ProcessShock2(RigDef::Shock2 & def);
     void ProcessShock3(RigDef::Shock3 & def);

--- a/source/main/physics/ActorSpawnerFlow.cpp
+++ b/source/main/physics/ActorSpawnerFlow.cpp
@@ -141,6 +141,7 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     PROCESS_ELEMENT(RigDef::Keyword::BRAKES, brakes, ProcessBrakes);
     PROCESS_ELEMENT(RigDef::Keyword::CUSTOMDASHBOARDINPUTS, customdashboardinputs, ProcessCustomDashInputs);
     PROCESS_ELEMENT(RigDef::Keyword::GUISETTINGS, guisettings, ProcessGuiSettings);
+    PROCESS_ELEMENT(RigDef::Keyword::SCRIPTS, scripts, ProcessScript);
 
     // ---------------------------- User-defined nodes ----------------------------
 


### PR DESCRIPTION
This fixes a crash that was triggered when calling AS functions `game.spawnTruck()` or `game.spawnTruckAI()`. This only affected actors that had scripts loaded for them (either from dashboard scripts or the `scripts` truckfile section).
The crash could also be easily triggered by loading scripted actors using the Vehicle AI menu (which uses `game.spawnTruckAI()` internally).
While I was at it, I also fixed the `scripts` section ignoring `sectionconfig`.

Here's a test mod I made for triggering the crashes and testing the `sectionconfig`, which is based on the lightweight template truck featured [here](https://docs.rigsofrods.org/vehicle-creation/weight-tuning/).
[RoRTruckScriptsCrashTest.zip](https://github.com/user-attachments/files/28271565/RoRTruckScriptsCrashTest.zip)
