### PR TITLE
Added dashboard cinecam visibility setting

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -284,6 +284,7 @@ CVar* ui_default_truck_dash;
 CVar* ui_legacy_truck_renderdash;
 CVar* ui_default_boat_dash;
 CVar* ui_always_show_fullsize;
+CVar* ui_dashboard_cinecam;
 
 // Instance access
 AppContext*            GetAppContext         () { return &g_app_context; };

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -831,6 +831,7 @@ extern CVar* ui_default_truck_dash;        //!< string; name of the '.dashboard'
 extern CVar* ui_legacy_truck_renderdash;   //!< string; name of the '.dashboard' file in modcache.
 extern CVar* ui_default_boat_dash;         //!< string; name of the '.dashboard' file in modcache.
 extern CVar* ui_always_show_fullsize;
+extern CVar* ui_dashboard_cinecam;
 
 // ------------------------------------------------------------------------------------------------
 // Global objects

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -431,7 +431,7 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
 
         m_cct_player_actor->prepareInside(true);
 
-        if ( RoR::App::GetOverlayWrapper() != nullptr )
+        if ( RoR::App::GetOverlayWrapper() != nullptr && App::ui_dashboard_cinecam->getBool() )
         {
             bool visible = m_cct_player_actor->ar_driveable == AIRPLANE && !App::GetGuiManager()->IsGuiHidden();
             RoR::App::GetOverlayWrapper()->showDashboardOverlays(visible, m_cct_player_actor);

--- a/source/main/gui/panels/GUI_GameSettings.cpp
+++ b/source/main/gui/panels/GUI_GameSettings.cpp
@@ -373,6 +373,8 @@ void GameSettings::DrawUiSettings()
 
     DrawGCheckbox(App::gfx_speedo_imperial, _LC("GameSettings", "Imperial units"));
 
+    DrawGCheckbox(App::ui_dashboard_cinecam, _LC("GameSettings", "Hide dashboard in cinecam view"));
+
     DrawGCheckbox(App::ui_show_live_repair_controls, _LC("GameSettings", "Show controls in live repair box"));
     
     DrawGCheckbox(App::ui_show_vehicle_buttons, _LC("GameSettings", "Show vehicle buttons menu"));

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -224,6 +224,7 @@ void Console::cVarSetupBuiltins()
     App::ui_legacy_truck_renderdash        = this->cVarCreate("ui_legacy_truck_renderdash",        "", CVAR_ARCHIVE, "rdd_classic.dashboard");
     App::ui_default_boat_dash              = this->cVarCreate("ui_default_boat_dash",              "", CVAR_ARCHIVE, "default_boat.dashboard");
     App::ui_always_show_fullsize           = this->cVarCreate("ui_always_show_fullsize",           "", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "false");
+    App::ui_dashboard_cinecam              = this->cVarCreate("ui_dashboard_cinecam", "Hide dashboard in cinecam view", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "true");
 }
 
 CVar* Console::cVarCreate(std::string const& name, std::string const& long_name,


### PR DESCRIPTION
Currently the dashboard HUD auto hides while in cinecam view. This behavior can now be changed with "Hide dashboard in cinecam view" in UI settings. When disabled the HUD will always be visible regardless of camera mode.