### PR TITLE
:arrow_up: Updated dependencies

### DIFF
--- a/.github/workflows/build-game.yml
+++ b/.github/workflows/build-game.yml
@@ -45,7 +45,7 @@ jobs:
           conan profile detect --force
           echo "tools.system.package_manager:mode = install" > ~/.conan2/global.conf
           echo "tools.system.package_manager:sudo = True" >> ~/.conan2/global.conf
-          conan remote add rigs-of-rods-deps https://conan.cloudsmith.io/rigs-of-rods/deps/ -f
+          conan remote add rigs-of-rods-deps https://nexus.anotherfoxguy.com/repository/rigs-of-rods/ -f
           cmake . -GNinja -DCMAKE_BUILD_TYPE=Release -Bbuild -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=cmake/conan_provider.cmake -DCMAKE_INSTALL_PREFIX=redist -DCREATE_CONTENT_FOLDER=ON
         shell: bash
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Configure
         run: |
-          conan remote add rigs-of-rods-deps https://conan.cloudsmith.io/rigs-of-rods/deps/ -f
+          conan remote add rigs-of-rods-deps https://nexus.anotherfoxguy.com/repository/rigs-of-rods/ -f
           cmake . -GNinja -DCMAKE_BUILD_TYPE=Release -Bbuild -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=cmake/conan_provider.cmake -DCMAKE_INSTALL_PREFIX=redist -DCREATE_CONTENT_FOLDER=ON
         shell: cmd
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,15 +24,16 @@ class RoR(ConanFile):
         self.requires("ogre3d-pagedgeometry/1.2.0@anotherfoxguy/stable")
         self.requires("ogre3d/1.11.6.1@anotherfoxguy/stable", force=True)
         self.requires("ois/1.4.1@rigsofrods/custom")
-        self.requires("openal-soft/1.22.2")
+        self.requires("openal-soft/1.24.3")
         self.requires("openssl/3.1.2", force=True)
         self.requires("rapidjson/cci.20211112", force=True)
         self.requires("socketw/3.11.0@anotherfoxguy/stable")
 
         self.requires("jasper/4.2.4", override=True)
-        self.requires("libpng/1.6.39", override=True)
-        self.requires("libwebp/1.3.2", override=True)
-        self.requires("zlib/1.2.13", override=True)
+        self.requires("libpng/1.6.58", override=True)
+        self.requires("libwebp/1.6.0", override=True)
+        self.requires("zlib/1.3.2", override=True)
+        self.requires("zziplib/0.13.78@anotherfoxguy/stable", override=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
       ],
       "registryUrls": [
         "https://center2.conan.io",
-        "https://conan.cloudsmith.io/rigs-of-rods/deps/"
+        "https://nexus.anotherfoxguy.com/repository/rigs-of-rods/"
       ]
     }
   ],


### PR DESCRIPTION
Updated the following dependecies to get RoR to build with VS 2026
```
openal-soft 1.22.2 > 1.24.3
libpng 1.6.39 > 1.6.58
libwebp 1.3.2 > 1.6.0
zlib 1.2.13 > 1.3.2
```