### PR TITLE
SkinZips now also work for beam materials.

### DIFF
--- a/source/main/physics/ActorSpawner.cpp
+++ b/source/main/physics/ActorSpawner.cpp
@@ -5844,7 +5844,7 @@ void ActorSpawner::SetBeamDeformationThreshold(beam_t & beam, std::shared_ptr<Ri
 void ActorSpawner::CreateBeamVisuals(beam_t & beam, int beam_index, bool visible, std::shared_ptr<RigDef::BeamDefaults> const& beam_defaults, std::string material_override)
 {
     std::string material_name = material_override;
-    if (material_name.empty())
+    if (material_name == "")
     {
         if (beam.bm_type == BEAM_HYDRO)
         {
@@ -5853,16 +5853,6 @@ void ActorSpawner::CreateBeamVisuals(beam_t & beam, int beam_index, bool visible
         else
         {
             material_name = beam_defaults->beam_material_name;
-            // Check for existing substitute
-            auto it = m_managed_materials.find(material_name);
-            if (it != m_managed_materials.end())
-            {
-                auto material = it->second;
-                if (material)
-                {
-                    material_name = material->getName();
-                }
-            }
         }
     }
 
@@ -5874,7 +5864,8 @@ void ActorSpawner::CreateBeamVisuals(beam_t & beam, int beam_index, bool visible
     try
     {
         Ogre::Entity* entity = App::GetGfxScene()->GetSceneManager()->createEntity(this->ComposeName("beam", beam_index), "beam.mesh");
-        entity->setMaterialName(material_name);
+        Ogre::MaterialPtr mat = this->FindOrCreateCustomizedMaterial(material_name, m_custom_resource_group);
+        entity->setMaterial(mat);
 
         BeamGfx beamx;
         beamx.rod_diameter = beam_defaults->visual_beam_diameter;


### PR DESCRIPTION
Test vehicle:  Starling Island firetruck (MB LF 16) from https://forum.rigsofrods.org/resources/starling-island.532/

Test skinzip by Manieczek:
[Polish-Emergency-Vehicles-Starling-IslandHD.zip](https://github.com/user-attachments/files/30877987/Polish-Emergency-Vehicles-Starling-IslandHD.zip)


Implemented by hooking-in the existing `FindOrCreateCustomizedMaterial()` used almost everywhere else.

Fixes #3451