### PR TITLE
Added setting to keep current search term to SelectorUI

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -285,6 +285,7 @@ CVar* ui_legacy_truck_renderdash;
 CVar* ui_default_boat_dash;
 CVar* ui_always_show_fullsize;
 CVar* ui_dashboard_cinecam;
+CVar* ui_keep_search;
 
 // Instance access
 AppContext*            GetAppContext         () { return &g_app_context; };

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -832,6 +832,7 @@ extern CVar* ui_legacy_truck_renderdash;   //!< string; name of the '.dashboard'
 extern CVar* ui_default_boat_dash;         //!< string; name of the '.dashboard' file in modcache.
 extern CVar* ui_always_show_fullsize;
 extern CVar* ui_dashboard_cinecam;
+extern CVar* ui_keep_search;
 
 // ------------------------------------------------------------------------------------------------
 // Global objects

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -163,14 +163,38 @@ void MainSelector::Draw()
     m_searchbox_was_active = ImGui::IsItemActive();
     const ImVec2 separator_cursor = ImGui::GetCursorPos()
         + ImVec2(0, ImGui::GetStyle().WindowPadding.y - ImGui::GetStyle().ItemSpacing.y);
-    
-    // advanced search hint
-    const char* searchbox_hint = "(?)";
-    ImGui::SetCursorPos(searchbox_cursor + ImVec2(searchbox_width - (ImGui::CalcTextSize(searchbox_hint).x + ImGui::GetStyle().FramePadding.x), ImGui::GetStyle().FramePadding.y));
-    ImGui::TextDisabled(searchbox_hint);
-    if (ImGui::IsItemHovered())
+
+    if (!m_settings_icon)
     {
-        ImGui::BeginTooltip();
+        try
+        {
+            App::GetContentManager()->AddResourcePack(ContentManager::ResourcePack::FAMICONS);
+            m_settings_icon = Ogre::TextureManager::getSingleton().load(
+                "cog.png", ContentManager::ResourcePack::FAMICONS.resource_group_name);
+        }
+        catch (...) {} // Logged by OGRE
+    }
+
+    // search settings
+    ImGui::SetItemAllowOverlap();
+    ImVec2 p_min = ImGui::GetItemRectMin();
+    ImVec2 p_max = ImGui::GetItemRectMax();
+    ImGui::SetCursorScreenPos(ImVec2(
+        p_max.x - 16.0f - ImGui::GetStyle().FramePadding.x,
+        p_min.y + ImGui::GetStyle().FramePadding.y - 3.0f));
+    if (m_settings_icon)
+    {
+        if (ImGui::ImageButton(reinterpret_cast<ImTextureID>(m_settings_icon->getHandle()), ImVec2(16, 16)))
+        {
+            ImGui::OpenPopup("##SelectorSearchSettings");
+        }
+    }
+
+    ImGui::SetNextWindowPos(ImGui::GetItemRectMin(), ImGuiCond_Always);
+    if (ImGui::BeginPopup("##SelectorSearchSettings", ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
+    {
+        ImGui::TextDisabled("Search settings");
+        ImGui::Separator();
         ImGui::TextDisabled("Fulltext search:");
         ImGui::Text("~ partial name, filename, description, author name or e-mail");
         ImGui::TextDisabled("Advanced search:");
@@ -178,7 +202,7 @@ void MainSelector::Draw()
         ImGui::Text("author: ~ partial author name or e-mail");
         ImGui::Text("wheels: ~ wheel configuration (i.e. 4x4)");
         ImGui::Text("file: ~ partial file name");
-        ImGui::EndTooltip();
+        ImGui::EndPopup();
     }
     
     ImGui::SetCursorPos(separator_cursor);

--- a/source/main/gui/panels/GUI_MainSelector.cpp
+++ b/source/main/gui/panels/GUI_MainSelector.cpp
@@ -67,17 +67,46 @@ void MainSelector::Show(LoaderType type, std::string const& filter_guid, CacheEn
 {
     m_loader_type = type;
     m_search_method = CacheSearchMethod::NONE;
-    m_search_input.Clear();
-    m_search_string.clear();
+    if (!App::ui_keep_search->getBool())
+    {
+        m_search_input.Clear();
+        m_search_string.clear();
+        m_kept_searchstring.clear();
+    }
+    else
+    {
+        auto current_search = m_kept_searchstring.find(type);
+        if (current_search != m_kept_searchstring.end())
+        {
+            m_search_input = current_search->second.c_str();
+        }
+        else
+        {
+            m_search_input.Clear();
+        }
+        this->UpdateSearchParams();
+    }
     m_filter_guid = filter_guid;
     m_advertised_entry = advertised_entry;
     m_selected_cid = m_last_selected_cid[type];
-    if (m_selected_cid == 0)
-        m_selected_cid = CID_All;
-    this->UpdateDisplayLists();
-    if (m_last_selected_category[m_loader_type] < m_display_categories.size())
+    if (App::ui_keep_search->getBool())
     {
-        m_selected_category = m_last_selected_category[m_loader_type];
+        m_selected_category = 0;
+        m_selected_cid = CID_All;
+    }
+    else
+    {
+        m_selected_cid = m_last_selected_cid[type];
+        if (m_selected_cid == 0)
+            m_selected_cid = CID_All;
+    }
+    this->UpdateDisplayLists();
+    if (!App::ui_keep_search->getBool())
+    {
+        if (m_last_selected_category[m_loader_type] < m_display_categories.size())
+        {
+            m_selected_category = m_last_selected_category[m_loader_type];
+        }
     }
     if (m_last_selected_entry[m_loader_type] < m_display_entries.size())
     {
@@ -154,6 +183,10 @@ void MainSelector::Draw()
     ImGui::PushItemWidth(searchbox_width);
     if (ImGui::InputText("##SelectorSearch", m_search_input.GetBuffer(), m_search_input.GetCapacity()))
     {
+        if (App::ui_keep_search->getBool())
+        {
+            m_kept_searchstring[m_loader_type] = m_search_input.ToCStr();
+        }
         m_selected_category = 0; // 'All'
         m_selected_cid = CID_All;
         this->UpdateSearchParams();
@@ -193,7 +226,8 @@ void MainSelector::Draw()
     ImGui::SetNextWindowPos(ImGui::GetItemRectMin(), ImGuiCond_Always);
     if (ImGui::BeginPopup("##SelectorSearchSettings", ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
     {
-        ImGui::TextDisabled("Search settings");
+        ImGui::TextDisabled("Search settings:");
+        DrawGCheckbox(App::ui_keep_search, _LC("SelectorSearchSettings", "Keep search"));
         ImGui::Separator();
         ImGui::TextDisabled("Fulltext search:");
         ImGui::Text("~ partial name, filename, description, author name or e-mail");

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -106,6 +106,7 @@ private:
     std::map<LoaderType, int> m_last_selected_category; //!< Last category-combobox position for each loader type
     std::map<LoaderType, int> m_last_selected_cid;      //!< Last selected category-ID for each loader type
     std::map<LoaderType, int> m_last_selected_entry;    //!< Stores the last manually selected entry index for each loader type
+    std::map<LoaderType, std::string> m_kept_searchstring; //!< Stays empty if 'ui_keep_search' is false
 };
 
 } // namespace GUI

--- a/source/main/gui/panels/GUI_MainSelector.h
+++ b/source/main/gui/panels/GUI_MainSelector.h
@@ -92,6 +92,7 @@ private:
     std::string        m_search_string;
     std::string        m_filter_guid;                //!< Used for skins
     Str<500>           m_search_input;
+    Ogre::TexturePtr   m_settings_icon;
     bool               m_show_details = false;
     bool               m_searchbox_was_active = false;
     CacheEntryPtr      m_advertised_entry; //!< Always shown on top, even if not existing in modcache (i.e. dummy default skin)

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -225,6 +225,7 @@ void Console::cVarSetupBuiltins()
     App::ui_default_boat_dash              = this->cVarCreate("ui_default_boat_dash",              "", CVAR_ARCHIVE, "default_boat.dashboard");
     App::ui_always_show_fullsize           = this->cVarCreate("ui_always_show_fullsize",           "", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "false");
     App::ui_dashboard_cinecam              = this->cVarCreate("ui_dashboard_cinecam", "Hide dashboard in cinecam view", CVAR_ARCHIVE | CVAR_TYPE_BOOL, "true");
+    App::ui_keep_search                    = this->cVarCreate("ui_keep_search",       "Retain selector search text",    CVAR_ARCHIVE | CVAR_TYPE_BOOL, "false");
 }
 
 CVar* Console::cVarCreate(std::string const& name, std::string const& long_name,


### PR DESCRIPTION
My attempt at resolving #3411 

Replaces the search hint tooltip with a settings menu containing a new setting to retain the current search term upon reopening the selector.

<img width="73" height="96" alt="RoR_2026-07-20_15-27-02" src="https://github.com/user-attachments/assets/df3cff38-710f-41d9-954b-d2821b4a5713" />
<br>
<img width="401" height="258" alt="RoR_2026-07-20_15-27-14" src="https://github.com/user-attachments/assets/b4d7de25-b401-456f-b0eb-8eba16bdfce5" />