### PR TITLE
🐛 More dashboard system-related fixes

### DIFF
--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -857,22 +857,20 @@ void DashBoard::update(float dt)
                 float scale = (val - animation.vmin) * (animation.wmax - animation.wmin) / (animation.vmax - animation.vmin) + animation.wmin;
                 if (animation.direction == DIRECTION_UP)
                 {
-                    controls[i].widget->setPosition(controls[i].initialPosition.left, controls[i].initialPosition.top - scale);
+                    finalVerticalTranslation -= scale;
                     controls[i].widget->setSize(controls[i].initialSize.width, controls[i].initialSize.height + scale);
                 }
                 else if (animation.direction == DIRECTION_DOWN)
                 {
-                    controls[i].widget->setPosition(controls[i].initialPosition.left, controls[i].initialPosition.top);
                     controls[i].widget->setSize(controls[i].initialSize.width, controls[i].initialSize.height + scale);
                 }
                 else if (animation.direction == DIRECTION_LEFT)
                 {
-                    controls[i].widget->setPosition(controls[i].initialPosition.left - scale, controls[i].initialPosition.top);
+                    finalHorizontalTranslation -= scale;
                     controls[i].widget->setSize(controls[i].initialSize.width + scale, controls[i].initialSize.height);
                 }
                 else if (animation.direction == DIRECTION_RIGHT)
                 {
-                    controls[i].widget->setPosition(controls[i].initialPosition.left, controls[i].initialPosition.top);
                     controls[i].widget->setSize(controls[i].initialSize.width + scale, controls[i].initialSize.height);
                 }
             }

--- a/source/main/gui/DashBoardManager.cpp
+++ b/source/main/gui/DashBoardManager.cpp
@@ -73,6 +73,7 @@ DashBoardManager::DashBoardManager(ActorPtr actor) : visible(true), m_actor(acto
     INITDATA(DD_TRACTIONCONTROL_MODE    , DC_INT  , "tractioncontrol_mode");
     INITDATA(DD_ANTILOCKBRAKE_MODE      , DC_INT  , "antilockbrake_mode");
     INITDATA(DD_TIES_MODE               , DC_INT  , "ties_mode");
+    INITDATA(DD_CRUISECONTROL_ACTIVE    , DC_BOOL , "cruisecontrol_active");
     INITDATA(DD_SCREW_THROTTLE_0        , DC_FLOAT, "screw_throttle_0");
     INITDATA(DD_SCREW_THROTTLE_1        , DC_FLOAT, "screw_throttle_1");
     INITDATA(DD_SCREW_THROTTLE_2        , DC_FLOAT, "screw_throttle_2");

--- a/source/main/gui/DashBoardManager.h
+++ b/source/main/gui/DashBoardManager.h
@@ -122,6 +122,7 @@ enum DashData
     DD_TRACTIONCONTROL_MODE,
     DD_ANTILOCKBRAKE_MODE,
     DD_TIES_MODE, /// ties locked
+    DD_CRUISECONTROL_ACTIVE,
 
     // water things
     DD_SCREW_THROTTLE_0, // throttle for screwprop 0

--- a/source/main/physics/Actor.cpp
+++ b/source/main/physics/Actor.cpp
@@ -4266,6 +4266,9 @@ void Actor::updateDashBoards(float dt)
     }
     ar_dashboard->setInt(DD_TIES_MODE, ties_mode);
 
+    // Cruise control lamp
+    ar_dashboard->setBool(DD_CRUISECONTROL_ACTIVE, cc_mode);
+
     // Boat things now: screwprops and alike
     if (ar_num_screwprops)
     {

--- a/source/main/physics/ActorSpawnerFlow.cpp
+++ b/source/main/physics/ActorSpawnerFlow.cpp
@@ -97,12 +97,6 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
 
     this->InitializeRig();
 
-    // Set up the built-in "renderdash" material for use in meshes.
-    // Must be done before 'props' are processed because those traditionally use it.
-    // Must be always created, there is no mechanism to declare the need for it. It can be acessed from any mesh, not only dashboard-prop.
-    // Example content: https://github.com/RigsOfRods/rigs-of-rods/files/3044343/45fc291a9d2aa5faaa36cca6df9571cd6d1f1869_Actros_8x8-englisch.zip
-    this->PrepareRenderdashMaterial();
-
     this->CreateDashboardRttLayers();
 
     // Vehicle name
@@ -134,7 +128,21 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     PROCESS_ELEMENT(RigDef::Keyword::GLOBALS, globals, ProcessGlobals);
     // MUST be done before "guisettings" (overrides help panel material)
     PROCESS_ELEMENT(RigDef::Keyword::HELP, help, ProcessHelp);
+
+    // ---------------------------- User-defined nodes ----------------------------
+
+    m_actor->m_gfx_actor = std::unique_ptr<RoR::GfxActor>(
+        new RoR::GfxActor(m_actor, this, m_custom_resource_group));
+
+    PROCESS_ELEMENT(RigDef::Keyword::NODES, nodes, ProcessNode);
+
+    // Elements that determine the actor type must be loaded here
     PROCESS_ELEMENT(RigDef::Keyword::ENGINE, engine, ProcessEngine);
+    PROCESS_ELEMENT(RigDef::Keyword::TURBOJETS, turbojets, ProcessTurbojet);
+    PROCESS_ELEMENT(RigDef::Keyword::PISTONPROPS, pistonprops, ProcessPistonprop);
+    PROCESS_ELEMENT(RigDef::Keyword::TURBOPROPS2, turboprops2, ProcessTurboprop2); // 'turboprops' are auto-imported as 'turboprops2'.
+    PROCESS_ELEMENT(RigDef::Keyword::SCREWPROPS, screwprops, ProcessScrewprop);
+
     PROCESS_ELEMENT(RigDef::Keyword::ENGOPTION, engoption, ProcessEngoption);
     PROCESS_ELEMENT(RigDef::Keyword::ENGTURBO, engturbo, ProcessEngturbo);
     PROCESS_ELEMENT(RigDef::Keyword::TORQUECURVE, torquecurve, ProcessTorqueCurve);
@@ -143,12 +151,14 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     PROCESS_ELEMENT(RigDef::Keyword::GUISETTINGS, guisettings, ProcessGuiSettings);
     PROCESS_ELEMENT(RigDef::Keyword::SCRIPTS, scripts, ProcessScript);
 
-    // ---------------------------- User-defined nodes ----------------------------
-
-    m_actor->m_gfx_actor = std::unique_ptr<RoR::GfxActor>(
-        new RoR::GfxActor(m_actor, this, m_custom_resource_group));
-
-    PROCESS_ELEMENT(RigDef::Keyword::NODES, nodes, ProcessNode);
+    // Set up the built-in "renderdash" material for use in meshes.
+    // Must be done before 'props' are processed because those traditionally use it.
+    // Must be always created, there is no mechanism to declare the need for it. It can be acessed from any mesh, not only dashboard-prop.
+    // Example content: https://github.com/RigsOfRods/rigs-of-rods/files/3044343/45fc291a9d2aa5faaa36cca6df9571cd6d1f1869_Actros_8x8-englisch.zip
+    if (m_actor->ar_driveable == TRUCK)
+    {
+        this->PrepareRenderdashMaterial();
+    }
 
     // Old-format exhaust (defined by flags 'x/y' in section 'nodes', one per vehicle)
     if (m_actor->ar_exhaust_pos_node != 0 && m_actor->ar_exhaust_dir_node != 0)
@@ -201,7 +211,6 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     PROCESS_ELEMENT(RigDef::Keyword::ROPABLES, ropables, ProcessRopable);
     PROCESS_ELEMENT(RigDef::Keyword::ANIMATORS, animators, ProcessAnimator);
     PROCESS_ELEMENT(RigDef::Keyword::FUSEDRAG, fusedrag, ProcessFusedrag);
-    PROCESS_ELEMENT(RigDef::Keyword::TURBOJETS, turbojets, ProcessTurbojet);
     PROCESS_ELEMENT(RigDef::Keyword::PROPS, props, ProcessProp);
     PROCESS_ELEMENT(RigDef::Keyword::TRACTIONCONTROL, tractioncontrol, ProcessTractionControl);
     PROCESS_ELEMENT(RigDef::Keyword::ROTATORS, rotators, ProcessRotator);
@@ -216,9 +225,6 @@ void ActorSpawner::ProcessNewActor(ActorPtr actor, ActorSpawnRequest rq, RigDef:
     PROCESS_ELEMENT(RigDef::Keyword::EXHAUSTS, exhausts, ProcessExhaust);
     PROCESS_ELEMENT(RigDef::Keyword::EXTCAMERA, extcamera, ProcessExtCamera);
     PROCESS_ELEMENT(RigDef::Keyword::CAMERARAIL, camerarail, ProcessCameraRail);
-    PROCESS_ELEMENT(RigDef::Keyword::PISTONPROPS, pistonprops, ProcessPistonprop);
-    PROCESS_ELEMENT(RigDef::Keyword::TURBOPROPS2, turboprops2, ProcessTurboprop2); // 'turboprops' are auto-imported as 'turboprops2'.
-    PROCESS_ELEMENT(RigDef::Keyword::SCREWPROPS, screwprops, ProcessScrewprop);
     PROCESS_ELEMENT(RigDef::Keyword::FIXES, fixes, ProcessFixedNode);
     PROCESS_ELEMENT(RigDef::Keyword::FLEXBODIES, flexbodies, ProcessFlexbody); // (needs GfxActor to exist)
     PROCESS_ELEMENT(RigDef::Keyword::WINGS, wings, ProcessWing); // (needs GfxActor to exist)

--- a/source/main/scripting/bindings/DashBoardManagerAngelscript.cpp
+++ b/source/main/scripting/bindings/DashBoardManagerAngelscript.cpp
@@ -35,11 +35,11 @@ void RoR::RegisterDashBoardManager(asIScriptEngine* engine)
     result = engine->RegisterObjectMethod("DashBoardManagerClass", "void setInt(int key, int value)", asMETHOD(DashBoardManager, setInt), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("DashBoardManagerClass", "void setFloat(int key, float value)", asMETHOD(DashBoardManager, setFloat), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 
-    result = engine->RegisterObjectMethod("DashBoardManagerClass", "void setString(int key, const string& value)", asFUNCTIONPR([](DashBoardManager* self, int key, const std::string& value) {
-        self->setChar(key, value.c_str()); }, (DashBoardManager*, int, const std::string&), void), asCALL_CDECL_OBJFIRST); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("DashBoardManagerClass", "void setString(int key, const string value)", asFUNCTIONPR([](DashBoardManager* self, int key, const std::string value) {
+        self->setChar(key, value.c_str()); }, (DashBoardManager*, int, const std::string), void), asCALL_CDECL_OBJFIRST); ROR_ASSERT(result >= 0);
 
     result = engine->RegisterObjectMethod("DashBoardManagerClass", "void setEnabled(int key, bool value)", asMETHOD(DashBoardManager, setEnabled), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("DashBoardManagerClass", "DashboardDataTypes getDataType(int key)", asMETHOD(DashBoardManager, getDataType), asCALL_THISCALL); ROR_ASSERT(result >= 0);
-    result = engine->RegisterObjectMethod("DashBoardManagerClass", "int getLinkIDForName(string& key)", asMETHOD(DashBoardManager, getLinkIDForName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
+    result = engine->RegisterObjectMethod("DashBoardManagerClass", "int getLinkIDForName(string key)", asMETHOD(DashBoardManager, getLinkIDForName), asCALL_THISCALL); ROR_ASSERT(result >= 0);
     result = engine->RegisterObjectMethod("DashBoardManagerClass", "void updateFeatures()", asMETHOD(DashBoardManager, updateFeatures), asCALL_THISCALL); ROR_ASSERT(result >= 0);
 }


### PR DESCRIPTION
This PR fixes the following issues:

- Dashboard scripts didn't build when calling `getLinkIDForName()` or `setString()` with literal strings as parameters (e.g. `getLinkIDForName("cruisecontrol_active")`). I suspect the issue was triggered by the recent AngelScript update, but in any case scripts now build successfully.
- Scale animations for MyGUI dashboards didn't work properly (I inadvertently broke that in #3351, oops).
- Added missing input source: `cruisecontrol_active`. This input source was referenced by many dashboards (even built-ins) and was never included for some reason.
- Renderdash textures were pointlessly loaded (and not freed) for actors other than trucks.