### PR TITLE
AngelScript: fixed `game.addWaypoint()` doing nothing, added missing `game.clearWaypoints()`

### DIFF
--- a/doc/angelscript/Script2Game/GameScriptClass.h
+++ b/doc/angelscript/Script2Game/GameScriptClass.h
@@ -606,6 +606,7 @@ public:
     BeamClass@ spawnTruckAI(string truckName, vector3 pos, string truckSectionConfig, string truckSkin, int x);
     array<vector3>@ getWaypoints(int x);
     void addWaypoint(vector3 pos);
+    void clearWaypoints();
     int getAIVehicleCount();
     int getAIVehicleDistance();
     int getAIVehiclePositionScheme();

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -1211,11 +1211,9 @@ AngelScript::CScriptArray* GameScript::getAllTrucks()
 
 void GameScript::addWaypoint(const Ogre::Vector3& pos)
 {
-    std::vector<Ogre::Vector3> waypoints;
-    for (int i = 0; i < App::GetGuiManager()->TopMenubar.ai_waypoints.size(); i++)
-    {
-        waypoints.push_back(App::GetGuiManager()->TopMenubar.ai_waypoints[i].position);
-    }
+    ai_events wp_data;
+    wp_data.position = pos;
+    App::GetGuiManager()->TopMenubar.ai_waypoints.push_back(wp_data);
 }
 
 AngelScript::CScriptArray* GameScript::getWaypointsSpeed()

--- a/source/main/scripting/GameScript.cpp
+++ b/source/main/scripting/GameScript.cpp
@@ -1216,6 +1216,11 @@ void GameScript::addWaypoint(const Ogre::Vector3& pos)
     App::GetGuiManager()->TopMenubar.ai_waypoints.push_back(wp_data);
 }
 
+void GameScript::clearWaypoints()
+{
+    App::GetGuiManager()->TopMenubar.ai_waypoints.clear();
+}
+
 AngelScript::CScriptArray* GameScript::getWaypointsSpeed()
 {
     std::vector<int> vec;

--- a/source/main/scripting/GameScript.h
+++ b/source/main/scripting/GameScript.h
@@ -501,6 +501,7 @@ public:
     AngelScript::CScriptArray* getWaypoints(int x);
     AngelScript::CScriptArray* getWaypointsSpeed();
     void addWaypoint(const Ogre::Vector3& pos);
+    void clearWaypoints();
     int getAIVehicleCount();
     int getAIVehicleDistance();
     int getAIVehiclePositionScheme();

--- a/source/main/scripting/bindings/GameScriptAngelscript.cpp
+++ b/source/main/scripting/bindings/GameScriptAngelscript.cpp
@@ -183,6 +183,7 @@ void RoR::RegisterGameScript(asIScriptEngine *engine)
     result = engine->RegisterObjectMethod("GameScriptClass", "array<vector3> @getWaypoints(int x)", AngelScript::asMETHOD(GameScript, getWaypoints), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "array<int> @getWaypointsSpeed()", AngelScript::asMETHOD(GameScript, getWaypointsSpeed), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "void addWaypoint(vector3 &in)", asMETHOD(GameScript, addWaypoint), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("GameScriptClass", "void clearWaypoints()", asMETHOD(GameScript, clearWaypoints), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleCount()", AngelScript::asMETHOD(GameScript, getAIVehicleCount), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehicleDistance()", AngelScript::asMETHOD(GameScript, getAIVehicleDistance), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("GameScriptClass", "int getAIVehiclePositionScheme()", AngelScript::asMETHOD(GameScript, getAIVehiclePositionScheme), AngelScript::asCALL_THISCALL); ROR_ASSERT(result >= 0);


### PR DESCRIPTION
Reported by user 'bobz' on Discord.

Test snippet:
```
int state = 0; // 0=not started, 1=init done, 2=cleanup done

void frameStep(float dt)
{
    if (state == 0 )
    {
        game.addWaypoint(vector3(0,0,0));
        array<vector3> waypoints = game.getWaypoints(0);
        game.log("waypoints 0 length =  "+ formatInt(waypoints.length())); 
        state=1;
    }
    else if (state == 1)
    {
        game.clearWaypoints();
        array<vector3> waypoints = game.getWaypoints(0);
        game.log("waypoints 1 length =  "+ formatInt(waypoints.length())); 
        state=2;
    }
}
```

<img width="1321" height="911" alt="image" src="https://github.com/user-attachments/assets/eac0320c-d3b0-47b6-a092-e81e4451abbe" />

Broken 3 years ago (9/17/2023) in 3b51915e878ce8f4d78a1e291362fb84c0e70f11 likely by accident (perhaps bad merge).