### PR TITLE
Added ignition animation source + engine_off input source

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -1853,6 +1853,7 @@ void RoR::GfxActor::UpdateSimDataBuffer()
         m_simbuf.simbuf_has_engine      = true;
         m_simbuf.simbuf_gear            = m_actor->ar_engine->getGear();
         m_simbuf.simbuf_autoshift       = m_actor->ar_engine->getAutoShift();
+        m_simbuf.simbuf_engine_ignition = m_actor->ar_engine->hasContact();
         m_simbuf.simbuf_engine_rpm      = m_actor->ar_engine->getRPM();
         m_simbuf.simbuf_engine_turbo_psi= m_actor->ar_engine->getTurboPSI();
         m_simbuf.simbuf_engine_accel    = m_actor->ar_engine->getAcc();
@@ -2736,6 +2737,14 @@ void RoR::GfxActor::CalcPropAnimation(PropAnim& anim, float& cstate, int& div, f
         if (m_simbuf.simbuf_lightmask & RoRnet::LIGHTMASK_BLINK_RIGHT)
             signal = 1.0f;
         cstate -= signal;
+        div++;
+    }
+
+    //ignition
+    if (has_engine && anim.animFlags & PROP_ANIM_FLAG_IGNITION)
+    {
+        float ignition = m_simbuf.simbuf_engine_ignition;
+        cstate += ignition;
         div++;
     }
 

--- a/source/main/gfx/GfxData.h
+++ b/source/main/gfx/GfxData.h
@@ -76,6 +76,7 @@ const PropAnimFlag_t PROP_ANIM_FLAG_ELEVATORS     = BITMASK64(32);
 const PropAnimFlag_t PROP_ANIM_FLAG_DASHBOARD     = BITMASK64(33); //!< Used with dashboard system inputs, see `enum DashData` in file DashBoardManager.h
 const PropAnimFlag_t PROP_ANIM_FLAG_SIGNALSTALK   = BITMASK64(34); //!< Turn indicator stalk position (-1=left, 0=off, 1=right)
 const PropAnimFlag_t PROP_ANIM_FLAG_GEAR          = BITMASK64(35); //!< 'gearreverse' (animOpt3=-1), 'gearneutral' (animOpt3=0), 'gear#' (animOpt3=#)
+const PropAnimFlag_t PROP_ANIM_FLAG_IGNITION      = BITMASK64(36);
 
 typedef BitMask_t PropAnimMode_t;
 

--- a/source/main/gfx/SimBuffers.h
+++ b/source/main/gfx/SimBuffers.h
@@ -142,6 +142,7 @@ struct ActorSB
     float             simbuf_hydro_dir_state          = 0;     // State of steering actuator ('hydro'), for steeringwheel display
     float             simbuf_brake                    = 0;
     bool              simbuf_has_engine               = false;
+    bool              simbuf_engine_ignition          = false;
     int               simbuf_gear                     = 0;
     int               simbuf_autoshift                = 0;    
     float             simbuf_engine_rpm               = 0;

--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -52,6 +52,7 @@ DashBoardManager::DashBoardManager(ActorPtr actor) : visible(true), m_actor(acto
     INITDATA(DD_ENGINE_TURBO            , DC_FLOAT, "engine_turbo");
     INITDATA(DD_ENGINE_IGNITION         , DC_BOOL , "engine_ignition");
     INITDATA(DD_ENGINE_RUNNING          , DC_BOOL , "engine_running");
+    INITDATA(DD_ENGINE_OFF              , DC_BOOL , "engine_off");
     INITDATA(DD_ENGINE_BATTERY          , DC_BOOL , "engine_battery");
     INITDATA(DD_ENGINE_CLUTCH_WARNING   , DC_BOOL , "engine_clutch_warning");
     INITDATA(DD_ENGINE_GEAR             , DC_INT  , "engine_gear");

--- a/source/main/gui/DashBoardManager.h
+++ b/source/main/gui/DashBoardManager.h
@@ -93,6 +93,7 @@ enum DashData
     DD_ENGINE_TURBO,           /// turbo gauge
     DD_ENGINE_IGNITION,
     DD_ENGINE_RUNNING,
+    DD_ENGINE_OFF,
     DD_ENGINE_BATTERY,         /// battery lamp
     DD_ENGINE_CLUTCH_WARNING,  /// clutch warning lamp
 

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4123,6 +4123,10 @@ void Actor::updateDashBoards(float dt)
         bool engRun = ar_engine->isRunning();
         ar_dashboard->setBool(DD_ENGINE_RUNNING, engRun);
 
+        // engine off
+        bool engOff = !ar_engine->isRunning();
+        ar_dashboard->setBool(DD_ENGINE_OFF, engOff);
+
         // turbo
         float turbo = ar_engine->getTurboPSI() * 3.34f; // MAGIC :/
         ar_dashboard->setFloat(DD_ENGINE_TURBO, turbo);

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -2036,6 +2036,9 @@ void ActorSpawner::ProcessProp(RigDef::Prop & def)
             BITMASK_SET_1(anim.animFlags, PROP_ANIM_FLAG_GEAR);
             anim.animOpt3 = 0;
         }
+        if (BITMASK_IS_1(anim_def.source, RigDef::Animation::SOURCE_IGNITION)) {
+            BITMASK_SET_1(anim.animFlags, PROP_ANIM_FLAG_IGNITION);
+        }
 
         /* Motor/Gear-indexed sources */
         std::list<RigDef::Animation::MotorSource>::iterator source_itor = anim_def.motor_sources.begin();

--- a/source/main/resources/rig_def_fileformat/RigDef_File.h
+++ b/source/main/resources/rig_def_fileformat/RigDef_File.h
@@ -393,6 +393,7 @@ struct Animation
     static const BitMask64_t SOURCE_AUTOSHIFTERLIN    = BITMASK64(35);
     static const BitMask64_t SOURCE_GEAR_NEUTRAL      = BITMASK64(36);
     static const BitMask64_t SOURCE_GEAR_REVERSE      = BITMASK64(37);
+    static const BitMask64_t SOURCE_IGNITION          = BITMASK64(38);
 
     // Mode flags
     static const BitMask_t MODE_ROTATION_X          = BITMASK(1);

--- a/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
+++ b/source/main/resources/rig_def_fileformat/RigDef_Parser.cpp
@@ -1296,6 +1296,7 @@ void Parser::ParseDirectiveAddAnimation()
                     else if (value == "signalstalk")   { animation.source |= Animation::SOURCE_SIGNALSTALK;       }
                     else if (value == "gearreverse")   { animation.source |= Animation::SOURCE_GEAR_REVERSE;      }
                     else if (value == "gearneutral")   { animation.source |= Animation::SOURCE_GEAR_NEUTRAL;      }
+                    else if (value == "ignition")      { animation.source |= Animation::SOURCE_IGNITION;          }
 
                     else
                     {


### PR DESCRIPTION
Adds an `ignition` source to `add_animation`, resolves #3023:

https://github.com/user-attachments/assets/5ae716ce-a31c-42ee-885e-66d53e2fc0cb

Also added an `engine_off` input source, requested by redliner720 on [Discord](https://discord.com/channels/136544456244461568/409871728597139457/1495224292483534928).