### PR TITLE
Added mouse-look smoothing & settings

### DIFF
--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -269,6 +269,8 @@ CVar* gfx_reduce_shadows;
 CVar* gfx_enable_rtshaders;
 CVar* gfx_alt_actor_materials;
 CVar* gfx_auto_lod;
+CVar* io_freecam_mouse_speed;
+CVar* io_freecam_mouse_smooth;
 
 // Flexbodies
 CVar* flexbody_defrag_enabled;

--- a/source/main/Application.cpp
+++ b/source/main/Application.cpp
@@ -269,8 +269,8 @@ CVar* gfx_reduce_shadows;
 CVar* gfx_enable_rtshaders;
 CVar* gfx_alt_actor_materials;
 CVar* gfx_auto_lod;
-CVar* io_freecam_mouse_speed;
-CVar* io_freecam_mouse_smooth;
+CVar* io_mouselook_speed;
+CVar* io_mouselook_smoothing;
 
 // Flexbodies
 CVar* flexbody_defrag_enabled;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -815,6 +815,8 @@ extern CVar* gfx_reduce_shadows;
 extern CVar* gfx_enable_rtshaders;
 extern CVar* gfx_alt_actor_materials;
 extern CVar* gfx_auto_lod;
+extern CVar* io_freecam_mouse_speed;
+extern CVar* io_freecam_mouse_smooth;
 
 // Flexbodies
 extern CVar* flexbody_defrag_enabled;

--- a/source/main/Application.h
+++ b/source/main/Application.h
@@ -815,8 +815,8 @@ extern CVar* gfx_reduce_shadows;
 extern CVar* gfx_enable_rtshaders;
 extern CVar* gfx_alt_actor_materials;
 extern CVar* gfx_auto_lod;
-extern CVar* io_freecam_mouse_speed;
-extern CVar* io_freecam_mouse_smooth;
+extern CVar* io_mouselook_speed;
+extern CVar* io_mouselook_smoothing;
 
 // Flexbodies
 extern CVar* flexbody_defrag_enabled;

--- a/source/main/gameplay/SceneMouse.cpp
+++ b/source/main/gameplay/SceneMouse.cpp
@@ -296,7 +296,7 @@ bool SceneMouse::handleMousePressed()
             {
                 player_actor->ar_custom_camera_node = nearest_node_index;
                 player_actor->calculateAveragePosition();
-                App::GetCameraManager()->NotifyContextChange(); // Reset last 'look at' pos
+                App::GetCameraManager()->ResetLookatPos(); // Reset last 'look at' pos
             }
         }
     }

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -157,8 +157,7 @@ void CameraManager::UpdateCurrentBehavior(float dt)
     switch(m_current_behavior)
     {
     case CAMERA_BEHAVIOR_CHARACTER: {
-        if (m_mouse_moved)
-            this->CameraBehaviorCharacterMouseMoved();
+        this->CameraBehaviorCharacterMouseMoved(dt); // Always update for smoothing to work.
         if (!App::GetGameContext()->GetPlayerCharacter())
             return;
         m_cam_target_direction = -App::GetGameContext()->GetPlayerCharacter()->getRotation() - Radian(Math::HALF_PI);
@@ -489,7 +488,8 @@ void CameraManager::DeactivateCurrentBehavior()
         return;
 
     case CAMERA_BEHAVIOR_FREE:
-        m_freecam_smooth_mousevec = Ogre::Vector2::ZERO;
+    case CAMERA_BEHAVIOR_CHARACTER:
+        m_mouselook_smooth_vec = Ogre::Vector2::ZERO;
         return;
 
     default:
@@ -575,25 +575,22 @@ bool CameraManager::handleMouseMoved()
     }
 }
 
-bool CameraManager::CameraBehaviorCharacterMouseMoved()
+bool CameraManager::CameraBehaviorCharacterMouseMoved(float dt)
 {
-    if (!App::GetGameContext()->GetPlayerCharacter())
+    Character* chara = App::GetGameContext()->GetPlayerCharacter();
+
+    if (!chara)
         return false;
+
     if (!m_charactercam_is_3rdperson)
     {
-        // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
-        //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
-        const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
+        this->UpdateMouseLook(dt);
 
-        Radian angle = App::GetGameContext()->GetPlayerCharacter()->getRotation();
+        chara->setRotation(chara->getRotation() - Degree(m_mouselook_smooth_vec.x));
 
-        m_cam_rot_y += Degree(ms.Y.rel * 0.13f);
-        angle += Degree(ms.X.rel * 0.13f);
-
+        m_cam_rot_y -= Degree(m_mouselook_smooth_vec.y);
         m_cam_rot_y = Radian(std::min(+Math::HALF_PI * 0.65f, m_cam_rot_y.valueRadians()));
         m_cam_rot_y = Radian(std::max(m_cam_rot_y.valueRadians(), -Math::HALF_PI * 0.9f));
-
-        App::GetGameContext()->GetPlayerCharacter()->setRotation(angle);
 
         RoR::App::GetGuiManager()->SetMouseCursorVisibility(RoR::GUIManager::MouseCursorVisibility::HIDDEN);
 
@@ -605,22 +602,27 @@ bool CameraManager::CameraBehaviorCharacterMouseMoved()
 
 bool CameraManager::CameraBehaviorFreeMouseMoved(float dt)
 {
-    // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
-    //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
-    const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
+    this->UpdateMouseLook(dt);
+
     Ogre::SceneNode* cam_node = App::GetCameraManager()->GetCameraNode();
-    const float cam_speed = App::io_freecam_mouse_speed->getFloat();
-    const float cam_smooth = App::io_freecam_mouse_smooth->getFloat();
-
-    const Ogre::Vector2 cur_mousevec(-ms.X.rel * cam_speed * dt, -ms.Y.rel * cam_speed * dt);
-    m_freecam_smooth_mousevec = cur_mousevec * (1.f - cam_smooth) + m_freecam_smooth_mousevec * cam_smooth;
-
-    cam_node->yaw(Degree(m_freecam_smooth_mousevec.x), Ogre::Node::TS_WORLD);
-    cam_node->pitch(Degree(m_freecam_smooth_mousevec.y));
+    cam_node->yaw(Degree(m_mouselook_smooth_vec.x), Ogre::Node::TS_WORLD);
+    cam_node->pitch(Degree(m_mouselook_smooth_vec.y));
 
     App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
 
     return true;
+}
+
+void CameraManager::UpdateMouseLook(float dt)
+{
+    // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
+    //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
+    const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
+    const float cam_speed = App::io_mouselook_speed->getFloat();
+    const float cam_smooth = App::io_mouselook_smoothing->getFloat();
+
+    const Ogre::Vector2 cur_mousevec(-ms.X.rel * cam_speed * dt, -ms.Y.rel * cam_speed * dt);
+    m_mouselook_smooth_vec = cur_mousevec * (1.f - cam_smooth) + m_mouselook_smooth_vec * cam_smooth;
 }
 
 bool CameraManager::handleMousePressed()

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -152,7 +152,7 @@ bool CameraManager::EvaluateSwitchBehavior()
     }
 }
 
-void CameraManager::UpdateCurrentBehavior()
+void CameraManager::UpdateCurrentBehavior(float dt)
 {
     switch(m_current_behavior)
     {
@@ -163,19 +163,19 @@ void CameraManager::UpdateCurrentBehavior()
         Ogre::Vector3 offset = (!m_charactercam_is_3rdperson) ? CHARACTERCAM_OFFSET_1ST_PERSON : CHARACTERCAM_OFFSET_3RD_PERSON;
         m_cam_look_at = App::GetGameContext()->GetPlayerCharacter()->getPosition() + offset;
 
-        CameraManager::CameraBehaviorOrbitUpdate();
+        CameraManager::CameraBehaviorOrbitUpdate(dt);
         return;
     }
 
     case CAMERA_BEHAVIOR_STATIC:
         m_staticcam_fov_exponent = App::gfx_static_cam_fov_exp->getFloat();
-        this->UpdateCameraBehaviorStatic();
+        this->UpdateCameraBehaviorStatic(dt);
         return;
 
-    case CAMERA_BEHAVIOR_VEHICLE:         this->UpdateCameraBehaviorVehicle();  return;
-    case CAMERA_BEHAVIOR_VEHICLE_SPLINE:  this->CameraBehaviorVehicleSplineUpdate();  return;
+    case CAMERA_BEHAVIOR_VEHICLE:         this->UpdateCameraBehaviorVehicle(dt);  return;
+    case CAMERA_BEHAVIOR_VEHICLE_SPLINE:  this->CameraBehaviorVehicleSplineUpdate(dt);  return;
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM: {
-        CameraManager::CameraBehaviorOrbitUpdate();
+        CameraManager::CameraBehaviorOrbitUpdate(dt);
 
         const NodeNum_t pos_node  = m_current_actor->ar_camera_node_pos [m_current_actor->ar_current_cinecam];
         const NodeNum_t dir_node  = m_current_actor->ar_camera_node_dir [m_current_actor->ar_current_cinecam];
@@ -200,8 +200,8 @@ void CameraManager::UpdateCurrentBehavior()
         this->GetCameraNode()->setOrientation(orientation);
         return;
     }
-    case CAMERA_BEHAVIOR_FREE:            this->UpdateCameraBehaviorFree(); return;
-    case CAMERA_BEHAVIOR_FIXED:           this->UpdateCameraBehaviorFixed(); return;
+    case CAMERA_BEHAVIOR_FREE:            this->UpdateCameraBehaviorFree(dt); return;
+    case CAMERA_BEHAVIOR_FIXED:           this->UpdateCameraBehaviorFixed(dt); return;
     case CAMERA_BEHAVIOR_ISOMETRIC:       return;
     case CAMERA_BEHAVIOR_INVALID:         return;
     default:                              return;
@@ -217,9 +217,6 @@ void CameraManager::UpdateInputEvents(float dt) // Called every frame
     }
 
     m_current_actor = App::GetGameContext()->GetPlayerActor();
-    m_cct_dt           = dt;
-    m_cct_rot_scale    = Degree(TRANS_SPEED * dt);
-    m_cct_trans_scale  = ROTATE_SPEED * dt;
 
     // Handle forced cinecam
     if (m_current_actor && m_current_actor->ar_forced_cinecam != CINECAMERAID_INVALID)
@@ -250,7 +247,7 @@ void CameraManager::UpdateInputEvents(float dt) // Called every frame
 
     if (m_current_behavior != CAMERA_BEHAVIOR_INVALID)
     {
-        this->UpdateCurrentBehavior();
+        this->UpdateCurrentBehavior(dt);
     }
     else
     {
@@ -677,7 +674,7 @@ void CameraManager::ToggleCameraBehavior(CameraBehaviors new_behavior) // Only a
     }
 }
 
-void CameraManager::UpdateCameraBehaviorStatic()
+void CameraManager::UpdateCameraBehaviorStatic(float dt)
 {
     Vector3 velocity = Vector3::ZERO;
     Radian angle = Degree(90);
@@ -796,7 +793,7 @@ bool CameraManager::CameraBehaviorStaticMouseMoved()
     return false;
 }
 
-void CameraManager::CameraBehaviorOrbitUpdate()
+void CameraManager::CameraBehaviorOrbitUpdate(float dt)
 {
     if (RoR::App::GetInputEngine()->getEventBoolValueBounce(EV_CAMERA_LOOKBACK))
     {
@@ -810,34 +807,36 @@ void CameraManager::CameraBehaviorOrbitUpdate()
         }
     }
 
+    const Degree rot_scale(ROTATE_SPEED * dt);
     if (App::io_invert_orbitcam->getBool() && this->GetCurrentBehavior() != CameraManager::CAMERA_BEHAVIOR_VEHICLE_CINECAM)
     {
-        m_cam_rot_x += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_LEFT) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_RIGHT)) * m_cct_rot_scale;
-        m_cam_rot_y += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_DOWN) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_UP)) * m_cct_rot_scale;
+        m_cam_rot_x += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_LEFT) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_RIGHT)) * rot_scale;
+        m_cam_rot_y += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_DOWN) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_UP)) * rot_scale;
     }
     else
     {
-        m_cam_rot_x += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_RIGHT) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_LEFT)) * m_cct_rot_scale;
-        m_cam_rot_y += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_UP) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_DOWN)) * m_cct_rot_scale;
+        m_cam_rot_x += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_RIGHT) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_LEFT)) * rot_scale;
+        m_cam_rot_y += (RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_UP) - RoR::App::GetInputEngine()->getEventValue(EV_CAMERA_ROTATE_DOWN)) * rot_scale;
     }
     m_cam_rot_y = std::max((Radian)Degree(-80), m_cam_rot_y);
     m_cam_rot_y = std::min(m_cam_rot_y, (Radian)Degree(88));
 
+    const float trans_scale(TRANS_SPEED * dt);
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CAMERA_ZOOM_IN) && m_cam_dist > 1)
     {
-        m_cam_dist -= m_cct_trans_scale;
+        m_cam_dist -= trans_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CAMERA_ZOOM_IN_FAST) && m_cam_dist > 1)
     {
-        m_cam_dist -= m_cct_trans_scale * 10;
+        m_cam_dist -= trans_scale * 10;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CAMERA_ZOOM_OUT))
     {
-        m_cam_dist += m_cct_trans_scale;
+        m_cam_dist += trans_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CAMERA_ZOOM_OUT_FAST))
     {
-        m_cam_dist += m_cct_trans_scale * 10;
+        m_cam_dist += trans_scale * 10;
     }
 
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CAMERA_RESET))
@@ -958,81 +957,80 @@ void CameraManager::CameraBehaviorOrbitReset()
     App::GetCameraManager()->GetCamera()->setFOVy(Degree(App::gfx_fov_external->getInt()));
 }
 
-void CameraManager::UpdateCameraBehaviorFree()
+void CameraManager::UpdateCameraBehaviorFree(float dt)
 {
-    Degree mRotX(0.0f);
-    Degree mRotY(0.0f);
-    Degree cct_rot_scale(m_cct_rot_scale * 5.0f * m_cct_dt);
-    Vector3 mTrans(Vector3::ZERO);
-    Real cct_trans_scale(m_cct_trans_scale * 5.0f * m_cct_dt);
-
+    float trans_scale(TRANS_SPEED * 5.0f * dt);
+    Degree rot_scale(ROTATE_SPEED * 5.0f * dt);
     if (RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) || RoR::App::GetInputEngine()->isKeyDown(OIS::KC_RSHIFT))
     {
-        cct_rot_scale *= 3.0f;
-        cct_trans_scale *= 5.0f;
+        rot_scale *= 3.0f;
+        trans_scale *= 5.0f;
     }
     if (RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LCONTROL))
     {
-        cct_rot_scale *= 6.0f;
-        cct_trans_scale *= 10.0f;
+        rot_scale *= 6.0f;
+        trans_scale *= 10.0f;
     }
     if (RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LMENU))
     {
-        cct_rot_scale *= 0.2f;
-        cct_trans_scale *= 0.2f;
+        rot_scale *= 0.2f;
+        trans_scale *= 0.2f;
     }
 
+    Vector3 trans(Vector3::ZERO);
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CHARACTER_SIDESTEP_LEFT))
     {
-        mTrans.x -= cct_trans_scale;
+        trans.x -= trans_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CHARACTER_SIDESTEP_RIGHT))
     {
-        mTrans.x += cct_trans_scale;
+        trans.x += trans_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CHARACTER_FORWARD))
     {
-        mTrans.z -= cct_trans_scale;
+        trans.z -= trans_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CHARACTER_BACKWARDS))
     {
-        mTrans.z += cct_trans_scale;
+        trans.z += trans_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CAMERA_UP))
     {
-        mTrans.y += cct_trans_scale;
+        trans.y += trans_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CAMERA_DOWN))
     {
-        mTrans.y -= cct_trans_scale;
+        trans.y -= trans_scale;
     }
 
+    Degree rot_x(0.0f);
+    Degree rot_y(0.0f);
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CHARACTER_RIGHT))
     {
-        mRotX -= cct_rot_scale;
+        rot_x -= rot_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CHARACTER_LEFT))
     {
-        mRotX += cct_rot_scale;
+        rot_x += rot_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CHARACTER_ROT_UP))
     {
-        mRotY += cct_rot_scale;
+        rot_y += rot_scale;
     }
     if (RoR::App::GetInputEngine()->getEventBoolValue(EV_CHARACTER_ROT_DOWN))
     {
-        mRotY -= cct_rot_scale;
+        rot_y -= rot_scale;
     }
 
-    App::GetCameraManager()->GetCameraNode()->yaw(mRotX, Ogre::Node::TS_WORLD);
-    App::GetCameraManager()->GetCameraNode()->pitch(mRotY);
+    App::GetCameraManager()->GetCameraNode()->yaw(rot_x, Ogre::Node::TS_WORLD);
+    App::GetCameraManager()->GetCameraNode()->pitch(rot_y);
 
-    Vector3 camPosition = this->GetCameraNode()->getPosition() + this->GetCameraNode()->getOrientation() * mTrans.normalisedCopy() * cct_trans_scale;
+    Vector3 camPosition = this->GetCameraNode()->getPosition() + this->GetCameraNode()->getOrientation() * trans.normalisedCopy() * trans_scale;
 
     this->GetCameraNode()->setPosition(camPosition);
 }
 
-void CameraManager::UpdateCameraBehaviorFixed()
+void CameraManager::UpdateCameraBehaviorFixed(float dt)
 {
 	if (App::gfx_fixed_cam_tracking->getBool())
     {
@@ -1041,7 +1039,7 @@ void CameraManager::UpdateCameraBehaviorFixed()
     }
 }
 
-void CameraManager::UpdateCameraBehaviorVehicle()
+void CameraManager::UpdateCameraBehaviorVehicle(float dt)
 {
 	Vector3 dir = m_current_actor->getDirection();
 
@@ -1053,13 +1051,13 @@ void CameraManager::UpdateCameraBehaviorVehicle()
 		m_cam_target_pitch = -asin(dir.dotProduct(Vector3::UNIT_Y));
 	}
 
-	m_cam_ratio = 1.0f / (m_cct_dt * 4.0f);
+	m_cam_ratio = 1.0f / (dt * 4.0f);
 
 	m_cam_dist_min = std::min(m_current_actor->getMinimalCameraRadius() * 2.0f, 33.0f);
 
 	m_cam_look_at = m_current_actor->getPosition();
 
-	CameraManager::CameraBehaviorOrbitUpdate();
+	CameraManager::CameraBehaviorOrbitUpdate(dt);
 }
 
 void CameraManager::CameraBehaviorVehicleReset()
@@ -1111,7 +1109,7 @@ bool CameraManager::CameraBehaviorVehicleMousePressed()
 	return false;
 }
 
-void CameraManager::CameraBehaviorVehicleSplineUpdate()
+void CameraManager::CameraBehaviorVehicleSplineUpdate(float dt)
 {
     if (m_current_actor->ar_num_camera_rails <= 0)
     {
@@ -1122,6 +1120,7 @@ void CameraManager::CameraBehaviorVehicleSplineUpdate()
     Vector3 dir = m_current_actor->getDirection();
 
     m_cam_target_pitch = 0.0f;
+    m_cam_ratio = 1.0f / (dt * 4.0f);
 
     if (App::gfx_extcam_mode->getEnum<GfxExtCamMode>() == GfxExtCamMode::PITCHING)
     {
@@ -1165,7 +1164,7 @@ void CameraManager::CameraBehaviorVehicleSplineUpdate()
         }
     }
 
-    CameraManager::CameraBehaviorOrbitUpdate();
+    CameraManager::CameraBehaviorOrbitUpdate(dt);
 }
 
 bool CameraManager::CameraBehaviorVehicleSplineMouseMoved(  )
@@ -1173,8 +1172,6 @@ bool CameraManager::CameraBehaviorVehicleSplineMouseMoved(  )
     // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
     //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
     const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
-
-    m_cam_ratio = 1.0f / (m_cct_dt * 4.0f);
 
     if (RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LCONTROL) && ms.buttonDown(OIS::MB_Right))
     {

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -80,38 +80,8 @@ bool intersectsTerrain(Vector3 a, Vector3 start, Vector3 end, float interval) //
     return false;
 }
 
-CameraManager::CameraManager() :
-      m_current_behavior(CAMERA_BEHAVIOR_INVALID)
-    , m_cct_dt(0.0f)
-    , m_cct_trans_scale(1.0f)
-    , m_cam_before_toggled(CAMERA_BEHAVIOR_INVALID)
-    , m_prev_toggled_cam(CAMERA_BEHAVIOR_INVALID)
-    , m_charactercam_is_3rdperson(true)
-    , m_splinecam_num_linked_beams(0)
-    , m_splinecam_auto_tracking(false)
-    , m_splinecam_spline(new SimpleSpline())
-    , m_splinecam_spline_closed(false)
-    , m_splinecam_spline_len(1.0f)
-    , m_splinecam_mo(0)
-    , m_splinecam_spline_pos(0.5f)
-    , m_staticcam_force_update(false)
-    , m_staticcam_fov_exponent(1.0f)
-    , m_cam_rot_x(0.0f)
-    , m_cam_rot_y(0.3f)
-    , m_cam_dist(5.f)
-    , m_cam_dist_min(0.f)
-    , m_cam_dist_max(0.f)
-    , m_cam_target_direction(0.f)
-    , m_cam_target_pitch(0.f)
-    , m_cam_ratio (11.f)
-    , m_cam_look_at(Ogre::Vector3::ZERO)
-    , m_cam_look_at_last(Ogre::Vector3::ZERO)
-    , m_cam_look_at_smooth(Ogre::Vector3::ZERO)
-    , m_cam_look_at_smooth_last(Ogre::Vector3::ZERO)
-    , m_cam_limit_movement(true)
-    , m_camera_node(nullptr)
+CameraManager::CameraManager()
 {
-    m_cct_player_actor = nullptr;
     m_staticcam_update_timer.reset();
 
     m_camera = App::GetGfxScene()->GetSceneManager()->createCamera("PlayerCam");
@@ -165,11 +135,11 @@ bool CameraManager::EvaluateSwitchBehavior()
     case CAMERA_BEHAVIOR_VEHICLE:         return true;
     case CAMERA_BEHAVIOR_VEHICLE_SPLINE:  return true;
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM: {
-        if ( (m_cct_player_actor != nullptr)
-            && (m_cct_player_actor->ar_current_cinecam) < (m_cct_player_actor->ar_num_cinecams-1) )
+        if ( (m_current_actor != nullptr)
+            && (m_current_actor->ar_current_cinecam) < (m_current_actor->ar_num_cinecams-1) )
         {
-            m_cct_player_actor->ar_current_cinecam++;
-            m_cct_player_actor->NotifyActorCameraChanged();
+            m_current_actor->ar_current_cinecam++;
+            m_current_actor->NotifyActorCameraChanged();
             return false;
         }
         return true;
@@ -207,16 +177,16 @@ void CameraManager::UpdateCurrentBehavior()
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM: {
         CameraManager::CameraBehaviorOrbitUpdate();
 
-        const NodeNum_t pos_node  = m_cct_player_actor->ar_camera_node_pos [m_cct_player_actor->ar_current_cinecam];
-        const NodeNum_t dir_node  = m_cct_player_actor->ar_camera_node_dir [m_cct_player_actor->ar_current_cinecam];
-        const NodeNum_t roll_node = m_cct_player_actor->ar_camera_node_roll[m_cct_player_actor->ar_current_cinecam];
+        const NodeNum_t pos_node  = m_current_actor->ar_camera_node_pos [m_current_actor->ar_current_cinecam];
+        const NodeNum_t dir_node  = m_current_actor->ar_camera_node_dir [m_current_actor->ar_current_cinecam];
+        const NodeNum_t roll_node = m_current_actor->ar_camera_node_roll[m_current_actor->ar_current_cinecam];
 
-        Vector3 dir  = (m_cct_player_actor->ar_nodes[pos_node].AbsPosition
-                - m_cct_player_actor->ar_nodes[dir_node].AbsPosition).normalisedCopy();
-        Vector3 roll = (m_cct_player_actor->ar_nodes[pos_node].AbsPosition
-                - m_cct_player_actor->ar_nodes[roll_node].AbsPosition).normalisedCopy();
+        Vector3 dir  = (m_current_actor->ar_nodes[pos_node].AbsPosition
+                - m_current_actor->ar_nodes[dir_node].AbsPosition).normalisedCopy();
+        Vector3 roll = (m_current_actor->ar_nodes[pos_node].AbsPosition
+                - m_current_actor->ar_nodes[roll_node].AbsPosition).normalisedCopy();
 
-        if ( m_cct_player_actor->ar_camera_node_roll_inv[m_cct_player_actor->ar_current_cinecam] )
+        if ( m_current_actor->ar_camera_node_roll_inv[m_current_actor->ar_current_cinecam] )
         {
             roll = -roll;
         }
@@ -226,7 +196,7 @@ void CameraManager::UpdateCurrentBehavior()
 
         Quaternion orientation = Quaternion(m_cam_rot_x, up) * Quaternion(Degree(180.0) + m_cam_rot_y, roll) * Quaternion(roll, up, dir);
 
-        this->GetCameraNode()->setPosition(m_cct_player_actor->ar_nodes[m_cct_player_actor->ar_cinecam_node[m_cct_player_actor->ar_current_cinecam]].AbsPosition);
+        this->GetCameraNode()->setPosition(m_current_actor->ar_nodes[m_current_actor->ar_cinecam_node[m_current_actor->ar_current_cinecam]].AbsPosition);
         this->GetCameraNode()->setOrientation(orientation);
         return;
     }
@@ -246,16 +216,16 @@ void CameraManager::UpdateInputEvents(float dt) // Called every frame
         return;
     }
 
-    m_cct_player_actor = App::GetGameContext()->GetPlayerActor();
+    m_current_actor = App::GetGameContext()->GetPlayerActor();
     m_cct_dt           = dt;
     m_cct_rot_scale    = Degree(TRANS_SPEED * dt);
     m_cct_trans_scale  = ROTATE_SPEED * dt;
 
     // Handle forced cinecam
-    if (m_cct_player_actor && m_cct_player_actor->ar_forced_cinecam != CINECAMERAID_INVALID)
+    if (m_current_actor && m_current_actor->ar_forced_cinecam != CINECAMERAID_INVALID)
     {
         this->switchBehavior(CAMERA_BEHAVIOR_VEHICLE_CINECAM);
-        m_cct_player_actor->ar_current_cinecam = m_cct_player_actor->ar_forced_cinecam;
+        m_current_actor->ar_current_cinecam = m_current_actor->ar_forced_cinecam;
     }
     else
     {
@@ -401,7 +371,7 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
         break;
 
     case CAMERA_BEHAVIOR_VEHICLE_SPLINE:
-        if ( (m_cct_player_actor == nullptr) || m_cct_player_actor->ar_num_camera_rails <= 0)
+        if ( (m_current_actor == nullptr) || m_current_actor->ar_num_camera_rails <= 0)
         {
             this->switchToNextBehavior();
             return;
@@ -411,11 +381,11 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
             this->CameraBehaviorVehicleSplineReset();
             this->CameraBehaviorVehicleSplineCreateSpline();
         }
-        m_cct_player_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_SPLINE;
+        m_current_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_SPLINE;
         break;
 
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM:
-        if ((m_cct_player_actor == nullptr) || (m_cct_player_actor->ar_num_cinecams <= 0))
+        if ((m_current_actor == nullptr) || (m_current_actor->ar_num_cinecams <= 0))
         {
             this->switchToNextBehavior();
             return;
@@ -427,22 +397,22 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
 
         App::GetCameraManager()->GetCamera()->setFOVy(Degree(App::gfx_fov_internal->getInt()));
 
-        m_cct_player_actor->prepareInside(true);
+        m_current_actor->prepareInside(true);
 
         if ( RoR::App::GetOverlayWrapper() != nullptr && App::ui_dashboard_cinecam->getBool() )
         {
-            bool visible = m_cct_player_actor->ar_driveable == AIRPLANE && !App::GetGuiManager()->IsGuiHidden();
-            RoR::App::GetOverlayWrapper()->showDashboardOverlays(visible, m_cct_player_actor);
+            bool visible = m_current_actor->ar_driveable == AIRPLANE && !App::GetGuiManager()->IsGuiHidden();
+            RoR::App::GetOverlayWrapper()->showDashboardOverlays(visible, m_current_actor);
         }
 
-        m_cct_player_actor->ar_current_cinecam = std::max(0, m_cct_player_actor->ar_current_cinecam);
-        m_cct_player_actor->NotifyActorCameraChanged();
+        m_current_actor->ar_current_cinecam = std::max(0, m_current_actor->ar_current_cinecam);
+        m_current_actor->NotifyActorCameraChanged();
 
-        m_cct_player_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_CINECAM;
+        m_current_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_CINECAM;
         break;
 
     case CAMERA_BEHAVIOR_VEHICLE:
-        if ( m_cct_player_actor == nullptr )
+        if ( m_current_actor == nullptr )
         {
             this->switchToNextBehavior();
             return;
@@ -451,11 +421,11 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
         {
             this->ResetCurrentBehavior();
         }
-        m_cct_player_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_3rdPERSON;
+        m_current_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_3rdPERSON;
         break;
 
     case CAMERA_BEHAVIOR_CHARACTER:
-        if (m_cct_player_actor != nullptr)
+        if (m_current_actor != nullptr)
         {
             this->switchToNextBehavior();
             return;
@@ -480,11 +450,11 @@ void CameraManager::DeactivateCurrentBehavior()
     }
     else if (m_current_behavior == CAMERA_BEHAVIOR_VEHICLE_CINECAM)
     {
-        if ( m_cct_player_actor != nullptr )
+        if ( m_current_actor != nullptr )
         {
             App::GetCameraManager()->GetCamera()->setFOVy(Degree(App::gfx_fov_external->getInt()));
-            m_cct_player_actor->prepareInside(false);
-            m_cct_player_actor->NotifyActorCameraChanged();
+            m_current_actor->prepareInside(false);
+            m_current_actor->NotifyActorCameraChanged();
         }
     }
 }
@@ -498,16 +468,16 @@ void CameraManager::switchBehavior(CameraBehaviors new_behavior)
 
     this->DeactivateCurrentBehavior();
 
-    if (m_cct_player_actor != nullptr)
+    if (m_current_actor != nullptr)
     {
-        m_cct_player_actor->ar_camera_mode = ACTORCAMERAMODE_EXTERNAL;
+        m_current_actor->ar_camera_mode = ACTORCAMERAMODE_EXTERNAL;
         if (!App::GetGuiManager()->IsGuiHidden())
         {
-            RoR::App::GetOverlayWrapper()->showDashboardOverlays(true, m_cct_player_actor);
+            RoR::App::GetOverlayWrapper()->showDashboardOverlays(true, m_current_actor);
         }
         if (m_current_behavior == CAMERA_BEHAVIOR_VEHICLE_CINECAM)
         {
-            m_cct_player_actor->ar_current_cinecam = CINECAMERAID_INVALID;
+            m_current_actor->ar_current_cinecam = CINECAMERAID_INVALID;
         }
     }
 
@@ -518,12 +488,12 @@ void CameraManager::SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, 
 {
     if (new_behavior == m_current_behavior)
     {
-        this->NotifyContextChange();
+        this->ResetLookatPos();
     }
 
     this->DeactivateCurrentBehavior();
 
-    m_cct_player_actor = new_vehicle;
+    m_current_actor = new_vehicle;
 
     this->ActivateNewBehavior(new_behavior, new_behavior != m_current_behavior);
 }
@@ -621,7 +591,7 @@ bool CameraManager::handleMousePressed()
     }
 }
 
-void CameraManager::NotifyContextChange()
+void CameraManager::ResetLookatPos()
 {
     switch(m_current_behavior)
     {
@@ -642,7 +612,7 @@ void CameraManager::NotifyVehicleChanged(ActorPtr new_vehicle)
     // Getting out of vehicle
     if (new_vehicle == nullptr)
     {
-        m_cct_player_actor = nullptr;
+        m_current_actor = nullptr;
         if (this->m_current_behavior != CAMERA_BEHAVIOR_FIXED && this->m_current_behavior != CAMERA_BEHAVIOR_STATIC &&
                 this->m_current_behavior != CAMERA_BEHAVIOR_FREE)
         {
@@ -714,24 +684,24 @@ void CameraManager::UpdateCameraBehaviorStatic()
     float radius = 3.0f;
     float speed = 0.0f;
 
-    if (m_cct_player_actor)
+    if (m_current_actor)
     {
-        if (m_cct_player_actor->isBeingReset())
+        if (m_current_actor->isBeingReset())
         {
-            m_staticcam_force_update |= m_cct_player_actor->getPosition().distance(m_staticcam_look_at) > 100.0f;
+            m_staticcam_force_update |= m_current_actor->getPosition().distance(m_staticcam_look_at) > 100.0f;
         }
-        m_staticcam_look_at = m_cct_player_actor->getPosition();
-        velocity = m_cct_player_actor->ar_nodes[0].Velocity * App::GetGameContext()->GetActorManager()->GetSimulationSpeed();
+        m_staticcam_look_at = m_current_actor->getPosition();
+        velocity = m_current_actor->ar_nodes[0].Velocity * App::GetGameContext()->GetActorManager()->GetSimulationSpeed();
         if (App::GetGameContext()->GetPlayerActor()->ar_driveable != AIRPLANE)
         {
-            radius = m_cct_player_actor->getMinCameraRadius();
+            radius = m_current_actor->getMinCameraRadius();
         }
         angle = (m_staticcam_look_at - m_staticcam_position).angleBetween(velocity);
         speed = velocity.normalise();
 
-        if (m_cct_player_actor->ar_state == ActorState::LOCAL_REPLAY)
+        if (m_current_actor->ar_state == ActorState::LOCAL_REPLAY)
         {
-            speed *= m_cct_player_actor->getReplay()->getPrecision();
+            speed *= m_current_actor->getReplay()->getPrecision();
         }
     }
     else
@@ -938,7 +908,7 @@ void CameraManager::CameraBehaviorOrbitUpdate()
     }
     else
     {
-        if (m_cct_player_actor && m_cct_player_actor->ar_state == ActorState::LOCAL_REPLAY && camDisplacement != Vector3::ZERO)
+        if (m_current_actor && m_current_actor->ar_state == ActorState::LOCAL_REPLAY && camDisplacement != Vector3::ZERO)
             this->GetCameraNode()->setPosition(desiredPosition);
         else
             this->GetCameraNode()->setPosition(camPosition);
@@ -1066,14 +1036,14 @@ void CameraManager::UpdateCameraBehaviorFixed()
 {
 	if (App::gfx_fixed_cam_tracking->getBool())
     {
-        Vector3 look_at = m_cct_player_actor ? m_cct_player_actor->getPosition() : App::GetGameContext()->GetPlayerCharacter()->getPosition();
+        Vector3 look_at = m_current_actor ? m_current_actor->getPosition() : App::GetGameContext()->GetPlayerCharacter()->getPosition();
         App::GetCameraManager()->GetCameraNode()->lookAt(look_at, Ogre::Node::TS_WORLD);
     }
 }
 
 void CameraManager::UpdateCameraBehaviorVehicle()
 {
-	Vector3 dir = m_cct_player_actor->getDirection();
+	Vector3 dir = m_current_actor->getDirection();
 
 	m_cam_target_direction = -atan2(dir.dotProduct(Vector3::UNIT_X), dir.dotProduct(-Vector3::UNIT_Z));
 	m_cam_target_pitch     = 0.0f;
@@ -1085,9 +1055,9 @@ void CameraManager::UpdateCameraBehaviorVehicle()
 
 	m_cam_ratio = 1.0f / (m_cct_dt * 4.0f);
 
-	m_cam_dist_min = std::min(m_cct_player_actor->getMinimalCameraRadius() * 2.0f, 33.0f);
+	m_cam_dist_min = std::min(m_current_actor->getMinimalCameraRadius() * 2.0f, 33.0f);
 
-	m_cam_look_at = m_cct_player_actor->getPosition();
+	m_cam_look_at = m_current_actor->getPosition();
 
 	CameraManager::CameraBehaviorOrbitUpdate();
 }
@@ -1096,7 +1066,7 @@ void CameraManager::CameraBehaviorVehicleReset()
 {
 	CameraManager::CameraBehaviorOrbitReset();
 	m_cam_rot_y = 0.35f;
-	m_cam_dist_min = std::min(m_cct_player_actor->getMinimalCameraRadius() * 2.0f, 33.0f);
+	m_cam_dist_min = std::min(m_current_actor->getMinimalCameraRadius() * 2.0f, 33.0f);
 	m_cam_dist = m_cam_dist_min * 1.5f + 2.0f;
 }
 
@@ -1108,10 +1078,10 @@ bool CameraManager::CameraBehaviorVehicleMousePressed()
 
 	if ( ms.buttonDown(OIS::MB_Middle) && RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) )
 	{
-		if ( m_cct_player_actor && m_cct_player_actor->ar_custom_camera_node != NODENUM_INVALID)
+		if ( m_current_actor && m_current_actor->ar_custom_camera_node != NODENUM_INVALID)
 		{
 			// Calculate new camera distance
-			Vector3 lookAt = m_cct_player_actor->ar_nodes[m_cct_player_actor->ar_custom_camera_node].AbsPosition;
+			Vector3 lookAt = m_current_actor->ar_nodes[m_current_actor->ar_custom_camera_node].AbsPosition;
 			m_cam_dist = 2.0f * this->GetCameraNode()->getPosition().distance(lookAt);
 
 			// Calculate new camera pitch
@@ -1119,7 +1089,7 @@ bool CameraManager::CameraBehaviorVehicleMousePressed()
 			m_cam_rot_y = asin(camDir.y);
 
 			// Calculate new camera yaw
-			Vector3 dir = -m_cct_player_actor->getDirection();
+			Vector3 dir = -m_current_actor->getDirection();
 			Quaternion rotX = dir.getRotationTo(camDir, Vector3::UNIT_Y);
 			m_cam_rot_x = rotX.getYaw();
 
@@ -1143,13 +1113,13 @@ bool CameraManager::CameraBehaviorVehicleMousePressed()
 
 void CameraManager::CameraBehaviorVehicleSplineUpdate()
 {
-    if (m_cct_player_actor->ar_num_camera_rails <= 0)
+    if (m_current_actor->ar_num_camera_rails <= 0)
     {
         this->switchToNextBehavior();
         return;
     }
 
-    Vector3 dir = m_cct_player_actor->getDirection();
+    Vector3 dir = m_current_actor->getDirection();
 
     m_cam_target_pitch = 0.0f;
 
@@ -1158,7 +1128,7 @@ void CameraManager::CameraBehaviorVehicleSplineUpdate()
         m_cam_target_pitch = -asin(dir.dotProduct(Vector3::UNIT_Y));
     }
 
-    if (m_cct_player_actor->ar_linked_actors.size() != m_splinecam_num_linked_beams)
+    if (m_current_actor->ar_linked_actors.size() != m_splinecam_num_linked_beams)
     {
         this->CameraBehaviorVehicleSplineCreateSpline();
     }
@@ -1182,7 +1152,7 @@ void CameraManager::CameraBehaviorVehicleSplineUpdate()
 
     if (m_splinecam_auto_tracking)
     {
-        Vector3 centerDir = m_cct_player_actor->getPosition() - m_cam_look_at;
+        Vector3 centerDir = m_current_actor->getPosition() - m_cam_look_at;
         if (centerDir.length() > 1.0f)
         {
             centerDir.normalise();
@@ -1260,7 +1230,7 @@ void CameraManager::CameraBehaviorVehicleSplineReset()
 {
     CameraManager::CameraBehaviorOrbitReset();
 
-    m_cam_dist = std::min(m_cct_player_actor->getMinimalCameraRadius() * 2.0f, 33.0f);
+    m_cam_dist = std::min(m_current_actor->getMinimalCameraRadius() * 2.0f, 33.0f);
 
     m_splinecam_spline_pos = 0.5f;
 }
@@ -1273,12 +1243,12 @@ void CameraManager::CameraBehaviorVehicleSplineCreateSpline()
     m_splinecam_spline->clear();
     m_splinecam_spline_nodes.clear();
 
-    for (int i = 0; i < m_cct_player_actor->ar_num_camera_rails; i++)
+    for (int i = 0; i < m_current_actor->ar_num_camera_rails; i++)
     {
-        m_splinecam_spline_nodes.push_back(&m_cct_player_actor->ar_nodes[m_cct_player_actor->ar_camera_rail[i]]);
+        m_splinecam_spline_nodes.push_back(&m_current_actor->ar_nodes[m_current_actor->ar_camera_rail[i]]);
     }
 
-    auto linkedBeams = m_cct_player_actor->ar_linked_actors;
+    auto linkedBeams = m_current_actor->ar_linked_actors;
 
     m_splinecam_num_linked_beams = static_cast<int>(linkedBeams.size());
 

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -413,7 +413,7 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
             this->CameraBehaviorVehicleSplineReset();
             this->CameraBehaviorVehicleSplineCreateSpline();
         }
-        m_cct_player_actor->ar_camera_context.behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_SPLINE;
+        m_cct_player_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_SPLINE;
         break;
 
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM:
@@ -440,7 +440,7 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
         m_cct_player_actor->ar_current_cinecam = std::max(0, m_cct_player_actor->ar_current_cinecam);
         m_cct_player_actor->NotifyActorCameraChanged();
 
-        m_cct_player_actor->ar_camera_context.behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_CINECAM;
+        m_cct_player_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_CINECAM;
         break;
 
     case CAMERA_BEHAVIOR_VEHICLE:
@@ -453,7 +453,7 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
         {
             this->ResetCurrentBehavior();
         }
-        m_cct_player_actor->ar_camera_context.behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_3rdPERSON;
+        m_cct_player_actor->ar_camera_mode = ACTORCAMERAMODE_VEHICLE_3rdPERSON;
         break;
 
     case CAMERA_BEHAVIOR_CHARACTER:
@@ -502,7 +502,7 @@ void CameraManager::switchBehavior(CameraBehaviors new_behavior)
 
     if (m_cct_player_actor != nullptr)
     {
-        m_cct_player_actor->ar_camera_context.behavior = RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_EXTERNAL;
+        m_cct_player_actor->ar_camera_mode = ACTORCAMERAMODE_EXTERNAL;
         if (!App::GetGuiManager()->IsGuiHidden())
         {
             RoR::App::GetOverlayWrapper()->showDashboardOverlays(true, m_cct_player_actor);
@@ -658,17 +658,17 @@ void CameraManager::NotifyVehicleChanged(ActorPtr new_vehicle)
             this->m_current_behavior != CAMERA_BEHAVIOR_FREE)
     {
         // Change camera
-        switch (new_vehicle->ar_camera_context.behavior)
+        switch (new_vehicle->ar_camera_mode)
         {
-        case RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_3rdPERSON:
+        case ACTORCAMERAMODE_VEHICLE_3rdPERSON:
             this->SwitchBehaviorOnVehicleChange(CAMERA_BEHAVIOR_VEHICLE, new_vehicle);
             break;
 
-        case RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_SPLINE:
+        case ACTORCAMERAMODE_VEHICLE_SPLINE:
             this->SwitchBehaviorOnVehicleChange(CAMERA_BEHAVIOR_VEHICLE_SPLINE, new_vehicle);
             break;
 
-        case RoR::PerVehicleCameraContext::CAMCTX_BEHAVIOR_VEHICLE_CINECAM:
+        case ACTORCAMERAMODE_VEHICLE_CINECAM:
             this->SwitchBehaviorOnVehicleChange(CAMERA_BEHAVIOR_VEHICLE_CINECAM, new_vehicle);
             break;
 

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -84,7 +84,6 @@ CameraManager::CameraManager() :
       m_current_behavior(CAMERA_BEHAVIOR_INVALID)
     , m_cct_dt(0.0f)
     , m_cct_trans_scale(1.0f)
-    , m_cct_sim_speed(1.0f)
     , m_cam_before_toggled(CAMERA_BEHAVIOR_INVALID)
     , m_prev_toggled_cam(CAMERA_BEHAVIOR_INVALID)
     , m_charactercam_is_3rdperson(true)
@@ -248,7 +247,6 @@ void CameraManager::UpdateInputEvents(float dt) // Called every frame
     }
 
     m_cct_player_actor = App::GetGameContext()->GetPlayerActor();
-    m_cct_sim_speed    = App::GetGameContext()->GetActorManager()->GetSimulationSpeed();
     m_cct_dt           = dt;
     m_cct_rot_scale    = Degree(TRANS_SPEED * dt);
     m_cct_trans_scale  = ROTATE_SPEED * dt;
@@ -723,7 +721,7 @@ void CameraManager::UpdateCameraBehaviorStatic()
             m_staticcam_force_update |= m_cct_player_actor->getPosition().distance(m_staticcam_look_at) > 100.0f;
         }
         m_staticcam_look_at = m_cct_player_actor->getPosition();
-        velocity = m_cct_player_actor->ar_nodes[0].Velocity * m_cct_sim_speed;
+        velocity = m_cct_player_actor->ar_nodes[0].Velocity * App::GetGameContext()->GetActorManager()->GetSimulationSpeed();
         if (App::GetGameContext()->GetPlayerActor()->ar_driveable != AIRPLANE)
         {
             radius = m_cct_player_actor->getMinCameraRadius();

--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -46,8 +46,8 @@ static const Ogre::Vector3 CHARACTERCAM_OFFSET_1ST_PERSON(0.0f, 1.82f, 0.0f);
 static const Ogre::Vector3 CHARACTERCAM_OFFSET_3RD_PERSON(0.0f, 1.1f, 0.0f);
 static const int           SPLINECAM_DRAW_RESOLUTION = 200;
 static const int           DEFAULT_INTERNAL_CAM_PITCH = -15;
-static const float         TRANS_SPEED = 50.f;
-static const float         ROTATE_SPEED = 100.f;
+static const float         TRANS_SPEED = 25.f;
+static const float         ROTATE_SPEED = 45.f;
 
 bool intersectsTerrain(Vector3 a, Vector3 b) // internal helper
 {
@@ -157,6 +157,8 @@ void CameraManager::UpdateCurrentBehavior(float dt)
     switch(m_current_behavior)
     {
     case CAMERA_BEHAVIOR_CHARACTER: {
+        if (m_mouse_moved)
+            this->CameraBehaviorCharacterMouseMoved();
         if (!App::GetGameContext()->GetPlayerCharacter())
             return;
         m_cam_target_direction = -App::GetGameContext()->GetPlayerCharacter()->getRotation() - Radian(Math::HALF_PI);
@@ -168,13 +170,33 @@ void CameraManager::UpdateCurrentBehavior(float dt)
     }
 
     case CAMERA_BEHAVIOR_STATIC:
+        if (m_mouse_moved)
+            this->CameraBehaviorStaticMouseMoved();
         m_staticcam_fov_exponent = App::gfx_static_cam_fov_exp->getFloat();
         this->UpdateCameraBehaviorStatic(dt);
         return;
 
-    case CAMERA_BEHAVIOR_VEHICLE:         this->UpdateCameraBehaviorVehicle(dt);  return;
-    case CAMERA_BEHAVIOR_VEHICLE_SPLINE:  this->CameraBehaviorVehicleSplineUpdate(dt);  return;
+    case CAMERA_BEHAVIOR_VEHICLE:
+        if (m_mouse_pressed)
+            this->CameraBehaviorVehicleMousePressed();
+        if (m_mouse_pressed)
+            this->CameraBehaviorVehicleMousePressed();
+        this->UpdateCameraBehaviorVehicle(dt);
+        return;
+
+    case CAMERA_BEHAVIOR_VEHICLE_SPLINE:
+        if (m_mouse_moved)
+            this->CameraBehaviorVehicleSplineMouseMoved();
+        if (m_mouse_pressed)
+            this->CameraBehaviorVehicleMousePressed();
+        this->CameraBehaviorVehicleSplineUpdate(dt);
+        return;
+
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM: {
+        if (m_mouse_moved)
+            this->CameraBehaviorOrbitMouseMoved();
+        if (m_mouse_pressed)
+            this->CameraBehaviorVehicleMousePressed();
         CameraManager::CameraBehaviorOrbitUpdate(dt);
 
         const NodeNum_t pos_node  = m_current_actor->ar_camera_node_pos [m_current_actor->ar_current_cinecam];
@@ -200,8 +222,15 @@ void CameraManager::UpdateCurrentBehavior(float dt)
         this->GetCameraNode()->setOrientation(orientation);
         return;
     }
-    case CAMERA_BEHAVIOR_FREE:            this->UpdateCameraBehaviorFree(dt); return;
-    case CAMERA_BEHAVIOR_FIXED:           this->UpdateCameraBehaviorFixed(dt); return;
+    case CAMERA_BEHAVIOR_FREE:
+        this->CameraBehaviorFreeMouseMoved(dt); // Always update to make smoothing work.
+        this->UpdateCameraBehaviorFree(dt);
+        return;
+
+    case CAMERA_BEHAVIOR_FIXED:
+        this->UpdateCameraBehaviorFixed(dt);
+        return;
+
     case CAMERA_BEHAVIOR_ISOMETRIC:       return;
     case CAMERA_BEHAVIOR_INVALID:         return;
     default:                              return;
@@ -289,6 +318,9 @@ void CameraManager::UpdateInputEvents(float dt) // Called every frame
             App::GetConsole()->putMessage(Console::CONSOLE_MSGTYPE_INFO, Console::CONSOLE_SYSTEM_NOTICE, msg.ToCStr());
         }
     }
+
+    m_mouse_moved = false;
+    m_mouse_pressed = false;
 }
 
 void CameraManager::switchToNextBehavior()
@@ -441,18 +473,27 @@ void CameraManager::ActivateNewBehavior(CameraBehaviors new_behavior, bool reset
 
 void CameraManager::DeactivateCurrentBehavior()
 {
-    if (m_current_behavior == CAMERA_BEHAVIOR_STATIC)
+    switch (m_current_behavior)
     {
+    case CAMERA_BEHAVIOR_STATIC:
         App::GetCameraManager()->GetCamera()->setFOVy(m_staticcam_previous_fov);
-    }
-    else if (m_current_behavior == CAMERA_BEHAVIOR_VEHICLE_CINECAM)
-    {
+        return;
+
+    case CAMERA_BEHAVIOR_VEHICLE_CINECAM:
         if ( m_current_actor != nullptr )
         {
             App::GetCameraManager()->GetCamera()->setFOVy(Degree(App::gfx_fov_external->getInt()));
             m_current_actor->prepareInside(false);
             m_current_actor->NotifyActorCameraChanged();
         }
+        return;
+
+    case CAMERA_BEHAVIOR_FREE:
+        m_freecam_smooth_mousevec = Ogre::Vector2::ZERO;
+        return;
+
+    default:
+        return;
     }
 }
 
@@ -507,7 +548,6 @@ void CameraManager::ResetAllBehaviors()
 
 bool CameraManager::handleMouseMoved()
 {
-
     if (App::sim_state->getEnum<SimState>() == SimState::PAUSED)
     {
         return true; // Do nothing when paused
@@ -517,49 +557,70 @@ bool CameraManager::handleMouseMoved()
     //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
     const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
 
+    // Processing the mouse motion is deferred until 'dt' is known.
+    // For now, we just evaluate if it should be captured.
+    m_mouse_moved = true;
     switch(m_current_behavior)
     {
-    case CAMERA_BEHAVIOR_CHARACTER: {
-        if (!App::GetGameContext()->GetPlayerCharacter())
-            return false;
-        if (!m_charactercam_is_3rdperson)
-        {
-            Radian angle = App::GetGameContext()->GetPlayerCharacter()->getRotation();
-
-            m_cam_rot_y += Degree(ms.Y.rel * 0.13f);
-            angle += Degree(ms.X.rel * 0.13f);
-
-            m_cam_rot_y = Radian(std::min(+Math::HALF_PI * 0.65f, m_cam_rot_y.valueRadians()));
-            m_cam_rot_y = Radian(std::max(m_cam_rot_y.valueRadians(), -Math::HALF_PI * 0.9f));
-
-            App::GetGameContext()->GetPlayerCharacter()->setRotation(angle);
-
-            RoR::App::GetGuiManager()->SetMouseCursorVisibility(RoR::GUIManager::MouseCursorVisibility::HIDDEN);
-
-            return true;
-        }
-
-        return CameraManager::CameraBehaviorOrbitMouseMoved();
-    }
-    case CAMERA_BEHAVIOR_STATIC:          return CameraBehaviorStaticMouseMoved();
-    case CAMERA_BEHAVIOR_VEHICLE:         return CameraBehaviorOrbitMouseMoved();
-    case CAMERA_BEHAVIOR_VEHICLE_SPLINE:  return this->CameraBehaviorVehicleSplineMouseMoved();
-    case CAMERA_BEHAVIOR_VEHICLE_CINECAM: return CameraBehaviorOrbitMouseMoved();
-    case CAMERA_BEHAVIOR_FREE: {
-
-        App::GetCameraManager()->GetCameraNode()->yaw(Degree(-ms.X.rel * 0.13f), Ogre::Node::TS_WORLD);
-        App::GetCameraManager()->GetCameraNode()->pitch(Degree(-ms.Y.rel * 0.13f));
-
-        App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
-
-        return true;
-    }
-
+    case CAMERA_BEHAVIOR_CHARACTER:       return App::GetGameContext()->GetPlayerCharacter() && (!m_charactercam_is_3rdperson || ms.buttonDown(OIS::MB_Right));
+    case CAMERA_BEHAVIOR_STATIC:          return ms.buttonDown(OIS::MB_Right);
+    case CAMERA_BEHAVIOR_VEHICLE:         return ms.buttonDown(OIS::MB_Right);
+    case CAMERA_BEHAVIOR_VEHICLE_SPLINE:  return (RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LCONTROL) && ms.buttonDown(OIS::MB_Right)) || ms.buttonDown(OIS::MB_Right);
+    case CAMERA_BEHAVIOR_VEHICLE_CINECAM: return ms.buttonDown(OIS::MB_Right);
+    case CAMERA_BEHAVIOR_FREE:            return true;
     case CAMERA_BEHAVIOR_FIXED:           return false;
     case CAMERA_BEHAVIOR_ISOMETRIC:       return false;
     case CAMERA_BEHAVIOR_INVALID:         return false;
     default:                              return false;
     }
+}
+
+bool CameraManager::CameraBehaviorCharacterMouseMoved()
+{
+    if (!App::GetGameContext()->GetPlayerCharacter())
+        return false;
+    if (!m_charactercam_is_3rdperson)
+    {
+        // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
+        //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
+        const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
+
+        Radian angle = App::GetGameContext()->GetPlayerCharacter()->getRotation();
+
+        m_cam_rot_y += Degree(ms.Y.rel * 0.13f);
+        angle += Degree(ms.X.rel * 0.13f);
+
+        m_cam_rot_y = Radian(std::min(+Math::HALF_PI * 0.65f, m_cam_rot_y.valueRadians()));
+        m_cam_rot_y = Radian(std::max(m_cam_rot_y.valueRadians(), -Math::HALF_PI * 0.9f));
+
+        App::GetGameContext()->GetPlayerCharacter()->setRotation(angle);
+
+        RoR::App::GetGuiManager()->SetMouseCursorVisibility(RoR::GUIManager::MouseCursorVisibility::HIDDEN);
+
+        return true;
+    }
+
+    return CameraManager::CameraBehaviorOrbitMouseMoved();
+}
+
+bool CameraManager::CameraBehaviorFreeMouseMoved(float dt)
+{
+    // IMPORTANT: get mouse button state from InputEngine, not from OIS directly
+    //  - that state may be dirty, see commentary in `InputEngine::getMouseState()`
+    const OIS::MouseState ms = App::GetInputEngine()->getMouseState();
+    Ogre::SceneNode* cam_node = App::GetCameraManager()->GetCameraNode();
+    const float cam_speed = App::io_freecam_mouse_speed->getFloat();
+    const float cam_smooth = App::io_freecam_mouse_smooth->getFloat();
+
+    const Ogre::Vector2 cur_mousevec(-ms.X.rel * cam_speed * dt, -ms.Y.rel * cam_speed * dt);
+    m_freecam_smooth_mousevec = cur_mousevec * (1.f - cam_smooth) + m_freecam_smooth_mousevec * cam_smooth;
+
+    cam_node->yaw(Degree(m_freecam_smooth_mousevec.x), Ogre::Node::TS_WORLD);
+    cam_node->pitch(Degree(m_freecam_smooth_mousevec.y));
+
+    App::GetGuiManager()->SetMouseCursorVisibility(GUIManager::MouseCursorVisibility::HIDDEN);
+
+    return true;
 }
 
 bool CameraManager::handleMousePressed()
@@ -573,13 +634,16 @@ bool CameraManager::handleMousePressed()
         ResetCurrentBehavior();
     }
 
+    // Processing the mouse button press is deferred until 'dt' is known.
+    // For now, we just evaluate if it should be captured.
+    m_mouse_pressed = true;
     switch(m_current_behavior)
     {
     case CAMERA_BEHAVIOR_CHARACTER:       return false;
     case CAMERA_BEHAVIOR_STATIC:          return false;
-    case CAMERA_BEHAVIOR_VEHICLE:         return this->CameraBehaviorVehicleMousePressed();
-    case CAMERA_BEHAVIOR_VEHICLE_SPLINE:  return this->CameraBehaviorVehicleMousePressed();
-    case CAMERA_BEHAVIOR_VEHICLE_CINECAM: return this->CameraBehaviorVehicleMousePressed();
+    case CAMERA_BEHAVIOR_VEHICLE:         return ms.buttonDown(OIS::MB_Middle) && RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT);
+    case CAMERA_BEHAVIOR_VEHICLE_SPLINE:  return ms.buttonDown(OIS::MB_Middle) && RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT);
+    case CAMERA_BEHAVIOR_VEHICLE_CINECAM: return ms.buttonDown(OIS::MB_Middle) && RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT);
     case CAMERA_BEHAVIOR_FREE:            return false;
     case CAMERA_BEHAVIOR_FIXED:           return false;
     case CAMERA_BEHAVIOR_ISOMETRIC:       return false;

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -92,7 +92,7 @@ protected:
     void CameraBehaviorOrbitUpdate(float dt);
 
     // Character cam
-    bool CameraBehaviorCharacterMouseMoved();
+    bool CameraBehaviorCharacterMouseMoved(float dt);
 
     // Static cam
     void UpdateCameraBehaviorStatic(float dt);
@@ -120,6 +120,7 @@ protected:
 
     // Internal helpers
     void CreateCameraNode();
+    void UpdateMouseLook(float dt);
 
     Ogre::Camera*        m_camera {nullptr};
     Ogre::SceneNode*     m_camera_node {nullptr};
@@ -134,6 +135,8 @@ protected:
     // Note the actual mouse data are buffered by `InputEngine`.
     bool                 m_mouse_moved = false;
     bool                 m_mouse_pressed = false;
+    // Common mouse smoothing for freecam + 1st person charactercam.
+    Ogre::Vector2        m_mouselook_smooth_vec {Ogre::Vector2::ZERO};
 
     // `CameraBehaviorOrbit` attributes
     Ogre::Radian         m_cam_rot_x {0.f};
@@ -171,8 +174,6 @@ protected:
     std::deque<node_t*>  m_splinecam_spline_nodes;
     unsigned int         m_splinecam_num_linked_beams {0};
 
-    // Free camera attributes
-    Ogre::Vector2       m_freecam_smooth_mousevec {Ogre::Vector2::ZERO};
 };
 
 /// @} // addtogroup Camera

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -91,12 +91,16 @@ protected:
     bool CameraBehaviorOrbitMouseMoved();
     void CameraBehaviorOrbitUpdate(float dt);
 
+    // Character cam
+    bool CameraBehaviorCharacterMouseMoved();
+
     // Static cam
     void UpdateCameraBehaviorStatic(float dt);
     bool CameraBehaviorStaticMouseMoved();
 
     // Free cam
     void UpdateCameraBehaviorFree(float dt);
+    bool CameraBehaviorFreeMouseMoved(float dt);
 
     // Free-fix cam
     void UpdateCameraBehaviorFixed(float dt);
@@ -125,6 +129,11 @@ protected:
 
     CameraBehaviors      m_cam_before_toggled {CAMERA_BEHAVIOR_INVALID};  //!< Toggled modes (FREE, FREEFIX) remember original state.
     CameraBehaviors      m_prev_toggled_cam {CAMERA_BEHAVIOR_INVALID};    //!< Switching toggled modes (FREE, FREEFIX) keeps 1-slot history.
+
+    // We defer processing mouse input (received via listener) until we have 'dt' (received via `UpdateInputEvents()`).
+    // Note the actual mouse data are buffered by `InputEngine`.
+    bool                 m_mouse_moved = false;
+    bool                 m_mouse_pressed = false;
 
     // `CameraBehaviorOrbit` attributes
     Ogre::Radian         m_cam_rot_x {0.f};
@@ -161,6 +170,9 @@ protected:
     bool                 m_splinecam_auto_tracking {false};
     std::deque<node_t*>  m_splinecam_spline_nodes;
     unsigned int         m_splinecam_num_linked_beams {0};
+
+    // Free camera attributes
+    Ogre::Vector2       m_freecam_smooth_mousevec {Ogre::Vector2::ZERO};
 };
 
 /// @} // addtogroup Camera

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -82,32 +82,32 @@ protected:
     void SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, ActorPtr new_vehicle);
     void ToggleCameraBehavior(CameraBehaviors new_behavior); //!< Only accepts FREE and FREEFIX modes
     void ActivateNewBehavior(CameraBehaviors new_behavior, bool reset);
-    void UpdateCurrentBehavior();
+    void UpdateCurrentBehavior(float dt);
     void ResetCurrentBehavior();
     void DeactivateCurrentBehavior();
 
     // Orbit cam (helper)
     void CameraBehaviorOrbitReset();
     bool CameraBehaviorOrbitMouseMoved();
-    void CameraBehaviorOrbitUpdate();
+    void CameraBehaviorOrbitUpdate(float dt);
 
     // Static cam
-    void UpdateCameraBehaviorStatic();
+    void UpdateCameraBehaviorStatic(float dt);
     bool CameraBehaviorStaticMouseMoved();
 
     // Free cam
-    void UpdateCameraBehaviorFree();
+    void UpdateCameraBehaviorFree(float dt);
 
     // Free-fix cam
-    void UpdateCameraBehaviorFixed();
+    void UpdateCameraBehaviorFixed(float dt);
 
     // Vehicle cam
-    void UpdateCameraBehaviorVehicle();
+    void UpdateCameraBehaviorVehicle(float dt);
     void CameraBehaviorVehicleReset();
     bool CameraBehaviorVehicleMousePressed();
 
     // Vehicle-spline cam
-    void CameraBehaviorVehicleSplineUpdate();
+    void CameraBehaviorVehicleSplineUpdate(float dt);
     bool CameraBehaviorVehicleSplineMouseMoved();
     void CameraBehaviorVehicleSplineReset();
     void CameraBehaviorVehicleSplineCreateSpline();
@@ -125,11 +125,8 @@ protected:
 
     CameraBehaviors      m_cam_before_toggled {CAMERA_BEHAVIOR_INVALID};  //!< Toggled modes (FREE, FREEFIX) remember original state.
     CameraBehaviors      m_prev_toggled_cam {CAMERA_BEHAVIOR_INVALID};    //!< Switching toggled modes (FREE, FREEFIX) keeps 1-slot history.
-    // Old `CameraContext`
-    Ogre::Degree         m_cct_rot_scale;
-    Ogre::Real           m_cct_dt;
-    Ogre::Real           m_cct_trans_scale;
-    // Old `CameraBehaviorOrbit` attributes
+
+    // `CameraBehaviorOrbit` attributes
     Ogre::Radian         m_cam_rot_x {0.f};
     Ogre::Radian         m_cam_rot_y {0.3f};
     Ogre::Radian         m_cam_target_direction {0.f};
@@ -143,6 +140,7 @@ protected:
     Ogre::Vector3        m_cam_look_at_last {Ogre::Vector3::ZERO};
     Ogre::Vector3        m_cam_look_at_smooth {Ogre::Vector3::ZERO};
     Ogre::Vector3        m_cam_look_at_smooth_last {Ogre::Vector3::ZERO};
+
     // Static cam attributes
     bool                 m_staticcam_force_update {false};
     float                m_staticcam_fov_exponent {1.f};
@@ -150,8 +148,10 @@ protected:
     Ogre::Vector3        m_staticcam_look_at {Ogre::Vector3::ZERO};
     Ogre::Vector3        m_staticcam_position {Ogre::Vector3::ZERO};
     Ogre::Timer          m_staticcam_update_timer;
+
     // Character cam attributes
     bool                 m_charactercam_is_3rdperson {true};
+
     // Spline cam attributes
     Ogre::ManualObject*  m_splinecam_mo {nullptr};
     Ogre::SimpleSpline*  m_splinecam_spline {new Ogre::SimpleSpline()};

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -63,12 +63,8 @@ public:
     Ogre::SceneNode*  GetCameraNode()             { return m_camera_node; }
     Ogre::Camera*     GetCamera()                 { return m_camera; }
 
-    void NotifyContextChange();
+    void ResetLookatPos();
     void NotifyVehicleChanged(ActorPtr new_vehicle);
-
-    void CameraBehaviorOrbitReset();
-    bool CameraBehaviorOrbitMouseMoved();
-    void CameraBehaviorOrbitUpdate();
 
     bool handleMouseMoved();
     bool handleMousePressed();
@@ -81,6 +77,7 @@ public:
 
 protected:
 
+    // Camera behavior management
     void switchBehavior(CameraBehaviors new_behavior);
     void SwitchBehaviorOnVehicleChange(CameraBehaviors new_behavior, ActorPtr new_vehicle);
     void ToggleCameraBehavior(CameraBehaviors new_behavior); //!< Only accepts FREE and FREEFIX modes
@@ -88,64 +85,82 @@ protected:
     void UpdateCurrentBehavior();
     void ResetCurrentBehavior();
     void DeactivateCurrentBehavior();
+
+    // Orbit cam (helper)
+    void CameraBehaviorOrbitReset();
+    bool CameraBehaviorOrbitMouseMoved();
+    void CameraBehaviorOrbitUpdate();
+
+    // Static cam
     void UpdateCameraBehaviorStatic();
     bool CameraBehaviorStaticMouseMoved();
+
+    // Free cam
     void UpdateCameraBehaviorFree();
+
+    // Free-fix cam
     void UpdateCameraBehaviorFixed();
+
+    // Vehicle cam
     void UpdateCameraBehaviorVehicle();
     void CameraBehaviorVehicleReset();
     bool CameraBehaviorVehicleMousePressed();
+
+    // Vehicle-spline cam
     void CameraBehaviorVehicleSplineUpdate();
     bool CameraBehaviorVehicleSplineMouseMoved();
     void CameraBehaviorVehicleSplineReset();
     void CameraBehaviorVehicleSplineCreateSpline();
     void CameraBehaviorVehicleSplineUpdateSpline();
     void CameraBehaviorVehicleSplineUpdateSplineDisplay();
+
+    // Internal helpers
     void CreateCameraNode();
 
-    Ogre::Camera*        m_camera;
-    Ogre::SceneNode*     m_camera_node;
+    Ogre::Camera*        m_camera {nullptr};
+    Ogre::SceneNode*     m_camera_node {nullptr};
 
-    CameraBehaviors      m_current_behavior;
-    CameraBehaviors      m_cam_before_toggled;  //!< Toggled modes (FREE, FREEFIX) remember original state.
-    CameraBehaviors      m_prev_toggled_cam;    //!< Switching toggled modes (FREE, FREEFIX) keeps 1-slot history.
+    CameraBehaviors      m_current_behavior {CAMERA_BEHAVIOR_INVALID};
+    ActorPtr             m_current_actor; //!< Kept around for the camera-switching process (deactivate old/activate new).
+
+    CameraBehaviors      m_cam_before_toggled {CAMERA_BEHAVIOR_INVALID};  //!< Toggled modes (FREE, FREEFIX) remember original state.
+    CameraBehaviors      m_prev_toggled_cam {CAMERA_BEHAVIOR_INVALID};    //!< Switching toggled modes (FREE, FREEFIX) keeps 1-slot history.
     // Old `CameraContext`
-    ActorPtr             m_cct_player_actor; // TODO: duplicates `GameContext::m_player_actor`
     Ogre::Degree         m_cct_rot_scale;
     Ogre::Real           m_cct_dt;
     Ogre::Real           m_cct_trans_scale;
     // Old `CameraBehaviorOrbit` attributes
-    Ogre::Radian         m_cam_rot_x;
-    Ogre::Radian         m_cam_rot_y;
-    Ogre::Radian         m_cam_target_direction;
-    Ogre::Radian         m_cam_target_pitch;
-    float                m_cam_dist;
-    float                m_cam_dist_min;
-    float                m_cam_dist_max;
-    float                m_cam_ratio;
-    Ogre::Vector3        m_cam_look_at;
-    bool                 m_cam_limit_movement;
-    Ogre::Vector3        m_cam_look_at_last;
-    Ogre::Vector3        m_cam_look_at_smooth;
-    Ogre::Vector3        m_cam_look_at_smooth_last;
+    Ogre::Radian         m_cam_rot_x {0.f};
+    Ogre::Radian         m_cam_rot_y {0.3f};
+    Ogre::Radian         m_cam_target_direction {0.f};
+    Ogre::Radian         m_cam_target_pitch {0.f};
+    float                m_cam_dist {5.f};
+    float                m_cam_dist_min {0.f};
+    float                m_cam_dist_max {0.f};
+    float                m_cam_ratio {11.f};
+    Ogre::Vector3        m_cam_look_at {Ogre::Vector3::ZERO};
+    bool                 m_cam_limit_movement {true};
+    Ogre::Vector3        m_cam_look_at_last {Ogre::Vector3::ZERO};
+    Ogre::Vector3        m_cam_look_at_smooth {Ogre::Vector3::ZERO};
+    Ogre::Vector3        m_cam_look_at_smooth_last {Ogre::Vector3::ZERO};
     // Static cam attributes
-    bool                 m_staticcam_force_update;
-    float                m_staticcam_fov_exponent;
-    Ogre::Radian         m_staticcam_previous_fov;
-    Ogre::Vector3        m_staticcam_look_at;
-    Ogre::Vector3        m_staticcam_position;
+    bool                 m_staticcam_force_update {false};
+    float                m_staticcam_fov_exponent {1.f};
+    Ogre::Radian         m_staticcam_previous_fov {Ogre::Radian(0)};
+    Ogre::Vector3        m_staticcam_look_at {Ogre::Vector3::ZERO};
+    Ogre::Vector3        m_staticcam_position {Ogre::Vector3::ZERO};
     Ogre::Timer          m_staticcam_update_timer;
     // Character cam attributes
-    bool                 m_charactercam_is_3rdperson;
+    bool                 m_charactercam_is_3rdperson {true};
     // Spline cam attributes
-    Ogre::ManualObject*  m_splinecam_mo;
-    Ogre::SimpleSpline*  m_splinecam_spline;
-    Ogre::Real           m_splinecam_spline_len;
-    Ogre::Real           m_splinecam_spline_pos;
-    bool                 m_splinecam_spline_closed;
-    bool                 m_splinecam_auto_tracking;
+    Ogre::ManualObject*  m_splinecam_mo {nullptr};
+    Ogre::SimpleSpline*  m_splinecam_spline {new Ogre::SimpleSpline()};
+    Ogre::Real           m_splinecam_spline_len {1.f};
+    Ogre::Real           m_splinecam_spline_pos {0.5f};
+    bool                 m_splinecam_spline_closed {false};
+    bool                 m_splinecam_auto_tracking {false};
     std::deque<node_t*>  m_splinecam_spline_nodes;
-    unsigned int         m_splinecam_num_linked_beams;
+    unsigned int         m_splinecam_num_linked_beams {0};
 };
 
 /// @} // addtogroup Camera

--- a/source/main/gfx/camera/CameraManager.h
+++ b/source/main/gfx/camera/CameraManager.h
@@ -114,7 +114,6 @@ protected:
     Ogre::Degree         m_cct_rot_scale;
     Ogre::Real           m_cct_dt;
     Ogre::Real           m_cct_trans_scale;
-    float                m_cct_sim_speed; // TODO: duplicates `ActorManager::m_simulation_speed`
     // Old `CameraBehaviorOrbit` attributes
     Ogre::Radian         m_cam_rot_x;
     Ogre::Radian         m_cam_rot_y;

--- a/source/main/gfx/camera/PerVehicleCameraContext.h
+++ b/source/main/gfx/camera/PerVehicleCameraContext.h
@@ -10,22 +10,13 @@ namespace RoR
 /// @addtogroup Camera
 /// @{
 
-struct PerVehicleCameraContext
+enum ActorCameraMode
 {
-    enum CameraCtxBehavior
-    {
-        CAMCTX_BEHAVIOR_INVALID,
-        CAMCTX_BEHAVIOR_EXTERNAL,
-        CAMCTX_BEHAVIOR_VEHICLE_3rdPERSON,
-        CAMCTX_BEHAVIOR_VEHICLE_SPLINE,
-        CAMCTX_BEHAVIOR_VEHICLE_CINECAM
-    };
-
-    PerVehicleCameraContext():
-        behavior(CAMCTX_BEHAVIOR_EXTERNAL)
-    {}
-
-    CameraCtxBehavior  behavior;
+    ACTORCAMERAMODE_INVALID,
+    ACTORCAMERAMODE_EXTERNAL,
+    ACTORCAMERAMODE_VEHICLE_3rdPERSON,
+    ACTORCAMERAMODE_VEHICLE_SPLINE,
+    ACTORCAMERAMODE_VEHICLE_CINECAM
 };
 
 /// @} // addtogroup Camera

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -609,6 +609,7 @@ void TopMenubar::Draw(float dt)
             // CAMERA SETTINGS
             if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_STATIC)
             {
+                // Static camera has it's own FOV
                 ImGui::Separator();
                 ImGui::TextColored(GRAY_HINT_TEXT, "%s", _LC("TopMenubar", "Camera:"));
                 DrawGFloatSlider(App::gfx_static_cam_fov_exp, _LC("TopMenubar", "FOV"), 0.8f, 1.5f);
@@ -637,6 +638,14 @@ void TopMenubar::Draw(float dt)
                 if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_FIXED)
                 {
                     DrawGCheckbox(App::gfx_fixed_cam_tracking, _LC("TopMenubar", "Tracking"));
+                }
+                // Mouse-look settings (free camera and 1st person character camera)
+                // In both those modes, UI is unavailable, so we display them on the next best occasion.
+                if (App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_CHARACTER
+                    || App::GetCameraManager()->GetCurrentBehavior() == CameraManager::CAMERA_BEHAVIOR_FIXED)
+                {
+                    DrawGFloatSlider(App::io_mouselook_speed, _LC("TopMenubar", "Mouse-look speed"), 1.f, 25.f);
+                    DrawGFloatSlider(App::io_mouselook_smoothing, _LC("TopMenubar", "Mouse-look smoothing"), 0.f, 0.99f);
                 }
             }
 

--- a/source/main/physics/Actor.h
+++ b/source/main/physics/Actor.h
@@ -536,9 +536,10 @@ public:
     // NOTE camera#0 is special - serves a general orientation frame for the whole actor. Cinecam#0 isn't required to exist, but camera#0 is.
     CineCameraID_t    ar_current_cinecam = CINECAMERAID_INVALID; //!< Sim state; index of current CineCam (`CINECAMERAID_INVALID` if using 3rd-person camera)
     NodeNum_t         ar_custom_camera_node = NODENUM_INVALID; //!< Sim state; custom tracking node for 3rd-person camera
-    PerVehicleCameraContext ar_camera_context;
+    ActorCameraMode   ar_camera_mode = ACTORCAMERAMODE_EXTERNAL;
     CineCameraID_t    ar_forced_cinecam = CINECAMERAID_INVALID; //!< Sim state; index of CineCam forced by script (`CINECAMERAID_INVALID` if not forced)
     BitMask_t         ar_forced_cinecam_flags = 0; //!< Sim state; flags for forced CineCam supplied by script
+
 
     // TractionControl
     float             tc_ratio = 0.f;                   //!< Regulating force

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -154,8 +154,8 @@ void Console::cVarSetupBuiltins()
     App::io_outgauge_id          = this->cVarCreate("io_outgauge_id",          "OutGauge ID",                CVAR_ARCHIVE | CVAR_TYPE_INT);
     App::io_discord_rpc          = this->cVarCreate("io_discord_rpc",          "Discord Rich Presence",      CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
     App::io_invert_orbitcam      = this->cVarCreate("io_invert_orbitcam",      "Invert orbit camera",        CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
-    App::io_freecam_mouse_speed  = this->cVarCreate("io_freecam_mouse_speed",  "Freecam mouse sensitivity",  CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "8.0");
-    App::io_freecam_mouse_smooth = this->cVarCreate("io_freecam_mouse_smooth", "Freecam mouse smoothing",    CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "0.6");
+    App::io_mouselook_speed      = this->cVarCreate("io_mouselook_speed",      "Mouse-look sensitivity",     CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "8.0");
+    App::io_mouselook_smoothing  = this->cVarCreate("io_mouselook_smoothing",  "Mouse-look smoothing",       CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "0.6");
 
     App::audio_master_volume                       = this->cVarCreate("audio_master_volume",                       "Sound Volume",                          CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "1.0");
     App::audio_enable_creak                        = this->cVarCreate("audio_enable_creak",                        "Creak Sound",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");

--- a/source/main/system/CVar.cpp
+++ b/source/main/system/CVar.cpp
@@ -154,6 +154,8 @@ void Console::cVarSetupBuiltins()
     App::io_outgauge_id          = this->cVarCreate("io_outgauge_id",          "OutGauge ID",                CVAR_ARCHIVE | CVAR_TYPE_INT);
     App::io_discord_rpc          = this->cVarCreate("io_discord_rpc",          "Discord Rich Presence",      CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "true");
     App::io_invert_orbitcam      = this->cVarCreate("io_invert_orbitcam",      "Invert orbit camera",        CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");
+    App::io_freecam_mouse_speed  = this->cVarCreate("io_freecam_mouse_speed",  "Freecam mouse sensitivity",  CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "8.0");
+    App::io_freecam_mouse_smooth = this->cVarCreate("io_freecam_mouse_smooth", "Freecam mouse smoothing",    CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "0.6");
 
     App::audio_master_volume                       = this->cVarCreate("audio_master_volume",                       "Sound Volume",                          CVAR_ARCHIVE | CVAR_TYPE_FLOAT,   "1.0");
     App::audio_enable_creak                        = this->cVarCreate("audio_enable_creak",                        "Creak Sound",                           CVAR_ARCHIVE | CVAR_TYPE_BOOL,    "false");

--- a/source/main/utils/InputEngine.cpp
+++ b/source/main/utils/InputEngine.cpp
@@ -634,6 +634,11 @@ String InputEngine::getKeyNameForKeyCode(OIS::KeyCode keycode)
 
 void InputEngine::Capture()
 {
+    // Reset buffered mouse motion data.
+    mouseState.X = OIS::Axis();
+    mouseState.Y = OIS::Axis();
+    mouseState.Z = OIS::Axis();
+
     mKeyboard->capture();
     mMouse->capture();
 


### PR DESCRIPTION
Fixes #3406

There are 2 new cvars:
* io_mouselook_speed ~ Mouse sensitivity, default 8.0 - there is a slider to TopMenubar/Settings
* io_mouselook_smoothing ~ How much to smoothen the movement (0.0 - 0.99), default 0.6 - there is a slider to TopMenubar/Settings

Both are stored in RoR.log.

Additionally, free camera key movement was adjusted a bit (slightly slower translation, much slower rotation).