### PR TITLE
:scroll: Added faux param `ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE`

### DIFF
--- a/doc/angelscript/Script2Game/enums/ActorSimAttr.h
+++ b/doc/angelscript/Script2Game/enums/ActorSimAttr.h
@@ -44,6 +44,7 @@ enum ActorSimAttr
     ACTORSIMATTR_ENGOPTION_MAX_IDLE_MIXTURE, //!< Max throttle to maintain idle RPM - Param #9 of 'engoption'
     ACTORSIMATTR_ENGOPTION_MIN_IDLE_MIXTURE, //!< Min throttle to maintain idle RPM - Param #10 of 'engoption'
     ACTORSIMATTR_ENGOPTION_BRAKING_TORQUE, //!< How much engine brakes on zero throttle - Param #11 of 'engoption'
+    ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE, //!< Node number representing air intake - stalls engine if submerged in water (pass '-1' to disable); Defaults to cinecam ref node (classic behavior) except for electric engine where it's disabled by default.
 
     // Engturbo2 (actually 'engturbo' with Param #1 [type] set to "2" - the recommended variant)
     ACTORSIMATTR_ENGTURBO2_INERTIA_FACTOR, //!< Time to spool up - Param #2 of 'engturbo2'

--- a/source/main/gameplay/Engine.cpp
+++ b/source/main/gameplay/Engine.cpp
@@ -257,6 +257,16 @@ void Engine::SetEngineOptions(float einertia, char etype, float eclutch, float c
 
 void Engine::UpdateEngine(float dt, int doUpdate)
 {
+    // if engine air intake is defined and under water, stop engine
+    const auto water = App::GetGameContext()->GetTerrain()->getWater();
+    if (m_air_intake_node != NODENUM_INVALID && water)
+    {
+        if (water->IsUnderWater(m_actor->ar_nodes[m_air_intake_node].AbsPosition))
+        {
+            this->stopEngine();
+        }
+    }
+
     float acc = m_cur_acc;
 
     acc = std::max(getIdleMixture(), acc);

--- a/source/main/gameplay/Engine.h
+++ b/source/main/gameplay/Engine.h
@@ -25,6 +25,7 @@
 
 #include "Application.h"
 #include "RefCountingObject.h"
+#include "SimData.h"
 
 #include <Ogre.h>
 #include <vector>
@@ -224,6 +225,7 @@ private:
     bool           m_engine_is_priming;     //!< Engine
     TorqueCurve*   m_torque_curve;
     float          m_air_pressure;
+    NodeNum_t      m_air_intake_node = NODENUM_INVALID; //!< Node number of the air intake node (if any) - defaults to cinecam ref node (classic behavior) but can be overriden by ACTORSIMATTR_AIRINTAKENODE
 
     // Ignition
     bool           m_contact;               //!< Ignition switch is in ON/RUN position.

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -5122,6 +5122,7 @@ void Actor::setSimAttribute(ActorSimAttr attr, float val)
     case ACTORSIMATTR_ENGOPTION_MAX_IDLE_MIXTURE: if (ar_engine) { ar_engine->m_max_idle_mixture = val; } return;
     case ACTORSIMATTR_ENGOPTION_MIN_IDLE_MIXTURE: if (ar_engine) { ar_engine->m_min_idle_mixture = val; } return;
     case ACTORSIMATTR_ENGOPTION_BRAKING_TORQUE:   if (ar_engine) { ar_engine->m_braking_torque = val; } return;
+    case ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE:  if (ar_engine) { ar_engine->m_air_intake_node = (int)val; } return; // -1 = no air intake node (casted to `NodeNum_t` produces 65535 which is NODENUM_INVALID)
 
         // Engturbo2 (actually 'engturbo' with type=2) 
     case ACTORSIMATTR_ENGTURBO2_INERTIA_FACTOR:      if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_inertia_factor = val; } return;
@@ -5172,6 +5173,7 @@ float Actor::getSimAttribute(ActorSimAttr attr)
     case ACTORSIMATTR_ENGOPTION_MAX_IDLE_MIXTURE: if (ar_engine) { return ar_engine->m_max_idle_mixture; } return 0.f;
     case ACTORSIMATTR_ENGOPTION_MIN_IDLE_MIXTURE: if (ar_engine) { return ar_engine->m_min_idle_mixture; } return 0.f;
     case ACTORSIMATTR_ENGOPTION_BRAKING_TORQUE:   if (ar_engine) { return ar_engine->m_braking_torque; } return 0.f;
+    case ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE:  if (ar_engine) { return (ar_engine->m_air_intake_node == NODENUM_INVALID) ? -1.f : (float)ar_engine->m_air_intake_node; } return 0.f; // -1 = no air intake node (casted to `NodeNum_t` produces 65535 which is NODENUM_INVALID)
 
         // Engturbo2 (actually 'engturbo' with type=2) 
     case ACTORSIMATTR_ENGTURBO2_INERTIA_FACTOR:        if (ar_engine && ar_engine->m_turbo_ver == 2) { return ar_engine->m_turbo_inertia_factor; } return 0.f;

--- a/source/main/physics/ActorForcesEuler.cpp
+++ b/source/main/physics/ActorForcesEuler.cpp
@@ -1685,11 +1685,7 @@ void Actor::CalcNodes()
                     // basic buoyance
                     ar_nodes[i].Forces += ar_nodes[i].buoyancy * Vector3::UNIT_Y;
                 }
-                // engine stall
-                if (i == ar_cinecam_node[0] && ar_engine)
-                {
-                    ar_engine->stopEngine();
-                }
+                // NOTE: Engine stalling in water is now checked in `Engine::UpdateEngine()` and controlled by `Engine::m_air_intake_node`
             }
             ar_nodes[i].nd_under_water = is_under_water;
         }

--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -618,6 +618,13 @@ void ActorSpawner::FinalizeRig()
 
     this->UpdateCollcabContacterNodes();
 
+    // Set the engine air intake node to the camera ref node - user can override via `ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE` if desired.
+    // For electric engine, leave it as NODENUM_INVALID (engine needs no air intake).
+    if (m_actor->ar_engine && m_actor->ar_engine->getEngineType() != 'e' && m_actor->ar_num_cameras > 0)
+    {
+        m_actor->ar_engine->m_air_intake_node = m_actor->ar_camera_node_pos[0];
+    }
+
     m_flex_factory.SaveFlexbodiesToCache();
 
     m_actor->GetGfxActor()->SortFlexbodies();

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -949,6 +949,7 @@ enum ActorSimAttr
     ACTORSIMATTR_ENGOPTION_MAX_IDLE_MIXTURE, //!< Max throttle to maintain idle RPM - Param #9 of 'engoption'
     ACTORSIMATTR_ENGOPTION_MIN_IDLE_MIXTURE, //!< Min throttle to maintain idle RPM - Param #10 of 'engoption'
     ACTORSIMATTR_ENGOPTION_BRAKING_TORQUE, //!< How much engine brakes on zero throttle - Param #11 of 'engoption'
+    ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE, //!< Node number representing air intake - Prototype only; Not yet recognized by 'engoption'
 
     // Engturbo2 (actually 'engturbo' with Param #1 [type] set to "2" - the recommended variant)
     ACTORSIMATTR_ENGTURBO2_INERTIA_FACTOR, //!< Time to spool up - Param #2 of 'engturbo2'

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -104,6 +104,7 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGOPTION_MAX_IDLE_MIXTURE", (int)ACTORSIMATTR_ENGOPTION_MAX_IDLE_MIXTURE); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGOPTION_MIN_IDLE_MIXTURE", (int)ACTORSIMATTR_ENGOPTION_MIN_IDLE_MIXTURE); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGOPTION_BRAKING_TORQUE", (int)ACTORSIMATTR_ENGOPTION_BRAKING_TORQUE); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE", (int)ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE); ROR_ASSERT(result >= 0);
         // ... Engturbo2 (actually'engturbo'withtype=2)
     result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGTURBO2_INERTIA_FACTOR", (int)ACTORSIMATTR_ENGTURBO2_INERTIA_FACTOR); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGTURBO2_NUM_TURBOS", (int)ACTORSIMATTR_ENGTURBO2_NUM_TURBOS); ROR_ASSERT(result >= 0);


### PR DESCRIPTION
Specifies the node which should be considered the air intake.  You can override it using `setSimAttribute()` - value of -1 will make the engine fully waterproof. Defaults to cinecam ref node (classic behavior) except for electric engine where it defaults to invalid node (thus disabling the water check altogether).

To set it automatically on every spawn, attach a script like this to the actor ([how to attach scripts to actors](https://docs.rigsofrods.org/vehicle-creation/fileformat-truck/#scripts)):
```
// dafsemi engine intake node test
void main()
{
    thisActor.setSimAttribute(ACTORSIMATTR_ENGOPTION_AIR_INTAKE_NODE, 30.f);
    game.log('air intake node set to 30');
}
```

Although it has 'engoption' in name, I didn't bother actually adding it to the truck file format (engoption has many args as it is) - I'll add it if there's interest. Or maybe I should name it 'ENGOPTIONX'?

Fixes #3213

Download test vehicle:
[dafsemi_engintake.zip](https://github.com/user-attachments/files/30068206/dafsemi_engintake.zip)
