### PR TITLE
🎮  Added new indexed sim attributes and methods for `BeamClass`

### DIFF
--- a/doc/angelscript/Script2Game/BeamClass.h
+++ b/doc/angelscript/Script2Game/BeamClass.h
@@ -236,6 +236,10 @@ public:
      * @brief Sets the flaps level for aircraft, from 0 (flaps up) to 5 (flaps fully down).
      */
     void setAircraftFlaps(int level);
+
+    void wakeUp();
+
+    void sendToSleep();
     
     //! @}
     
@@ -244,12 +248,32 @@ public:
     // PLEASE maintain the same ordering as in 'Actor.h' and 'scripting/bindings/ActorAngelscript.cpp'  
 
     /**
+     * Returns whether the parking brake is engaged.
+     */
+    bool getParkingBrake();
+
+    /**
+     * Returns whether traction control is enabled.
+     */
+    bool getTractionControl();
+
+    /**
+     * Returns whether the anti-lock brake system (ABS) is enabled.
+     */
+    bool getAntiLockBrake();
+
+    /**
+     * Returns whether cruise control is engaged.
+     */
+    bool getCruiseControl();
+
+    /**
      * Toggles the parking brake.
      */
     void parkingbrakeToggle();
     
     /**
-     * Toggles the tracktion control.
+     * Toggles the traction control.
      */
     void tractioncontrolToggle();
 
@@ -257,6 +281,11 @@ public:
      * Toggles the anti-lock brakes.
      */
     void antilockbrakeToggle();
+
+    /**
+     * Toggles the cruise control.
+     */
+    void cruisecontrolToggle();
 
     /**
      * Toggles the custom particles.
@@ -297,6 +326,26 @@ public:
     * Reports number of installed cinecams.
     */
     int getNumCinecams() const;
+
+    /**
+    * Reports number of installed cameras.
+    */
+    int getCameraCount() const;
+
+    /**
+    * Returns the position node number for the camera at the specified index.
+    */
+    int getCameraPosNode(int camIndex) const;
+
+    /**
+    * Returns the direction node number for the camera at the specified index.
+    */
+    int getCameraDirNode(int camIndex) const;
+
+    /**
+    * Returns the roll node number for the camera at the specified index.
+    */
+    int getCameraRollNode(int camIndex) const;
     
     //! @}
 

--- a/doc/angelscript/Script2Game/enums/ActorSimAttr.h
+++ b/doc/angelscript/Script2Game/enums/ActorSimAttr.h
@@ -59,7 +59,17 @@ enum ActorSimAttr
     ACTORSIMATTR_ENGTURBO2_ANTILAG_ENABLED, //!<  Param #11 of 'engturbo2'
     ACTORSIMATTR_ENGTURBO2_ANTILAG_CHANCE, //!<  Param #12 of 'engturbo2'
     ACTORSIMATTR_ENGTURBO2_ANTILAG_MIN_RPM, //!<  Param #13 of 'engturbo2'
-    ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER, //!<  Param #14 of 'engturbo2'    
+    ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER, //!<  Param #14 of 'engturbo2'  
+
+    // Turbojets
+    ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST, //!< - Param #5 of 'turbojets': Maximum thrust without afterburner, in kilonewtons (indexed)
+    ACTORSIMATTR_TURBOJET_MAX_WET_THRUST, //!< - Param #6 of 'turbojets': Maximum thrust with afterburner, in kilonewtons (indexed)
+
+    // Propeller engine (turboprops/pistonprops)
+    ACTORSIMATTR_PROPENGINE_MAX_POWER, //!< - Param #7 of 'turboprops'/Param #8 of 'pistonprops', in kilowatts (indexed)
+
+    // Screwprops
+    ACTORSIMATTR_SCREWPROP_MAX_POWER, //!< - Param #4 of 'screwprops' (indexed)  
 };
 
 } // namespace Script2Game

--- a/doc/angelscript/Script2Game/enums/angelScriptManipulationType.h
+++ b/doc/angelscript/Script2Game/enums/angelScriptManipulationType.h
@@ -19,7 +19,7 @@ enum angelScriptManipulationType
     ASMANIP_CONSOLE_SNIPPET_EXECUTED = 0, // 0 for Backwards compatibility.
     ASMANIP_SCRIPT_LOADED,                //!< Triggered after the script's `main()` completed; may trigger additional processing (for example, it delivers the *.mission file to mission system script). Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
     ASMANIP_SCRIPT_UNLOADING,              //!< Triggered before unloading the script to let it clean up (important for missions). Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
-    ASMANIP_ACTORSIMATTR_SET              //!< Triggered when `setSimAttribute()` is called; additional args: #2 `RoR::ActorSimAtr`, #3 ---, #4 ---, #5 attr name, #6 value converted to string.
+    ASMANIP_ACTORSIMATTR_SET              //!< Triggered when `setSimAttribute()` or `setIndexedSimAttribute()` is called; additional args: #2 `RoR::ActorSimAttr`, #3 index (-1 if not set), #4 ---, #5 attr name, #6 value converted to string.
 };
 
 } // namespace Script2Game

--- a/resources/scripts/example_aircraft_engines.as
+++ b/resources/scripts/example_aircraft_engines.as
@@ -6,6 +6,8 @@
 
 // Window [X] button handler
 imgui_utils::CloseWindowPrompt closeBtnHandler;
+array<float> originalPropellerPowers;
+int lastTruckNum;
 
 string YesOrNo(bool b)
 {
@@ -31,6 +33,11 @@ void ShowEngineType(AircraftEngineClass@ engine)
     ImGui::BulletText("Type: " + engType);
 }
 
+void main()
+{
+    lastTruckNum = game.getCurrentTruckNumber();
+}
+
 void frameStep(float dt)
 {
     ImGui::SetNextWindowSize(vector2(440, 520));
@@ -38,6 +45,18 @@ void frameStep(float dt)
     {
         closeBtnHandler.draw();
         BeamClass@ truck = game.getCurrentTruck();
+        int currentTruckID = -1;
+        if (@truck != null)
+            currentTruckID = truck.getInstanceId();
+
+        if (lastTruckNum != currentTruckID)
+        {
+            // The current truck has changed. Empty the list to add the new power values afterwards.
+            lastTruckNum = currentTruckID;
+            while (originalPropellerPowers.length() > 0)
+                originalPropellerPowers.removeLast();
+        }
+
         if (@truck != null)
         {
             ImGui::Text("Vehicle: " + truck.getTruckName());
@@ -88,6 +107,9 @@ void frameStep(float dt)
 
                     if (engine.getType() == AE_TURBOJET)
                     {
+                        if (int(originalPropellerPowers.length()) < engCount)
+                            originalPropellerPowers.insertLast(0);
+
                         TurbojetClass@ turbojet = truck.getTurbojet(i);
                         ImGui::Text("Turbojet info:");
                         ImGui::BulletText("Dry thrust: " + formatFloat(turbojet.getMaxDryThrust(), '', 0, 1) + " kN");
@@ -95,17 +117,40 @@ void frameStep(float dt)
                         if (turbojet.getAfterburner())
                             ImGui::BulletText("Afterburner thrust: " + formatFloat(turbojet.getAfterburnerThrust(), '', 0, 1) + " kN");
                         ImGui::BulletText("Exhaust velocity: " + formatFloat(turbojet.getExhaustVelocity(), '', 0, 1) + " m/s");
+
+
+                        ImGui::PushID("DRYTHR" + formatInt(i));
+                        float maxDryThrust = truck.getIndexedSimAttribute(ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST, i);
+                        if (ImGui::SliderFloat("Set maximum dry thrust", maxDryThrust, 0, turbojet.getAfterburnerThrust()))
+                            truck.setIndexedSimAttribute(ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST, maxDryThrust, i);
+                        ImGui::PopID();
+
+                        ImGui::PushID("WETTHR" + formatInt(i));
+                        float maxWetThrust = truck.getIndexedSimAttribute(ACTORSIMATTR_TURBOJET_MAX_WET_THRUST, i);
+                        if (ImGui::SliderFloat("Set maximum afterburner thrust", maxWetThrust, turbojet.getMaxDryThrust(), turbojet.getMaxDryThrust() * 2))
+                            truck.setIndexedSimAttribute(ACTORSIMATTR_TURBOJET_MAX_WET_THRUST, maxWetThrust, i);
+                        ImGui::PopID();
                     }
                     else if (engine.getType() == AE_PROPELLER)
                     {
                         TurbopropClass@ propeller = truck.getTurboprop(i);
+                        float maxPower = truck.getIndexedSimAttribute(ACTORSIMATTR_PROPENGINE_MAX_POWER, i);
+                        if (int(originalPropellerPowers.length()) < engCount)
+                            originalPropellerPowers.insertLast(maxPower);
+
                         ImGui::Text("Propeller info:");
                         ImGui::BulletText("Pitch: " + formatFloat(propeller.getPropellerPitch(), '', 0, 1));
                         ImGui::BulletText("Torque: " + formatFloat(propeller.getPropellerIndicatedTorque(), '', 0, 1) + " N m");
                         ImGui::BulletText("Max torque: " + formatFloat(propeller.getPropellerMaxTorque(), '', 0, 1) + " N m");
                         ImGui::BulletText("Max power: " + formatFloat(propeller.getPropellerMaxPower(), '', 0, 1) + " kW");
                         ImGui::BulletText("Is piston prop: " + YesOrNo(propeller.isPistonProp()));
+
+                        ImGui::PushID("PROPPWR" + formatInt(i));
+                        if (ImGui::SliderFloat("Set maximum power", maxPower, 0, originalPropellerPowers[i] * 2))
+                            truck.setIndexedSimAttribute(ACTORSIMATTR_PROPENGINE_MAX_POWER, maxPower, i);
+                        ImGui::PopID();
                     }
+
                 }
             }
         }

--- a/resources/scripts/example_angelscript_manipulationevents.as
+++ b/resources/scripts/example_angelscript_manipulationevents.as
@@ -62,8 +62,10 @@ void eventCallbackEx(scriptEvents ev, int a1, int a2, int a3, int a4, string a5,
         }
         else if (a1 == ASMANIP_ACTORSIMATTR_SET)
         {
-            log(" - Attribute number: " + formatInt(a2) + isItMe);
+            log(" - Attribute number: " + formatInt(a2));
             log(" - Attribute name: " + a5);
+            if (a3 >= 0)
+                log(" - Attribute index: " + a3);
         }
     }
 }

--- a/resources/scripts/example_manual_vehicle_controls.as
+++ b/resources/scripts/example_manual_vehicle_controls.as
@@ -1,0 +1,309 @@
+// \title Manual vehicle controls
+// \brief Demo of functions to manually control vehicles in AngelScript
+// ===================================================
+
+#include "imgui_utils.as"
+
+// Window [X] button handler
+imgui_utils::CloseWindowPrompt closeBtnHandler;
+
+void ShowGenericControl(BeamClass@ vehicle, inputEvents input, string sliderCaption)
+{
+    float val = vehicle.getEventSimulatedValue(input) * 100;
+    if (ImGui::SliderFloat(sliderCaption, val, 0, 100))
+    {
+        if (val > 0)
+            vehicle.setEventSimulatedValue(input, val / 100);
+        else
+            vehicle.resetEventSimulatedValue(input);
+    }
+}
+
+void ShowLeftRightControl(BeamClass@ vehicle, inputEvents left, inputEvents right, string sliderCaption)
+{
+    float sum =
+        (vehicle.getEventSimulatedValue(right) - vehicle.getEventSimulatedValue(left)) * 100;
+    if (ImGui::SliderFloat(sliderCaption, sum, -100, 100))
+    {
+        if (sum > 0)
+        {
+            vehicle.setEventSimulatedValue(right, sum / 100);
+        }
+        else if (sum < 0)
+        {
+            vehicle.setEventSimulatedValue(left, -sum / 100);
+        }
+        else
+        {
+            vehicle.resetEventSimulatedValue(right);
+            vehicle.resetEventSimulatedValue(left);
+        }
+    }
+
+    if (ImGui::Button("Reset " + sliderCaption))
+    {
+        vehicle.resetEventSimulatedValue(right);
+        vehicle.resetEventSimulatedValue(left);
+    }
+}
+
+float engineThrottle = 0;
+void ShowThrottleControl(BeamClass@ vehicle)
+{
+    int truckType = vehicle.getTruckType();
+    if (truckType == TT_TRUCK)
+    {
+        ShowGenericControl(vehicle, EV_TRUCK_ACCELERATE, "Throttle");
+    }
+    else if (truckType == TT_AIRPLANE)
+    {
+        // Calculate average throttle value
+        float throttle = 0;
+        for (int i = 0; i < vehicle.getAircraftEngineCount(); i++)
+        {
+            AircraftEngineClass@ aircraftEng = vehicle.getAircraftEngine(i);
+            throttle += aircraftEng.getThrottle();
+        }
+        throttle /= vehicle.getAircraftEngineCount();
+
+        throttle *= 100;
+        if (ImGui::SliderFloat("Throttle", throttle, 0, 100))
+        {
+            for (int i = 0; i < vehicle.getAircraftEngineCount(); i++)
+            {
+                AircraftEngineClass@ aircraftEng = vehicle.getAircraftEngine(i);
+                aircraftEng.setThrottle(throttle / 100);
+            }
+        }
+    }
+    else if (truckType == TT_BOAT)
+    {
+        // Calculate average throttle value
+        float throttle = 0;
+        for (int i = 0; i < vehicle.getScrewpropCount(); i++)
+        {
+            ScrewpropClass@ screwprop = vehicle.getScrewprop(i);
+            throttle += screwprop.getThrottle();
+        }
+        throttle /= vehicle.getScrewpropCount();
+
+        throttle *= 100;
+        if (ImGui::SliderFloat("Throttle", throttle, -100, 100))
+        {
+            for (int i = 0; i < vehicle.getScrewpropCount(); i++)
+            {
+                ScrewpropClass@ screwprop = vehicle.getScrewprop(i);
+                screwprop.setThrottle(throttle / 100);
+            }
+        }
+    }
+}
+
+void ShowRudderControl(BeamClass@ vehicle)
+{
+    int truckType = vehicle.getTruckType();
+    if (truckType == TT_AIRPLANE)
+    {
+        ShowLeftRightControl(vehicle, EV_AIRPLANE_RUDDER_LEFT, EV_AIRPLANE_RUDDER_RIGHT, "Rudder");
+    }
+    else if (truckType == TT_BOAT)
+    {
+        // Calculate average rudder value
+        float rudder = 0;
+        for (int i = 0; i < vehicle.getScrewpropCount(); i++)
+        {
+            ScrewpropClass@ screwprop = vehicle.getScrewprop(i);
+            rudder += screwprop.getRudder();
+        }
+        rudder /= vehicle.getScrewpropCount();
+
+        if (ImGui::SliderFloat("Rudder", rudder, -1, 1))
+        {
+            for (int i = 0; i < vehicle.getScrewpropCount(); i++)
+            {
+                ScrewpropClass@ screwprop = vehicle.getScrewprop(i);
+                screwprop.setRudder(rudder);
+            }
+        }
+    }
+}
+
+void ShowAircraftControls(BeamClass@ vehicle)
+{
+    ShowLeftRightControl(vehicle, EV_AIRPLANE_STEER_LEFT, EV_AIRPLANE_STEER_RIGHT, "Aileron");
+    ShowLeftRightControl(vehicle, EV_AIRPLANE_ELEVATOR_DOWN, EV_AIRPLANE_ELEVATOR_UP, "Elevator");
+
+    ImGui::Text("Flaps: " + formatInt(vehicle.getAircraftFlaps()));
+    if (ImGui::Button("More flaps"))
+        vehicle.setAircraftFlaps(vehicle.getAircraftFlaps() + 1);
+    if (ImGui::Button("Less flaps"))
+        vehicle.setAircraftFlaps(vehicle.getAircraftFlaps() - 1);
+
+    ImGui::Text("Air brakes: " + formatInt(int(vehicle.getAirbrakeIntensity())));
+    if (ImGui::Button("More air braking"))
+        vehicle.setAirbrakeIntensity(vehicle.getAirbrakeIntensity() + 1.0);
+    if (ImGui::Button("Less air braking"))
+        vehicle.setAirbrakeIntensity(vehicle.getAirbrakeIntensity() - 1.0);
+}
+
+void ShowAircraftEngineControls(BeamClass@ vehicle)
+{
+    int engCount = vehicle.getAircraftEngineCount();
+    if (engCount > 0)
+    {
+        for (int i = 0; i < engCount; i++)
+        {
+            AircraftEngineClass@ engine = vehicle.getAircraftEngine(i);
+
+            string engineNumStr = formatInt(i + 1);
+            ImGui::Text("Aircraft engine #" + engineNumStr);
+            
+            string engineIgnitionLabel = engine.getIgnition() ? "Stop" : "Start";
+            ImGui::PushID("ENGSTART" + engineNumStr);
+            if (ImGui::Button(engineIgnitionLabel))
+                engine.flipStart();
+            
+            string engineReverserLabel = (engine.getReverse() ? "Disengage" : "Engage") + " thrust reverser";
+            ImGui::PushID("ENGREV" + engineNumStr);
+            if (ImGui::Button(engineReverserLabel))
+                engine.toggleReverse();
+        }
+    }
+}
+
+void ShowParkingBrakeControl(BeamClass@ vehicle)
+{
+    string btnLabel = vehicle.getParkingBrake() ? "Disengage parking brake" : "Engage parking brake";
+    if (ImGui::Button(btnLabel))
+        vehicle.parkingbrakeToggle();
+}
+
+void ShowIgnitionControl(BeamClass@ vehicle)
+{
+    EngineClass@ engine = vehicle.getEngine();
+    if (@engine != null)
+    {
+        string btnLabel = engine.hasContact() ? "Disable ignition" : "Enable ignition";
+        if (ImGui::Button(btnLabel))
+            engine.toggleContact();
+    }
+}
+
+void ShowStarterControl(BeamClass@ vehicle)
+{
+    EngineClass@ engine = vehicle.getEngine();
+    if (@engine != null)
+    {
+        if (ImGui::Button("Start engine"))
+            engine.startEngine();
+    }
+}
+
+void ShowShiftingControls(BeamClass@ vehicle)
+{
+    EngineClass@ engine = vehicle.getEngine();
+    if (@engine != null)
+    {
+        ImGui::Separator();
+
+        ImGui::Text("Gearbox mode");
+        SimGearboxMode mode = engine.getAutoMode();
+        bool isAuto = mode == SimGearboxMode::AUTO;
+        if (ImGui::RadioButton("Automatic", isAuto))
+            mode = SimGearboxMode::AUTO;
+
+        bool isSemiAuto = mode == SimGearboxMode::SEMI_AUTO;
+        if (ImGui::RadioButton("Semi-automatic (manual shift with auto clutch)", isSemiAuto))
+            mode = SimGearboxMode::SEMI_AUTO;
+
+        bool isManual = mode == SimGearboxMode::MANUAL;
+        if (ImGui::RadioButton("Manual", isManual))
+            mode = SimGearboxMode::MANUAL;
+
+        bool isManualStick = mode == SimGearboxMode::MANUAL_STICK;
+        if (ImGui::RadioButton("Manual (stick shift)", isManualStick))
+            mode = SimGearboxMode::MANUAL_STICK;
+
+        bool isManualRanges = mode == SimGearboxMode::MANUAL_RANGES;
+        if (ImGui::RadioButton("Manual, with ranges", isManualRanges))
+            mode = SimGearboxMode::MANUAL_RANGES;
+
+        engine.setAutoMode(mode);
+
+        if (ImGui::Button("Shift up"))
+            engine.shift(1);
+        if (ImGui::Button("Shift down"))
+            engine.shift(-1);
+
+        ImGui::Separator();
+    }
+}
+
+void ShowABSControl(BeamClass@ vehicle)
+{
+    string btnLabel = vehicle.getAntiLockBrake() ? "Disable ABS" : "Enable ABS";
+    if (ImGui::Button(btnLabel))
+        vehicle.antilockbrakeToggle();
+}
+
+void ShowTractionControl(BeamClass@ vehicle)
+{
+    string btnLabel = vehicle.getTractionControl() ? "Disable traction control" : "Enable traction control";
+    if (ImGui::Button(btnLabel))
+        vehicle.tractioncontrolToggle();
+}
+
+void ShowCruiseControl(BeamClass@ vehicle)
+{
+    string btnLabel = vehicle.getCruiseControl() ? "Disable cruise control" : "Enable cruise control";
+    if (ImGui::Button(btnLabel))
+        vehicle.cruisecontrolToggle();
+}
+
+void frameStep(float dt)
+{
+    ImGui::SetNextWindowSize(vector2(480, 640));
+    if (ImGui::Begin("Manual Vehicle Controls", closeBtnHandler.windowOpen, 0))
+    {
+        closeBtnHandler.draw();
+        BeamClass@ vehicle = game.getCurrentTruck();
+        if (@vehicle != null)
+        {
+            int truckType = vehicle.getTruckType();
+            ImGui::Text("Vehicle: " + vehicle.getTruckName());
+            ImGui::Text("Controls");
+
+            ShowThrottleControl(vehicle);
+            ShowGenericControl(vehicle, EV_TRUCK_MANUAL_CLUTCH, "Clutch");
+            ShowGenericControl(vehicle, EV_TRUCK_BRAKE, "Brake");
+            if (truckType == TT_TRUCK)
+                ShowLeftRightControl(vehicle, EV_TRUCK_STEER_LEFT, EV_TRUCK_STEER_RIGHT, "Steering");
+
+            ImGui::Separator();
+
+            ShowRudderControl(vehicle);
+            if (truckType == TT_AIRPLANE)
+            {
+                ShowAircraftControls(vehicle);
+                ShowAircraftEngineControls(vehicle);
+            }
+
+            ImGui::Separator();
+
+            ShowParkingBrakeControl(vehicle);
+            ShowIgnitionControl(vehicle);
+            ShowStarterControl(vehicle);
+            ShowShiftingControls(vehicle);
+            ShowABSControl(vehicle);
+            ShowTractionControl(vehicle);
+            ShowCruiseControl(vehicle);
+        }
+        else
+        {
+            engineThrottle = 0;
+            ImGui::Text("You are on foot.");
+        }
+
+        ImGui::End();
+    }
+}

--- a/resources/scripts/example_screwprops.as
+++ b/resources/scripts/example_screwprops.as
@@ -1,4 +1,3 @@
-
 // \title Screwprops
 // \brief Demo of ScrewpropClass binding
 // ===================================================
@@ -7,6 +6,8 @@
 
 // Window [X] button handler
 imgui_utils::CloseWindowPrompt closeBtnHandler;
+array<float> originalScrewpropPowers;
+int lastTruckNum;
 
 string YesOrNo(bool b)
 {
@@ -23,6 +24,11 @@ string RudderDeflection(float rudderDefl)
     return formatFloat(rudderDefl * 100, '', 0, 1) + " %% (" + direction + ")";
 }
 
+void main()
+{
+    lastTruckNum = game.getCurrentTruckNumber();
+}
+
 void frameStep(float dt)
 {
     ImGui::SetNextWindowSize(vector2(440, 520));
@@ -30,6 +36,18 @@ void frameStep(float dt)
     {
         closeBtnHandler.draw();
         BeamClass@ truck = game.getCurrentTruck();
+        int currentTruckID = -1;
+        if (@truck != null)
+            currentTruckID = truck.getInstanceId();
+
+        if (lastTruckNum != currentTruckID)
+        {
+            // The current truck has changed. Empty the list to add the new power values afterwards.
+            lastTruckNum = currentTruckID;
+            while (originalScrewpropPowers.length() > 0)
+                originalScrewpropPowers.removeLast();
+        }
+
         if (@truck != null)
         {
             ImGui::Text("Vehicle: " + truck.getTruckName());
@@ -43,10 +61,14 @@ void frameStep(float dt)
                     ImGui::Separator();
                     ScrewpropClass@ screwprop = truck.getScrewprop(i);
 
+                    float maxForce = truck.getIndexedSimAttribute(ACTORSIMATTR_SCREWPROP_MAX_POWER, i);
+                    if (int(originalScrewpropPowers.length()) < screwpropCount)
+                        originalScrewpropPowers.insertLast(maxForce);
+
                     ImGui::Text("Screwprop #" + formatInt(i + 1) + ":");
                     ImGui::BulletText("Throttle: " + formatFloat(screwprop.getThrottle() * 100, '', 0, 1) + " %%");
                     ImGui::BulletText("Rudder deflection: " + RudderDeflection(screwprop.getRudder()));
-                    ImGui::BulletText("Max force: " + formatFloat(screwprop.getMaxPower() / 1000, '', 0, 1) + " kN");
+                    ImGui::BulletText("Max force: " + formatFloat(maxForce / 1000, '', 0, 1) + " kN");
                     ImGui::BulletText("Reverser: " + YesOrNo(screwprop.getReverse()));
                     ImGui::BulletText("Reference node: " + formatInt(screwprop.getRefNode()));
                     ImGui::BulletText("Back node: " + formatInt(screwprop.getBackNode()));
@@ -59,6 +81,11 @@ void frameStep(float dt)
                     ImGui::PushID("THR" + formatInt(i));
                     if (ImGui::SliderFloat("Set throttle", throttle, -100, 100))
                         screwprop.setThrottle(throttle / 100);
+                    ImGui::PopID();
+
+                    ImGui::PushID("MAXPWR" + formatInt(i));
+                    if (ImGui::SliderFloat("Set max force", maxForce, 0, originalScrewpropPowers[i] * 2))
+                        truck.setIndexedSimAttribute(ACTORSIMATTR_SCREWPROP_MAX_POWER, maxForce, i);
                     ImGui::PopID();
 
                     ImGui::PushID("RUDD" + formatInt(i));

--- a/source/main/gameplay/ScriptEvents.h
+++ b/source/main/gameplay/ScriptEvents.h
@@ -75,7 +75,7 @@ enum angelScriptManipulationType
     ASMANIP_SCRIPT_LOADED,                //!< Triggered after the script's `main()` completed; Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
     ASMANIP_SCRIPT_LOAD_FAILED,           //!< Triggered if the script fails to start at all. Args: #2 unused, #3 RoR::ScriptCategory, #4 unused, #5 filename.
     ASMANIP_SCRIPT_UNLOADING,             //!< Triggered before unloading the script to let it clean up. Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename.
-    ASMANIP_ACTORSIMATTR_SET              //!< Triggered when `setSimAttribute()` is called; additional args: #2 `RoR::ActorSimAtrr`, #3 ---, #4 ---, #5 attr name, #6 value converted to string.
+    ASMANIP_ACTORSIMATTR_SET              //!< Triggered when `setSimAttribute()` or `setIndexedSimAttribute()` is called; additional args: #2 `RoR::ActorSimAttr`, #3 index (-1 if not set), #4 ---, #5 attr name, #6 value converted to string.
 };
 
 enum angelScriptThreadStatus

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -2995,6 +2995,23 @@ void Actor::setAircraftFlaps(int flapsLevel)
     ar_aerial_flap = flapsLevel;
 }
 
+void Actor::wakeUp()
+{
+    if (ar_state == ActorState::LOCAL_SLEEPING)
+    {
+        ar_state = ActorState::LOCAL_SIMULATED;
+        ar_sleep_counter = 0.0f;
+    }
+}
+
+void Actor::sendToSleep()
+{
+    if (ar_state == ActorState::LOCAL_SIMULATED)
+    {
+        ar_state = ActorState::LOCAL_SLEEPING;
+    }
+}
+
 float Actor::getEventValue(int eventID, bool pure, InputSourceType valueSource)
 {
     std::map<int, float>::const_iterator simulated_value_info =

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -5082,64 +5082,101 @@ int Actor::getShockNode2(int shock_number)
     return -1.f;
 }
 
-void Actor::setSimAttribute(ActorSimAttr attr, float val)
+bool Actor::shouldSetSimAttribute(ActorSimAttr attr, float val, int index)
 {
     if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
     {
         App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_WARNING,
             "Cannot change simulation attributes in multiplayer mode.");
-        return;
+        return false;
     }
 
-    LOG(fmt::format("[RoR|Actor] setSimAttribute: '{}' = {}", ActorSimAttrToString(attr), val));
-
-    TRIGGER_EVENT_ASYNC(SE_ANGELSCRIPT_MANIPULATIONS, ASMANIP_ACTORSIMATTR_SET, attr, 0, 0, ActorSimAttrToString(attr), fmt::format("{}", val));
-
-    // PLEASE maintain the same order as in `enum ActorSimAttr`
-    switch (attr)
+    if (index >= 0)
     {
+        LOG(fmt::format("[RoR|Actor] setIndexedSimAttribute: '{}' @ {} = {}", ActorSimAttrToString(attr), index, val));
+        TRIGGER_EVENT_ASYNC(SE_ANGELSCRIPT_MANIPULATIONS, ASMANIP_ACTORSIMATTR_SET, attr, index, 0, ActorSimAttrToString(attr), fmt::format("{}", val));
+    }
+    else
+    {
+        LOG(fmt::format("[RoR|Actor] setSimAttribute: '{}' = {}", ActorSimAttrToString(attr), val));
+        TRIGGER_EVENT_ASYNC(SE_ANGELSCRIPT_MANIPULATIONS, ASMANIP_ACTORSIMATTR_SET, attr, -1, 0, ActorSimAttrToString(attr), fmt::format("{}", val));
+    }
+
+    return true;
+}
+
+void Actor::setSimAttribute(ActorSimAttr attr, float val)
+{
+    if (shouldSetSimAttribute(attr, val))
+    {
+        // PLEASE maintain the same order as in `enum ActorSimAttr`
+        switch (attr)
+        {
         // TractionControl
-    case ACTORSIMATTR_TC_RATIO: tc_ratio = val; return;
-    case ACTORSIMATTR_TC_PULSE_TIME: tc_pulse_time = val; return;
-    case ACTORSIMATTR_TC_WHEELSLIP_CONSTANT: tc_wheelslip_constant = val; return;
+        case ACTORSIMATTR_TC_RATIO: tc_ratio = val; return;
+        case ACTORSIMATTR_TC_PULSE_TIME: tc_pulse_time = val; return;
+        case ACTORSIMATTR_TC_WHEELSLIP_CONSTANT: tc_wheelslip_constant = val; return;
 
         // Engine
-    case ACTORSIMATTR_ENGINE_SHIFTDOWN_RPM:     if (ar_engine) { ar_engine->m_engine_min_rpm = val; } return;
-    case ACTORSIMATTR_ENGINE_SHIFTUP_RPM:       if (ar_engine) { ar_engine->m_engine_max_rpm = val; } return;
-    case ACTORSIMATTR_ENGINE_TORQUE:            if (ar_engine) { ar_engine->m_engine_torque = val; } return;
-    case ACTORSIMATTR_ENGINE_DIFF_RATIO:        if (ar_engine) { ar_engine->m_diff_ratio = val; } return;
-    case ACTORSIMATTR_ENGINE_GEAR_RATIOS_ARRAY: return;
+        case ACTORSIMATTR_ENGINE_SHIFTDOWN_RPM:     if (ar_engine) { ar_engine->m_engine_min_rpm = val; } return;
+        case ACTORSIMATTR_ENGINE_SHIFTUP_RPM:       if (ar_engine) { ar_engine->m_engine_max_rpm = val; } return;
+        case ACTORSIMATTR_ENGINE_TORQUE:            if (ar_engine) { ar_engine->m_engine_torque = val; } return;
+        case ACTORSIMATTR_ENGINE_DIFF_RATIO:        if (ar_engine) { ar_engine->m_diff_ratio = val; } return;
+        case ACTORSIMATTR_ENGINE_GEAR_RATIOS_ARRAY: return;
 
         // Engoption
-    case ACTORSIMATTR_ENGOPTION_ENGINE_INERTIA:   if (ar_engine) { ar_engine->m_engine_inertia = val; } return;
-    case ACTORSIMATTR_ENGOPTION_ENGINE_TYPE:      if (ar_engine) { ar_engine->m_engine_type = (char)val; } return;
-    case ACTORSIMATTR_ENGOPTION_CLUTCH_FORCE:     if (ar_engine) { ar_engine->m_clutch_force = val; } return;
-    case ACTORSIMATTR_ENGOPTION_SHIFT_TIME:       if (ar_engine) { ar_engine->m_shift_time = val; } return;
-    case ACTORSIMATTR_ENGOPTION_CLUTCH_TIME:      if (ar_engine) { ar_engine->m_clutch_time = val; } return;
-    case ACTORSIMATTR_ENGOPTION_POST_SHIFT_TIME:  if (ar_engine) { ar_engine->m_post_shift_time = val; } return;
-    case ACTORSIMATTR_ENGOPTION_STALL_RPM:        if (ar_engine) { ar_engine->m_engine_stall_rpm = val; } return;
-    case ACTORSIMATTR_ENGOPTION_IDLE_RPM:         if (ar_engine) { ar_engine->m_engine_idle_rpm = val; } return;
-    case ACTORSIMATTR_ENGOPTION_MAX_IDLE_MIXTURE: if (ar_engine) { ar_engine->m_max_idle_mixture = val; } return;
-    case ACTORSIMATTR_ENGOPTION_MIN_IDLE_MIXTURE: if (ar_engine) { ar_engine->m_min_idle_mixture = val; } return;
-    case ACTORSIMATTR_ENGOPTION_BRAKING_TORQUE:   if (ar_engine) { ar_engine->m_braking_torque = val; } return;
+        case ACTORSIMATTR_ENGOPTION_ENGINE_INERTIA:   if (ar_engine) { ar_engine->m_engine_inertia = val; } return;
+        case ACTORSIMATTR_ENGOPTION_ENGINE_TYPE:      if (ar_engine) { ar_engine->m_engine_type = (char)val; } return;
+        case ACTORSIMATTR_ENGOPTION_CLUTCH_FORCE:     if (ar_engine) { ar_engine->m_clutch_force = val; } return;
+        case ACTORSIMATTR_ENGOPTION_SHIFT_TIME:       if (ar_engine) { ar_engine->m_shift_time = val; } return;
+        case ACTORSIMATTR_ENGOPTION_CLUTCH_TIME:      if (ar_engine) { ar_engine->m_clutch_time = val; } return;
+        case ACTORSIMATTR_ENGOPTION_POST_SHIFT_TIME:  if (ar_engine) { ar_engine->m_post_shift_time = val; } return;
+        case ACTORSIMATTR_ENGOPTION_STALL_RPM:        if (ar_engine) { ar_engine->m_engine_stall_rpm = val; } return;
+        case ACTORSIMATTR_ENGOPTION_IDLE_RPM:         if (ar_engine) { ar_engine->m_engine_idle_rpm = val; } return;
+        case ACTORSIMATTR_ENGOPTION_MAX_IDLE_MIXTURE: if (ar_engine) { ar_engine->m_max_idle_mixture = val; } return;
+        case ACTORSIMATTR_ENGOPTION_MIN_IDLE_MIXTURE: if (ar_engine) { ar_engine->m_min_idle_mixture = val; } return;
+        case ACTORSIMATTR_ENGOPTION_BRAKING_TORQUE:   if (ar_engine) { ar_engine->m_braking_torque = val; } return;
 
         // Engturbo2 (actually 'engturbo' with type=2) 
-    case ACTORSIMATTR_ENGTURBO2_INERTIA_FACTOR:      if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_inertia_factor = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_NUM_TURBOS:          if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_num_turbos = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_MAX_RPM:             if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_max_turbo_rpm = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_ENGINE_RPM_OP:       if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_engine_rpm_operation = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_BOV_ENABLED:         if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_has_bov = (bool)val; } return;
-    case ACTORSIMATTR_ENGTURBO2_BOV_MIN_PSI:         if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_min_bov_psi = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_WASTEGATE_ENABLED:   if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_has_wastegate = (bool)val; } return;
-    case ACTORSIMATTR_ENGTURBO2_WASTEGATE_MAX_PSI:   if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_min_wastegate_psi = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_WASTEGATE_THRESHOLD_N: if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_wg_threshold_n = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_WASTEGATE_THRESHOLD_P: if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_wg_threshold_p = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_ANTILAG_ENABLED:     if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_has_antilag = (bool)val; } return;
-    case ACTORSIMATTR_ENGTURBO2_ANTILAG_CHANCE:      if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_antilag_rand_chance = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_ANTILAG_MIN_RPM:     if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_antilag_min_rpm = val; } return;
-    case ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER:       if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_antilag_power_factor = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_INERTIA_FACTOR:      if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_inertia_factor = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_NUM_TURBOS:          if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_num_turbos = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_MAX_RPM:             if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_max_turbo_rpm = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_ENGINE_RPM_OP:       if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_engine_rpm_operation = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_BOV_ENABLED:         if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_has_bov = (bool)val; } return;
+        case ACTORSIMATTR_ENGTURBO2_BOV_MIN_PSI:         if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_min_bov_psi = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_WASTEGATE_ENABLED:   if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_has_wastegate = (bool)val; } return;
+        case ACTORSIMATTR_ENGTURBO2_WASTEGATE_MAX_PSI:   if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_min_wastegate_psi = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_WASTEGATE_THRESHOLD_N: if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_wg_threshold_n = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_WASTEGATE_THRESHOLD_P: if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_wg_threshold_p = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_ANTILAG_ENABLED:     if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_turbo_has_antilag = (bool)val; } return;
+        case ACTORSIMATTR_ENGTURBO2_ANTILAG_CHANCE:      if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_antilag_rand_chance = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_ANTILAG_MIN_RPM:     if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_antilag_min_rpm = val; } return;
+        case ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER:       if (ar_engine && ar_engine->m_turbo_ver == 2) { ar_engine->m_antilag_power_factor = val; } return;
 
-    default: return;
+        default: return;
+        }
+    }
+}
+
+void Actor::setIndexedSimAttribute(ActorSimAttr attr, float val, int index)
+{
+    if (index >= 0 && shouldSetSimAttribute(attr, val, index))
+    {
+        // PLEASE maintain the same order as in `enum ActorSimAttr`
+        switch (attr)
+        {
+        // Turbojets
+        case ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST:     if (index < getAircraftEngineCount() && ar_aeroengines[index]->getType() == AeroEngineType::AE_TURBOJET) { dynamic_cast<Turbojet*>(ar_aeroengines[index].GetRef())->setMaxDryThrust(val); } return;
+        case ACTORSIMATTR_TURBOJET_MAX_WET_THRUST:     if (index < getAircraftEngineCount() && ar_aeroengines[index]->getType() == AeroEngineType::AE_TURBOJET) { dynamic_cast<Turbojet*>(ar_aeroengines[index].GetRef())->setAfterburnThrust(val); } return;
+
+        // Propeller engines
+        case ACTORSIMATTR_PROPENGINE_MAX_POWER:        if (index < getAircraftEngineCount() && ar_aeroengines[index]->getType() == AeroEngineType::AE_XPROP) { dynamic_cast<Turboprop*>(ar_aeroengines[index].GetRef())->setMaxPower(val); } return;
+        
+        // Screwprops
+        case ACTORSIMATTR_SCREWPROP_MAX_POWER:        if (index < getScrewpropCount()) { ar_screwprops[index]->setMaxPower(val); } return;
+
+        default: return;
+        }
     }
 }
 
@@ -5191,6 +5228,29 @@ float Actor::getSimAttribute(ActorSimAttr attr)
 
     default: return 0.f;
     }
+}
+
+float Actor::getIndexedSimAttribute(ActorSimAttr attr, int index)
+{
+    if (index >= 0)
+    {
+        // PLEASE maintain the same order as in `enum ActorSimAttr`
+        switch (attr)
+        {
+            // Turbojets
+        case ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST:     if (index < getAircraftEngineCount() && ar_aeroengines[index]->getType() == AeroEngineType::AE_TURBOJET) { return dynamic_cast<Turbojet*>(ar_aeroengines[index].GetRef())->getMaxDryThrust(); }
+        case ACTORSIMATTR_TURBOJET_MAX_WET_THRUST:     if (index < getAircraftEngineCount() && ar_aeroengines[index]->getType() == AeroEngineType::AE_TURBOJET) { return dynamic_cast<Turbojet*>(ar_aeroengines[index].GetRef())->getAfterburnThrust(); }
+
+            // Propeller engines
+        case ACTORSIMATTR_PROPENGINE_MAX_POWER:        if (index < getAircraftEngineCount() && ar_aeroengines[index]->getType() == AeroEngineType::AE_XPROP) { return dynamic_cast<Turboprop*>(ar_aeroengines[index].GetRef())->getMaxPower(); }
+
+            // Screwprops
+        case ACTORSIMATTR_SCREWPROP_MAX_POWER:        if (index < getScrewpropCount()) { return ar_screwprops[index]->getMaxPower(); }
+
+        }
+    }
+
+    return 0.f;
 }
 
 void Actor::setForcedCinecam(CineCameraID_t cinecam_id, BitMask_t flags)

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -151,6 +151,8 @@ public:
     void              recalculateNodeMasses();
     void              setAirbrakeIntensity(float intensity);
     void              setAircraftFlaps(int flapsLevel);
+    void              wakeUp();
+    void              sendToSleep();
     // not exported to scripting:
     void              applyNodeBeamScales();               //!< For GUI::NodeBeamUtils
     void              searchBeamDefaults();                //!< Searches for more stable beam defaults
@@ -162,9 +164,14 @@ public:
     /// @name User interaction
     /// @{
     // PLEASE maintain the same order as in 'scripting/bindings/ActorAngelscript.cpp' and 'doc/angelscript/.../BeamClass.h'
+    bool              getParkingBrake() { return ar_parking_brake; }
+    bool              getTractionControl() { return tc_mode; }
+    bool              getAntiLockBrake() { return alb_mode; }
+    bool              getCruiseControl() { return cc_mode; }
     void              parkingbrakeToggle();
     void              tractioncontrolToggle();
     void              antilockbrakeToggle();
+    void              cruisecontrolToggle();               //!< Defined in 'gameplay/CruiseControl.cpp'
     void              toggleCustomParticles();
     bool              getCustomParticleMode();
     bool              isLocked();                          //!< Are hooks locked?
@@ -172,6 +179,10 @@ public:
     void              clearForcedCinecam();
     bool              getForcedCinecam(CineCameraID_t& cinecam_id, BitMask_t& flags);
     int               getNumCinecams() { return ar_num_cinecams; }
+    int               getCameraCount() { return ar_num_cameras; }
+    int               getCameraPosNode(int camIndex) { return camIndex >= 0 && camIndex < ar_num_cameras ? ar_camera_node_pos[camIndex] : NODENUM_INVALID; }
+    int               getCameraDirNode(int camIndex) { return camIndex >= 0 && camIndex < ar_num_cameras ? ar_camera_node_dir[camIndex] : NODENUM_INVALID; }
+    int               getCameraRollNode(int camIndex) { return camIndex >= 0 && camIndex < ar_num_cameras ? ar_camera_node_roll[camIndex] : NODENUM_INVALID; }
     // not exported to scripting:
     void              mouseMove(NodeNum_t node, Ogre::Vector3 pos, float force);
     void              tieToggle(int group=-1, ActorLinkingRequestType mode=ActorLinkingRequestType::TIE_TOGGLE, ActorInstanceID_t forceunlock_filter=ACTORINSTANCEID_INVALID);
@@ -180,8 +191,6 @@ public:
     void              ropeToggle(int group=-1, ActorLinkingRequestType mode=ActorLinkingRequestType::ROPE_TOGGLE, ActorInstanceID_t forceunlock_filter=ACTORINSTANCEID_INVALID);
     void              engineTriggerHelper(int engineNumber, EngineTriggerType type, float triggerValue);
     void              toggleSlideNodeLock();
-    bool              getParkingBrake() { return ar_parking_brake; }
-    void              cruisecontrolToggle();               //!< Defined in 'gameplay/CruiseControl.cpp'
     void              toggleAxleDiffMode();                //! Cycles through the available inter axle diff modes
     void              displayAxleDiffMode();               //! Writes info to console/notify box
     int               getAxleDiffMode() { return m_num_axle_diffs; }
@@ -195,9 +204,6 @@ public:
     void              displayTransferCaseMode();           //! Writes info to console/notify area
     void              setSmokeEnabled(bool enabled) { m_disable_smoke = !enabled; }
     bool              getSmokeEnabled() const { return !m_disable_smoke; }
-    bool              isEventAnalog(int eventID);
-    bool              isEventDefined(int eventID);
-    float             getEventBounceTime(int eventID);
     //! @}
 
     /// @name Input engine overrides
@@ -218,6 +224,9 @@ public:
     // other than the player actor, without it being affected by InputEngine
     // values.
     bool              ShouldAllowNonSimulatedInputs();
+    bool              isEventAnalog(int eventID);
+    bool              isEventDefined(int eventID);
+    float             getEventBounceTime(int eventID);
     //! @}
 
     /// @name Vehicle lights

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -145,7 +145,9 @@ public:
     void              setNodeMass(int nodeNumber, float m);
     void              setNodeMassOptions(int nodeNumber, bool loaded, bool overrideMass);
     void              setSimAttribute(ActorSimAttr attr, float val); //!< HAZARDOUS - values may not be checked; Pay attention to 'safe values' at each attribute description.
+    void              setIndexedSimAttribute(ActorSimAttr attr, float val, int index); //!< - Sets a sim attribute for a particular object (e.g. aircraft engine) at the specified index.
     float             getSimAttribute(ActorSimAttr attr);
+    float             getIndexedSimAttribute(ActorSimAttr attr, int index);
     void              recalculateNodeMasses();
     void              setAirbrakeIntensity(float intensity);
     void              setAircraftFlaps(int flapsLevel);
@@ -154,6 +156,7 @@ public:
     void              searchBeamDefaults();                //!< Searches for more stable beam defaults
     void              updateInitPosition();
     void              propagateNodeBeamChangesToDef(); //!< Back-propagates changes done by N/B-utils UI to the def-document.
+    bool              shouldSetSimAttribute(ActorSimAttr attr, float val, int index = -1);
     /// @}
 
     /// @name User interaction

--- a/source/main/physics/SimData.cpp
+++ b/source/main/physics/SimData.cpp
@@ -149,7 +149,17 @@ const char* RoR::ActorSimAttrToString(ActorSimAttr attr)
     case ACTORSIMATTR_ENGTURBO2_ANTILAG_ENABLED:         return "ENGTURBO2_ANTILAG_ENABLED";     
     case ACTORSIMATTR_ENGTURBO2_ANTILAG_CHANCE:          return "ENGTURBO2_ANTILAG_CHANCE";      
     case ACTORSIMATTR_ENGTURBO2_ANTILAG_MIN_RPM:         return "ENGTURBO2_ANTILAG_MIN_RPM";     
-    case ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER:           return "ENGTURBO2_ANTILAG_POWER";       
+    case ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER:           return "ENGTURBO2_ANTILAG_POWER";
+
+    // Turbojets
+    case ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST:           return "TURBOJET_MAX_DRY_THRUST";
+    case ACTORSIMATTR_TURBOJET_MAX_WET_THRUST:           return "TURBOJET_MAX_WET_THRUST";
+
+    // Propeller engine (turboprops/pistonprops)
+    case ACTORSIMATTR_PROPENGINE_MAX_POWER:              return "PROPENGINE_MAX_POWER";
+
+    // Screwprops
+    case ACTORSIMATTR_SCREWPROP_MAX_POWER:               return "SCREWPROP_MAX_POWER";
 
     default: return "";
     }

--- a/source/main/physics/SimData.h
+++ b/source/main/physics/SimData.h
@@ -966,6 +966,15 @@ enum ActorSimAttr
     ACTORSIMATTR_ENGTURBO2_ANTILAG_MIN_RPM, //!<  - Param #13 of 'engturbo2'
     ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER, //!<  - Param #14 of 'engturbo2'
 
+    // Turbojets
+    ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST, //!< - Param #5 of 'turbojets': Maximum thrust without afterburner, in kilonewtons (indexed)
+    ACTORSIMATTR_TURBOJET_MAX_WET_THRUST, //!< - Param #6 of 'turbojets': Maximum thrust with afterburner, in kilonewtons (indexed)
+
+    // Propeller engine (turboprops/pistonprops)
+    ACTORSIMATTR_PROPENGINE_MAX_POWER, //!< - Param #7 of 'turboprops'/Param #8 of 'pistonprops', in kilowatts (indexed)
+
+    // Screwprops
+    ACTORSIMATTR_SCREWPROP_MAX_POWER, //!< - Param #4 of 'screwprops' (indexed)
 };
 const char* ActorSimAttrToString(ActorSimAttr attr);
 

--- a/source/main/physics/air/TurboJet.cpp
+++ b/source/main/physics/air/TurboJet.cpp
@@ -305,6 +305,22 @@ void Turbojet::setRPM(float _rpm)
     m_rpm_percent = _rpm;
 }
 
+void Turbojet::setMaxDryThrust(float thrust)
+{
+    if (thrust >= 0 && thrust <= m_afterburn_thrust)
+    {
+        m_max_dry_thrust = thrust;
+    }
+}
+
+void Turbojet::setAfterburnThrust(float abThrust)
+{
+    if (abThrust >= m_max_dry_thrust)
+    {
+        m_afterburn_thrust = abThrust;
+    }
+}
+
 void Turbojet::reset()
 {
     m_rpm_percent = 0;

--- a/source/main/physics/air/TurboJet.h
+++ b/source/main/physics/air/TurboJet.h
@@ -85,6 +85,8 @@ public:
     float getMaxDryThrust() { return m_max_dry_thrust; };
     float getAfterburner() { return (float)m_afterburner_active; };
     float getAfterburnThrust() const { return m_afterburn_thrust; }
+    void setMaxDryThrust(float thrust);
+    void setAfterburnThrust(float abThrust);
     float getExhaustVelocity() const { return m_exhaust_velocity; }
     float getRPM() { return m_rpm_percent; }; // FIXME - bad func name
     float getRPMpc() { return m_rpm_percent; };

--- a/source/main/physics/air/TurboProp.cpp
+++ b/source/main/physics/air/TurboProp.cpp
@@ -456,6 +456,14 @@ void Turboprop::setRPM(float _rpm)
     rpm = _rpm;
 }
 
+void Turboprop::setMaxPower(float power)
+{
+    if (power >= 0)
+    {
+        fullpower = power;
+    }
+}
+
 void Turboprop::reset()
 {
     rpm = 0;

--- a/source/main/physics/air/TurboProp.h
+++ b/source/main/physics/air/TurboProp.h
@@ -91,6 +91,7 @@ public:
     bool getWarmup() { return warmup; };
     float getRadius() { return radius; };
     float getMaxPower() const { return fullpower; };
+    void setMaxPower(float power);
 
     // Visuals
     void updateVisuals(RoR::GfxActor* gfx_actor) override;

--- a/source/main/physics/water/ScrewProp.cpp
+++ b/source/main/physics/water/ScrewProp.cpp
@@ -100,6 +100,14 @@ void Screwprop::setRudder(float val)
     rudder = val * 45.0;
 }
 
+void Screwprop::setMaxPower(float power)
+{
+    if (power >= 0)
+    {
+        fullpower = power;
+    }
+}
+
 float Screwprop::getThrottle()
 {
     if (reverse)

--- a/source/main/physics/water/ScrewProp.h
+++ b/source/main/physics/water/ScrewProp.h
@@ -46,6 +46,7 @@ public:
     float getThrottle();
     float getRudder();
     float getMaxPower() { return fullpower; }
+    void setMaxPower(float power);
     bool getReverse() { return reverse; }
     void reset();
     void toggleReverse();

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -119,6 +119,13 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGTURBO2_ANTILAG_CHANCE", (int)ACTORSIMATTR_ENGTURBO2_ANTILAG_CHANCE); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGTURBO2_ANTILAG_MIN_RPM", (int)ACTORSIMATTR_ENGTURBO2_ANTILAG_MIN_RPM); ROR_ASSERT(result >= 0);
     result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER", (int)ACTORSIMATTR_ENGTURBO2_ANTILAG_POWER); ROR_ASSERT(result >= 0);
+    // ... Turbojets
+    result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST", (int)ACTORSIMATTR_TURBOJET_MAX_DRY_THRUST); ROR_ASSERT(result >= 0);
+    result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_TURBOJET_MAX_WET_THRUST", (int)ACTORSIMATTR_TURBOJET_MAX_WET_THRUST); ROR_ASSERT(result >= 0);
+    // ... Turboprops/Pistonprops
+    result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_PROPENGINE_MAX_POWER", (int)ACTORSIMATTR_PROPENGINE_MAX_POWER); ROR_ASSERT(result >= 0);
+    // ... Screwprops
+    result = engine->RegisterEnumValue("ActorSimAttr", "ACTORSIMATTR_SCREWPROP_MAX_POWER", (int)ACTORSIMATTR_SCREWPROP_MAX_POWER); ROR_ASSERT(result >= 0);
 
     // class Actor (historically Beam)
     Actor::RegisterRefCountingObject(engine, "BeamClass");
@@ -166,7 +173,9 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "void setNodeMass(int, float)", asMETHOD(Actor, setNodeMass), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "void setNodeMassOptions(int, bool, bool)", asMETHOD(Actor, setNodeMassOptions), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "void setSimAttribute(ActorSimAttr, float)", asMETHOD(Actor, setSimAttribute), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "void setIndexedSimAttribute(ActorSimAttr, float, int)", asMETHOD(Actor, setIndexedSimAttribute), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "float getSimAttribute(ActorSimAttr)", asMETHOD(Actor, getSimAttribute), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "float getIndexedSimAttribute(ActorSimAttr, int)", asMETHOD(Actor, getIndexedSimAttribute), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "void recalculateNodeMasses()", asMETHOD(Actor,recalculateNodeMasses), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void setAirbrakeIntensity(float)", asMETHOD(Actor,setAirbrakeIntensity), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void setAircraftFlaps(int)", asMETHOD(Actor,setAircraftFlaps), asCALL_THISCALL); ROR_ASSERT(result>=0);

--- a/source/main/scripting/bindings/ActorAngelscript.cpp
+++ b/source/main/scripting/bindings/ActorAngelscript.cpp
@@ -165,6 +165,8 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "int getShockNode2(int)", AngelScript::asMETHOD(Actor, getShockNode2), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "float getAirbrakeIntensity()", asMETHOD(Actor,getAirbrakeIntensity), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "int getAircraftFlaps()", asMETHOD(Actor,getAircraftFlaps), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void wakeUp()", asMETHOD(Actor, wakeUp), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "void sendToSleep()", asMETHOD(Actor, sendToSleep), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 
     // - physics editing (PLEASE maintain the same order as 'Actor.h' and 'doc/angelscript/.../BeamClass.h')
     result = engine->RegisterObjectMethod("BeamClass", "void scaleTruck(float)", asMETHOD(Actor,scaleTruck), asCALL_THISCALL); ROR_ASSERT(result>=0);
@@ -181,9 +183,14 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "void setAircraftFlaps(int)", asMETHOD(Actor,setAircraftFlaps), asCALL_THISCALL); ROR_ASSERT(result>=0);
     
     // - user interaction (PLEASE maintain the same order as 'Actor.h' and 'doc/angelscript/.../BeamClass.h')
+    result = engine->RegisterObjectMethod("BeamClass", "bool getParkingBrake()", asMETHOD(Actor, getParkingBrake), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "bool getTractionControl()", asMETHOD(Actor, getTractionControl), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "bool getAntiLockBrake()", asMETHOD(Actor, getAntiLockBrake), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "bool getCruiseControl()", asMETHOD(Actor, getCruiseControl), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "void parkingbrakeToggle()", asMETHOD(Actor,parkingbrakeToggle), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void tractioncontrolToggle()", asMETHOD(Actor,tractioncontrolToggle), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void antilockbrakeToggle()", asMETHOD(Actor,antilockbrakeToggle), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("BeamClass", "void cruisecontrolToggle()", asMETHOD(Actor, cruisecontrolToggle), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "void toggleCustomParticles()", asMETHOD(Actor,toggleCustomParticles), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool getCustomParticleMode()", asMETHOD(Actor,getCustomParticleMode), asCALL_THISCALL); ROR_ASSERT(result>=0);
     result = engine->RegisterObjectMethod("BeamClass", "bool isLocked()", asMETHOD(Actor,isLocked), asCALL_THISCALL); ROR_ASSERT(result>=0);
@@ -191,6 +198,12 @@ void RoR::RegisterActor(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("BeamClass", "void clearForcedCinecam()", asMETHOD(Actor, clearForcedCinecam), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "bool getForcedCinecam(int& inout, int& inout)", asMETHOD(Actor, getForcedCinecam), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "int getNumCinecams() const", asMETHOD(Actor, getNumCinecams), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "int getCameraCount() const", asMETHOD(Actor, getCameraCount), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "int getCameraPosNode(int) const", asMETHOD(Actor, getCameraPosNode), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "int getCameraDirNode(int) const", asMETHOD(Actor, getCameraDirNode), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("BeamClass", "int getCameraRollNode(int) const", asMETHOD(Actor, getCameraRollNode), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    
+    // - input engine overrides (PLEASE maintain the same order as 'Actor.h' and 'doc/angelscript/.../BeamClass.h')
     result = engine->RegisterObjectMethod("BeamClass", "float getEventValue(inputEvents, bool = false, inputSourceType = inputSourceType::IST_ANY)", asMETHOD(Actor, getEventValue), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "bool getEventBoolValue(inputEvents)", asMETHOD(Actor, getEventBoolValue), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("BeamClass", "bool getEventBoolValueBounce(inputEvents, float = 0.2f)", asMETHOD(Actor, getEventBoolValueBounce), asCALL_THISCALL); ROR_ASSERT(result >= 0);


### PR DESCRIPTION
This PR brings the last remaining changes from #3392, and implements some new features and suggestions.
## Indexed sim attributes
Now sim attributes can be set for a particular object (e.g. an aircraft engine) by specifying an index.
New attributes:

- `TURBOJET_MAX_DRY_THRUST`
- `TURBOJET_MAX_WET_THRUST`
- `PROPENGINE_MAX_POWER`
- `SCREWPROP_MAX_POWER`

## Changes for `BeamClass`

- Added `wakeUp()` and `sendToSleep()`, suggested [here](https://github.com/RigsOfRods/rigs-of-rods/pull/3427#pullrequestreview-4575647513).
- Added getters and toggles for parking brake, traction control, ABS, and cruise control.
- Added getters for the reference nodes (position, direction, roll) of all actor's cameras.
