### PR TITLE
:angel:Script: added example of pedestrians 🚶

### DIFF
--- a/resources/gadgets/odef_browser.as
+++ b/resources/gadgets/odef_browser.as
@@ -7,6 +7,10 @@
 imgui_utils::CloseWindowPrompt closeBtnHandler;
 
 const float FLT_MIN = 1.17549435e-38F;
+#include "math_utils.as" // getMouseShortestDistance
+using namespace math_utils;
+
+
 
 
 //#region C O N F I G
@@ -631,61 +635,3 @@ void drawMainPanel()
 }
 //#endregion
 
-
-//#region    H E L P E R S
-
-
-int clamp(int minval, int val, int maxval)
-{
-    return max(minval, min(val, maxval));
-}
-
-int min(int a, int b)
-{
-    return (a < b) ? a : b;
-}
-
-int max(int a, int b)
-{
-    return (a > b) ? a : b;
-}
-
-float fmax(float a, float b)
-{
-    return (a > b) ? a : b;
-}
-
-float fmin(float a, float b)
-{
-    return (a < b) ? a : b;
-}
-
-int abs(int a)
-{
-    return (a < 0) ? -a : a;
-}
-
-float fabs(float f)
-{
-    return (f<0.f)?-f:f;
-}
-
-
-
-int getMouseShortestDistance(vector2 mouse, vector2 target)
-{
-    int dx = abs(int(mouse.x) - int(target.x));
-    int dy = abs(int(mouse.y) - int(target.y));
-    return max(dx, dy);
-}
-
-void setAxisVal(vector3&inout vec, int axis, float val) {
-    switch(axis) {
-        case 0: vec.x=val; break;
-        case 1: vec.y=val; break;
-        case 2: vec.z=val; break;
-        default: break;
-    }
-}
-
-//#endregion

--- a/resources/gadgets/odef_browser.as
+++ b/resources/gadgets/odef_browser.as
@@ -6,7 +6,6 @@
 #include "imgui_utils.as"
 imgui_utils::CloseWindowPrompt closeBtnHandler;
 
-const float FLT_MIN = 1.17549435e-38F;
 #include "math_utils.as" // getMouseShortestDistance
 using namespace math_utils;
 

--- a/resources/gadgets/road_editor.as
+++ b/resources/gadgets/road_editor.as
@@ -21,6 +21,9 @@
 
 #include "imgui_utils.as"
 
+#include "math_utils.as" // getMouseShortestDistance
+using namespace math_utils;
+
 // Game state
 CVarClass@ cvar_app_state = console.cVarFind("app_state"); // 0=bootstrap, 1=main menu, 2=simulation, see AppState in Application.h
 CVarClass@ cvar_sistate = console.cVarFind("sim_state"); // 0=off, 1=running, 2=paused, 3=terrain editor, see SimState in Application.h
@@ -917,39 +920,3 @@ void drawEditorCamUI()
 }
 //#endregion
 
-//#region Helper functions
-
-
-int clamp(int minval, int val, int maxval)
-{
-    return max(minval, min(val, maxval));
-}
-
-int min(int a, int b)
-{
-    return (a < b) ? a : b;
-}
-
-int max(int a, int b)
-{
-    return (a > b) ? a : b;
-}
-
-float fmax(float a, float b)
-{
-    return (a > b) ? a : b;
-}
-
-int abs(int a)
-{
-    return (a < 0) ? -a : a;
-}
-
-int getMouseShortestDistance(vector2 mouse, vector2 target)
-{
-    int dx = abs(int(mouse.x) - int(target.x));
-    int dy = abs(int(mouse.y) - int(target.y));
-    return max(dx, dy);
-}
-
-//#endregion

--- a/resources/gadgets/script_editor.as
+++ b/resources/gadgets/script_editor.as
@@ -120,12 +120,18 @@ string arg5ex, string arg6ex, string arg7ex, string arg8ex)
 {
     if (ev == SE_ANGELSCRIPT_MSGCALLBACK)
     {
-        for (uint i=0; i<editorWindow.tabs.length(); i++)
+        //Angelscript's "section name" gets set to filename (especially important for `#include`-s).
+        string sectionName = arg5ex;
+        int tabID = editorWindow.findTab(sectionName);
+        if (tabID == -1)
         {
-            editorWindow.tabs[editorWindow.currentTab].onEventAngelScriptMsg(
-            /*id:*/arg1, /*eType:*/arg2ex, /*row:*/arg3ex, /*col:*/arg4ex, // ints
-            /*sectionName:*/arg5ex, /*msg:*/arg6ex); // strings
+            // Tab not found - load it!
+            editorWindow.addTab(sectionName, game.loadTextResourceAsString(sectionName, RGN_SCRIPTS));
+            tabID = int(editorWindow.tabs.length() - 1);
         }
+        editorWindow.tabs[tabID].onEventAngelScriptMsg(
+            /*id:*/arg1, /*eType:*/arg2ex, /*row:*/arg3ex, /*col:*/arg4ex, // ints
+            sectionName, /*msg:*/arg6ex); // strings
     }
     else if (ev == SE_ANGELSCRIPT_MANIPULATIONS)
     {
@@ -232,6 +238,18 @@ class ScriptEditorWindow
             tabs.removeAt(i);
         }
     }
+    
+    int findTab(string tabName) // returns index or -1 if not found.
+    {
+        for (uint i = 0; i < this.tabs.length(); i++)
+        {
+            if (this.tabs[i].bufferName == tabName)
+            {
+                return int(i);
+            }
+        }
+        return -1;
+    }
 
     void draw(float dt)
     {
@@ -284,6 +302,17 @@ class ScriptEditorWindow
         ImGui::End();
 
     }
+    
+    // helper for `drawTabBar()` - Messages (err/warn/info) floating notifier box under the tab
+    private string getTabBarMessageStatsBox(int i)
+    {
+        if (0 == (this.tabs[i].messagesTotalErr + this.tabs[i].messagesTotalWarn + this.tabs[i].messagesTotalInfo))
+        {
+            return "";
+        }
+        
+        return " ("+this.tabs[i].messagesTotalErr+"E, " + this.tabs[i].messagesTotalWarn +"W, " + this.tabs[i].messagesTotalInfo+"i)";
+    }
 
     private void drawTabBar()
     {
@@ -298,15 +327,20 @@ class ScriptEditorWindow
                 {
                     tabFlags = ImGuiTabItemFlags_SetSelected;
                 }
-                bool tabDrawn = ImGui::BeginTabItem(this.tabs[i].bufferName, /*inout:*/tabOpen, tabFlags);
+                string tabTitle = this.tabs[i].bufferName + this.getTabBarMessageStatsBox(i);
+                bool tabDrawn = ImGui::BeginTabItem(tabTitle, /* [inout] */tabOpen, tabFlags);
                 if (tabDrawn)
                 {
                     ImGui::EndTabItem();
                 }
                 if (!tabOpen)
-                this.tabScheduledForRemoval = int(i);
+                {
+                    this.tabScheduledForRemoval = int(i);
+                }
                 else if (ImGui::IsItemClicked())
-                this.currentTab = i;
+                {
+                    this.currentTab = i;
+                }
             }
 
             ImGui::EndTabBar();
@@ -1242,8 +1276,7 @@ void setBuffer(string data)
 
 private void runBufferInternal() // do not invoke during drawing ~ use `requestRunBuffer`
 {
-    this.bufferMessageIDs.resize(0); // clear all
-    this.messages.resize(0); // clear all
+    this.mpanel.clearMessages();
     this.epanel.clearExceptions();
 
     this.backUpRegionFoldStates();
@@ -2350,6 +2383,15 @@ class MessagesPanel
         return 6.f + float(parentEditorTab.messages.length())*ImGui::GetTextLineHeightWithSpacing();
     }
     
+    void clearMessages()
+    {
+        this.parentEditorTab.messages.resize(0); // clear all
+        this.parentEditorTab.bufferMessageIDs.resize(0); // clear all
+        this.parentEditorTab.messagesTotalErr = 0;
+        this.parentEditorTab.messagesTotalWarn = 0;
+        this.parentEditorTab.messagesTotalInfo = 0;
+    }
+    
     void drawMessages()
     {
         string clearall_btn_text = "Clear all";
@@ -2357,8 +2399,7 @@ class MessagesPanel
         ImGui::SetCursorPosX(ImGui::GetWindowContentRegionMax().x - (ImGui::CalcTextSize(clearall_btn_text).x + 8.f));
         if (ImGui::SmallButton(clearall_btn_text))
         {
-            this.parentEditorTab.messages.resize(0); // clear all
-            this.parentEditorTab.bufferMessageIDs.resize(0); // clear all
+            this.clearMessages();
             return;
         }
         cursorBackup.y += 5.f;
@@ -2373,6 +2414,7 @@ class MessagesPanel
             int msgCol = int(msgInfo['col']);
             int msgType = int(msgInfo['type']);
             string msgText = string(msgInfo['message']);
+            string msgSection = string(msgInfo['sectionName']);
             bool msgShow = bool(msgInfo['show']);
             
             ImGui::Bullet();
@@ -2406,7 +2448,6 @@ class MessagesPanel
             }            
             ImGui::SameLine();
             ImGui::Text(msgText);
-
 
             ImGui::PopID(); // i
         }

--- a/resources/scripts/char_utils.as
+++ b/resources/scripts/char_utils.as
@@ -1,0 +1,32 @@
+/// \title Char constants and helpers
+/// \brief How to efficiently work with `chars` (AngelScript doesn't actually have them!)
+// ===================================================
+
+// By convention, all includes have filename '*_utils' and namespace matching filename.
+namespace char_utils
+{
+    
+    // CONSTANTS (AngelScript doesn't have `char` type and allocating a string each time adds up, see https://github.com/RigsOfRods/rigs-of-rods/commit/92d450ca4bceb9bb591db8d691cdbad7d559a16e
+    uint CHAR_NEWLINE          = string("\n")[0];
+    uint CHAR_CARRIAGERETURN   = string("\r")[0];
+    uint CHAR_TAB              = string("\t")[0];
+    uint CHAR_NUL              = string("\0")[0];
+    uint CHAR_BACKSLASH        = string("\\")[0];
+    uint CHAR_QUOTE            = string("\"")[0];
+    uint CHAR_SPACE            = string(" ")[0];
+    uint CHAR_SLASH            = string("/")[0];
+    uint CHAR_BRACE_OPEN       = string("{")[0];
+    uint CHAR_BRACE_CLOSE      = string("}")[0];
+    uint CHAR_PARENTHESE_OPEN  = string("(")[0];
+    uint CHAR_PARENTHESE_CLOSE = string(")")[0];
+    uint CHAR_BRACKET_OPEN     = string("[")[0];
+    uint CHAR_BRACKET_CLOSE    = string("]")[0];
+    uint CHAR_APOSTROPHE       = string("'")[0];
+    uint CHAR_DIGIT_NINE       = string("0")[0];
+    uint CHAR_DIGIT_ZERO       = string("9")[0];
+    
+    
+    bool isBlank(uint c) { return c==CHAR_NEWLINE || c==CHAR_CARRIAGERETURN || c==CHAR_TAB || c==CHAR_SPACE; }
+    bool isDigit(uint c) { return c>=CHAR_DIGIT_ZERO && c<=CHAR_DIGIT_NINE; }
+    
+} // namespace char_utils

--- a/resources/scripts/demo_script.as
+++ b/resources/scripts/demo_script.as
@@ -32,6 +32,7 @@ https://developer.rigsofrods.org/d4/d07/group___script2_game.html
 */
 
 #include "imgui_utils.as"
+#include "math_utils.as"
 
 /*
 ---------------------------------------------------------------------------
@@ -550,18 +551,11 @@ void drawTextResourceButtons()
     }
 }
 
-string formatVector3(vector3 val, int total, int frac)
-{
-    return "X:" + formatFloat(val.x, "", total, frac)
-    + " Y:" + formatFloat(val.y, "", total, frac)
-    + " Z:" + formatFloat(val.z, "", total, frac);
-}
-
 void drawActorAngles(BeamClass@ actor)
 {
     if (ImGui::CollapsingHeader("Actor positions/angles test"))
     {
-        ImGui::Text("getPosition(): [vector3] " + formatVector3(actor.getPosition(), 6,2));
+        ImGui::Text("getPosition(): [vector3] " + math_utils::formatVector3(actor.getPosition(), 6,2));
         //ImGui::Text("getRotation(): [float] " + formatFloat(actor.getRotation(), "", 6,2)); // returns valid yaw in radians, but prefer using `.getOrientation.getYaw()`
         ImGui::Text("getSpeed(): [float] " + formatFloat(actor.getSpeed(), "", 6,2));
         ImGui::Text("getOrientation(): [quaternion]");

--- a/resources/scripts/example_ImGui_nodeHighlight.as
+++ b/resources/scripts/example_ImGui_nodeHighlight.as
@@ -12,6 +12,9 @@
 #include "imgui_utils.as"
 imgui_utils::CloseWindowPrompt closeBtnHandler;
 
+#include "math_utils.as" // getMouseShortestDistance
+using namespace math_utils;
+
 //#region GAME CALLBACKS:
 
 // `main()` runs once when script is loaded.
@@ -239,29 +242,3 @@ void drawNodeHighlights(BeamClass@ actor)
 
 // #endregion
 
-// #region HELPERS
-
-// shamelessly copypasted from 'road_editor.as', line 803
-int getMouseShortestDistance(vector2 mouse, vector2 target)
-{
-    int dx = iabs(int(mouse.x) - int(target.x));
-    int dy = iabs(int(mouse.y) - int(target.y));
-    return imax(dx, dy);
-}
-
-int imin(int a, int b)
-{
-    return (a < b) ? a : b;
-}
-
-int imax(int a, int b)
-{
-    return (a > b) ? a : b;
-}
-
-int iabs(int a)
-{
-    return (a < 0) ? -a : a;
-}
-
-// #endregion

--- a/resources/scripts/example_angelscript_difftool.as
+++ b/resources/scripts/example_angelscript_difftool.as
@@ -1,0 +1,331 @@
+// DIFF TEST
+// ===================================================
+
+// Window [X] button handler
+#include "imgui_utils.as"
+imgui_utils::CloseWindowPrompt closeBtnHandler;
+
+#include "char_utils.as"
+
+//#region game glue
+
+void main()
+{
+    // Uncomment to close window without asking.
+    //closeBtnHandler.cfgCloseImmediatelly = true;
+}
+
+// `frameStep()` runs every frame; `dt` is delta time in seconds.
+void frameStep(float dt)
+{
+    // Begin drawing window
+    if (ImGui::Begin("Diff test", closeBtnHandler.windowOpen, 0))
+    {
+        // Draw the "Terminate this script?" prompt on the top (if not disabled by config).
+        closeBtnHandler.draw();
+        
+        drawDiff(diffLines);
+        
+        // End drawing window
+        ImGui::End();
+    }
+}
+
+//#endregion (game glue)
+
+//#region Data + preprocessing
+
+
+
+// TEST CODE (using 'heredoc' syntax; see https://www.angelcode.com/angelscript/sdk/docs/manual/doc_datatypes_strings.html)
+const string TEST_CODE_A =
+"""
+// \brief Parsing test code
+
+string msg = "Hello"
++ "Rigs of Rods!";
+
+game.log( msg);
+// Begin drawing window
+if (ImGui::Begin("Diff test", closeBtnHandler.windowOpen, 0))
+{
+    // Draw the "Terminate this script?" prompt on the top (if not disabled by config).
+    closeBtnHandler.draw();
+    
+    drawDiff(diffLines);
+    
+    // End drawing window
+    ImGui::End();
+}
+""";
+const string TEST_CODE_B =
+"""
+// \brief Parsing test code
+
+string msg = "Hello"
++ " World!";
+
+game.log( msg);
+
+// Begin drawing window
+if (ImGui::Begin("Diff test", closeBtnHandler.windowOpen, 0))
+{
+    // Draw the "Terminate this script?" prompt on the top (if not disabled by config).
+    closeBtnHandler.draw();
+    
+    drawBiff(diffLines);
+    
+    // End drawing window
+    ImGui::End();
+}
+""";
+
+array<string> splitLines(const string &in text)
+{
+    
+    
+    array<string> lines;
+    string line;
+    uint c;
+    
+    for (uint i = 0; i < text.length(); i++)
+    {
+        c = text[i];
+        
+        if (c == char_utils::CHAR_NEWLINE)
+        {
+            lines.insertLast(line);
+            line = "";
+        }
+        else if (c != char_utils::CHAR_CARRIAGERETURN)
+        {
+            line += text.substr(i, 1);
+        }
+    }
+    
+    lines.insertLast(line);
+    return lines;
+}
+
+array<string> aLines = splitLines(TEST_CODE_A);
+array<string> bLines = splitLines(TEST_CODE_B);
+
+
+
+//#endregion 
+
+// #region LCS algorithm
+// The Longest Common Subsequence (LCS) algorithm is the standard backbone of diff tools. It’s easy to implement and good enough for text files.
+
+enum DiffType { Same, Added, Removed };
+
+class DiffLine
+{
+    DiffType type;
+    string text;
+}
+
+int maxInt(int a, int b)
+{
+    return (a > b) ? a : b;
+}
+
+array<array<int>> buildLCSTable(const array<string> &in A, const array<string> &in B)
+{
+    uint n = A.length();
+    uint m = B.length();
+    
+    array<array<int>> dp(n + 1);
+    for (uint i = 0; i <= n; i++)
+    dp[i].resize(m + 1);
+    
+    for (uint i = 1; i <= n; i++)
+    {
+        for (uint j = 1; j <= m; j++)
+        {
+            if (A[i - 1] == B[j - 1])
+            dp[i][j] = dp[i - 1][j - 1] + 1;
+            else
+            dp[i][j] = maxInt(dp[i - 1][j], dp[i][j - 1]);
+        }
+    }
+    return dp;
+}
+
+// Backtrack to produce diff
+array<DiffLine> buildDiff(
+const array<string> &in A,
+const array<string> &in B)
+{
+    array<array<int>> dp = buildLCSTable(A, B);
+    array<DiffLine> result;
+    
+    int i = int(A.length());
+    int j = int(B.length());
+    
+    while (i > 0 || j > 0)
+    {
+        if (i > 0 && j > 0 && A[i - 1] == B[j - 1])
+        {
+            DiffLine d;
+            d.type = Same;
+            d.text = A[i - 1];
+            result.insertLast(d);
+            i--; j--;
+        }
+        else if (j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j]))
+        {
+            DiffLine d;
+            d.type = Added;
+            d.text = B[j - 1];
+            result.insertLast(d);
+            j--;
+        }
+        else
+        {
+            DiffLine d;
+            d.type = Removed;
+            d.text = A[i - 1];
+            result.insertLast(d);
+            i--;
+        }
+    }
+    
+    result.reverse();
+    return result;
+}
+
+array<DiffLine> diffLines = buildDiff(aLines, bLines);
+
+// #endregion
+
+// #region Rendering
+
+color COLOR_SAME (1, 1, 1, 1);
+color COLOR_ADDED (0.6f, 1.0f, 0.6f, 1);
+color COLOR_REMOVED (1.0f, 0.6f, 0.6f, 1);
+
+color COLOR_LINENUM_SAME    (0.6f, 0.6f, 0.6f, 1);
+color COLOR_LINENUM_ADDED   (0.4f, 0.9f, 0.4f, 1);
+color COLOR_LINENUM_REMOVED (0.9f, 0.4f, 0.4f, 1);
+
+
+class SimpleClipper
+{
+    int displayStart;
+    int displayEnd;
+}
+
+SimpleClipper computeClipper(int itemCount, float itemHeight)
+{
+    SimpleClipper c;
+    
+    float scrollY     = ImGui::GetScrollY();
+    float windowH     = ImGui::GetWindowHeight();
+    
+    int first = int(scrollY / itemHeight);
+    int last  = int((scrollY + windowH) / itemHeight) + 1;
+    
+    if (first < 0) first = 0;
+    if (last > itemCount) last = itemCount;
+    
+    c.displayStart = first;
+    c.displayEnd   = last;
+    return c;
+}
+
+
+
+void drawDiff(const array<DiffLine> &in diff)
+{
+    ImGui::BeginChild("DiffView");
+    
+    float lineHeight = ImGui::GetTextLineHeight();
+    float numberWidth = 60.0f;
+    
+    ImGui::Dummy(vector2(0, diff.length() * lineHeight));
+    
+    SimpleClipper clip = computeClipper(diff.length(), lineHeight);
+    
+    int lineA = 1;
+    int lineB = 1;
+    
+    for (int i = 0; i < clip.displayStart; i++)
+    {
+        if (diff[i].type != Added)   lineA++;
+        if (diff[i].type != Removed) lineB++;
+    }
+    
+    ImGui::SetCursorPosY(clip.displayStart * lineHeight);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, vector2(0,0));
+    
+    for (int i = clip.displayStart; i < clip.displayEnd; i++)
+    {
+        const DiffLine@ d = diff[i];
+        ImGui::PushID(i);
+        
+        // --- Line numbers ---
+        ImGui::BeginGroup();
+        
+        if (d.type == Added)
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_LINENUM_ADDED);
+        else if (d.type == Removed)
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_LINENUM_REMOVED);
+        else
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_LINENUM_SAME);
+        
+        if (d.type != Added)
+        ImGui::Text("" + lineA);
+        else
+        ImGui::Text(" ");
+        
+        ImGui::PopStyleColor();
+        ImGui::SameLine(0, 8);
+        
+        if (d.type == Added)
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_LINENUM_ADDED);
+        else if (d.type == Removed)
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_LINENUM_REMOVED);
+        else
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_LINENUM_SAME);
+        
+        if (d.type != Removed)
+        ImGui::Text("" + lineB);
+        else
+        ImGui::Text(" ");
+        
+        ImGui::PopStyleColor();
+        ImGui::EndGroup();
+        
+        // --- Text ---
+        ImGui::SameLine(numberWidth);
+        
+        if (d.type == Added)
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_ADDED);
+        else if (d.type == Removed)
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_REMOVED);
+        else
+        ImGui::PushStyleColor(ImGuiCol_Text, COLOR_SAME);
+        
+        string prefix = "  ";
+        if (d.type == Added)   prefix = "+ ";
+        if (d.type == Removed) prefix = "- ";
+        
+        ImGui::Text(prefix + d.text);
+        ImGui::PopStyleColor();
+        
+        if (d.type != Added)   lineA++;
+        if (d.type != Removed) lineB++;
+        
+        ImGui::PopID();
+    }
+    
+    ImGui::PopStyleVar(); // ItemSpacing
+    
+    ImGui::EndChild();
+}
+
+
+
+
+// #endregion

--- a/resources/scripts/example_angelscript_difftool.as
+++ b/resources/scripts/example_angelscript_difftool.as
@@ -33,7 +33,7 @@ void frameStep(float dt)
 
 //#endregion (game glue)
 
-//#region Data + preprocessing
+//#region Test data
 
 
 
@@ -79,6 +79,10 @@ if (ImGui::Begin("Diff test", closeBtnHandler.windowOpen, 0))
     ImGui::End();
 }
 """;
+
+//#endregion
+
+//#region Data preprocessing
 
 array<string> splitLines(const string &in text)
 {
@@ -277,7 +281,10 @@ void drawDiff(const array<DiffLine> &in diff)
         if (d.type != Added)
         ImGui::Text("" + lineA);
         else
-        ImGui::Text(" ");
+        {
+            vector2 digitSize = ImGui::CalcTextSize(""+lineA);
+            ImGui::Dummy(digitSize);
+        }
         
         ImGui::PopStyleColor();
         ImGui::SameLine(0, 8);
@@ -292,7 +299,10 @@ void drawDiff(const array<DiffLine> &in diff)
         if (d.type != Removed)
         ImGui::Text("" + lineB);
         else
-        ImGui::Text(" ");
+        {
+            vector2 digitSize = ImGui::CalcTextSize(""+lineB);
+            ImGui::Dummy(digitSize);
+        }
         
         ImGui::PopStyleColor();
         ImGui::EndGroup();

--- a/resources/scripts/example_angelscript_lexer.as
+++ b/resources/scripts/example_angelscript_lexer.as
@@ -1,0 +1,317 @@
+// ============================================================
+/// \title AngelScript Tokenizer
+/// \brief Compact lexer: identifiers, keywords, numbers, strings, comments, operators/punctuation.
+// ============================================================
+
+//#region Token defs
+enum TokType {
+    TT_EOF, TT_IDENT, TT_KEYWORD, TT_INT, TT_FLOAT, TT_LINEBREAK,
+    TT_STRING, TT_COMMENT, TT_PUNCT, TT_UNKNOWN
+}
+
+string TokTypeName(TokType t) {
+    switch (t) {
+        case TT_IDENT:   return "IDENT";
+        case TT_KEYWORD: return "KEYWORD";
+        case TT_INT:     return "INT";
+        case TT_FLOAT:   return "FLOAT";
+        case TT_STRING:  return "STRING";
+        case TT_COMMENT: return "COMMENT";
+        case TT_PUNCT:   return "PUNCT";
+        case TT_EOF:     return "EOF";
+        default:         return "UNKNOWN";
+    }
+}
+
+class Token {
+    TokType   type;
+    string    text;
+    uint      pos;
+    uint      line;
+    Token(TokType t, const string &in s, uint p, uint l) {
+        type = t; text = s; pos = p; line = l;
+    }
+}
+//#endregion
+
+
+// #region the tokenizer
+class ASTokenizer {
+    
+    string src;
+    uint   i, len, lineNo;
+    array<Token@> toks;
+    
+    // -- char helpers (byte-wise, ASCII) --------------------
+string ch(uint k) { return k < len ? src.substr(k, 1) : ""; }
+bool isDigit(const string &in c) { return c >= "0" && c <= "9"; }
+bool isHex(const string &in c)   { return isDigit(c) || (c>="a"&&c<="f") || (c>="A"&&c<="F"); }
+bool isAlpha(const string &in c) { return (c>="a"&&c<="z") || (c>="A"&&c<="Z") || c=="_"; }
+bool isAlnum(const string &in c) { return isAlpha(c) || isDigit(c); }
+    
+    // -- keyword table ---------------------------------------
+    array<string> kw = {
+        "and","abstract","auto","bool","break","case","cast","class","const",
+        "continue","default","do","double","else","enum","explicit","external",
+        "false","final","float","for","from","funcdef","function","get","if",
+        "import","in","inout","int","int8","int16","int32","int64","interface",
+        "is","mixin","namespace","not","null","or","out","override","private",
+        "property","protected","return","set","shared","super","switch","this",
+        "true","typedef","uint","uint8","uint16","uint32","uint64","void",
+        "while","xor"
+    };
+    bool isKeyword(const string &in s) {
+        for (uint k = 0; k < kw.length(); k++) if (kw[k] == s) return true;
+        return false;
+    }
+    
+    // -- multi-char punctuation, longest first ---------------
+    array<string> ops = {
+        ">>>=","**=","<<=",">>=",">>>","&&","||","^^","==","!=","<=",">=",
+        "++","--","+=","-=","*=","/=","%=","&=","|=","^=","<<",">>","::","..",
+        "**","@","!","~","&","|","^","%","*","/","+","-","<",">","=","?",":",
+    ";",",",".","(",")","{","}","[","]"
+    };
+    string matchOp() {
+        for (uint k = 0; k < ops.length(); k++) {
+            uint L = ops[k].length();
+            if (i + L <= len && src.substr(i, L) == ops[k]) return ops[k];
+        }
+        return "";
+    }
+    
+void add(TokType t, const string &in s, uint p) { toks.insertLast(Token(t, s, p, lineNo)); }
+    
+    // -- main entry -------------------------------------------
+    array<Token@>@ Tokenize(const string &in code) {
+        src = code; len = src.length(); i = 0; lineNo = 1; toks.resize(0);
+        
+        while (i < len) {
+            string c = ch(i);
+            
+            // linebreak
+            if (c == "\n") {
+                add(TT_LINEBREAK, "", 0);
+            lineNo++; i++; continue; }
+            
+            // whitespace
+        if (c == " " || c == "\t" || c == "\r") { i++; continue; }
+            
+            // line comment
+            if (c == "/" && ch(i+1) == "/") {
+                uint p = i;
+                while (i < len && ch(i) != "\n") i++;
+                add(TT_COMMENT, src.substr(p, i - p), p);
+                continue;
+            }
+            
+            // block comment
+            if (c == "/" && ch(i+1) == "*") {
+                uint p = i; i += 2;
+                while (i < len && !(ch(i) == "*" && ch(i+1) == "/")) {
+                    if (ch(i) == "\n") lineNo++;
+                    i++;
+                }
+                i = i + 2 <= len ? i + 2 : len;
+                add(TT_COMMENT, src.substr(p, i - p), p);
+                continue;
+            }
+            
+            // string literal: '...' "..." or heredoc '''...'''
+            if (c == "\"" || c == "'") {
+                uint p = i;
+                string q = c;
+                bool heredoc = (ch(i+1) == q && ch(i+2) == q);
+                if (heredoc) {
+                    i += 3;
+                    while (i < len && !(ch(i)==q && ch(i+1)==q && ch(i+2)==q)) i++;
+                    i = i + 3 <= len ? i + 3 : len;
+                } else {
+                    i++;
+                    while (i < len && ch(i) != q) {
+                        if (ch(i) == "\\") i++;   // skip escaped char
+                        i++;
+                    }
+                    if (i < len) i++;             // closing quote
+                }
+                add(TT_STRING, src.substr(p, i - p), p);
+                continue;
+            }
+            
+            // number: int / hex / oct / bin / float
+            if (isDigit(c) || (c == "." && isDigit(ch(i+1)))) {
+                uint p = i;
+                if (c == "0" && (ch(i+1) == "x" || ch(i+1) == "X")) {
+                    i += 2; while (isHex(ch(i))) i++;
+                } else if (c == "0" && (ch(i+1) == "b" || ch(i+1) == "B")) {
+                    i += 2; while (ch(i) == "0" || ch(i) == "1") i++;
+                } else if (c == "0" && (ch(i+1) == "o" || ch(i+1) == "O")) {
+                    i += 2; while (ch(i) >= "0" && ch(i) <= "7") i++;
+                } else {
+                    bool isFloat = false;
+                    while (isDigit(ch(i))) i++;
+                if (ch(i) == ".") { isFloat = true; i++; while (isDigit(ch(i))) i++; }
+                    if (ch(i) == "e" || ch(i) == "E") {
+                        isFloat = true; i++;
+                        if (ch(i) == "+" || ch(i) == "-") i++;
+                        while (isDigit(ch(i))) i++;
+                    }
+                if (ch(i) == "f" || ch(i) == "F") { isFloat = true; i++; }
+                    add(isFloat ? TT_FLOAT : TT_INT, src.substr(p, i - p), p);
+                    continue;
+                }
+                add(TT_INT, src.substr(p, i - p), p);
+                continue;
+            }
+            
+            // identifier / keyword
+            if (isAlpha(c)) {
+                uint p = i;
+                while (isAlnum(ch(i))) i++;
+                string word = src.substr(p, i - p);
+                add(isKeyword(word) ? TT_KEYWORD : TT_IDENT, word, p);
+                continue;
+            }
+            
+            // operator / punctuation
+            string op = matchOp();
+        if (op != "") { add(TT_PUNCT, op, i); i += op.length(); continue; }
+            
+            // unknown byte, skip
+            add(TT_UNKNOWN, c, i);
+            i++;
+        }
+        
+        add(TT_EOF, "", i);
+        return @toks;
+    }
+}
+
+//#endregion
+
+
+// #region Example data
+
+string sample = 
+"""
+namespace foo {
+    float x = 3.14e2f;
+    string s = "hi \"there\"";
+    // compute factorial
+    int fact(int n) {
+        if (n <= 1) return 1;
+        return n * fact(n - 1);
+    }
+} // namespace foo
+""";
+
+
+array<Token@> tokens; // tokenization done in `main()`
+
+
+//#endregion
+
+
+// #region Rendering tokens with auto-indent
+
+color TokColor(TokType t) {
+    switch (t) {
+        case TT_KEYWORD: return color(0.36f, 0.55f, 0.95f, 1.0f); // blue
+        case TT_IDENT:   return color(0.85f, 0.85f, 0.85f, 1.0f); // light gray
+        case TT_INT:
+        case TT_FLOAT:   return color(0.70f, 0.55f, 0.95f, 1.0f); // purple
+        case TT_STRING:  return color(0.90f, 0.55f, 0.30f, 1.0f); // orange
+        case TT_COMMENT: return color(0.45f, 0.60f, 0.40f, 1.0f); // green
+        case TT_PUNCT:   return color(0.80f, 0.80f, 0.50f, 1.0f); // yellow-gray
+        default:         return color(0.60f, 0.15f, 0.15f, 1.0f); // red (unknown)
+    }
+}
+
+
+
+void DrawTokens(array<Token@>@ tokens) {
+    int indentLevel=0;
+    bool firstOnLine=true;
+    for (uint i = 0; i < tokens.length(); i++) {
+        Token@ t = tokens[i];
+        if (t.type == TT_EOF) break;
+        
+        if (t.type == TT_PUNCT) { 
+        if (t.text=="{") indentLevel++; else if (t.text=="}") indentLevel--; 
+        }
+        
+        if (t.type == TT_LINEBREAK) 
+        {
+            firstOnLine=true;
+            continue;
+        }
+        
+        
+        if (firstOnLine) { 
+        for(int n=0;n<indentLevel; n++) { ImGui::Text("    "); ImGui::SameLine(0.f,0.f);} firstOnLine=false;
+        }
+        else ImGui::SameLine(0.f, 0.f);
+        
+        color col = TokColor(t.type);
+        
+        // only comments and (potentially multi-line) strings need
+        // to be split on embedded newlines; everything else is
+        // guaranteed single-line by the tokenizer.
+        if (t.type == TT_COMMENT || t.type == TT_STRING) {
+            uint p = 0, L = t.text.length();
+            for (uint k = 0; k <= L; k++) {
+                if (k == L || t.text[k] == "\n"[0]) {
+                    string seg = t.text.substr(p, k - p);
+                    if (seg.length() > 0) {
+                        ImGui::TextColored(col, seg);
+                        
+                    }
+                    p = k + 1;
+                }
+            }
+            continue;
+        }
+        
+        ImGui::TextColored(col, t.text);
+        
+    }
+}
+
+//#endregion
+
+
+// #region game glue
+
+// Window [X] button handler
+#include "imgui_utils.as"
+imgui_utils::CloseWindowPrompt closeBtnHandler;
+
+
+void main()
+{
+    // Uncomment to close window without asking.
+    //closeBtnHandler.cfgCloseImmediatelly = true;
+    ASTokenizer tz;
+    tokens = tz.Tokenize(sample);
+}
+
+// `frameStep()` runs every frame; `dt` is delta time in seconds.
+void frameStep(float dt)
+{
+    // Begin drawing window
+    if (ImGui::Begin("Lexer script", closeBtnHandler.windowOpen, 0))
+    {
+        // Draw the "Terminate this script?" prompt on the top (if not disabled by config).
+        closeBtnHandler.draw();
+        
+        ImGui::Text(sample);
+        ImGui::Separator();
+        
+        DrawTokens(tokens);
+        
+        // End drawing window
+        ImGui::End();
+    }
+}
+
+//#endregion

--- a/resources/scripts/example_game_camera.as
+++ b/resources/scripts/example_game_camera.as
@@ -5,6 +5,8 @@
 #include "imgui_utils.as"
 imgui_utils::CloseWindowPrompt closeBtnHandler;
 
+#include "math_utils.as" //formatVector
+
 //#region yaw,pitch,roll
 bool setRoll = false;
 float rollAngle = 0.f;
@@ -195,8 +197,8 @@ void frameStep(float dt)
         
         //#region UI-Getters
         ImGui::TextDisabled("Getters:");
-        ImGui::Text("game.getCameraPosition(): " + formatVector3(game.getCameraPosition(), 7, 2));
-        ImGui::Text("game.getCameraDirection(): " + formatVector3(game.getCameraDirection(), 5, 2));
+        ImGui::Text("game.getCameraPosition(): " + math_utils::formatVector3(game.getCameraPosition(), 7, 2));
+        ImGui::Text("game.getCameraDirection(): " + math_utils::formatVector3(game.getCameraDirection(), 5, 2));
         //#endregion
         ImGui::Separator();
         //#region UI-Setters
@@ -233,11 +235,3 @@ void frameStep(float dt)
     }
 }
 
-//#region Helpers
-string formatVector3(vector3 val, int total, int frac)
-{
-    return "X:" + formatFloat(val.x, "", total, frac)
-    + " Y:" + formatFloat(val.y, "", total, frac)
-    + " Z:" + formatFloat(val.z, "", total, frac);
-}
-//#endregion

--- a/resources/scripts/example_game_pedestrians.as
+++ b/resources/scripts/example_game_pedestrians.as
@@ -1,6 +1,7 @@
 /// \title Example pedestrian NPCs (characters following path network)
 /// based on OGRE example - character posing (skeletal animations)
 
+#include "math_utils.as"
 
 // Window [X] button handler
 #include "imgui_utils.as"
@@ -144,7 +145,6 @@ void drawPathEditor()
     
     gVertsViewer.end();
     
-    
 }
 
 //#endregion
@@ -280,7 +280,7 @@ vector2 drawWaypointSelectionUI(vector2 controlsCursor)
 // copypasted from "imgui - node higlight" demo
 void drawWaypointHighlights()
 {
-    
+    using namespace math_utils;
     int mouseClosestNodeID = -1;
     
     int mouseClosestNodeDist = 999999;
@@ -339,40 +339,6 @@ void drawWaypointHighlights()
 
 // #endregion
 
-// #region HELPERS
-
-// shamelessly copypasted from 'road_editor.as', line 803
-int getMouseShortestDistance(vector2 mouse, vector2 target)
-{
-    int dx = iabs(int(mouse.x) - int(target.x));
-    int dy = iabs(int(mouse.y) - int(target.y));
-    return imax(dx, dy);
-}
-
-int imin(int a, int b)
-{
-    return (a < b) ? a : b;
-}
-
-int imax(int a, int b)
-{
-    return (a > b) ? a : b;
-}
-
-int iabs(int a)
-{
-    return (a < 0) ? -a : a;
-}
-
-// from demo_script.as
-string formatVector3(vector3 val, int total, int frac)
-{
-    return "X:" + formatFloat(val.x, "", total, frac)
-    + " Y:" + formatFloat(val.y, "", total, frac)
-    + " Z:" + formatFloat(val.z, "", total, frac);
-}
-
-// #endregion
 
 
 
@@ -502,6 +468,7 @@ class NpcCharacter
     
     void draw()
     {
+using namespace math_utils;
         ImGui::PushID(this.uniqueName);
         vector3 pos1 = npcWaypoints[this.currentWp1].position;
         vector3 pos2 = npcWaypoints[this.currentWp2].position;

--- a/resources/scripts/example_game_pedestrians.as
+++ b/resources/scripts/example_game_pedestrians.as
@@ -82,7 +82,7 @@ void addPathBetweenSelected()
 gridviewer_utils::GridViewer gVertsViewer;
 
 // waypoint display conf
-float gBottomBarHeight = 80;
+float gBottomBarHeight = 0;
 // surveymap texture
 Ogre::TexturePtr gTex;
 color gColorViewerImageTint(1,1,1,1); // white
@@ -106,7 +106,7 @@ void setupPathEditor()
 void drawPathEditor()
 {
     vector2 windowSize = ImGui::GetWindowContentRegionMax() - ImGui::GetWindowContentRegionMin();    
-    float spaceUnderViewer = 50;
+    float spaceUnderViewer = 0;
     vector2 viewerSize = vector2(windowSize.x , windowSize.y - (gBottomBarHeight+spaceUnderViewer));
     
     gVertsViewer.begin(viewerSize);
@@ -131,15 +131,20 @@ void drawPathEditor()
     
     updateWaypointMouseControls();
     
-    gVertsViewer.end();
+    vector2 controlsCursor = gVertsViewer.endGridBeginControls();
     
-    ImGui::TextColored( cfgNodeColor, "Total waypoints: "+npcWaypoints.length() + " (use right mouse button to create)");
-    drawWaypointSelectionUI();
+    controlsCursor = drawWaypointSelectionUI(controlsCursor);
     
+    // Walker management
+    ImGui::SetCursorPos(controlsCursor);
     if (ImGui::SmallButton("release a walker!"))
     {
         releaseWalker();
     }
+    
+    gVertsViewer.end();
+    
+    
 }
 
 //#endregion
@@ -203,8 +208,17 @@ void updateWaypointMouseControls()
     }
 }
 
-void drawWaypointSelectionUI()
+vector2 drawWaypointSelectionUI(vector2 controlsCursor)
 {
+    // First line
+    ImGui::SetCursorPos(controlsCursor);
+    
+    ImGui::TextColored( cfgNodeColor, "Total waypoints: "+npcWaypoints.length() + " (use right mouse button to create)");
+    
+    // Next line
+    controlsCursor.y += ImGui::GetTextLineHeightWithSpacing();
+    ImGui::SetCursorPos(controlsCursor);
+    
     int totalSelected = 0;
     string strSelected = "";
     string strJoiner = "";
@@ -217,10 +231,11 @@ void drawWaypointSelectionUI()
             totalSelected++;
         }
     }
-    ImGui::TextDisabled("Selected waypoints (" + totalSelected + ")" + mouseHoverDebugString);
+    ImGui::TextDisabled("Selected waypoints (" + totalSelected + ")"); // + mouseHoverDebugString);
     lastNumSelected = totalSelected; // for editing checks
-    ImGui::Text(strSelected);
-    if (ImGui::Button("Select all"))
+    //   ImGui::Text(strSelected);
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Select all"))
     {
         for (uint i=0; i < npcWaypoints.length(); i++)
         {
@@ -228,7 +243,7 @@ void drawWaypointSelectionUI()
         }
     }
     ImGui::SameLine();
-    if (ImGui::Button("UnSelect all"))
+    if (ImGui::SmallButton("UnSelect all"))
     {
         for (uint i=0; i < npcWaypoints.length(); i++)
         {
@@ -236,13 +251,17 @@ void drawWaypointSelectionUI()
         }
     }
     ImGui::SameLine();
-    if (ImGui::Button("Flip selection"))
+    if (ImGui::SmallButton("Flip selection"))
     {
         for (uint i=0; i < npcWaypoints.length(); i++)
         {
             npcWaypoints[i].selected = !npcWaypoints[i].selected;
         }
     }
+    
+    // Next line
+    controlsCursor.y += ImGui::GetTextLineHeightWithSpacing();
+    ImGui::SetCursorPos(controlsCursor);
     
     // Path editing buttons
     ImGui::TextColored(cfgPathColor, "Path tools (total paths: "+int(npcPaths.length())+")");
@@ -251,6 +270,10 @@ void drawWaypointSelectionUI()
     {
         addPathBetweenSelected();
     }    
+    
+    // Next line
+    controlsCursor.y += ImGui::GetTextLineHeightWithSpacing();
+    return controlsCursor;
 }
 
 
@@ -398,7 +421,7 @@ class NpcCharacter
     {
         // we have wp1 and want to select new wp2, preferably a different one than we came from
         int usableWp = -1;
-     game.log("DBG findRoute() currentWp1="+this.currentWp1+", previousWp1="+previousWp1);
+        game.log("DBG findRoute() currentWp1="+this.currentWp1+", previousWp1="+previousWp1);
         for (int i = 0; i<int(npcPaths.length()); i++)
         {
             game.log("DBG findRoute() i="+i+" Wp1="+npcPaths[i].wp1+", Wp2="+npcPaths[i].wp2);
@@ -415,7 +438,7 @@ class NpcCharacter
             if (testWp != -1)
             {
                 usableWp = testWp;
- game.log("DBG findRoute() found usable wp="+usableWp);
+                game.log("DBG findRoute() found usable wp="+usableWp);
                 if (previousWp1 !=  testWp)
                 {
                     this.currentWp2 =  testWp;
@@ -437,7 +460,7 @@ class NpcCharacter
         {
             // skip to new path
             newDist = newDist - totalDist;
-int prevWp1 = this.currentWp1;
+            int prevWp1 = this.currentWp1;
             this.currentWp1 = this.currentWp2;
             this.findRoute(prevWp1);
             totalDist = npcWaypoints[this.currentWp1].position.distance(npcWaypoints[this.currentWp2].position);
@@ -449,16 +472,16 @@ int prevWp1 = this.currentWp1;
         vector3 pos2 = npcWaypoints[this.currentWp2].position;
         TerrainClass@ terrain = game.getTerrain();
         
-vector3 walkVec = (pos2-pos1);
+        vector3 walkVec = (pos2-pos1);
         vector3 charaPos = pos1 + walkVec*pctDist;
         charaPos.y = terrain.getHeightAt(charaPos.x, charaPos.z);
         snode.setPosition(charaPos);
         this.currentPos = charaPos;
         
         // update character rotation
-
+        
         snode.lookAt(pos2, Ogre::TS_WORLD);
-snode.yaw(radian(degree(90).valueRadians()), Ogre::TS_WORLD);
+        snode.yaw(radian(degree(90).valueRadians()), Ogre::TS_WORLD);
         
         // update character walking animation
         
@@ -482,8 +505,8 @@ snode.yaw(radian(degree(90).valueRadians()), Ogre::TS_WORLD);
         ImGui::PushID(this.uniqueName);
         vector3 pos1 = npcWaypoints[this.currentWp1].position;
         vector3 pos2 = npcWaypoints[this.currentWp2].position;
-vector3 walkVec = (pos2-pos1);
-         ImGui::Text("DBG rot str: " + this.dbgRotStr+ " walkVec="+formatVector3(walkVec, 7, 2));
+        vector3 walkVec = (pos2-pos1);
+        ImGui::Text("DBG rot str: " + this.dbgRotStr+ " walkVec="+formatVector3(walkVec, 7, 2));
         ImGui::Text("DBG position:"+formatVector3(this.currentPos, 7, 2));
         ImGui::Text("DBG error: " + this.error);
         ImGui::Text("DBG wp1= " + this.currentWp1 + ", wp2="+this.currentWp2);
@@ -602,6 +625,7 @@ vector3 walkVec = (pos2-pos1);
         
     }
 };
+// #region Walker management
 array<NpcCharacter@> npcCharacters;
 void releaseWalker()
 {
@@ -645,6 +669,18 @@ void releaseWalker()
     }
 }
 
+void killWalker(int iKill)
+{
+    if (iKill < 0 || iKill >= int( npcCharacters.length()))
+    {
+        gErrorStr = "cannot delete npcCahcarcter "+iKill+", count is "+npcCharacters.length();
+        return;
+    }
+    npcCharacters[iKill].removeFromScene();
+    npcCharacters.removeAt(iKill);
+    
+}
+
 void advanceWalkers(float dt)
 {
     // advance the NPC characters
@@ -663,10 +699,10 @@ void advanceWalkers(float dt)
     }
     if (iKill != -1)
     {
-        npcCharacters[iKill].removeFromScene();
-        npcCharacters.removeAt(iKill);
+        killWalker(iKill);
     }
 }
+//#endregion
 
 // #region Game callbacks
 

--- a/resources/scripts/example_game_pedestrians.as
+++ b/resources/scripts/example_game_pedestrians.as
@@ -1,0 +1,719 @@
+/// \title Example pedestrian NPCs (characters following path network)
+/// based on OGRE example - character posing (skeletal animations)
+
+
+// Window [X] button handler
+#include "imgui_utils.as"
+imgui_utils::CloseWindowPrompt closeBtnHandler;
+
+string gErrorStr = "";
+
+//#region Path network data
+// Waypoints are global, paths are defined by connecting 2 waypoints
+// this is much like verts/indices in a mesh, except there's a edge-list instead of a triangle-list.
+class NpcWaypoint
+{
+    vector3 position;
+    bool deleted; // Waypoints are reffered to by array positions, so deleted ones must stay until pruned.
+    bool selected;
+NpcWaypoint(){deleted=false; selected=false;}
+NpcWaypoint(vector3 pos){deleted=false; selected=false; position=pos;}
+};
+array<NpcWaypoint> npcWaypoints;
+class NpcPath
+{
+    int wp1, wp2;
+NpcPath(){wp1=-1; wp2=-1;}
+NpcPath(int wayp1, int wayp2){wp1=wayp1; wp2 = wayp2;}
+};
+array<NpcPath> npcPaths;
+//#endregion
+
+// #region Path network manip
+bool pathExistsBetween(int wp1, int wp2)
+{
+    if (wp1 < 0 || wp1 > int(npcWaypoints.length()) || wp2 < 0 || wp2 > int(npcWaypoints.length()))
+    {
+        gErrorStr = "pathExistsBetween() - bad IDs! wp1="+wp1+", wp2="+wp2+", len:"+int(npcWaypoints.length());
+        return false;
+    }
+    
+    for (int i = 0; i<int(npcPaths.length()); i++)
+    {
+        if ( (npcPaths[i].wp1 == wp1 && npcPaths[i].wp2 == wp2)
+        || (npcPaths[i].wp1 == wp2 && npcPaths[i].wp2 == wp1 ))
+        {
+            return true; // already exists.
+        }
+    }
+    return false;
+}
+void addPathBetweenWaypoints(int wp1, int wp2)
+{
+if (pathExistsBetween(wp1,wp2)) { return; }
+    // not existing
+    npcPaths.insertLast(NpcPath(wp1,wp2));
+}
+void addPathBetweenSelected()
+{
+    if (lastNumSelected < 2) 
+    {
+        game.log("addPathBetweenSelected() - at least 2 waypoints must be selected!");
+    }
+    
+    // each-to-each (i=front, j=rear)
+    int numPathsBefore =int(npcPaths.length());
+    for (int i=0; i<int(npcWaypoints.length()); i++)
+    {
+    if (!npcWaypoints[i].selected) {continue;}
+        for (int j=i; j<int(npcWaypoints.length()); j++)
+        {
+        if (i==j || !npcWaypoints[j].selected) {continue;}
+            addPathBetweenWaypoints(i,j);
+        }
+        
+    }
+    game.log("addPathBetweenSelected() - added " + (int(npcPaths.length()) - numPathsBefore) + " new paths");
+}
+//#endregion
+
+//#region Path editor UI
+#include "gridviewer_utils.as"
+gridviewer_utils::GridViewer gVertsViewer;
+
+// waypoint display conf
+float gBottomBarHeight = 80;
+// surveymap texture
+Ogre::TexturePtr gTex;
+color gColorViewerImageTint(1,1,1,1); // white
+
+void setupPathEditor()
+{
+    gVertsViewer.childWindowID="Waypoints and paths";
+    // axes are X=0, Y=1, Z=2, Y is up, we want top-down view (XZ)
+    gVertsViewer.hAxis = 0; // X
+    gVertsViewer.vAxis = 2; // Z
+    
+    // load surveymap texture
+    gTex = Ogre::TextureManager::getSingleton().load("SurveyMapStatic", "OgreAutodetect");
+    if (gTex.isNull())
+    {
+        gErrorStr = "couldn't load tex";
+        return;
+    }    
+}
+
+void drawPathEditor()
+{
+    vector2 windowSize = ImGui::GetWindowContentRegionMax() - ImGui::GetWindowContentRegionMin();    
+    float spaceUnderViewer = 50;
+    vector2 viewerSize = vector2(windowSize.x , windowSize.y - (gBottomBarHeight+spaceUnderViewer));
+    
+    gVertsViewer.begin(viewerSize);
+    
+    // draw the texture - size MUST match terrain or waypoint positions will be off.
+    // FIXME: actually get terrain size from the game!
+    vector3 terrainSize(1024,1,1024); // dummy for testing on simple2
+    vector2 imgImgMin = gVertsViewer.localToScreenPos(vector3(0,0,0));
+    vector2 imgImgMax = gVertsViewer.localToScreenPos(terrainSize);
+    ImGui::GetWindowDrawList().AddImage(gTex, imgImgMin, imgImgMax, vector2(0,0), vector2(1,1), gColorViewerImageTint);
+    
+    // draw paths
+    for (int i = 0; i<int(npcPaths.length()); i++)
+    {
+        vector2 pos1=gVertsViewer.localToScreenPos(npcWaypoints[npcPaths[i].wp1].position);
+        vector2 pos2=gVertsViewer.localToScreenPos(npcWaypoints[npcPaths[i].wp2].position);
+        ImGui::GetWindowDrawList().AddLine(pos1,pos2,cfgPathColor);
+        
+    }
+    
+    drawWaypointHighlights();
+    
+    updateWaypointMouseControls();
+    
+    gVertsViewer.end();
+    
+    ImGui::TextColored( cfgNodeColor, "Total waypoints: "+npcWaypoints.length() + " (use right mouse button to create)");
+    drawWaypointSelectionUI();
+    
+    if (ImGui::SmallButton("release a walker!"))
+    {
+        releaseWalker();
+    }
+}
+
+//#endregion
+
+ 
+// #region CONFIG
+
+color cfgNodeColor = color(0.9, 0.8, 0.5, 1);
+color cfgPathColor = color(0.8, 0.85, 0.5, 1);
+float cfgNodeRadius = 3.f;
+int cfgNodeNumSegments = 5;
+
+int cfgNodeHoverMaxCursorDist = 10; // Only confirm the hovered state if the cursor is less than 10 pixels away from it in any direction.
+color cfgNodeHoverColor = color(1,0,0,1);
+float cfgNodeHoverRadius = 5.f;
+float cfgNodeHoverThickness = 2.f;
+color cfgSelectedNodeColor = color(0.8f,1.f,0.1f,1.f);
+float cfgSelectedNodeSize = 7.f; // drawn as rectangle
+
+void drawConfigUI()
+{
+    
+    ImGui::InputFloat("Node radius", cfgNodeRadius);
+    ImGui::InputInt("Node num segments", cfgNodeNumSegments);
+    //DOC: bool ColorEdit3(const string&in, color&inout)
+    ImGui::ColorEdit3("Node color", cfgNodeColor);
+    ImGui::ColorEdit3("Path color", cfgPathColor);
+    
+    
+    ImGui::ColorEdit3("Hover color", cfgNodeHoverColor);
+    ImGui::InputFloat("Hover radius", cfgNodeHoverRadius);
+    ImGui::InputFloat("Hover thickness", cfgNodeHoverThickness);
+    ImGui::InputInt("Hover max cursor dist.", cfgNodeHoverMaxCursorDist);
+    
+    ImGui::ColorEdit3("Selected node color", cfgSelectedNodeColor);
+    ImGui::InputFloat("Selected node size", cfgSelectedNodeSize);
+}
+//#endregion
+
+// #region Waypoint interaction
+
+int mouseHoveredNodeID = -1;
+string mouseHoverDebugString;
+int lastNumSelected = 0;
+
+void updateWaypointMouseControls()
+{
+    // Left mouse button click = flip the selection state of the waypoint
+    if (mouseHoveredNodeID != -1 && ImGui::IsMouseClicked(0))
+    {
+        npcWaypoints[mouseHoveredNodeID].selected = !npcWaypoints[mouseHoveredNodeID].selected;
+    }
+    
+    // Right mouse button click = add new waypoint
+    if (ImGui::IsMouseClicked(1))
+    {
+        
+        vector3 desiredPos = gVertsViewer.screenToLocalPos(ImGui::GetMousePos());
+        game.log("right mouse clicked! ");
+        npcWaypoints.insertLast(NpcWaypoint(desiredPos));
+    }
+}
+
+void drawWaypointSelectionUI()
+{
+    int totalSelected = 0;
+    string strSelected = "";
+    string strJoiner = "";
+    for (uint i=0; i < npcWaypoints.length(); i++)
+    {
+        if (npcWaypoints[i].selected)
+        {
+            strSelected += (strJoiner + i);
+            strJoiner = ",";
+            totalSelected++;
+        }
+    }
+    ImGui::TextDisabled("Selected waypoints (" + totalSelected + ")" + mouseHoverDebugString);
+    lastNumSelected = totalSelected; // for editing checks
+    ImGui::Text(strSelected);
+    if (ImGui::Button("Select all"))
+    {
+        for (uint i=0; i < npcWaypoints.length(); i++)
+        {
+            npcWaypoints[i].selected = true;
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("UnSelect all"))
+    {
+        for (uint i=0; i < npcWaypoints.length(); i++)
+        {
+            npcWaypoints[i].selected = false;
+        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Flip selection"))
+    {
+        for (uint i=0; i < npcWaypoints.length(); i++)
+        {
+            npcWaypoints[i].selected = !npcWaypoints[i].selected;
+        }
+    }
+    
+    // Path editing buttons
+    ImGui::TextColored(cfgPathColor, "Path tools (total paths: "+int(npcPaths.length())+")");
+    ImGui::SameLine();
+    if (ImGui::Button("Add between selected"))
+    {
+        addPathBetweenSelected();
+    }    
+}
+
+
+// copypasted from "imgui - node higlight" demo
+void drawWaypointHighlights()
+{
+    
+    int mouseClosestNodeID = -1;
+    
+    int mouseClosestNodeDist = 999999;
+    
+    // this function draws inside the gridviewer
+    ImDrawList@ drawlist = ImGui::GetWindowDrawList();
+    for (int i = 0; i < int(npcWaypoints.length()); i++)
+    {
+        
+        color col = cfgNodeColor;
+        
+        vector2 pos = gVertsViewer.localToScreenPos(npcWaypoints[i].position);
+        
+        // Draw the node
+        if (npcWaypoints[i].selected)
+        {
+            // DOC: void AddRectFilled(const vector2&in p_min, const vector2&in p_max, const color&in col, float rounding = 0.0f, int rounding_corners = 15)
+            vector2 halfSize(cfgSelectedNodeSize/2.f, cfgSelectedNodeSize/2.f);
+            drawlist.AddRectFilled(pos-halfSize, pos+halfSize, cfgSelectedNodeColor);
+        }
+        else
+        {            
+            //DOC: void ImDrawList::AddCircleFilled(const ImVec2& center, float radius, ImU32 col, int num_segments)
+            drawlist.AddCircleFilled(pos, cfgNodeRadius, col, cfgNodeNumSegments);
+        }
+        
+        // Accumulate mouse hover info
+        int nodeDist = getMouseShortestDistance(game.getMouseScreenPosition(), pos);
+        if (nodeDist < mouseClosestNodeDist)
+        {
+            mouseClosestNodeID = i;
+            mouseClosestNodeDist = nodeDist;
+        }
+        
+        // Draw mouse hover marker
+        if (i == mouseHoveredNodeID)
+        {
+            // DOC: void AddCircle(const vector2&in center, float radius, const color&in col, int num_segments = 12, float thickness = 1.f)
+            drawlist.AddCircle(pos, cfgNodeHoverRadius, cfgNodeHoverColor, cfgNodeNumSegments, cfgNodeHoverThickness);
+        }
+        
+        
+    }
+    
+    // Finalize hover detection
+    mouseHoverDebugString="<DBG drawNodeHighlights> Mouse closest node: " + mouseClosestNodeID + " (dist:" + mouseClosestNodeDist + ")";
+    if (mouseClosestNodeDist <= cfgNodeHoverMaxCursorDist)
+    {
+        mouseHoveredNodeID = mouseClosestNodeID;
+    }
+    else
+    {
+        mouseHoveredNodeID = -1;
+    }
+}
+
+// #endregion
+
+// #region HELPERS
+
+// shamelessly copypasted from 'road_editor.as', line 803
+int getMouseShortestDistance(vector2 mouse, vector2 target)
+{
+    int dx = iabs(int(mouse.x) - int(target.x));
+    int dy = iabs(int(mouse.y) - int(target.y));
+    return imax(dx, dy);
+}
+
+int imin(int a, int b)
+{
+    return (a < b) ? a : b;
+}
+
+int imax(int a, int b)
+{
+    return (a > b) ? a : b;
+}
+
+int iabs(int a)
+{
+    return (a < 0) ? -a : a;
+}
+
+// from demo_script.as
+string formatVector3(vector3 val, int total, int frac)
+{
+    return "X:" + formatFloat(val.x, "", total, frac)
+    + " Y:" + formatFloat(val.y, "", total, frac)
+    + " Z:" + formatFloat(val.z, "", total, frac);
+}
+
+// #endregion
+
+
+
+
+
+
+int npcIdCounter = 1;
+class NpcCharacter
+{
+    Ogre::Entity@ ent;
+    Ogre::SceneNode@ snode;
+    string error;
+    string uniqueName;
+    vector3 currentPos;
+    degree currentRot;
+    int currentWp1;
+    int currentWp2;
+    float walkSpeed;
+    float animSpeed;
+    string dbgRotStr;
+    
+    NpcCharacter(int aInitialWp1, float aWalkSpd)
+    {
+        // we prepend the ScriptUnitID to avoid conflicts with leftover items from previous invocations of the script.
+        uniqueName = "[NID " + thisScript + "] NpcCharacter"+npcIdCounter++ ;
+        
+        game.log("NpcCharacter() '"+uniqueName+"' is being set up");
+        currentWp1 = aInitialWp1;
+        this.findRoute(-1);
+        
+        walkSpeed = aWalkSpd;
+        
+        this.putToScene();
+        // set initial  position - VERY IMPORTANT, the path progression is calculated from this.
+        this.currentPos = npcWaypoints[this.currentWp1].position;
+        
+        // walking animation - enable once
+        this.animSpeed = 1;
+        Ogre::AnimationStateSet@ stateSet = this.ent.getAllAnimationStates();
+        Ogre::AnimationStateDict@ stateDict = stateSet.getAnimationStates(); 
+        Ogre::AnimationState@ anim = stateDict["Walk"];
+        anim.setEnabled(true);
+    }
+    
+    void findRoute(int previousWp1)
+    {
+        // we have wp1 and want to select new wp2, preferably a different one than we came from
+        int usableWp = -1;
+     game.log("DBG findRoute() currentWp1="+this.currentWp1+", previousWp1="+previousWp1);
+        for (int i = 0; i<int(npcPaths.length()); i++)
+        {
+            game.log("DBG findRoute() i="+i+" Wp1="+npcPaths[i].wp1+", Wp2="+npcPaths[i].wp2);
+            int testWp = -1;
+            if  (npcPaths[i].wp1 ==currentWp1 )
+            {
+                testWp = npcPaths[i].wp2;
+            }
+            else if ( npcPaths[i].wp2 == currentWp1)
+            {
+                testWp = npcPaths[i].wp1;
+            }
+            
+            if (testWp != -1)
+            {
+                usableWp = testWp;
+ game.log("DBG findRoute() found usable wp="+usableWp);
+                if (previousWp1 !=  testWp)
+                {
+                    this.currentWp2 =  testWp;
+                    break; // we have a new unused path!
+                }
+            }
+        }
+        
+        // no unused path found - revert to the usable one
+        this.currentWp2 = usableWp;
+    }
+    
+    void advance(float dt)
+    {
+        float totalDist = npcWaypoints[this.currentWp1].position.distance(npcWaypoints[this.currentWp2].position);
+        float curDist = npcWaypoints[this.currentWp1].position.distance(this.currentPos);
+        float newDist = curDist + (this.walkSpeed * dt);
+        while (newDist > totalDist)
+        {
+            // skip to new path
+            newDist = newDist - totalDist;
+int prevWp1 = this.currentWp1;
+            this.currentWp1 = this.currentWp2;
+            this.findRoute(prevWp1);
+            totalDist = npcWaypoints[this.currentWp1].position.distance(npcWaypoints[this.currentWp2].position);
+        }
+        
+        // walk the rest and update character position
+        float pctDist = newDist/totalDist;
+        vector3 pos1 = npcWaypoints[this.currentWp1].position;
+        vector3 pos2 = npcWaypoints[this.currentWp2].position;
+        TerrainClass@ terrain = game.getTerrain();
+        
+vector3 walkVec = (pos2-pos1);
+        vector3 charaPos = pos1 + walkVec*pctDist;
+        charaPos.y = terrain.getHeightAt(charaPos.x, charaPos.z);
+        snode.setPosition(charaPos);
+        this.currentPos = charaPos;
+        
+        // update character rotation
+
+        snode.lookAt(pos2, Ogre::TS_WORLD);
+snode.yaw(radian(degree(90).valueRadians()), Ogre::TS_WORLD);
+        
+        // update character walking animation
+        
+        if (@this.ent != null)
+        {
+            Ogre::AnimationStateSet@ stateSet = this.ent.getAllAnimationStates();
+            Ogre::AnimationStateDict@ stateDict = stateSet.getAnimationStates(); 
+            Ogre::AnimationState@ anim = stateDict["Walk"];
+            
+            float timepos = anim.getTimePosition() + (this.animSpeed * dt);
+            
+            
+            anim.setTimePosition(timepos);
+            
+            
+        }
+    }
+    
+    void draw()
+    {
+        ImGui::PushID(this.uniqueName);
+        vector3 pos1 = npcWaypoints[this.currentWp1].position;
+        vector3 pos2 = npcWaypoints[this.currentWp2].position;
+vector3 walkVec = (pos2-pos1);
+         ImGui::Text("DBG rot str: " + this.dbgRotStr+ " walkVec="+formatVector3(walkVec, 7, 2));
+        ImGui::Text("DBG position:"+formatVector3(this.currentPos, 7, 2));
+        ImGui::Text("DBG error: " + this.error);
+        ImGui::Text("DBG wp1= " + this.currentWp1 + ", wp2="+this.currentWp2);
+        float totalDist = npcWaypoints[this.currentWp1].position.distance(npcWaypoints[this.currentWp2].position);
+        float curDist = npcWaypoints[this.currentWp1].position.distance(this.currentPos);
+        float pctDist = curDist/totalDist;
+        ImGui::Text("DBG curDist= " +curDist + ", totalDist="+totalDist+", pctDist="+pctDist+" walkSpeed="+walkSpeed);
+        ImGui::Text("DBG pos1" + formatVector3(npcWaypoints[this.currentWp1].position, 7, 2));
+        ImGui::Text("DBG pos2" + formatVector3(npcWaypoints[this.currentWp2].position, 7, 2));
+        
+        Ogre::AnimationStateSet@ stateSet = this.ent.getAllAnimationStates();
+        Ogre::AnimationStateDict@ stateDict = stateSet.getAnimationStates(); 
+        Ogre::AnimationState@ anim = stateDict["Walk"];
+        anim.setEnabled(true);
+        float timepos = anim.getTimePosition() ;
+        ImGui::Text("DBG walk anim timepos: "+ timepos + "(anim speed: "+this.animSpeed+")");
+        
+        if (@this.ent != null && @this.ent.getAllAnimationStates() != null)
+        {
+            this.drawAnimationControls(this.ent.getAllAnimationStates());
+        }
+        ImGui::PopID(); //(this.uniqueName);
+        
+    }
+    
+    private void drawAnimationControls(Ogre::AnimationStateSet@ stateSet)
+    {
+        Ogre::AnimationStateDict@ stateDict = stateSet.getAnimationStates(); 
+        array<string> stateNames = stateDict.getKeys();
+        for (uint i = 0; i < stateDict.getSize(); i++)
+        {
+            
+            
+            Ogre::AnimationState@ anim = stateDict[stateNames[i]];
+            ImGui::PushID(anim.getAnimationName());
+            ImGui::BulletText('"' + anim.getAnimationName() + '"');
+            
+            
+            
+            
+            ImGui::SameLine();
+            bool enabled = anim.getEnabled();
+            if (ImGui::Checkbox("Enabled", enabled))
+            {
+                anim.setEnabled(enabled);
+            }
+            
+            if (anim.getEnabled())
+            {
+                ImGui::SameLine();
+                float weight = anim.getWeight();
+                ImGui::SetNextItemWidth(75.f);
+                if (ImGui::SliderFloat("BlendWeight", weight, 0.f, 1.f))
+                {
+                    anim.setWeight(weight);
+                }
+                
+                ImGui::Dummy(vector2(25.f, 0.f)); // Indent
+                ImGui::SameLine();
+                float timepos = anim.getTimePosition();
+                if (ImGui::SliderFloat("TimePos", timepos, 0.f, anim.getLength()))
+                {
+                    anim.setTimePosition(timepos);
+                }
+            }
+            
+            ImGui::PopID(); // anim.getAnimationName()
+        }
+    }
+    
+    void putToScene()
+    {
+        if (@this.ent == null)
+        {      
+            game.log("DBG putToScene() '"+uniqueName+"'"); 
+            // Load the rorbot
+            @this.ent = game.getSceneManager().createEntity(uniqueName+"-entity", "character.mesh" );
+            if (@this.ent == null)
+            {
+                error = "Could not load 'character.mesh'";
+                return;
+            }
+            
+            // Put to scene
+            @this.snode = game.getSceneManager().getRootSceneNode().createChildSceneNode(uniqueName+"-node");
+            this.snode.attachObject(this.ent);
+            // 'character.mesh' has wrong scale, the game scales it down to <0.02, 0.02, 0.02>
+            this.snode.setScale(vector3(0.02, 0.02, 0.02));
+            // dress up directly with the shared material, we won't be changing shirt color
+            this.ent.setMaterialName("tracks/character");
+        }
+    }
+    
+    void moveTo(vector3 pos, degree rot)
+    {
+        this.currentPos = pos;
+        this.currentRot = rot;
+        
+        this.snode.setPosition(currentPos);
+        this.snode.yaw(currentRot.valueDegrees());    
+    }
+    
+    void removeFromScene()
+    {
+        if (@this.ent != null)
+        {
+            this.ent.detachFromParent();
+            game.getSceneManager().destroyEntity(this.ent);
+            @this.ent = null;
+            
+            game.getSceneManager().destroySceneNode(this.snode);
+            @this.snode = null;
+            
+            
+        }
+        
+    }
+};
+array<NpcCharacter@> npcCharacters;
+void releaseWalker()
+{
+    if (npcPaths.length()<1) 
+    {
+        game.log("releaseWalker(): There must be at least one path to add NPC pedestrian.");
+    }
+    else     if (lastNumSelected < 1)
+    {
+        game.log("releaseWalker(): A starting waypoint must be selected. In case of multi selecion, the first one is used."); 
+    }
+    else
+    {
+        // check the selected waypoint is connected to a path!
+        // each-to-each (i=front, j=rear)
+        int numPathsBefore =int(npcPaths.length());
+        for (int i=0; i<int(npcWaypoints.length()); i++)
+        {
+            if (!npcWaypoints[i].selected)
+            {
+                continue;
+            }
+            for (int j=i; j<int(npcWaypoints.length()); j++)
+            {
+            if (i==j) {continue;}
+                if (            pathExistsBetween(i,j))
+                {
+                    // found usable path! add the walker.
+                    float speed = 1;
+                    npcCharacters.insertLast(NpcCharacter(i, speed));
+                    return;
+                }
+                else
+                {
+                    game.log("DBG releaseWalker(): no path between selected" + i + " and tested "+ j);
+                }
+            }
+            
+        }
+        game.log("releaseWalker(): No usable path found among the selected waypoints");
+    }
+}
+
+void advanceWalkers(float dt)
+{
+    // advance the NPC characters
+    int iKill = -1;
+    for (int i=0; i<int(npcCharacters.length()); i++)
+    {
+        npcCharacters[i].advance(dt);
+        if (ImGui::CollapsingHeader(npcCharacters[i].uniqueName))
+        {
+            if (ImGui::SmallButton("Kill this walker"))
+            {
+                iKill = i;
+            }
+            npcCharacters[i].draw(); // draw UI for animations.
+        }
+    }
+    if (iKill != -1)
+    {
+        npcCharacters[iKill].removeFromScene();
+        npcCharacters.removeAt(iKill);
+    }
+}
+
+// #region Game callbacks
+
+void main()
+{
+    setupPathEditor();
+    game.registerForEvent(SE_ANGELSCRIPT_MANIPULATIONS );  // we want to clean up after ourselves at exit
+}
+
+void frameStep(float dt)
+{
+    ImGui::Begin("Pedestrians example", closeBtnHandler.windowOpen, 0);
+    closeBtnHandler.draw();
+    if (gErrorStr == "")
+    {
+        drawPathEditor();
+        advanceWalkers(dt);
+    }
+    else
+    {
+        ImGui::TextDisabled("E R R O R !!");
+        ImGui::TextColored(color(1, 0.2, 0, 1), gErrorStr);
+    }
+    ImGui::End();    
+}
+
+void eventCallbackEx(scriptEvents ev, // Invoked by the game when a registered event is triggered
+int arg1, int arg2ex, int arg3ex, int arg4ex,
+string arg5ex, string arg6ex, string arg7ex, string arg8ex)
+{
+    // when the script is exiting, we want to clean up after ourselves
+    //ASMANIP_SCRIPT_UNLOADING
+    //Args: #2 ScriptUnitId_t, #3 RoR::ScriptCategory, #4 unused, #5 filename. 
+    if (ev == SE_ANGELSCRIPT_MANIPULATIONS 
+    && arg1 == ASMANIP_SCRIPT_UNLOADING
+    && arg2ex == thisScript)
+    {
+        for (int i=0; i<int(npcCharacters.length()); i++)
+        {
+            npcCharacters[i].removeFromScene();
+            
+        }
+    }
+    
+    
+    
+}
+
+// #endregion
+

--- a/resources/scripts/example_ogre_textureBlitting.as
+++ b/resources/scripts/example_ogre_textureBlitting.as
@@ -6,6 +6,9 @@
 #include "imgui_utils.as"
 imgui_utils::CloseWindowPrompt closeBtnHandler;
 
+#include "math_utils.as" // fmin+fmax
+using namespace math_utils;
+
 #include "gridviewer_utils.as"
 
 gridviewer_utils::GridViewer gDstViewer;
@@ -24,9 +27,6 @@ color gColorImageOutline = color(0.7,0.4,0.3,1);
 float gBottomBarHeight = 50;
 color gColorViewerImageTint(1,1,1,1); // white
 bool gIsMouseDown = false;
-
-float fmax(float a, float b) { return a>b?a:b; }
-float fmin(float a, float b) { return a<b?a:b; }
 
 string makeID(string name)
 {

--- a/resources/scripts/example_ogre_vertexData.as
+++ b/resources/scripts/example_ogre_vertexData.as
@@ -6,6 +6,9 @@
 #include "imgui_utils.as"
 imgui_utils::CloseWindowPrompt closeBtnHandler;
 
+#include "math_utils.as" // fmin+fmax
+using namespace math_utils;
+
 #include "gridviewer_utils.as"
 
 gridviewer_utils::GridViewer gTexcoordsViewer;
@@ -25,9 +28,6 @@ int gVertNumSeg = 5;
 int gTexcoordNumSeg = 5;
 string gErrorStr = "";
 bool gShowRawTexcoords=false;
-
-float fmax(float a, float b) { return a>b?a:b; }
-float fmin(float a, float b) { return a<b?a:b; }
 
 // ================= entry points ===================
 

--- a/resources/scripts/gridviewer_utils.as
+++ b/resources/scripts/gridviewer_utils.as
@@ -22,6 +22,7 @@ namespace gridviewer_utils
         vector2 controlsBoxPadding = vector2(4,4);
         int gridSizeMin = 100;
         int gridSizeMax = 10000;
+        float mouseWheelToZoomRatio = 0.0001;
         
         // STATE:
         float zoom = 1.f;
@@ -44,6 +45,7 @@ namespace gridviewer_utils
             midWindowScreenPos = ImGui::GetWindowPos()+ contentRegionSize/2;
             nodesMin=vector2(FLT_MAX, FLT_MAX);
             nodesMax=vector2(-999999, -999999);
+            this.updateMouseWheelZoom();
             drawingControlsStarted=false;
         }
         
@@ -122,6 +124,18 @@ namespace gridviewer_utils
             ImGui::EndChild();
         }
         
+        // #region Mouse controls
+        void updateMouseWheelZoom()
+        {
+            // zooming with mouse when Ctrl is pressed
+            if (inputs.isKeyDown(KC_LCTRL) || inputs.isKeyDown(KC_RCTRL))
+            {
+                float deltaZoom = float(inputs.getMouseWheelMotion()) *this.mouseWheelToZoomRatio;
+                this.zoom += deltaZoom;
+                this.zoom = math_utils::fclamp(this.zoom, this.zoomMin, this.zoomMax);
+            }
+        }
+        //#endregion
         
         
     }

--- a/resources/scripts/gridviewer_utils.as
+++ b/resources/scripts/gridviewer_utils.as
@@ -5,120 +5,134 @@
 // By convention, all includes have filename '*_utils' and namespace matching filename.
 namespace gridviewer_utils
 {
-
-	class GridViewer
-	{
-		// CFG:
-		string childWindowID;
-		float zoomMax = 10.f;
-		float zoomMin = 0.1f;
-		float zoomDefault = (zoomMin + zoomMax) / 2;
-		int hAxis=0;
-		int vAxis=1;
-		array<color> axisLineColors = { color(1,0,0,1), color(0.2,0.3,1,1), color(0.1, 0.9, 0.05, 1) };
-		vector2 scrollRegionPadding = vector2(50,50);
-		vector2 controlsBoxPadding = vector2(4,4);
-		int gridSizeMin = 100;
-		int gridSizeMax = 10000;
-		
-		// STATE:
-		float zoom = 1.f;
-		vector2 contentRegionSize;
-		vector2 midWindowScreenPos;
-		vector2 childScreenPos;
-		vector2 nodesMin;
-		vector2 nodesMax;
-		int gridSize = 25;
-		bool isChildWindowHovered = false;
-		
-		// FUNCS:
-		void begin(vector2 size)
-		{
-			int flags = ImGuiWindowFlags_HorizontalScrollbar;
-			this.childScreenPos=ImGui::GetCursorScreenPos();
-			ImGui::BeginChild(childWindowID, size, true, flags);
-			contentRegionSize=ImGui::GetWindowContentRegionMax() - ImGui::GetWindowContentRegionMin();
-			midWindowScreenPos = ImGui::GetWindowPos()+ contentRegionSize/2;
-			nodesMin=vector2(FLT_MAX, FLT_MAX);
-			nodesMax=vector2(-999999, -999999);
-		}
-		
-		void drawControls()
-		{
-			ImGui::TextDisabled(this.childWindowID);
-			ImGui::SameLine();
-			ImGui::SetNextItemWidth(65);
-			ImGui::SliderFloat('Zoom', zoom, zoomMin, zoomMax);
-			ImGui::SameLine();
-			ImGui::SetNextItemWidth(65);
-			ImGui::SliderInt("Grid", gridSize, gridSizeMin, gridSizeMax);
-		}
-		
-		vector2 localToScreenPos(vector3 posIn)
-		{
-			// zoom only, without scrolling
-			vector2 pos= midWindowScreenPos+vector2(posIn[hAxis], posIn[vAxis])*zoom;
-			nodesMin=vector2(fmin(nodesMin.x, pos.x), fmin(nodesMin.y, pos.y));
-			nodesMax=vector2(fmax(nodesMax.x, pos.x), fmax(nodesMax.y, pos.y));
-			// add scrolling
-			pos += vector2(
-			ImGui::GetScrollMaxX() - 2*ImGui::GetScrollX(),
-			ImGui::GetScrollMaxY() - 2*ImGui::GetScrollY());
-			
-			return pos;
-		}
-		
-		vector3 screenToLocalPos(vector2 screenPosIn)
-		{
-			vector2 localXY = (screenPosIn -midWindowScreenPos)/zoom;
-			// add scrolling
-			localXY -= vector2(
-			ImGui::GetScrollMaxX() - 2*ImGui::GetScrollX(),
-			ImGui::GetScrollMaxY() - 2*ImGui::GetScrollY());
-			// screen to local, without scrolling
-			vector3 localPos(0,0,0);
-			setAxisVal(localPos, hAxis, localXY.x);
-			setAxisVal(localPos, vAxis, localXY.y);
-			
-			return localPos;
-		}
-		
-		void drawAxisLines()
-		{
-			vector2 origin = this.localToScreenPos(vector3(0,0,0));
-			ImGui::GetWindowDrawList().AddLine(origin+vector2(0, -9999), origin+vector2(0,9999), axisLineColors[vAxis]);
-			ImGui::GetWindowDrawList().AddLine(origin+vector2(-9999, 0), origin+vector2(9999, 0), axisLineColors[hAxis]);
-		}
-		
-		void end()
-		{
-			drawAxisLines();
-			// draw dummies - force scroll region
-			ImGui::SetCursorPos((nodesMin-scrollRegionPadding) - childScreenPos); ImGui::Dummy(vector2(1,1));
-			ImGui::SetCursorPos((nodesMax+scrollRegionPadding) - childScreenPos); ImGui::Dummy(vector2(1,1));
-			
-			// controls go on the top of the child, scrolling is cancelled out.
-			ImGui::SetCursorPos(vector2(ImGui::GetScrollX(), ImGui::GetScrollY()) + controlsBoxPadding);
-			drawControls();
-			isChildWindowHovered = ImGui::IsWindowHovered();
-			ImGui::EndChild();
-		}
-		
-		// HELPERS:
-		
-		private float fmax(float a, float b) { return a>b?a:b; }
-		
-		private float fmin(float a, float b) { return a<b?a:b; }
-		
-		private void setAxisVal(vector3&inout vec, int axis, float val)
-		{
-			switch(axis) {
-				case 0: vec.x=val; break;
-				case 1: vec.y=val; break;
-				case 2: vec.z=val; break;
-				default: break;
-			}
-		}
-	}
-
+    
+    class GridViewer
+    {
+        // CFG:
+        string childWindowID;
+        float zoomMax = 10.f;
+        float zoomMin = 0.1f;
+        float zoomDefault = (zoomMin + zoomMax) / 2;
+        int hAxis=0;
+        int vAxis=1;
+    array<color> axisLineColors = { color(1,0,0,1), color(0.2,0.3,1,1), color(0.1, 0.9, 0.05, 1) };
+        vector2 scrollRegionPadding = vector2(50,50);
+        vector2 controlsBoxPadding = vector2(4,4);
+        int gridSizeMin = 100;
+        int gridSizeMax = 10000;
+        
+        // STATE:
+        float zoom = 1.f;
+        vector2 contentRegionSize;
+        vector2 midWindowScreenPos;
+        vector2 childScreenPos;
+        vector2 nodesMin;
+        vector2 nodesMax;
+        int gridSize = 25;
+        bool isChildWindowHovered = false;
+        bool drawingControlsStarted=false;
+        
+        // FUNCS:
+        void begin(vector2 size)
+        {
+            int flags = ImGuiWindowFlags_HorizontalScrollbar;
+            this.childScreenPos=ImGui::GetCursorScreenPos();
+            ImGui::BeginChild(childWindowID, size, true, flags);
+            contentRegionSize=ImGui::GetWindowContentRegionMax() - ImGui::GetWindowContentRegionMin();
+            midWindowScreenPos = ImGui::GetWindowPos()+ contentRegionSize/2;
+            nodesMin=vector2(FLT_MAX, FLT_MAX);
+            nodesMax=vector2(-999999, -999999);
+            drawingControlsStarted=false;
+        }
+        
+        void drawControls()
+        {
+            ImGui::TextDisabled(this.childWindowID);
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(65);
+            ImGui::SliderFloat('Zoom', zoom, zoomMin, zoomMax);
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(65);
+            ImGui::SliderInt("Grid", gridSize, gridSizeMin, gridSizeMax);
+        }
+        
+        vector2 localToScreenPos(vector3 posIn)
+        {
+            // zoom only, without scrolling
+            vector2 pos= midWindowScreenPos+vector2(posIn[hAxis], posIn[vAxis])*zoom;
+            nodesMin=vector2(fmin(nodesMin.x, pos.x), fmin(nodesMin.y, pos.y));
+            nodesMax=vector2(fmax(nodesMax.x, pos.x), fmax(nodesMax.y, pos.y));
+            // add scrolling
+            pos += vector2(
+            ImGui::GetScrollMaxX() - 2*ImGui::GetScrollX(),
+            ImGui::GetScrollMaxY() - 2*ImGui::GetScrollY());
+            
+            return pos;
+        }
+        
+        vector3 screenToLocalPos(vector2 screenPosIn)
+        {
+            vector2 localXY = (screenPosIn -midWindowScreenPos)/zoom;
+            // add scrolling
+            localXY -= vector2(
+            ImGui::GetScrollMaxX() - 2*ImGui::GetScrollX(),
+            ImGui::GetScrollMaxY() - 2*ImGui::GetScrollY());
+            // screen to local, without scrolling
+            vector3 localPos(0,0,0);
+            setAxisVal(localPos, hAxis, localXY.x);
+            setAxisVal(localPos, vAxis, localXY.y);
+            
+            return localPos;
+        }
+        
+        void drawAxisLines()
+        {
+            vector2 origin = this.localToScreenPos(vector3(0,0,0));
+            ImGui::GetWindowDrawList().AddLine(origin+vector2(0, -9999), origin+vector2(0,9999), axisLineColors[vAxis]);
+            ImGui::GetWindowDrawList().AddLine(origin+vector2(-9999, 0), origin+vector2(9999, 0), axisLineColors[hAxis]);
+        }
+        
+        vector2 endGridBeginControls()
+        {
+            drawAxisLines();
+            // draw dummies - force scroll region
+            ImGui::SetCursorPos((nodesMin-scrollRegionPadding) - childScreenPos); ImGui::Dummy(vector2(1,1));
+            ImGui::SetCursorPos((nodesMax+scrollRegionPadding) - childScreenPos); ImGui::Dummy(vector2(1,1));
+            
+            // controls go on the top of the child, scrolling is cancelled out.
+            vector2 cursor = vector2(ImGui::GetScrollX(), ImGui::GetScrollY()) + controlsBoxPadding;
+            ImGui::SetCursorPos(cursor);
+            this.drawControls();
+            cursor.y += ImGui::GetTextLineHeightWithSpacing();
+            this.drawingControlsStarted=true;
+            return cursor;
+        }
+        void end()
+        {
+            if (!this.drawingControlsStarted)
+            {
+                this.endGridBeginControls();
+            }
+            
+            isChildWindowHovered = ImGui::IsWindowHovered();
+            ImGui::EndChild();
+        }
+        
+        // HELPERS:
+        
+    private float fmax(float a, float b) { return a>b?a:b; }
+        
+    private float fmin(float a, float b) { return a<b?a:b; }
+        
+        private void setAxisVal(vector3&inout vec, int axis, float val)
+        {
+            switch(axis) {
+                case 0: vec.x=val; break;
+                case 1: vec.y=val; break;
+                case 2: vec.z=val; break;
+                default: break;
+            }
+        }
+    }
+    
 } // namespace gridviewer_utils

--- a/resources/scripts/gridviewer_utils.as
+++ b/resources/scripts/gridviewer_utils.as
@@ -2,6 +2,8 @@
 /// \brief Generic scrolling & zooming UI for drawing via ImDrawList
 // ===================================================
 
+#include "math_utils.as"
+
 // By convention, all includes have filename '*_utils' and namespace matching filename.
 namespace gridviewer_utils
 {
@@ -58,6 +60,7 @@ namespace gridviewer_utils
         
         vector2 localToScreenPos(vector3 posIn)
         {
+            using namespace math_utils;
             // zoom only, without scrolling
             vector2 pos= midWindowScreenPos+vector2(posIn[hAxis], posIn[vAxis])*zoom;
             nodesMin=vector2(fmin(nodesMin.x, pos.x), fmin(nodesMin.y, pos.y));
@@ -72,6 +75,7 @@ namespace gridviewer_utils
         
         vector3 screenToLocalPos(vector2 screenPosIn)
         {
+            using namespace math_utils;
             vector2 localXY = (screenPosIn -midWindowScreenPos)/zoom;
             // add scrolling
             localXY -= vector2(
@@ -118,21 +122,8 @@ namespace gridviewer_utils
             ImGui::EndChild();
         }
         
-        // HELPERS:
         
-    private float fmax(float a, float b) { return a>b?a:b; }
         
-    private float fmin(float a, float b) { return a<b?a:b; }
-        
-        private void setAxisVal(vector3&inout vec, int axis, float val)
-        {
-            switch(axis) {
-                case 0: vec.x=val; break;
-                case 1: vec.y=val; break;
-                case 2: vec.z=val; break;
-                default: break;
-            }
-        }
     }
     
 } // namespace gridviewer_utils

--- a/resources/scripts/math_utils.as
+++ b/resources/scripts/math_utils.as
@@ -1,0 +1,60 @@
+/// \title MATH UTILS
+/// \brief min()/max()/abs() and the sort...
+/// Cleans up old copypasta between scripts:
+/// * imin(), imax(), iabs()
+/// * fmin(), fmax(), fabs(), fclamp()
+/// * getMouseShortestDistance()
+/// * setAxisVal() // vector3 helper
+/// * formatVector3()
+// ===================================================
+
+// By convention, all includes have filename '*_utils' and namespace matching filename.
+namespace math_utils
+{
+    
+float fmax(float a, float b) { return a>b?a:b; }
+    
+float fmin(float a, float b) { return a<b?a:b; }
+    
+float fclamp(float val, float vmin, float vmax) { return (val > vmax) ? vmax : ((val < vmin) ? vmin : val); }
+    
+    void setAxisVal(vector3&inout vec, int axis, float val)
+    {
+        switch(axis) {
+            case 0: vec.x=val; break;
+            case 1: vec.y=val; break;
+            case 2: vec.z=val; break;
+            default: break;
+        }
+    }
+    
+    int getMouseShortestDistance(vector2 mouse, vector2 target)
+    {
+        int dx = iabs(int(mouse.x) - int(target.x));
+        int dy = iabs(int(mouse.y) - int(target.y));
+        return imax(dx, dy);
+    }
+    
+    int imin(int a, int b)
+    {
+        return (a < b) ? a : b;
+    }
+    
+    int imax(int a, int b)
+    {
+        return (a > b) ? a : b;
+    }
+    
+    int iabs(int a)
+    {
+        return (a < 0) ? -a : a;
+    }
+    
+    string formatVector3(vector3 val, int total, int frac)
+    {
+        return "X:" + formatFloat(val.x, "", total, frac)
+        + " Y:" + formatFloat(val.y, "", total, frac)
+        + " Z:" + formatFloat(val.z, "", total, frac);
+    }
+    
+} // namespace math_utils

--- a/source/main/main.cpp
+++ b/source/main/main.cpp
@@ -2047,6 +2047,12 @@ int main(int argc, char *argv[])
             const float dt = std::chrono::duration<float>(now - start_time).count();
             start_time = now;
 
+            // Safety net against division by zero (doesn't normally happen)
+            if (dt == 0.f)
+            {
+                continue;
+            }
+
 #ifdef USE_SOCKETW
             // Process incoming network traffic
             if (App::mp_state->getEnum<MpState>() == MpState::CONNECTED)
@@ -2079,77 +2085,76 @@ int main(int argc, char *argv[])
 
             // Process input events
             OgreProfileBegin("Input processing");
-            if (dt != 0.f)
+
+            App::GetInputEngine()->Capture();
+            App::GetInputEngine()->updateKeyBounces(dt);
+
+            if (!App::GetGuiManager()->GameControls.IsInteractiveKeyBindingActive())
             {
-                App::GetInputEngine()->Capture();
-                App::GetInputEngine()->updateKeyBounces(dt);
-
-                if (!App::GetGuiManager()->GameControls.IsInteractiveKeyBindingActive())
+                if (!App::GetGuiManager()->MainSelector.IsVisible() && !App::GetGuiManager()->MultiplayerSelector.IsVisible() &&
+                    !App::GetGuiManager()->GameSettings.IsVisible() && !App::GetGuiManager()->GameControls.IsVisible() &&
+                    !App::GetGuiManager()->GameAbout.IsVisible() && !App::GetGuiManager()->RepositorySelector.IsVisible())
                 {
-                    if (!App::GetGuiManager()->MainSelector.IsVisible() && !App::GetGuiManager()->MultiplayerSelector.IsVisible() &&
-                        !App::GetGuiManager()->GameSettings.IsVisible() && !App::GetGuiManager()->GameControls.IsVisible() &&
-                        !App::GetGuiManager()->GameAbout.IsVisible() && !App::GetGuiManager()->RepositorySelector.IsVisible())
+                    App::GetGameContext()->HandleSavegameHotkeys();
+                }
+                App::GetGameContext()->UpdateGlobalInputEvents();
+                App::GetGuiManager()->UpdateInputEvents(dt);
+
+                if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
+                {
+                    if (App::sim_state->getEnum<SimState>() == SimState::EDITOR_MODE)
                     {
-                        App::GetGameContext()->HandleSavegameHotkeys();
+                        App::GetGameContext()->UpdateSkyInputEvents(dt);
+                        App::GetGameContext()->GetTerrain()->GetTerrainEditor()->UpdateInputEvents(dt);
                     }
-                    App::GetGameContext()->UpdateGlobalInputEvents();
-                    App::GetGuiManager()->UpdateInputEvents(dt);
-
-                    if (App::app_state->getEnum<AppState>() == AppState::SIMULATION)
+                    else
                     {
-                        if (App::sim_state->getEnum<SimState>() == SimState::EDITOR_MODE)
+                        App::GetGameContext()->GetCharacterFactory()->Update(dt); // Character MUST be updated before CameraManager, otherwise camera position is always 1 frame behind the character position, causing stuttering.
+                    }
+                    App::GetCameraManager()->UpdateInputEvents(dt);
+                    App::GetOverlayWrapper()->update(dt);
+                    App::GetGameContext()->GetRepairMode().UpdateInputEvents(dt);
+                    App::GetGameContext()->GetActorManager()->UpdateInputEvents(dt);
+                    if (App::sim_state->getEnum<SimState>() == SimState::RUNNING)
+                    {
+                        if (App::GetCameraManager()->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_FREE)
                         {
-                            App::GetGameContext()->UpdateSkyInputEvents(dt);
-                            App::GetGameContext()->GetTerrain()->GetTerrainEditor()->UpdateInputEvents(dt);
+                            App::GetGameContext()->UpdateSimInputEvents(dt);
                         }
-                        else
-                        {
-                            App::GetGameContext()->GetCharacterFactory()->Update(dt); // Character MUST be updated before CameraManager, otherwise camera position is always 1 frame behind the character position, causing stuttering.
-                        }
-                        App::GetCameraManager()->UpdateInputEvents(dt);
-                        App::GetOverlayWrapper()->update(dt);
-                        App::GetGameContext()->GetRepairMode().UpdateInputEvents(dt);
-                        App::GetGameContext()->GetActorManager()->UpdateInputEvents(dt);
-                        if (App::sim_state->getEnum<SimState>() == SimState::RUNNING)
-                        {
-                            if (App::GetCameraManager()->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_FREE)
-                            {
-                                App::GetGameContext()->UpdateSimInputEvents(dt);
-                            }
 
-                            App::GetGameContext()->UpdateSkyInputEvents(dt);
-                            for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
+                        App::GetGameContext()->UpdateSkyInputEvents(dt);
+                        for (ActorPtr actor : App::GetGameContext()->GetActorManager()->GetActors())
+                        {
+                            if (actor->ar_state != ActorState::NETWORKED_OK)
                             {
-                                if (actor->ar_state != ActorState::NETWORKED_OK)
+                                App::GetGameContext()->UpdateCommonInputEvents(dt, actor);
+                                if (actor->ar_state != ActorState::LOCAL_REPLAY)
                                 {
-                                    App::GetGameContext()->UpdateCommonInputEvents(dt, actor);
-                                    if (actor->ar_state != ActorState::LOCAL_REPLAY)
+                                    if (actor->ar_driveable == TRUCK)
                                     {
-                                        if (actor->ar_driveable == TRUCK)
-                                        {
-                                            App::GetGameContext()->UpdateTruckInputEvents(dt, actor);
-                                        }
-                                        if (actor->ar_driveable == AIRPLANE)
-                                        {
-                                            App::GetGameContext()->UpdateAirplaneInputEvents(dt, actor);
-                                        }
-                                        if (actor->ar_driveable == BOAT)
-                                        {
-                                            App::GetGameContext()->UpdateBoatInputEvents(dt, actor);
-                                        }
+                                        App::GetGameContext()->UpdateTruckInputEvents(dt, actor);
                                     }
+                                    if (actor->ar_driveable == AIRPLANE)
+                                    {
+                                        App::GetGameContext()->UpdateAirplaneInputEvents(dt, actor);
+                                    }
+                                    if (actor->ar_driveable == BOAT)
+                                    {
+                                        App::GetGameContext()->UpdateBoatInputEvents(dt, actor);
+                                    }
+                                }
 
-                                    actor->UpdatePropAnimInputEvents();
-                                    for (ActorPtr linked_actor : actor->ar_linked_actors)
-                                    {
-                                        linked_actor->UpdatePropAnimInputEvents();
-                                    }
+                                actor->UpdatePropAnimInputEvents();
+                                for (ActorPtr linked_actor : actor->ar_linked_actors)
+                                {
+                                    linked_actor->UpdatePropAnimInputEvents();
                                 }
                             }
                         }
-                    } // app state SIMULATION
-                } // interactive key binding mode
-            } // dt != 0
+                    }
+                } // app state SIMULATION
+            } // interactive key binding mode
+
             OgreProfileEnd("Input processing");
 
             // Update OutGauge device

--- a/source/main/scripting/ScriptEngine.cpp
+++ b/source/main/scripting/ScriptEngine.cpp
@@ -156,9 +156,13 @@ void ScriptEngine::init()
     AngelScript::RegisterStdString(engine);
     AngelScript::RegisterStdStringUtils(engine);
     AngelScript::RegisterScriptMath(engine);
+    static float SCRIPT_FLT_MIN = FLT_MIN;
     static float SCRIPT_FLT_MAX = FLT_MAX;
+    static int SCRIPT_INT_MIN = INT_MIN;
     static int SCRIPT_INT_MAX = INT_MAX;
+    result = engine->RegisterGlobalProperty("const float FLT_MIN", &SCRIPT_FLT_MIN); ROR_ASSERT( result >= 0 );
     result = engine->RegisterGlobalProperty("const float FLT_MAX", &SCRIPT_FLT_MAX); ROR_ASSERT( result >= 0 );
+    result = engine->RegisterGlobalProperty("const int INT_MIN", &SCRIPT_INT_MIN); ROR_ASSERT(result >= 0);
     result = engine->RegisterGlobalProperty("const int INT_MAX", &SCRIPT_INT_MAX); ROR_ASSERT(result >= 0);
     AngelScript::RegisterScriptAny(engine);
     AngelScript::RegisterScriptDictionary(engine);

--- a/source/main/scripting/bindings/InputEngineAngelscript.cpp
+++ b/source/main/scripting/bindings/InputEngineAngelscript.cpp
@@ -58,6 +58,7 @@ void registerInputEngineObject(asIScriptEngine* engine)
     
     // Direct input device states
     result = engine->RegisterObjectMethod("InputEngineClass", "bool isKeyDown(keyCodes keycode)", asMETHOD(InputEngine,isKeyDown), asCALL_THISCALL); ROR_ASSERT(result>=0);
+    result = engine->RegisterObjectMethod("InputEngineClass", "int getMouseWheelMotion()", asMETHOD(InputEngine,getMouseWheelMotion), asCALL_THISCALL); ROR_ASSERT(result>=0);
 }
 
 void registerInputSourceTypeEnum(asIScriptEngine* engine)

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -635,7 +635,12 @@ String InputEngine::getKeyNameForKeyCode(OIS::KeyCode keycode)
 void InputEngine::Capture()
 {
     mKeyboard->capture();
+    m_oisworkaround_frames_since_mousemoved++;
     mMouse->capture();
+    if (m_oisworkaround_frames_since_mousemoved > 0u)
+    {
+        this->mouseState.Z.rel = 0;
+    }
 
     for (int i = 0; i < free_joysticks; i++)
     {
@@ -706,6 +711,7 @@ void InputEngine::processMouseMotionEvent(const OIS::MouseEvent& arg)
     mouseState.X = arg.state.X;
     mouseState.Y = arg.state.Y;
     mouseState.Z = arg.state.Z;
+    m_oisworkaround_frames_since_mousemoved = 0u;
 }
 
 void InputEngine::processMousePressEvent(const OIS::MouseEvent& arg, OIS::MouseButtonID _id)
@@ -1179,6 +1185,12 @@ bool InputEngine::isKeyDown(OIS::KeyCode key)
     if (!mKeyboard)
         return false;
     return this->mKeyboard->isKeyDown(key);
+}
+
+int InputEngine::getMouseWheelMotion()
+{
+    OIS::MouseState ms = this->getMouseState();
+    return ms.Z.rel; 
 }
 
 bool InputEngine::isKeyDownEffective(OIS::KeyCode mod)

--- a/source/main/utils/InputEngine.h
+++ b/source/main/utils/InputEngine.h
@@ -550,6 +550,8 @@ public:
     OIS::JoyStickState* getCurrentJoyState(int joystickNumber);
     OIS::MouseState     getMouseState();
     bool                isKeyDown(OIS::KeyCode mod);                        //!< Asks OIS directly
+    int                 getMouseWheelMotion();
+    // Not exported to script:
     int                 getCurrentKeyCombo(Ogre::String* combo);            //!< Returns number of non-modifier keys pressed (or modifier count as negative number).
     int                 getCurrentJoyButton(int& joystickNumber, int& button);
     int                 getCurrentPovValue(int& joystickNumber, int& pov, int& povdir);
@@ -618,6 +620,10 @@ protected:
     // There's no way to recognize the event as fake, we must track number of frames and LMB presses since last reset.
     size_t m_oisworkaround_frames_since_reset = 0u;
     size_t m_oisworkaround_lmbdowns_since_reset = 0u;
+    // OIS WORKAROUND: mouse wheel motion counts as MouseMoved event,
+    //   but mouse wheel non-motion doesn't, so we need to clear the buffered
+    //   value ourselves
+    size_t m_oisworkaround_frames_since_mousemoved = 0u;
 };
 
 /// @} // @addtogroup Input


### PR DESCRIPTION
<img width="1565" height="1119" alt="image" src="https://github.com/user-attachments/assets/438c61cc-1a28-4c8a-9747-aa570173e41b" />

The script presents you with a waypoint/path editor window where you insert waypoints using RMB,  then make selection using LMB and add paths between them. When happy, press [release walker] button to add NPC pedestrians. Pedestrians will follow the path network, always trying to go somewhere they haven't been before, and returning the same way on dead ends.

Notes:
* A very messy prototype, mashed together from existing examples: skeletal animaton, node highlights (used for the waypoints), texture drawing in GridViewer.
* The `GridViewer` component needs fixing - zooming breaks the `screenToLocal()` conversion or so it seems. Also the zoom throws scrolling completely off - it should be centered.
* The node/beam (or waypoint/path in this case) mouse editing needs to be generalized - will be useful for actual node/beam editing later on.
* Some way of saving and loading presets needs to be added.